### PR TITLE
PPL: R2 audio hosting + upload script (#13)

### DIFF
--- a/docs/audio-hosting.md
+++ b/docs/audio-hosting.md
@@ -1,0 +1,81 @@
+# Audio Hosting — PPL Study
+
+## Why audio isn't in the repo
+
+Audio files (lesson narration, typically 2–4 MB each × 60 lessons = ~200 MB) are hosted on **Cloudflare R2**, not in git. The repo stays small, the CDN caches globally, and there are no egress fees.
+
+This project reuses the existing `suprun-media` R2 bucket set up for suprun.ca. A dedicated `ppl/` prefix keeps the two projects cleanly separated.
+
+## URL convention
+
+Every lesson has a predictable URL derived from its repo path:
+
+```
+https://media.suprun.workers.dev/ppl/lessons/{topic}/{NNN}-{slug}.m4a
+```
+
+| Lesson file | Public audio URL |
+|---|---|
+| `lessons/air-law/001-airspace-classifications.md` | `https://media.suprun.workers.dev/ppl/lessons/air-law/001-airspace-classifications.m4a` |
+| `lessons/navigation/001-vfr-charts.md` | `https://media.suprun.workers.dev/ppl/lessons/navigation/001-vfr-charts.m4a` |
+
+The R2 key mirrors the repo path exactly — derive one from the other by prepending `ppl/` and swapping `.md` for `.m4a`.
+
+> **Note on custom domain.** `media.suprun.ca` is the aspirational custom-domain CNAME (see `projects/suprun.ca/MEDIA-SETUP.md`), but as of 2026-04 it is not wired up at Cloudflare. The live hostname is `media.suprun.workers.dev`. Switch to the custom domain by doing a project-wide find/replace once the CNAME is active.
+
+## Infrastructure
+
+- **Bucket:** `suprun-media` (region ENAM, existing)
+- **Worker:** `suprun-media-proxy` on `media.suprun.workers.dev`
+- **Credentials:** `~/.cloudflare` (shared with suprun.ca — do not duplicate)
+- **CORS:** The worker currently returns `Access-Control-Allow-Origin: https://suprun.ca`. HTML5 `<audio controls>` tags play without CORS, so the React app at `ppl-study-suprun-ca.web.app` will work. If we later add JavaScript-level audio processing (e.g. `fetch` + `AudioContext`), add the ppl-study origin to the worker allowlist.
+
+## Uploading a lesson's audio
+
+### One-off (Python)
+
+```python
+import boto3, os
+from pathlib import Path
+
+env = {}
+for line in Path(os.path.expanduser('~/.cloudflare')).read_text().splitlines():
+    if '=' in line and not line.startswith('#'):
+        k, v = line.split('=', 1)
+        env[k.strip()] = v.strip().strip('"')
+
+s3 = boto3.client(
+    's3',
+    endpoint_url=env['R2_ENDPOINT'],
+    aws_access_key_id=env['R2_ACCESS_KEY_ID'],
+    aws_secret_access_key=env['R2_SECRET_ACCESS_KEY'],
+    region_name='auto',
+)
+
+s3.upload_file(
+    'path/to/local-lesson.m4a',
+    env['R2_BUCKET'],
+    'ppl/lessons/air-law/001-airspace-classifications.m4a',
+    ExtraArgs={'ContentType': 'audio/mp4'},
+)
+```
+
+### Helper script
+
+```bash
+scripts/upload-lesson-audio.sh <local-audio-file> <lesson-markdown-file>
+```
+
+Derives the R2 key from the lesson markdown path and prints the resulting public URL. See `scripts/upload-lesson-audio.sh --help`.
+
+## Verifying a URL
+
+Cloudflare's worker returns `200` + `content-type: audio/mp4` when the key exists. Note: on macOS, the built-in `curl` (LibreSSL) fails the TLS handshake against `*.workers.dev`. Use Python or Homebrew curl for verification.
+
+```bash
+python3 -c "import urllib.request; r = urllib.request.urlopen('https://media.suprun.workers.dev/ppl/lessons/air-law/001-airspace-classifications.m4a'); print(r.status, r.headers['content-type'])"
+```
+
+## Retention
+
+R2 storage is cheap ($0.015/GB/month) and egress is free. Keep everything indefinitely — no lifecycle rules.

--- a/docs/audio-hosting.md
+++ b/docs/audio-hosting.md
@@ -21,7 +21,7 @@ https://media.suprun.workers.dev/ppl/lessons/{topic}/{NNN}-{slug}.m4a
 
 The R2 key mirrors the repo path exactly — derive one from the other by prepending `ppl/` and swapping `.md` for `.m4a`.
 
-> **Note on custom domain.** `media.suprun.ca` is the aspirational custom-domain CNAME (see `projects/suprun.ca/MEDIA-SETUP.md`), but as of 2026-04 it is not wired up at Cloudflare. The live hostname is `media.suprun.workers.dev`. Switch to the custom domain by doing a project-wide find/replace once the CNAME is active.
+> **Hostname is permanent.** Always use `media.suprun.workers.dev`. The `media.suprun.ca` CNAME referenced in `projects/suprun.ca/MEDIA-SETUP.md` was attempted but never successfully wired, and setup is not planned. Treat `media.suprun.ca` as a stale doc reference, not a future target.
 
 ## Infrastructure
 

--- a/scripts/upload-lesson-audio.sh
+++ b/scripts/upload-lesson-audio.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# upload-lesson-audio.sh — upload a lesson narration file to Cloudflare R2.
+#
+# Usage:
+#   scripts/upload-lesson-audio.sh <local-audio.m4a> <lesson.md>
+#
+# The R2 key is derived from the lesson markdown path:
+#   lessons/{topic}/{NNN}-{slug}.md  ->  ppl/lessons/{topic}/{NNN}-{slug}.m4a
+# Prints the resulting public URL on success.
+
+set -euo pipefail
+
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+    awk '/^#!/ {next} /^#/ {print substr($0, 3); next} {exit}' "$0"
+    exit 0
+fi
+
+if [[ $# -ne 2 ]]; then
+    echo "Usage: $0 <local-audio.m4a> <lesson.md>" >&2
+    exit 2
+fi
+
+LOCAL_AUDIO="$1"
+LESSON_MD="$2"
+
+if [[ ! -f "$LOCAL_AUDIO" ]]; then
+    echo "Audio file not found: $LOCAL_AUDIO" >&2
+    exit 1
+fi
+
+if [[ ! -f "$LESSON_MD" ]]; then
+    echo "Lesson markdown file not found: $LESSON_MD" >&2
+    exit 1
+fi
+
+# Derive R2 key: strip everything up to and including "lessons/", drop .md, add .m4a, prepend ppl/
+REL_PATH="${LESSON_MD##*lessons/}"        # e.g. air-law/001-airspace-classifications.md
+REL_BASE="${REL_PATH%.md}"                # e.g. air-law/001-airspace-classifications
+R2_KEY="ppl/lessons/${REL_BASE}.m4a"
+PUBLIC_URL="https://media.suprun.workers.dev/${R2_KEY}"
+
+python3 - "$LOCAL_AUDIO" "$R2_KEY" <<'PYEOF'
+import boto3, os, sys
+from pathlib import Path
+
+local_audio, r2_key = sys.argv[1], sys.argv[2]
+
+env = {}
+for line in Path(os.path.expanduser('~/.cloudflare')).read_text().splitlines():
+    if '=' in line and not line.startswith('#'):
+        k, v = line.split('=', 1)
+        env[k.strip()] = v.strip().strip('"')
+
+s3 = boto3.client(
+    's3',
+    endpoint_url=env['R2_ENDPOINT'],
+    aws_access_key_id=env['R2_ACCESS_KEY_ID'],
+    aws_secret_access_key=env['R2_SECRET_ACCESS_KEY'],
+    region_name='auto',
+)
+
+s3.upload_file(
+    local_audio,
+    env['R2_BUCKET'],
+    r2_key,
+    ExtraArgs={'ContentType': 'audio/mp4'},
+)
+print(f"  key:  {r2_key}", file=sys.stderr)
+PYEOF
+
+echo "$PUBLIC_URL"


### PR DESCRIPTION
Closes #13.

## Summary
- Audio narration for PPL lessons is now hosted on Cloudflare R2 under the `ppl/` prefix of the existing `suprun-media` bucket (shared with suprun.ca — zero new infra).
- AL-001 narration uploaded and verified live:
  https://media.suprun.workers.dev/ppl/lessons/air-law/001-airspace-classifications.m4a
- `docs/audio-hosting.md` documents the URL convention, credential location, and uploader usage.
- `scripts/upload-lesson-audio.sh` derives the R2 key from a lesson markdown path and uploads — future lessons run through this one command.
- `audio/` directory removed from repo; excluded via `.gitignore` in the initial commit.

## Note on custom domain
The live hostname is `media.suprun.workers.dev`. The `media.suprun.ca` CNAME referenced in `projects/suprun.ca/MEDIA-SETUP.md` is aspirational but not yet wired up — flipping to that is a find/replace once the DNS is live.

## Test plan
- [x] `python3 urllib.request.urlopen(...)` returns 200 + `content-type: audio/mp4`
- [x] `scripts/upload-lesson-audio.sh --help` renders
- [x] R2 key derivation verified against `lessons/air-law/001-airspace-classifications.md`
- [ ] Manual: play audio in a browser via HTML5 `<audio>` (no CORS needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)