### PR TITLE
chore: issue templates, PR template, auto-merge on qa-pass

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,46 @@
+name: Bug Report
+description: Something is broken or behaves incorrectly
+title: "[Bug]: "
+labels: ["bug", "p2-medium"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What's wrong? What did you expect to happen?
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. Go to ...
+        2. Click on ...
+        3. Observe: ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+
+  - type: input
+    id: env
+    attributes:
+      label: Environment
+      placeholder: Browser + version, screen size, or "N/A for content bug"
+    validations:
+      required: false
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Screenshots, logs, references.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Discussion or design question
+    url: https://github.com/svv2014/ppl-study/discussions
+    about: For open-ended discussion, curriculum design debates, or questions not yet concrete enough for a ticket.

--- a/.github/ISSUE_TEMPLATE/lesson.yml
+++ b/.github/ISSUE_TEMPLATE/lesson.yml
@@ -1,0 +1,85 @@
+name: New Lesson
+description: Author a new 20-minute study lesson (content task, not dev)
+title: "[Lesson]: "
+labels: ["content", "p2-medium"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template to commission a new lesson file under `lessons/{topic}/{NNN}-{slug}.md`.
+        All lessons must follow the canonical frontmatter schema (see `docs/lesson-schema.md`) and cite Transport Canada sources (TP number or CAR section) for every specific rule or number.
+
+  - type: dropdown
+    id: topic
+    attributes:
+      label: Topic
+      options:
+        - air-law
+        - navigation
+        - meteorology
+        - general-knowledge
+    validations:
+      required: true
+
+  - type: input
+    id: lesson_id
+    attributes:
+      label: Lesson ID
+      description: Format AL-NNN / NAV-NNN / MET-NNN / GEN-NNN (check curriculum-plan.md for next free number)
+      placeholder: NAV-002
+    validations:
+      required: true
+
+  - type: input
+    id: slug
+    attributes:
+      label: Slug (filename)
+      description: lowercase, hyphen-separated, matches file path after the NNN prefix
+      placeholder: lat-lon-map-reading
+    validations:
+      required: true
+
+  - type: textarea
+    id: content_scope
+    attributes:
+      label: Content Scope (20-minute lesson)
+      description: What must this lesson cover? Be specific about concepts, numbers, and rules.
+      placeholder: |
+        - Concept 1 (with source citation)
+        - Concept 2
+        - Connection to which other lesson(s)
+    validations:
+      required: true
+
+  - type: textarea
+    id: sources
+    attributes:
+      label: Sources
+      description: Transport Canada sources to cite. TP number with chapter, or CAR section.
+      placeholder: |
+        - TP 12880E Chapter 9
+        - CAR 602.115
+    validations:
+      required: true
+
+  - type: textarea
+    id: questions
+    attributes:
+      label: Practice Questions
+      description: Specify what the 5 practice questions should test (the worker writes the actual questions).
+      placeholder: |
+        1. Degree-to-NM conversion
+        2. Reading a lat/lon grid position
+        3. Connecting scale from NAV-001
+        4. ...
+        5. ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: notes
+    attributes:
+      label: Notes
+      description: Anything else the author should know — tone, scope boundaries, what to avoid.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -1,0 +1,58 @@
+name: Task
+description: A concrete unit of dev work — feature, chore, or defined implementation
+title: "[Task]: "
+labels: ["dev", "p2-medium"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Tasks flow through the ASDLC pipeline: label `dev` → scanner picks up → worker implements → PR opened → `qa-pass` → auto-merge.
+        Write acceptance criteria precisely enough that a worker with no other context can ship it.
+
+  - type: textarea
+    id: objective
+    attributes:
+      label: Objective
+      description: What needs to be done, and why?
+      placeholder: One paragraph. State the goal and the motivation.
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance_criteria
+    attributes:
+      label: Acceptance Criteria
+      description: Testable checkboxes. A worker should be able to self-verify each one.
+      placeholder: |
+        - [ ] Criterion 1 (testable)
+        - [ ] Criterion 2 (testable)
+    validations:
+      required: true
+
+  - type: textarea
+    id: scope
+    attributes:
+      label: Files & Scope
+      description: Which files/directories should the worker touch? Which should it NOT touch?
+      placeholder: |
+        Touches: web-app/src/pages/Home.tsx, web-app/src/components/ProgressBar.tsx
+        Do not touch: firebase.json, lessons/
+    validations:
+      required: false
+
+  - type: textarea
+    id: dependencies
+    attributes:
+      label: Dependencies
+      description: Issues that must land first. The worker will wait on these.
+      placeholder: "#12, #14"
+    validations:
+      required: false
+
+  - type: textarea
+    id: notes
+    attributes:
+      label: Notes
+      description: Implementation hints, references, gotchas.
+    validations:
+      required: false

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,22 @@
+## Summary
+
+<!-- 1–3 bullets. What changed, why. -->
+
+## Closes
+
+<!-- Closes #N for each issue this PR resolves. -->
+
+## Test plan
+
+- [ ] ...
+
+## ASDLC flow
+
+Merging happens automatically once this PR is labeled `qa-pass`:
+
+1. Reviewer (human or QA worker) verifies the work matches acceptance criteria.
+2. Reviewer applies `qa-pass` label.
+3. `.github/workflows/auto-merge-qa-pass.yml` enables GitHub auto-merge.
+4. Once required checks are green, PR squash-merges and the branch is deleted.
+
+If you hit `qa-fail`, fix the issue and push — the same PR can be re-labelled `qa-pass` when ready.

--- a/.github/workflows/auto-merge-qa-pass.yml
+++ b/.github/workflows/auto-merge-qa-pass.yml
@@ -1,0 +1,24 @@
+name: Auto-merge on qa-pass
+
+on:
+  pull_request:
+    types: [labeled]
+
+permissions:
+  pull-requests: write
+  contents: write
+
+jobs:
+  auto-merge:
+    if: github.event.label.name == 'qa-pass'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enable auto-merge
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr merge ${{ github.event.pull_request.number }} \
+            --repo ${{ github.repository }} \
+            --squash \
+            --delete-branch \
+            --auto


### PR DESCRIPTION
## Summary
- Adds issue templates (Task / New Lesson / Bug) and a blank-disabling `config.yml`
- Adds PR template covering summary / closes / test plan / ASDLC qa-pass flow
- Adds `.github/workflows/auto-merge-qa-pass.yml` — when a PR is labeled `qa-pass`, GitHub auto-merge is enabled (squash, delete branch, respects required checks)
- Out-of-band: enabled repo-level `allow_auto_merge` + `delete_branch_on_merge` via `gh api`, and created missing priority labels (`p0-critical`/`p1-high`/`p2-medium`/`p3-low`) + `content` label referenced by templates

## Closes
No issue — this is infrastructure bootstrap.

## Test plan
- [ ] Templates render on https://github.com/svv2014/ppl-study/issues/new/choose
- [ ] Picking "Task" prefills labels `dev`, `p2-medium`
- [ ] Picking "New Lesson" prefills labels `content`, `p2-medium`
- [ ] Apply `qa-pass` to a draft PR → auto-merge enables (or shows the auto-merge banner)

## ASDLC flow
Merging happens automatically once this PR is labeled `qa-pass`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)