### PR TITLE
chore(ci): QA build+test on ready-for-qa, deploy on merge to main

### DIFF
--- a/.github/ISSUE_TEMPLATE/idea.md
+++ b/.github/ISSUE_TEMPLATE/idea.md
@@ -1,0 +1,18 @@
+---
+name: "Quick idea (PO will refine)"
+about: "Drop a rough description — the PO agent will expand it into a full spec before dev picks it up."
+title: "[IDEA] "
+labels: po-review
+assignees: ''
+---
+
+## What I want
+<!-- One or two sentences is enough. The PO agent will fill in the rest. -->
+
+
+## Why it matters
+<!-- Optional: what problem does this solve or what value does it add? -->
+
+
+## Constraints or hints
+<!-- Optional: things the worker should know, avoid, or check first. -->

--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -1,0 +1,35 @@
+name: Deploy to Firebase Hosting on merge
+
+# Builds web-app/ and deploys to Firebase Hosting (project suprun-ca, site ppl-study-suprun-ca)
+# on every push to main — i.e. after an auto-merge from qa-pass.
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  build_and_deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: web-app/package-lock.json
+
+      - name: Build
+        working-directory: web-app
+        run: npm ci && npm run build
+
+      - uses: FirebaseExtended/action-hosting-deploy@v0
+        with:
+          repoToken: '${{ secrets.GITHUB_TOKEN }}'
+          firebaseServiceAccount: '${{ secrets.FIREBASE_SERVICE_ACCOUNT_SUPRUN_CA }}'
+          channelId: live
+          projectId: suprun-ca

--- a/.github/workflows/qa-build-test.yml
+++ b/.github/workflows/qa-build-test.yml
@@ -1,0 +1,63 @@
+name: QA build + test
+
+# Runs only when a PR is labeled `ready-for-qa` — avoids burning CI on WIP pushes.
+# On success: applies `qa-pass` (which triggers auto-merge).
+# On failure: applies `qa-fail` and comments with a link to the run.
+
+on:
+  pull_request:
+    types: [labeled]
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  qa:
+    if: github.event.label.name == 'ready-for-qa'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: web-app/package-lock.json
+
+      - name: Install
+        working-directory: web-app
+        run: npm ci
+
+      - name: Build
+        working-directory: web-app
+        run: npm run build
+
+      - name: Test (if present)
+        working-directory: web-app
+        run: npm test --if-present
+
+      - name: Apply qa-pass
+        if: success()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr edit ${{ github.event.pull_request.number }} \
+            --repo ${{ github.repository }} \
+            --remove-label ready-for-qa \
+            --add-label qa-pass
+
+      - name: Apply qa-fail
+        if: failure()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr edit ${{ github.event.pull_request.number }} \
+            --repo ${{ github.repository }} \
+            --remove-label ready-for-qa \
+            --add-label qa-fail
+          gh pr comment ${{ github.event.pull_request.number }} \
+            --repo ${{ github.repository }} \
+            --body "QA build/test failed. See [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for details."

--- a/firebase.json
+++ b/firebase.json
@@ -1,11 +1,17 @@
 {
   "hosting": {
     "site": "ppl-study-suprun-ca",
-    "public": "public",
+    "public": "web-app/dist",
     "ignore": [
       "firebase.json",
       "**/.*",
       "**/node_modules/**"
+    ],
+    "rewrites": [
+      {
+        "source": "**",
+        "destination": "/index.html"
+      }
     ],
     "headers": [
       {
@@ -14,15 +20,6 @@
           {
             "key": "Cache-Control",
             "value": "public, max-age=3600"
-          }
-        ]
-      },
-      {
-        "source": "**/*.@(m4a|mp3|ogg)",
-        "headers": [
-          {
-            "key": "Cache-Control",
-            "value": "public, max-age=86400"
           }
         ]
       }


### PR DESCRIPTION
## Summary

Closes the autopilot loop with two workflows:

- `qa-build-test.yml` — triggered on PR label `ready-for-qa`. Runs `npm ci && npm run build` (plus `npm test --if-present`). On pass: applies `qa-pass` (→ existing auto-merge kicks in). On fail: applies `qa-fail` + comments with a workflow-run link. CI only burns when QA asks for it.
- `deploy-main.yml` — triggered on push to `main`. Builds `web-app/` and deploys `web-app/dist/` to Firebase Hosting (project `suprun-ca`, site `ppl-study-suprun-ca`) via the existing `FIREBASE_SERVICE_ACCOUNT_SUPRUN_CA` secret.

Also updates `firebase.json`:
- `hosting.public`: `public` (stale, non-existent) → `web-app/dist`
- Adds SPA rewrite `{ "**": "/index.html" }` needed by react-router
- Removes the audio Cache-Control rule (audio now lives on R2, not Firebase)

## Closes
- Partially supersedes #19 (Firebase public dir + rewrites). The remaining scope of #19 — retire `web/` directory — still needs a follow-up.

## Test plan

After merging this PR, validate end-to-end:
- [ ] Push to main fires `deploy-main.yml` and the scaffold app becomes live at `ppl-study-suprun-ca.web.app`
- [ ] Open a new PR (e.g. the next auto-labeled task), apply `ready-for-qa` → CI runs → on success applies `qa-pass` → auto-merge triggers
- [ ] Manually break a PR's build, apply `ready-for-qa` → CI applies `qa-fail` + comment

## ASDLC flow

Merging happens automatically once this PR is labeled `qa-pass`. (The QA CI in this very PR doesn't run yet — it's introduced by this PR. Review manually, then apply `qa-pass` for the one-time manual path.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)