### PR TITLE
[PPL-14] Migrate lessons to canonical frontmatter schema + validator

### DIFF
--- a/docs/lesson-schema.md
+++ b/docs/lesson-schema.md
@@ -1,0 +1,106 @@
+# Lesson Frontmatter Schema
+
+Every lesson file under `lessons/**/*.md` must begin with a YAML frontmatter block
+that conforms to this schema. The web app and validator both rely on it.
+
+## Required Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | string | Unique lesson identifier, e.g. `AL-001`, `NAV-003` |
+| `topic` | string | One of the four topic slugs (see allowed values below) |
+| `order` | integer | Lesson order within the topic, starting at 1 |
+| `slug` | string | URL-safe identifier matching the filename slug, e.g. `airspace-classifications` |
+| `title` | string | Human-readable lesson title |
+| `duration_min` | integer | Estimated study time in minutes (target: 20) |
+| `status` | string | One of: `planning`, `draft`, `complete` |
+| `audio` | string \| null | Full URL to the narration audio file, or `null` if not yet generated |
+| `visual` | string | Path to the visual/chart supplement, e.g. `/visuals/al001-airspace-classifications.html` |
+| `sources` | list of strings | Authoritative sources cited in the lesson (TP number or CARs section) |
+| `questions` | list of 5 question objects | Practice questions — see question schema below |
+
+### Allowed `topic` values
+
+| Value | Exam Section |
+|-------|-------------|
+| `air-law` | Air Law (CARs, airspace, rules of the air) |
+| `navigation` | Navigation (charts, dead reckoning, wind correction) |
+| `meteorology` | Meteorology (METAR, TAF, GFAs, weather hazards) |
+| `general-knowledge` | Aeronautics — General Knowledge (aircraft systems, instruments, W&B) |
+
+### Question object schema
+
+Each entry in `questions` must have:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | string | Question identifier within the lesson, e.g. `q1` … `q5` |
+| `prompt` | string | The question text |
+| `choices` | map | Key–value pairs where keys are single letters (A, B, C, D) and values are the choice text |
+| `answer` | letter | The correct answer key — must exist as a key in `choices` |
+| `explanation` | string | Why the answer is correct; cite the relevant CARs section or TP reference |
+
+## Annotated Example
+
+```yaml
+---
+id: AL-001
+topic: air-law
+order: 1
+slug: airspace-classifications
+title: "Canadian Airspace Classifications"
+duration_min: 20
+status: complete
+# Real URL once audio is generated; null until then
+audio: https://media.suprun.workers.dev/ppl/lessons/air-law/001-airspace-classifications.m4a
+visual: /visuals/al001-airspace-classifications.html
+sources:
+  - CARs Part VI        # Canadian Aviation Regulations, Part VI (Airspace)
+  - TP 12880E           # Aeroplane Flight Training Manual
+  - AIM RAC 2.0         # Aeronautical Information Manual, Rules of the Air
+questions:
+  - id: q1
+    prompt: "You are planning a VFR flight that will pass through Class C airspace. Before entering, you must:"
+    choices:
+      A: "Have a filed flight plan on record"
+      B: "Obtain an ATC clearance and establish two-way radio contact"
+      C: "Establish two-way radio contact only — no clearance is required"
+      D: "Fly at or below 700 feet AGL to remain clear of Class C"
+    answer: B          # must be a key that exists in choices above
+    explanation: "Class C requires both an ATC clearance and established two-way radio contact before entry. Source: CARs 601.07, TP 12880E Chapter 7."
+  # … questions q2–q5 follow the same structure
+---
+```
+
+## Audio URL Convention
+
+Audio files are hosted on Cloudflare R2 under the `suprun-media` bucket and served
+via a Cloudflare Worker:
+
+```
+https://media.suprun.workers.dev/ppl/lessons/{topic}/{NNN}-{slug}.m4a
+```
+
+Example:
+```
+https://media.suprun.workers.dev/ppl/lessons/air-law/001-airspace-classifications.m4a
+```
+
+Set `audio: null` in the frontmatter when the file has not yet been generated.
+
+## Validation
+
+Run the validator to check all lessons at once:
+
+```bash
+scripts/validate-lesson-schema.sh
+```
+
+The script exits `0` on success and `1` if any lesson fails. It checks:
+- YAML frontmatter block is present and parseable
+- All required fields exist
+- `topic` is in the allowed set
+- `questions` has exactly 5 entries
+- Each question's `answer` key exists in its `choices` map
+
+Requires Python 3 with PyYAML (`pip3 install pyyaml`).

--- a/lessons/air-law/001-airspace-classifications.md
+++ b/lessons/air-law/001-airspace-classifications.md
@@ -1,3 +1,65 @@
+---
+id: AL-001
+topic: air-law
+order: 1
+slug: airspace-classifications
+title: "Canadian Airspace Classifications"
+duration_min: 20
+status: complete
+audio: https://media.suprun.workers.dev/ppl/lessons/air-law/001-airspace-classifications.m4a
+visual: /visuals/al001-airspace-classifications.html
+sources:
+  - CARs Part VI
+  - TP 12880E
+  - AIM RAC 2.0
+questions:
+  - id: q1
+    prompt: "You are planning a VFR flight that will pass through Class C airspace. Before entering, you must:"
+    choices:
+      A: "Have a filed flight plan on record"
+      B: "Obtain an ATC clearance and establish two-way radio contact"
+      C: "Establish two-way radio contact only — no clearance is required"
+      D: "Fly at or below 700 feet AGL to remain clear of Class C"
+    answer: B
+    explanation: "Class C requires both an ATC clearance and established two-way radio contact before entry. A clearance (not just contact) is the threshold requirement — this distinguishes Class C from Class D, where contact alone is sufficient. Source: CARs 601.07, TP 12880E Chapter 7."
+  - id: q2
+    prompt: "Class A airspace in Canada begins at:"
+    choices:
+      A: "12,500 feet ASL"
+      B: "14,500 feet ASL"
+      C: "18,000 feet ASL"
+      D: "18,000 feet AGL"
+    answer: C
+    explanation: "Class A begins at 18,000 feet ASL. Note it is ASL (above sea level), not AGL. Class B occupies 12,500 to 18,000 feet ASL. Source: CARs 601.01, TP 12880E Chapter 7."
+  - id: q3
+    prompt: "In Class G airspace, at and below 1,000 feet AGL during the day, the minimum VFR weather requirements are:"
+    choices:
+      A: "3 statute miles visibility, 500 below / 1,000 above / 2,000 horizontal from cloud"
+      B: "1 statute mile visibility, clear of cloud"
+      C: "2 statute miles visibility, clear of cloud"
+      D: "3 statute miles visibility, clear of cloud"
+    answer: C
+    explanation: "At and below 1,000 feet AGL in Class G (day), the minimums are 2 statute miles visibility and clear of cloud. This is lower than the 3-mile / 500-1,000-2,000 minimums required in controlled airspace. Source: CARs 602.115, TP 12880E Chapter 7."
+  - id: q4
+    prompt: "Class F(A) airspace is best described as:"
+    choices:
+      A: "Airspace that is permanently restricted to IFR traffic only"
+      B: "Advisory airspace that warns pilots of potential hazards; entry does not require authorization"
+      C: "Airspace requiring ATC clearance for all aircraft"
+      D: "Restricted airspace that requires a specific permit from Transport Canada"
+    answer: B
+    explanation: "Class F has two subtypes. F(R) is Restricted — you need authorization to enter. F(A) is Advisory — it alerts pilots to hazards (like a parachute drop zone) but does not require authorization to enter. Source: CARs 601.15, AIM RAC 2.8."
+  - id: q5
+    prompt: "Which of the following statements about Class D airspace is correct?"
+    choices:
+      A: "A VFR pilot must obtain an ATC clearance before entering"
+      B: "VFR flight is not permitted in Class D airspace"
+      C: "A VFR pilot must establish two-way radio contact with ATC before entering"
+      D: "No radio communication is required; pilots should self-announce on CTAF"
+    answer: C
+    explanation: "Class D requires two-way radio contact — the controller must acknowledge your call sign by name — but does not require a formal clearance. This distinguishes Class D from Class C. Source: CARs 601.08, TP 12880E Chapter 7."
+---
+
 # Lesson AL-001: Canadian Airspace Classifications
 
 **Section:** Air Law  
@@ -52,68 +114,6 @@ That's the airspace framework. Review the chart below after this lesson — visu
 | E | Varies (airways, transitions) | Yes | Yes | Not required | Not required |
 | F | Varies (special use) | Varies | Advisory | Check NOTAM | Check NOTAM |
 | G | Below controlled airspace | Yes | Yes | Not required | Not required |
-
----
-
-## Practice Questions
-
-**Q1.** You are planning a VFR flight that will pass through Class C airspace. Before entering, you must:
-
-- A) Have a filed flight plan on record
-- B) Obtain an ATC clearance and establish two-way radio contact
-- C) Establish two-way radio contact only — no clearance is required
-- D) Fly at or below 700 feet AGL to remain clear of Class C
-
-**Answer: B**  
-*Explanation:* Class C requires both an ATC clearance and established two-way radio contact before entry. A clearance (not just contact) is the threshold requirement — this distinguishes Class C from Class D, where contact alone is sufficient. Source: CARs 601.07, TP 12880E Chapter 7.
-
----
-
-**Q2.** Class A airspace in Canada begins at:
-
-- A) 12,500 feet ASL
-- B) 14,500 feet ASL
-- C) 18,000 feet ASL
-- D) 18,000 feet AGL
-
-**Answer: C**  
-*Explanation:* Class A begins at 18,000 feet ASL. Note it is ASL (above sea level), not AGL. Class B occupies 12,500 to 18,000 feet ASL. Source: CARs 601.01, TP 12880E Chapter 7.
-
----
-
-**Q3.** In Class G airspace, at and below 1,000 feet AGL during the day, the minimum VFR weather requirements are:
-
-- A) 3 statute miles visibility, 500 below / 1,000 above / 2,000 horizontal from cloud
-- B) 1 statute mile visibility, clear of cloud
-- C) 2 statute miles visibility, clear of cloud
-- D) 3 statute miles visibility, clear of cloud
-
-**Answer: C**  
-*Explanation:* At and below 1,000 feet AGL in Class G (day), the minimums are 2 statute miles visibility and clear of cloud. This is lower than the 3-mile / 500-1,000-2,000 minimums required in controlled airspace. Source: CARs 602.115, TP 12880E Chapter 7.
-
----
-
-**Q4.** Class F(A) airspace is best described as:
-
-- A) Airspace that is permanently restricted to IFR traffic only
-- B) Advisory airspace that warns pilots of potential hazards; entry does not require authorization
-- C) Airspace requiring ATC clearance for all aircraft
-- D) Restricted airspace that requires a specific permit from Transport Canada
-
-**Answer: B**  
-*Explanation:* Class F has two subtypes. F(R) is Restricted — you need authorization to enter. F(A) is Advisory — it alerts pilots to hazards (like a parachute drop zone) but does not require authorization to enter. Source: CARs 601.15, AIM RAC 2.8.
-
----
-
-**Q5.** Which of the following statements about Class D airspace is correct?
-
-- A) A VFR pilot must obtain an ATC clearance before entering
-- B) VFR flight is not permitted in Class D airspace
-- C) A VFR pilot must establish two-way radio contact with ATC before entering
-- D) No radio communication is required; pilots should self-announce on CTAF
-
-**Answer: C**  
-*Explanation:* Class D requires two-way radio contact — the controller must acknowledge your call sign by name — but does not require a formal clearance. This distinguishes Class D from Class C. Source: CARs 601.08, TP 12880E Chapter 7.
 
 ---
 

--- a/lessons/air-law/002-controlled-vs-uncontrolled.md
+++ b/lessons/air-law/002-controlled-vs-uncontrolled.md
@@ -1,3 +1,65 @@
+---
+id: AL-002
+topic: air-law
+order: 2
+slug: controlled-vs-uncontrolled
+title: "Controlled vs Uncontrolled Airspace"
+duration_min: 20
+status: complete
+audio: null
+visual: /visuals/al002-controlled-vs-uncontrolled.html
+sources:
+  - CARs Part VI
+  - TP 12880E
+  - AIM RAC 2.0
+questions:
+  - id: q1
+    prompt: "In Class D airspace, what service does ATC provide to VFR pilots?"
+    choices:
+      A: "Full separation from all IFR and VFR traffic"
+      B: "Separation from IFR traffic only, plus traffic advisories for VFR"
+      C: "Traffic advisories only — no separation from any traffic"
+      D: "No service — VFR pilots are not permitted in Class D"
+    answer: C
+    explanation: "In Class D, ATC provides separation for IFR aircraft only. VFR pilots receive traffic information (advisories) but ATC does not guarantee separation between VFR and IFR, or VFR and VFR. This is different from Class C where ATC separates IFR from VFR. Source: CARs 601.08, TP 12880E Chapter 7."
+  - id: q2
+    prompt: "Which of the following airspace classes is considered 'controlled' but does NOT require radio contact for VFR pilots?"
+    choices:
+      A: "Class C"
+      B: "Class D"
+      C: "Class E"
+      D: "Class G"
+    answer: C
+    explanation: "Class E is controlled airspace — ATC provides services to IFR aircraft there — but VFR pilots are not required to establish radio contact to fly through it. This makes Class E unique: it's technically controlled, but VFR pilots have no communication requirement. Class G is uncontrolled. Classes C and D both require radio contact. Source: CARs 601.07–601.09."
+  - id: q3
+    prompt: "A VFR pilot is flying near a Class C airport. Which statement correctly describes ATC's responsibilities?"
+    choices:
+      A: "ATC provides separation between all IFR and all VFR aircraft"
+      B: "ATC provides separation between IFR aircraft, and between IFR and VFR aircraft; VFR-to-VFR is the pilot's responsibility"
+      C: "ATC provides traffic advisories only; all separation is the pilot's responsibility"
+      D: "ATC provides no services to VFR pilots in Class C"
+    answer: B
+    explanation: "In Class C, ATC separates IFR-IFR and IFR-VFR pairs, but VFR aircraft are not separated from each other by ATC. Pilots still must see and avoid other VFR traffic. This is a common exam trap — Class C protection is not total. Source: CARs 601.07, AIM RAC 2.7."
+  - id: q4
+    prompt: "Which of the following is required to enter Class D airspace as a VFR pilot?"
+    choices:
+      A: "ATC clearance and Mode C transponder"
+      B: "Two-way radio contact with ATC (call sign acknowledged)"
+      C: "ATC clearance only — transponder not required"
+      D: "No radio or clearance — VFR pilots may enter freely"
+    answer: B
+    explanation: "Class D requires two-way radio contact — the controller must acknowledge your call sign — but no formal clearance is required. A Mode C transponder is required in Class D. However, the question asks specifically about ATC communication requirements: the answer is two-way contact, not clearance. Source: CARs 601.08."
+  - id: q5
+    prompt: "In which airspace class does ATC provide NO separation services whatsoever?"
+    choices:
+      A: "Class E"
+      B: "Class D"
+      C: "Class F"
+      D: "Class G"
+    answer: D
+    explanation: "Class G is uncontrolled airspace. ATC provides no separation services of any kind — not for IFR, not for VFR. All traffic avoidance is the pilot's responsibility. Class E provides IFR separation. Class F is special use airspace with its own rules. Class D provides IFR separation. Source: CARs Part VI, TP 12880E Chapter 7."
+---
+
 # Lesson AL-002: Controlled vs Uncontrolled Airspace
 
 **Section:** Air Law  
@@ -109,68 +171,6 @@ The more urban your route, the more controlled airspace you'll encounter. The mo
 | Class D | Yes (IFR only) | No (info only) | Yes | No |
 | Class E | Yes (IFR only) | No | No | No |
 | Class G | No | No | No | No |
-
----
-
-## Practice Questions
-
-**Q1.** In Class D airspace, what service does ATC provide to VFR pilots?
-
-- A) Full separation from all IFR and VFR traffic
-- B) Separation from IFR traffic only, plus traffic advisories for VFR
-- C) Traffic advisories only — no separation from any traffic
-- D) No service — VFR pilots are not permitted in Class D
-
-**Answer: C**  
-*Explanation:* In Class D, ATC provides separation for IFR aircraft only. VFR pilots receive traffic information (advisories) but ATC does not guarantee separation between VFR and IFR, or VFR and VFR. This is different from Class C where ATC separates IFR from VFR. Source: CARs 601.08, TP 12880E Chapter 7.
-
----
-
-**Q2.** Which of the following airspace classes is considered "controlled" but does NOT require radio contact for VFR pilots?
-
-- A) Class C
-- B) Class D
-- C) Class E
-- D) Class G
-
-**Answer: C**  
-*Explanation:* Class E is controlled airspace — ATC provides services to IFR aircraft there — but VFR pilots are not required to establish radio contact to fly through it. This makes Class E unique: it's technically controlled, but VFR pilots have no communication requirement. Class G is uncontrolled. Classes C and D both require radio contact. Source: CARs 601.07–601.09.
-
----
-
-**Q3.** A VFR pilot is flying near a Class C airport. Which statement correctly describes ATC's responsibilities?
-
-- A) ATC provides separation between all IFR and all VFR aircraft
-- B) ATC provides separation between IFR aircraft, and between IFR and VFR aircraft; VFR-to-VFR is the pilot's responsibility
-- C) ATC provides traffic advisories only; all separation is the pilot's responsibility
-- D) ATC provides no services to VFR pilots in Class C
-
-**Answer: B**  
-*Explanation:* In Class C, ATC separates IFR-IFR and IFR-VFR pairs, but VFR aircraft are not separated from each other by ATC. Pilots still must see and avoid other VFR traffic. This is a common exam trap — Class C protection is not total. Source: CARs 601.07, AIM RAC 2.7.
-
----
-
-**Q4.** Which of the following is required to enter Class D airspace as a VFR pilot?
-
-- A) ATC clearance and Mode C transponder
-- B) Two-way radio contact with ATC (call sign acknowledged)
-- C) ATC clearance only — transponder not required
-- D) No radio or clearance — VFR pilots may enter freely
-
-**Answer: B**  
-*Explanation:* Class D requires two-way radio contact — the controller must acknowledge your call sign — but no formal clearance is required. A Mode C transponder is required in Class D. However, the question asks specifically about ATC communication requirements: the answer is two-way contact, not clearance. Source: CARs 601.08.
-
----
-
-**Q5.** In which airspace class does ATC provide NO separation services whatsoever?
-
-- A) Class E
-- B) Class D
-- C) Class F
-- D) Class G
-
-**Answer: D**  
-*Explanation:* Class G is uncontrolled airspace. ATC provides no separation services of any kind — not for IFR, not for VFR. All traffic avoidance is the pilot's responsibility. Class E provides IFR separation. Class F is special use airspace with its own rules. Class D provides IFR separation. Source: CARs Part VI, TP 12880E Chapter 7.
 
 ---
 

--- a/lessons/air-law/003-vfr-weather-minimums.md
+++ b/lessons/air-law/003-vfr-weather-minimums.md
@@ -1,3 +1,65 @@
+---
+id: AL-003
+topic: air-law
+order: 3
+slug: vfr-weather-minimums
+title: "VFR Weather Minimums"
+duration_min: 20
+status: complete
+audio: null
+visual: /visuals/al003-vfr-weather-minimums.html
+sources:
+  - CARs 602.114-602.117
+  - TP 12880E
+  - AIM RAC 2.0
+questions:
+  - id: q1
+    prompt: "A VFR pilot is flying through Class D airspace during the day. The minimum flight visibility required is:"
+    choices:
+      A: "1 statute mile"
+      B: "2 statute miles"
+      C: "3 statute miles"
+      D: "5 statute miles"
+    answer: C
+    explanation: "The standard daytime VFR minimum in Class C, D, and E controlled airspace is 3 statute miles visibility. At night the requirement increases to 5 statute miles. Source: CARs 602.115."
+  - id: q2
+    prompt: "You are flying VFR at 600 feet AGL in Class G airspace during the day. The minimum visibility required is:"
+    choices:
+      A: "1 statute mile"
+      B: "2 statute miles"
+      C: "3 statute miles"
+      D: "5 statute miles"
+    answer: B
+    explanation: "In Class G airspace at or below 1,000 feet AGL during the day, the minimum flight visibility is 2 statute miles and the aircraft must remain clear of cloud. The 1 statute mile minimum applies above 1,000 feet AGL in Class G during the day. Source: CARs 602.115."
+  - id: q3
+    prompt: "At night, the cloud clearance requirements in Class C airspace are:"
+    choices:
+      A: "The same as daytime — 500 ft below, 1,000 ft above, 2,000 ft horizontal"
+      B: "Doubled — 1,000 ft below, 2,000 ft above, 4,000 ft horizontal"
+      C: "Clear of cloud only"
+      D: "No cloud clearance is required at night"
+    answer: A
+    explanation: "In Class C, D, and E, the cloud clearance distances do not change between day and night. Only the flight visibility minimum increases (from 3 SM to 5 SM at night). Cloud clearance stays 500 below, 1,000 above, 2,000 horizontal. Source: CARs 602.115–602.116."
+  - id: q4
+    prompt: "A pilot flying VFR in Class G airspace above 1,000 feet AGL on a clear day needs a minimum flight visibility of:"
+    choices:
+      A: "2 statute miles"
+      B: "3 statute miles"
+      C: "5 statute miles"
+      D: "1 statute mile"
+    answer: D
+    explanation: "Above 1,000 feet AGL in Class G during the day, the minimum visibility is 1 statute mile — the lowest VFR visibility minimum in the regulations. The cloud clearance distances still apply (500-1,000-2,000), but only 1 mile of forward visibility is legally required. Source: CARs 602.115."
+  - id: q5
+    prompt: "Which of the following scenarios describes conditions that are NOT legal for VFR flight in Class E airspace during the day?"
+    choices:
+      A: "Visibility 5 SM, cloud base 2,000 ft AGL, cloud layer scattered"
+      B: "Visibility 3 SM, clear of cloud"
+      C: "Visibility 2 SM, cloud base 3,000 ft AGL"
+      D: "Visibility 4 SM, cloud base 1,800 ft AGL"
+    answer: C
+    explanation: "Class E is controlled airspace. The daytime minimum is 3 statute miles visibility. 2 SM is below the minimum, making VFR flight illegal regardless of cloud conditions. Option B is legal (3 SM, clear of cloud meets the visibility minimum). Option D has 4 SM visibility — sufficient — and cloud at 1,800 AGL; you'd need to stay 500 feet below cloud, so you'd be legal below 1,300 AGL. Source: CARs 602.115."
+---
+
 # Lesson AL-003: VFR Weather Minimums
 
 **Section:** Air Law  
@@ -107,68 +169,6 @@ These scenarios are the bread and butter of the weather minimums questions. Work
 | Class G ≤1,000 AGL — Day | 2 SM | Clear of cloud | Clear of cloud | Clear of cloud |
 | Class G >1,000 AGL — Day | 1 SM | 500 ft | 1,000 ft | 2,000 ft |
 | Class G — Night | 3 SM | 500 ft | 1,000 ft | 2,000 ft |
-
----
-
-## Practice Questions
-
-**Q1.** A VFR pilot is flying through Class D airspace during the day. The minimum flight visibility required is:
-
-- A) 1 statute mile
-- B) 2 statute miles
-- C) 3 statute miles
-- D) 5 statute miles
-
-**Answer: C**  
-*Explanation:* The standard daytime VFR minimum in Class C, D, and E controlled airspace is 3 statute miles visibility. At night the requirement increases to 5 statute miles. Source: CARs 602.115.
-
----
-
-**Q2.** You are flying VFR at 600 feet AGL in Class G airspace during the day. The minimum visibility required is:
-
-- A) 1 statute mile
-- B) 2 statute miles
-- C) 3 statute miles
-- D) 5 statute miles
-
-**Answer: B**  
-*Explanation:* In Class G airspace at or below 1,000 feet AGL during the day, the minimum flight visibility is 2 statute miles and the aircraft must remain clear of cloud. The 1 statute mile minimum applies above 1,000 feet AGL in Class G during the day. Source: CARs 602.115.
-
----
-
-**Q3.** At night, the cloud clearance requirements in Class C airspace are:
-
-- A) The same as daytime — 500 ft below, 1,000 ft above, 2,000 ft horizontal
-- B) Doubled — 1,000 ft below, 2,000 ft above, 4,000 ft horizontal
-- C) Clear of cloud only
-- D) No cloud clearance is required at night
-
-**Answer: A**  
-*Explanation:* In Class C, D, and E, the cloud clearance distances do not change between day and night. Only the flight visibility minimum increases (from 3 SM to 5 SM at night). Cloud clearance stays 500 below, 1,000 above, 2,000 horizontal. Source: CARs 602.115–602.116.
-
----
-
-**Q4.** A pilot flying VFR in Class G airspace above 1,000 feet AGL on a clear day needs a minimum flight visibility of:
-
-- A) 2 statute miles
-- B) 3 statute miles
-- C) 5 statute miles
-- D) 1 statute mile
-
-**Answer: D**  
-*Explanation:* Above 1,000 feet AGL in Class G during the day, the minimum visibility is 1 statute mile — the lowest VFR visibility minimum in the regulations. The cloud clearance distances still apply (500-1,000-2,000), but only 1 mile of forward visibility is legally required. Source: CARs 602.115.
-
----
-
-**Q5.** Which of the following scenarios describes conditions that are NOT legal for VFR flight in Class E airspace during the day?
-
-- A) Visibility 5 SM, cloud base 2,000 ft AGL, cloud layer scattered
-- B) Visibility 3 SM, clear of cloud
-- C) Visibility 2 SM, cloud base 3,000 ft AGL
-- D) Visibility 4 SM, cloud base 1,800 ft AGL
-
-**Answer: C**  
-*Explanation:* Class E is controlled airspace. The daytime minimum is 3 statute miles visibility. 2 SM is below the minimum, making VFR flight illegal regardless of cloud conditions. Option B is legal (3 SM, clear of cloud meets the visibility minimum). Option D has 4 SM visibility — sufficient — and cloud at 1,800 AGL; you'd need to stay 500 feet below cloud, so you'd be legal below 1,300 AGL. Source: CARs 602.115.
 
 ---
 

--- a/lessons/navigation/001-vfr-charts.md
+++ b/lessons/navigation/001-vfr-charts.md
@@ -1,3 +1,65 @@
+---
+id: NAV-001
+topic: navigation
+order: 1
+slug: vfr-charts
+title: "VFR Aeronautical Charts — Reading the Map"
+duration_min: 20
+status: complete
+audio: null
+visual: /visuals/nav001-vfr-charts.html
+sources:
+  - TP 12880E
+  - TP 9994
+  - VNC Chart Legend
+questions:
+  - id: q1
+    prompt: "On a Canadian VFR Navigation Chart (VNC), the scale is 1:500,000. Two airports on the chart are 6 centimetres apart. What is the approximate ground distance between them?"
+    choices:
+      A: "6 nautical miles"
+      B: "15 nautical miles"
+      C: "30 kilometres"
+      D: "30 nautical miles"
+    answer: C
+    explanation: "At 1:500,000, one centimetre on the chart equals 500,000 centimetres on the ground, which is 5 kilometres. So 6 cm = 30 km. Note: the answer in nautical miles would be approximately 16.2 NM, which isn't one of the options. The exam may use kilometres or nautical miles — read the question carefully. Source: TP 9994 VFR Chart User's Guide."
+  - id: q2
+    prompt: "The Maximum Elevation Figure (MEF) shown in a grid square on a VNC represents:"
+    choices:
+      A: "The elevation of the highest airport in that grid square"
+      B: "The altitude at which you must file an IFR flight plan"
+      C: "The highest terrain or obstacle in that grid square, plus a clearance buffer"
+      D: "The minimum safe cruising altitude for IFR traffic"
+    answer: C
+    explanation: "The MEF is the highest known elevation in each 30-minute grid square, which includes terrain, obstacles (towers, antennas), and a buffer. Flying above the MEF gives clearance over everything in that square. It is not the same as an IFR minimum altitude and does not require a flight plan. Source: TP 9994, TP 12880E Chapter 9."
+  - id: q3
+    prompt: "On a VNC, an airport shown with a blue circle and short tick marks indicates:"
+    choices:
+      A: "A seaplane base"
+      B: "An airport open only to IFR traffic"
+      C: "An airport with an operating control tower (ATC)"
+      D: "An airport with customs services available"
+    answer: C
+    explanation: "Blue circle with tick marks = controlled airport with an ATC tower. Yellow circle = uncontrolled airport. Magenta = seaplane base. The colour and symbol type communicate the type of facility, not the hours of operation or customs status. Source: VNC Chart Legend."
+  - id: q4
+    prompt: "On a VNC, the airspace floor and ceiling next to an airspace boundary is shown as '30/SFC'. This means:"
+    choices:
+      A: "The airspace extends from 3,000 feet MSL to the surface below"
+      B: "The airspace extends from the surface up to 3,000 feet ASL"
+      C: "The airspace starts at 300 feet AGL"
+      D: "The airspace ceiling is 30 feet above the surface"
+    answer: B
+    explanation: "On Canadian charts, airspace extents are shown as 'ceiling/floor' in hundreds of feet. '30/SFC' means the ceiling is 3,000 feet ASL and the floor is the Surface (SFC). The upper number is always the ceiling; lower number is the floor. Source: VNC Chart Legend, AIM RAC 2.0."
+  - id: q5
+    prompt: "Isogonic lines on a VNC are used to determine:"
+    choices:
+      A: "The boundaries between Class C and Class D airspace"
+      B: "The magnetic variation at a given location"
+      C: "Lines of equal pressure for weather planning"
+      D: "Areas where GPS signals may be unreliable"
+    answer: B
+    explanation: "Isogonic lines connect points of equal magnetic variation — the angular difference between True North and Magnetic North. In Canada, the variation is typically westerly (5°W to 25°W depending on location), meaning magnetic north is to the west of true north. Pilots must apply variation when converting true headings to magnetic headings for compass flying. Source: TP 12880E Chapter 9, TP 9994."
+---
+
 # Lesson NAV-001: VFR Aeronautical Charts — Reading the Map
 
 **Section:** Navigation  
@@ -109,68 +171,6 @@ For the written exam, you'll be given a chart excerpt and asked to identify symb
 | Compass rose + dot | VOR |
 | Purple dot circle | NDB |
 | Bold number in grid square | MEF (Maximum Elevation Figure) |
-
----
-
-## Practice Questions
-
-**Q1.** On a Canadian VFR Navigation Chart (VNC), the scale is 1:500,000. Two airports on the chart are 6 centimetres apart. What is the approximate ground distance between them?
-
-- A) 6 nautical miles
-- B) 15 nautical miles
-- C) 30 kilometres
-- D) 30 nautical miles
-
-**Answer: C — 30 kilometres**  
-*Explanation:* At 1:500,000, one centimetre on the chart equals 500,000 centimetres on the ground, which is 5 kilometres. So 6 cm = 30 km. Note: the answer in nautical miles would be approximately 16.2 NM, which isn't one of the options. The exam may use kilometres or nautical miles — read the question carefully. Source: TP 9994 VFR Chart User's Guide.
-
----
-
-**Q2.** The Maximum Elevation Figure (MEF) shown in a grid square on a VNC represents:
-
-- A) The elevation of the highest airport in that grid square
-- B) The altitude at which you must file an IFR flight plan
-- C) The highest terrain or obstacle in that grid square, plus a clearance buffer
-- D) The minimum safe cruising altitude for IFR traffic
-
-**Answer: C**  
-*Explanation:* The MEF is the highest known elevation in each 30-minute grid square, which includes terrain, obstacles (towers, antennas), and a buffer. Flying above the MEF gives clearance over everything in that square. It is not the same as an IFR minimum altitude and does not require a flight plan. Source: TP 9994, TP 12880E Chapter 9.
-
----
-
-**Q3.** On a VNC, an airport shown with a blue circle and short tick marks indicates:
-
-- A) A seaplane base
-- B) An airport open only to IFR traffic
-- C) An airport with an operating control tower (ATC)
-- D) An airport with customs services available
-
-**Answer: C**  
-*Explanation:* Blue circle with tick marks = controlled airport with an ATC tower. Yellow circle = uncontrolled airport. Magenta = seaplane base. The colour and symbol type communicate the type of facility, not the hours of operation or customs status. Source: VNC Chart Legend.
-
----
-
-**Q4.** On a VNC, the airspace floor and ceiling next to an airspace boundary is shown as "30/SFC". This means:
-
-- A) The airspace extends from 3,000 feet MSL to the surface below
-- B) The airspace extends from the surface up to 3,000 feet ASL
-- C) The airspace starts at 300 feet AGL
-- D) The airspace ceiling is 30 feet above the surface
-
-**Answer: B**  
-*Explanation:* On Canadian charts, airspace extents are shown as "ceiling/floor" in hundreds of feet. "30/SFC" means the ceiling is 3,000 feet ASL and the floor is the Surface (SFC). The upper number is always the ceiling; lower number is the floor. Source: VNC Chart Legend, AIM RAC 2.0.
-
----
-
-**Q5.** Isogonic lines on a VNC are used to determine:
-
-- A) The boundaries between Class C and Class D airspace
-- B) The magnetic variation at a given location
-- C) Lines of equal pressure for weather planning
-- D) Areas where GPS signals may be unreliable
-
-**Answer: B**  
-*Explanation:* Isogonic lines connect points of equal magnetic variation — the angular difference between True North and Magnetic North. In Canada, the variation is typically westerly (5°W to 25°W depending on location), meaning magnetic north is to the west of true north. Pilots must apply variation when converting true headings to magnetic headings for compass flying. Source: TP 12880E Chapter 9, TP 9994.
 
 ---
 

--- a/scripts/validate-lesson-schema.sh
+++ b/scripts/validate-lesson-schema.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+# Validates every lessons/**/*.md against the canonical frontmatter schema.
+# Exits 1 if any lesson fails validation — safe for CI use.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LESSONS_DIR="$SCRIPT_DIR/../lessons"
+
+if [ ! -d "$LESSONS_DIR" ]; then
+  echo "ERROR: lessons directory not found at $LESSONS_DIR" >&2
+  exit 1
+fi
+
+# Write the Python validator to a temp file so bash quoting stays clean
+TMPPY=$(mktemp /tmp/validate-lesson-XXXXXX.py)
+trap 'rm -f "$TMPPY"' EXIT
+
+cat > "$TMPPY" << 'PYEOF'
+#!/usr/bin/env python3
+"""Validate a single lesson markdown file against the canonical frontmatter schema."""
+import sys
+import re
+
+REQUIRED_FIELDS = [
+    "id", "topic", "order", "slug", "title",
+    "duration_min", "status", "audio", "visual",
+    "sources", "questions",
+]
+VALID_TOPICS = {"air-law", "navigation", "meteorology", "general-knowledge"}
+REQUIRED_QUESTION_FIELDS = {"id", "prompt", "choices", "answer", "explanation"}
+
+def fail(path, msg):
+    print(f"  FAIL  {path}: {msg}")
+    sys.exit(1)
+
+def main():
+    if len(sys.argv) != 2:
+        print("Usage: validate.py <lesson.md>", file=sys.stderr)
+        sys.exit(2)
+
+    path = sys.argv[1]
+    try:
+        with open(path, encoding="utf-8") as f:
+            content = f.read()
+    except OSError as e:
+        fail(path, f"cannot read file: {e}")
+
+    # ── 1. Frontmatter block ──────────────────────────────────────────────────
+    if not content.startswith("---"):
+        fail(path, "missing YAML frontmatter (file must start with ---)")
+
+    # Find closing ---
+    close = content.find("\n---", 3)
+    if close == -1:
+        fail(path, "YAML frontmatter block is never closed (missing closing ---)")
+
+    fm_text = content[3:close]
+
+    # ── 2. Parse YAML ─────────────────────────────────────────────────────────
+    try:
+        import yaml
+        fm = yaml.safe_load(fm_text)
+    except ImportError:
+        # Fallback: minimal key-presence check without full YAML parse
+        fm = _parse_minimal(fm_text, path)
+    except Exception as e:
+        fail(path, f"YAML parse error: {e}")
+
+    if not isinstance(fm, dict):
+        fail(path, "frontmatter is not a YAML mapping")
+
+    # ── 3. Required fields ────────────────────────────────────────────────────
+    for field in REQUIRED_FIELDS:
+        if field not in fm:
+            fail(path, f"missing required field: '{field}'")
+
+    # ── 4. topic must be in allowed set ──────────────────────────────────────
+    topic = fm.get("topic")
+    if topic not in VALID_TOPICS:
+        fail(path, f"invalid topic {topic!r}; must be one of {sorted(VALID_TOPICS)}")
+
+    # ── 5. questions must have exactly 5 entries ──────────────────────────────
+    questions = fm.get("questions")
+    if not isinstance(questions, list):
+        fail(path, "questions must be a YAML list")
+    if len(questions) != 5:
+        fail(path, f"questions must have exactly 5 entries (found {len(questions)})")
+
+    # ── 6. Each question's answer key must exist in its choices map ───────────
+    for i, q in enumerate(questions, start=1):
+        if not isinstance(q, dict):
+            fail(path, f"question {i} is not a YAML mapping")
+        for qf in REQUIRED_QUESTION_FIELDS:
+            if qf not in q:
+                fail(path, f"question {i} missing field '{qf}'")
+        choices = q.get("choices", {})
+        if not isinstance(choices, dict):
+            fail(path, f"question {i}: choices must be a YAML mapping")
+        answer = str(q.get("answer", ""))
+        if answer not in choices:
+            fail(path, (
+                f"question {i}: answer {answer!r} is not a key in choices "
+                f"(available: {sorted(choices.keys())})"
+            ))
+
+    print(f"  OK    {path}")
+    sys.exit(0)
+
+
+def _parse_minimal(fm_text, path):
+    """Bare-minimum key detector used when PyYAML is unavailable."""
+    keys = {}
+    for line in fm_text.splitlines():
+        m = re.match(r'^([a-zA-Z_][a-zA-Z0-9_]*):', line)
+        if m:
+            keys[m.group(1)] = True
+    # We can't validate values without a real YAML parser, so error out.
+    print(f"  ERROR {path}: PyYAML is required (pip3 install pyyaml)", file=sys.stderr)
+    sys.exit(2)
+
+
+if __name__ == "__main__":
+    main()
+PYEOF
+
+# ── Collect and validate all lesson files ────────────────────────────────────
+total=0
+failed=0
+
+while IFS= read -r -d '' file; do
+    total=$((total + 1))
+    if python3 "$TMPPY" "$file"; then
+        :
+    else
+        exit_code=$?
+        if [ "$exit_code" -eq 2 ]; then
+            # Fatal setup error (e.g. missing PyYAML)
+            echo ""
+            echo "Fatal: validator setup error — aborting." >&2
+            exit 2
+        fi
+        failed=$((failed + 1))
+    fi
+done < <(find "$LESSONS_DIR" -name "*.md" -print0 | sort -z)
+
+echo ""
+echo "Validated $total lesson(s) — $failed failure(s)"
+
+if [ "$failed" -gt 0 ]; then
+    exit 1
+fi
+
+exit 0
+PYEOF


### PR DESCRIPTION
Closes #14. Migrates all 4 existing lesson files to the canonical YAML frontmatter schema and adds a CI-ready validator script.

## Changes

### Lesson migration (4 files)
- `lessons/air-law/001-airspace-classifications.md` — `status: complete`, audio URL from #13, 5 structured questions extracted
- `lessons/air-law/002-controlled-vs-uncontrolled.md` — `status: complete`, `audio: null`, 5 structured questions extracted
- `lessons/air-law/003-vfr-weather-minimums.md` — `status: complete`, `audio: null`, 5 structured questions extracted
- `lessons/navigation/001-vfr-charts.md` — `status: complete`, `audio: null`, 5 structured questions extracted

Each file: full frontmatter block added, `## Practice Questions` prose section removed (questions now live exclusively in frontmatter `questions:` array).

### New files
- `scripts/validate-lesson-schema.sh` — validates every `lessons/**/*.md`; checks frontmatter presence, all required fields, topic in allowed set, exactly 5 questions, answer key exists in choices; exits 1 on any failure; `chmod +x`
- `docs/lesson-schema.md` — schema reference with annotated example, audio URL convention, and validator usage

## Validation result
```
  OK    lessons/air-law/001-airspace-classifications.md
  OK    lessons/air-law/002-controlled-vs-uncontrolled.md
  OK    lessons/air-law/003-vfr-weather-minimums.md
  OK    lessons/navigation/001-vfr-charts.md

Validated 4 lesson(s) — 0 failure(s)
```