### PR TITLE
chore(ci): manual deploy trigger + PAT-based auto-merge

### DIFF
--- a/.github/workflows/auto-merge-qa-pass.yml
+++ b/.github/workflows/auto-merge-qa-pass.yml
@@ -14,8 +14,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Enable auto-merge
+        # Use AUTOMERGE_PAT (Personal Access Token with `repo` + `workflow` scope)
+        # so the resulting push to main can trigger downstream workflows like deploy.
+        # Falls back to GITHUB_TOKEN if AUTOMERGE_PAT isn't set — but fallback will
+        # NOT trigger deploy because of GitHub's anti-recursion rule.
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.AUTOMERGE_PAT || secrets.GITHUB_TOKEN }}
         run: |
           gh pr merge ${{ github.event.pull_request.number }} \
             --repo ${{ github.repository }} \

--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -7,6 +7,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

Two small polish items to close the autopilot loop.

**1. `deploy-main.yml` — add `workflow_dispatch:` trigger.**
Lets us manually kick the deploy workflow via `gh workflow run deploy-main.yml --ref main` for first-deploy verification and recovery.

**2. `auto-merge-qa-pass.yml` — prefer `AUTOMERGE_PAT` over `GITHUB_TOKEN`.**
GitHub's anti-recursion rule: workflow runs that use `GITHUB_TOKEN` cannot trigger downstream workflows. That's why the deploy workflow did NOT fire when #23 and #24 auto-merged. With a PAT in scope, auto-merge → push to main → deploy flows as expected.

## Setup required (one-time)

After this PR merges:
1. Create fine-grained PAT at github.com/settings/tokens/beta — scope `svv2014/ppl-study` only, permissions: `Contents: write`, `Pull requests: write`, `Workflows: write`
2. Add as repo secret named `AUTOMERGE_PAT`

Falls back cleanly to `GITHUB_TOKEN` when the secret is missing, so merging this PR is safe even before the PAT is set.

## Test plan

- [ ] CI (qa-build-test) runs on this PR when labeled `ready-for-qa` — first PR to prove the CI gate works end-to-end (this branch is off current main which has the workflow)
- [ ] Merge with `qa-pass`, then `gh workflow run deploy-main.yml --ref main` fires the Firebase deploy
- [ ] Site at ppl-study-suprun-ca.web.app returns 200 after deploy
- [ ] Once AUTOMERGE_PAT is configured, the NEXT PR's auto-merge should trigger deploy naturally

🤖 Generated with [Claude Code](https://claude.com/claude-code)