### PR TITLE
[PPL-5] Update STATUS.md with current lesson count, phase, and audio status

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -1,15 +1,26 @@
 # PPL Study — Status
 
-Last updated: 2026-04-16
+Last updated: 2026-04-18
 
 ## Goal
 Pass Transport Canada PPL (Aeroplane) written exam. Target score: 80%+.
 
 ## Phase
-Planning — curriculum structure being designed.
+In Progress — lessons being authored.
 
 ## Lessons Created
-None yet.
+
+- **AL-001** `lessons/air-law/001-airspace-classifications.md`
+- **AL-002** `lessons/air-law/002-controlled-vs-uncontrolled.md`
+- **AL-003** `lessons/air-law/003-vfr-weather-minimums.md`
+- **NAV-001** `lessons/navigation/001-vfr-charts.md`
+
+## Audio
+
+- **AL-001** — narration available at `audio/ppl-lesson-al001-airspace.m4a`
+- **AL-002** — pending
+- **AL-003** — pending
+- **NAV-001** — pending
 
 ## Orchestrator
 Not yet wired — pending ASDLC generic cycle (architect.task in progress).


### PR DESCRIPTION
## Summary

- Updated `STATUS.md` to reflect current project state as of 2026-04-18
- Phase changed from **Planning** to **In Progress**
- Listed all 4 lessons created: AL-001, AL-002, AL-003, NAV-001 with full paths
- Added Audio section noting AL-001 has M4A narration; AL-002/AL-003/NAV-001 are pending

Closes #5