### PR TITLE
chore(ci): CI applies qa-pass via AUTOMERGE_PAT so auto-merge triggers

### DIFF
--- a/.github/workflows/qa-build-test.yml
+++ b/.github/workflows/qa-build-test.yml
@@ -42,7 +42,9 @@ jobs:
       - name: Apply qa-pass
         if: success()
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Use AUTOMERGE_PAT so the label change triggers auto-merge workflow
+          # (GITHUB_TOKEN-driven label changes don't trigger other workflows).
+          GH_TOKEN: ${{ secrets.AUTOMERGE_PAT || secrets.GITHUB_TOKEN }}
         run: |
           gh pr edit ${{ github.event.pull_request.number }} \
             --repo ${{ github.repository }} \
@@ -52,7 +54,9 @@ jobs:
       - name: Apply qa-fail
         if: failure()
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Use AUTOMERGE_PAT so the label change triggers auto-merge workflow
+          # (GITHUB_TOKEN-driven label changes don't trigger other workflows).
+          GH_TOKEN: ${{ secrets.AUTOMERGE_PAT || secrets.GITHUB_TOKEN }}
         run: |
           gh pr edit ${{ github.event.pull_request.number }} \
             --repo ${{ github.repository }} \


### PR DESCRIPTION
## Summary

Closes the last anti-recursion gap in the autopilot pipeline. CI-applied
\`qa-pass\` now uses \`AUTOMERGE_PAT\` (with \`GITHUB_TOKEN\` fallback)
so the label-change event triggers the auto-merge workflow.

After both this PR and the setup of \`AUTOMERGE_PAT\` secret land, the full
chain runs end-to-end with no human intervention:

- \`ready-for-qa\` → CI → \`qa-pass\` → auto-merge → push to main → deploy

## Closes
—

## Test plan
- [ ] Merge this (via \`qa-pass\` once labelled)
- [ ] Set repo secret \`AUTOMERGE_PAT\` to a fine-grained PAT
- [ ] On a subsequent PR, label \`ready-for-qa\` and watch the full chain complete unassisted