### PR TITLE
[PPL-32] Foundation: data layer (src/lib/)

### DIFF
--- a/web-app/package-lock.json
+++ b/web-app/package-lock.json
@@ -13,6 +13,7 @@
         "@fontsource/roboto": "^5.0.5",
         "@mui/icons-material": "^7.3.9",
         "@mui/material": "^7.3.9",
+        "js-yaml": "^4.1.0",
         "markdown-to-jsx": "^7.2.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -21,6 +22,7 @@
         "typescript": "^5.9.3"
       },
       "devDependencies": {
+        "@types/js-yaml": "^4.0.9",
         "@types/node": "^25.5.0",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
@@ -1620,6 +1622,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/js-yaml": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
+      "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "25.6.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
@@ -1690,6 +1699,12 @@
       "peerDependencies": {
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
     },
     "node_modules/babel-plugin-macros": {
       "version": "3.1.0",
@@ -2081,6 +2096,18 @@
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "license": "MIT"
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
     },
     "node_modules/jsesc": {
       "version": "3.1.0",

--- a/web-app/package.json
+++ b/web-app/package.json
@@ -8,6 +8,7 @@
     "@fontsource/roboto": "^5.0.5",
     "@mui/icons-material": "^7.3.9",
     "@mui/material": "^7.3.9",
+    "js-yaml": "^4.1.0",
     "markdown-to-jsx": "^7.2.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
@@ -21,6 +22,7 @@
     "preview": "vite preview"
   },
   "devDependencies": {
+    "@types/js-yaml": "^4.0.9",
     "@types/node": "^25.5.0",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",

--- a/web-app/src/lib/lesson-loader.ts
+++ b/web-app/src/lib/lesson-loader.ts
@@ -1,0 +1,78 @@
+/// <reference types="vite/client" />
+import jsYaml from 'js-yaml';
+import type { Lesson, Question, Topic } from './types';
+
+// Relative to this file (web-app/src/lib/), lessons/ is three levels up at ppl-study/lessons/
+const modules = import.meta.glob('../../../lessons/**/*.md', {
+  query: '?raw',
+  import: 'default',
+  eager: true,
+}) as Record<string, string>;
+
+const TOPIC_ORDER: Record<string, number> = {
+  'air-law': 0,
+  navigation: 1,
+  meteorology: 2,
+  'general-knowledge': 3,
+};
+
+function parseFrontmatter(raw: string): { fm: Record<string, unknown>; body: string } {
+  if (!raw.startsWith('---')) {
+    return { fm: {}, body: raw };
+  }
+  const close = raw.indexOf('\n---', 3);
+  if (close === -1) {
+    return { fm: {}, body: raw };
+  }
+  const fmText = raw.slice(3, close);
+  const body = raw.slice(close + 4).trimStart();
+  const fm = (jsYaml.load(fmText) ?? {}) as Record<string, unknown>;
+  return { fm, body };
+}
+
+function toLesson(fm: Record<string, unknown>, body: string): Lesson {
+  return {
+    id: fm.id as string,
+    topic: fm.topic as Topic,
+    order: fm.order as number,
+    slug: fm.slug as string,
+    title: fm.title as string,
+    duration_min: fm.duration_min as number,
+    status: fm.status as Lesson['status'],
+    audio: (fm.audio ?? null) as string | null,
+    visual: fm.visual as string,
+    sources: (fm.sources ?? []) as string[],
+    questions: (fm.questions ?? []) as Question[],
+    body,
+  };
+}
+
+let _cache: Lesson[] | null = null;
+
+export function getAllLessons(): Lesson[] {
+  if (_cache) return _cache;
+
+  const lessons: Lesson[] = [];
+
+  for (const raw of Object.values(modules)) {
+    if (typeof raw !== 'string') continue;
+    const { fm, body } = parseFrontmatter(raw);
+    if (!fm.id) continue;
+    lessons.push(toLesson(fm, body));
+  }
+
+  _cache = lessons.sort((a, b) => {
+    const td = (TOPIC_ORDER[a.topic] ?? 99) - (TOPIC_ORDER[b.topic] ?? 99);
+    return td !== 0 ? td : a.order - b.order;
+  });
+
+  return _cache;
+}
+
+export function getLessonBySlug(topic: string, slug: string): Lesson | undefined {
+  return getAllLessons().find((l) => l.topic === topic && l.slug === slug);
+}
+
+export function getLessonsByTopic(topic: string): Lesson[] {
+  return getAllLessons().filter((l) => l.topic === topic);
+}

--- a/web-app/src/lib/progress.ts
+++ b/web-app/src/lib/progress.ts
@@ -1,0 +1,137 @@
+import { useState, useEffect, useCallback } from 'react';
+import type { Progress, ProgressStore, QuizAttempt } from './types';
+
+const STORAGE_KEY = 'ppl-study-progress';
+
+function emptyProgress(): Progress {
+  return {
+    completed: [],
+    lastExamScores: {},
+    quizHistory: [],
+    lastUpdated: new Date().toISOString(),
+  };
+}
+
+function load(): Progress {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return emptyProgress();
+    const parsed = JSON.parse(raw) as Partial<Progress>;
+    return {
+      completed: parsed.completed ?? [],
+      lastExamScores: parsed.lastExamScores ?? {},
+      quizHistory: parsed.quizHistory ?? [],
+      lastUpdated: parsed.lastUpdated ?? new Date().toISOString(),
+    };
+  } catch {
+    return emptyProgress();
+  }
+}
+
+function save(progress: Progress): void {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(progress));
+}
+
+export class LocalStorageProgressStore implements ProgressStore {
+  getProgress(): Progress {
+    return load();
+  }
+
+  markComplete(lessonId: string): void {
+    const p = load();
+    if (!p.completed.includes(lessonId)) {
+      p.completed = [...p.completed, lessonId];
+      p.lastUpdated = new Date().toISOString();
+      save(p);
+    }
+  }
+
+  markIncomplete(lessonId: string): void {
+    const p = load();
+    p.completed = p.completed.filter((id) => id !== lessonId);
+    p.lastUpdated = new Date().toISOString();
+    save(p);
+  }
+
+  recordQuizAttempt(attempt: QuizAttempt): void {
+    const p = load();
+    p.quizHistory = [...p.quizHistory, attempt];
+    p.lastExamScores[attempt.lessonId] = attempt.percent;
+    p.lastUpdated = new Date().toISOString();
+    save(p);
+  }
+
+  setLastExamScore(lessonId: string, percent: number): void {
+    const p = load();
+    p.lastExamScores[lessonId] = percent;
+    p.lastUpdated = new Date().toISOString();
+    save(p);
+  }
+
+  reset(): void {
+    localStorage.removeItem(STORAGE_KEY);
+  }
+}
+
+const defaultStore = new LocalStorageProgressStore();
+
+export interface UseProgressResult {
+  progress: Progress;
+  store: ProgressStore;
+  markComplete: (lessonId: string) => void;
+  markIncomplete: (lessonId: string) => void;
+  isComplete: (lessonId: string) => boolean;
+  recordQuizAttempt: (attempt: QuizAttempt) => void;
+  reset: () => void;
+}
+
+export function useProgress(store: ProgressStore = defaultStore): UseProgressResult {
+  const [progress, setProgress] = useState<Progress>(() => store.getProgress());
+
+  // Sync across tabs
+  useEffect(() => {
+    function onStorage(e: StorageEvent) {
+      if (e.key === STORAGE_KEY) {
+        setProgress(store.getProgress());
+      }
+    }
+    window.addEventListener('storage', onStorage);
+    return () => window.removeEventListener('storage', onStorage);
+  }, [store]);
+
+  const markComplete = useCallback(
+    (lessonId: string) => {
+      store.markComplete(lessonId);
+      setProgress(store.getProgress());
+    },
+    [store],
+  );
+
+  const markIncomplete = useCallback(
+    (lessonId: string) => {
+      store.markIncomplete(lessonId);
+      setProgress(store.getProgress());
+    },
+    [store],
+  );
+
+  const isComplete = useCallback(
+    (lessonId: string) => progress.completed.includes(lessonId),
+    [progress.completed],
+  );
+
+  const recordQuizAttempt = useCallback(
+    (attempt: QuizAttempt) => {
+      store.recordQuizAttempt(attempt);
+      setProgress(store.getProgress());
+    },
+    [store],
+  );
+
+  const reset = useCallback(() => {
+    store.reset();
+    setProgress(emptyProgress());
+  }, [store]);
+
+  return { progress, store, markComplete, markIncomplete, isComplete, recordQuizAttempt, reset };
+}

--- a/web-app/src/lib/quiz.ts
+++ b/web-app/src/lib/quiz.ts
@@ -1,0 +1,41 @@
+import type { Question } from './types';
+
+export interface QuizPerQuestion {
+  questionId: string;
+  prompt: string;
+  userAnswer: string;
+  correctAnswer: string;
+  isCorrect: boolean;
+  explanation: string;
+}
+
+export interface QuizResult {
+  correct: number;
+  total: number;
+  percent: number;
+  perQuestion: QuizPerQuestion[];
+}
+
+export function scoreQuiz(
+  answers: Record<string, string>,
+  questions: Question[],
+): QuizResult {
+  const perQuestion: QuizPerQuestion[] = questions.map((q) => {
+    const userAnswer = answers[q.id] ?? '';
+    const isCorrect = userAnswer === q.answer;
+    return {
+      questionId: q.id,
+      prompt: q.prompt,
+      userAnswer,
+      correctAnswer: q.answer,
+      isCorrect,
+      explanation: q.explanation,
+    };
+  });
+
+  const correct = perQuestion.filter((r) => r.isCorrect).length;
+  const total = questions.length;
+  const percent = total > 0 ? Math.round((correct / total) * 100) : 0;
+
+  return { correct, total, percent, perQuestion };
+}

--- a/web-app/src/lib/types.ts
+++ b/web-app/src/lib/types.ts
@@ -1,0 +1,50 @@
+export type Topic = 'air-law' | 'navigation' | 'meteorology' | 'general-knowledge';
+export type LessonStatus = 'planning' | 'draft' | 'complete';
+
+export interface Question {
+  id: string;
+  prompt: string;
+  choices: Record<string, string>;
+  answer: string;
+  explanation: string;
+}
+
+export interface Lesson {
+  id: string;
+  topic: Topic;
+  order: number;
+  slug: string;
+  title: string;
+  duration_min: number;
+  status: LessonStatus;
+  audio: string | null;
+  visual: string;
+  sources: string[];
+  questions: Question[];
+  body: string;
+}
+
+export interface QuizAttempt {
+  lessonId: string;
+  timestamp: string;
+  score: number;
+  total: number;
+  percent: number;
+  answers: Record<string, string>;
+}
+
+export interface Progress {
+  completed: string[];
+  lastExamScores: Record<string, number>;
+  quizHistory: QuizAttempt[];
+  lastUpdated: string;
+}
+
+export interface ProgressStore {
+  getProgress(): Progress;
+  markComplete(lessonId: string): void;
+  markIncomplete(lessonId: string): void;
+  recordQuizAttempt(attempt: QuizAttempt): void;
+  setLastExamScore(lessonId: string, percent: number): void;
+  reset(): void;
+}


### PR DESCRIPTION
Closes #32

## Changes

- **`web-app/src/lib/types.ts`** — `Lesson`, `Question`, `Progress`, `QuizAttempt`, `ProgressStore` interfaces, `Topic` and `LessonStatus` type aliases mirroring every field in `docs/lesson-schema.md`
- **`web-app/src/lib/lesson-loader.ts`** — Vite-native `import.meta.glob('../../../lessons/**/*.md', { query: '?raw', import: 'default', eager: true })` with js-yaml frontmatter parsing; exports `getAllLessons()` sorted by topic→order, `getLessonBySlug(topic, slug)`, `getLessonsByTopic(topic)`
- **`web-app/src/lib/progress.ts`** — `ProgressStore` interface (swap-compatible with future `FirestoreProgressStore`), `LocalStorageProgressStore` (key: `ppl-study-progress`, JSON: `{ completed, lastExamScores, quizHistory, lastUpdated }`), `useProgress()` React hook with cross-tab `storage` event sync
- **`web-app/src/lib/quiz.ts`** — `scoreQuiz(answers, questions)` returning `{ correct, total, percent, perQuestion }` with per-question `{ questionId, prompt, userAnswer, correctAnswer, isCorrect, explanation }`
- **`web-app/package.json`** — `js-yaml ^4.1.0` in dependencies, `@types/js-yaml ^4.0.9` in devDependencies

## Test Plan

1. `cd web-app && npm run build` — passes with zero TypeScript errors ✓
2. `getAllLessons()` returns 4 lessons sorted `air-law→1,2,3` then `navigation→1`
3. `getLessonBySlug('air-law', 'airspace-classifications')` returns `AL-001`
4. `LocalStorageProgressStore.markComplete('AL-001')` writes to `ppl-study-progress` in localStorage
5. `scoreQuiz({ q1: 'B', q2: 'C', q3: 'C', q4: 'B', q5: 'C' }, al001.questions)` returns `{ correct: 5, total: 5, percent: 100 }`