### PR TITLE
[PPL-9] Mark AL-002 and AL-003 complete in curriculum plan

### DIFF
--- a/docs/curriculum-plan.md
+++ b/docs/curriculum-plan.md
@@ -162,6 +162,8 @@ Work through a Pilot's Operating Handbook alongside these lessons if one is avai
 | File | Status |
 |------|--------|
 | `lessons/air-law/001-airspace-classifications.md` | Complete |
+| `lessons/air-law/002-controlled-vs-uncontrolled.md` | Complete |
+| `lessons/air-law/003-vfr-weather-minimums.md` | Complete |
 | `lessons/navigation/001-vfr-charts.md` | Complete |
 
 ---


### PR DESCRIPTION
Closes #9

## Changes

- Added `lessons/air-law/002-controlled-vs-uncontrolled.md` to the **Lessons Already Created** table in `docs/curriculum-plan.md` with status `Complete`
- Added `lessons/air-law/003-vfr-weather-minimums.md` to the same table with status `Complete`
- No other content modified

## Test Plan

- [ ] `docs/curriculum-plan.md` Lessons Already Created section lists AL-001, AL-002, AL-003, and NAV-001 — all with `Complete` status
- [ ] No other lines in `docs/curriculum-plan.md` were changed (`git diff` shows only 2 inserted rows)
- [ ] No lesson files, workflow files, or source code modified