### PR TITLE
[PPL-35] QuizRunner + Exam page for practice quiz flow

### DIFF
--- a/web-app/src/components/QuizRunner.tsx
+++ b/web-app/src/components/QuizRunner.tsx
@@ -1,0 +1,101 @@
+import { useState } from 'react';
+import Alert from '@mui/material/Alert';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import FormControl from '@mui/material/FormControl';
+import FormControlLabel from '@mui/material/FormControlLabel';
+import LinearProgress from '@mui/material/LinearProgress';
+import Radio from '@mui/material/Radio';
+import RadioGroup from '@mui/material/RadioGroup';
+import Typography from '@mui/material/Typography';
+import type { Question } from '../lib/types';
+
+interface QuizRunnerProps {
+  questions: Question[];
+  onComplete: (answers: Record<string, string>) => void;
+}
+
+export default function QuizRunner({ questions, onComplete }: QuizRunnerProps) {
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const [selectedAnswer, setSelectedAnswer] = useState('');
+  const [submitted, setSubmitted] = useState(false);
+  const [answers, setAnswers] = useState<Record<string, string>>({});
+
+  const question = questions[currentIndex];
+  const isLast = currentIndex === questions.length - 1;
+  const isCorrect = submitted && selectedAnswer === question.answer;
+  const progress = ((currentIndex + 1) / questions.length) * 100;
+
+  function handleCheck() {
+    setAnswers((prev) => ({ ...prev, [question.id]: selectedAnswer }));
+    setSubmitted(true);
+  }
+
+  function handleNext() {
+    if (isLast) {
+      onComplete({ ...answers });
+    } else {
+      setCurrentIndex((i) => i + 1);
+      setSelectedAnswer('');
+      setSubmitted(false);
+    }
+  }
+
+  return (
+    <Box>
+      <Box sx={{ mb: 2 }}>
+        <Typography variant="body2" color="text.secondary" sx={{ mb: 0.5 }}>
+          Question {currentIndex + 1} of {questions.length}
+        </Typography>
+        <LinearProgress variant="determinate" value={progress} />
+      </Box>
+
+      <Typography variant="h6" sx={{ mb: 2 }}>
+        {question.prompt}
+      </Typography>
+
+      <FormControl component="fieldset" sx={{ width: '100%' }}>
+        <RadioGroup
+          value={selectedAnswer}
+          onChange={(e) => {
+            if (!submitted) setSelectedAnswer(e.target.value);
+          }}
+        >
+          {Object.entries(question.choices).map(([key, value]) => (
+            <FormControlLabel
+              key={key}
+              value={key}
+              control={<Radio disabled={submitted} />}
+              label={`${key}. ${value}`}
+            />
+          ))}
+        </RadioGroup>
+      </FormControl>
+
+      {submitted && (
+        <>
+          <Alert severity={isCorrect ? 'success' : 'error'} sx={{ mt: 2 }}>
+            {isCorrect
+              ? 'Correct!'
+              : `Incorrect — correct answer: ${question.answer}. ${question.choices[question.answer]}`}
+          </Alert>
+          <Typography variant="body2" sx={{ mt: 1.5, fontStyle: 'italic' }}>
+            {question.explanation}
+          </Typography>
+        </>
+      )}
+
+      <Box sx={{ mt: 3, display: 'flex', justifyContent: 'flex-end' }}>
+        {!submitted ? (
+          <Button variant="contained" disabled={!selectedAnswer} onClick={handleCheck}>
+            Check Answer
+          </Button>
+        ) : (
+          <Button variant="contained" onClick={handleNext}>
+            {isLast ? 'Finish' : 'Next'}
+          </Button>
+        )}
+      </Box>
+    </Box>
+  );
+}

--- a/web-app/src/pages/Exam.tsx
+++ b/web-app/src/pages/Exam.tsx
@@ -1,10 +1,226 @@
+import { useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import Alert from '@mui/material/Alert';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import CircularProgress from '@mui/material/CircularProgress';
 import Container from '@mui/material/Container';
+import Dialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+import DialogContentText from '@mui/material/DialogContentText';
+import DialogTitle from '@mui/material/DialogTitle';
+import Divider from '@mui/material/Divider';
+import FormControl from '@mui/material/FormControl';
+import InputLabel from '@mui/material/InputLabel';
+import MenuItem from '@mui/material/MenuItem';
+import Select from '@mui/material/Select';
 import Typography from '@mui/material/Typography';
+import { getAllLessons } from '../lib/lesson-loader';
+import { useProgress } from '../lib/progress';
+import { scoreQuiz } from '../lib/quiz';
+import type { QuizResult } from '../lib/quiz';
+import QuizRunner from '../components/QuizRunner';
+
+type Phase = 'select' | 'quiz' | 'results';
+
+function formatLessonLabel(id: string, title: string): string {
+  return `${id.toUpperCase()} · ${title}`;
+}
 
 export default function Exam() {
+  const [searchParams] = useSearchParams();
+  const { store } = useProgress();
+
+  const lessons = getAllLessons().filter((l) => l.questions.length > 0);
+
+  const [selectedLessonId, setSelectedLessonId] = useState<string>(() => {
+    const fromUrl = searchParams.get('lesson');
+    if (fromUrl && lessons.some((l) => l.id === fromUrl)) return fromUrl;
+    return lessons[0]?.id ?? '';
+  });
+  const [phase, setPhase] = useState<Phase>('select');
+  const [quizResult, setQuizResult] = useState<QuizResult | null>(null);
+  const [pendingLessonId, setPendingLessonId] = useState<string | null>(null);
+
+  const selectedLesson = lessons.find((l) => l.id === selectedLessonId);
+
+  function handleLessonChange(newId: string) {
+    if (phase === 'quiz') {
+      setPendingLessonId(newId);
+    } else {
+      setSelectedLessonId(newId);
+      setPhase('select');
+      setQuizResult(null);
+    }
+  }
+
+  function handleConfirmSwitch() {
+    if (pendingLessonId) {
+      setSelectedLessonId(pendingLessonId);
+      setPhase('select');
+      setQuizResult(null);
+      setPendingLessonId(null);
+    }
+  }
+
+  function handleCancelSwitch() {
+    setPendingLessonId(null);
+  }
+
+  function handleStartQuiz() {
+    setPhase('quiz');
+    setQuizResult(null);
+  }
+
+  function handleQuizComplete(answers: Record<string, string>) {
+    if (!selectedLesson) return;
+    const result = scoreQuiz(answers, selectedLesson.questions);
+    store.setLastExamScore(selectedLesson.id, result.percent);
+    setQuizResult(result);
+    setPhase('results');
+  }
+
+  function handleRetake() {
+    setPhase('select');
+    setQuizResult(null);
+  }
+
+  if (lessons.length === 0) {
+    return (
+      <Container maxWidth="md" sx={{ py: 4 }}>
+        <Typography variant="h4" sx={{ mb: 3 }}>
+          Practice Exam
+        </Typography>
+        <Alert severity="info">No lessons with quiz questions found.</Alert>
+      </Container>
+    );
+  }
+
   return (
-    <Container>
-      <Typography variant="h3">Exam</Typography>
+    <Container maxWidth="md" sx={{ py: 4 }}>
+      <Typography variant="h4" sx={{ mb: 3 }}>
+        Practice Exam
+      </Typography>
+
+      <FormControl fullWidth sx={{ mb: 3 }}>
+        <InputLabel id="lesson-select-label">Lesson</InputLabel>
+        <Select
+          labelId="lesson-select-label"
+          value={selectedLessonId}
+          label="Lesson"
+          onChange={(e) => handleLessonChange(e.target.value)}
+        >
+          {lessons.map((l) => (
+            <MenuItem key={l.id} value={l.id}>
+              {formatLessonLabel(l.id, l.title)}
+            </MenuItem>
+          ))}
+        </Select>
+      </FormControl>
+
+      {phase === 'select' && selectedLesson && (
+        <Box>
+          <Typography variant="body1" sx={{ mb: 2 }}>
+            {selectedLesson.questions.length} question
+            {selectedLesson.questions.length !== 1 ? 's' : ''} · {selectedLesson.title}
+          </Typography>
+          <Button variant="contained" onClick={handleStartQuiz}>
+            Start Quiz
+          </Button>
+        </Box>
+      )}
+
+      {phase === 'quiz' && selectedLesson && (
+        <QuizRunner questions={selectedLesson.questions} onComplete={handleQuizComplete} />
+      )}
+
+      {phase === 'results' && quizResult && selectedLesson && (
+        <Box>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 3, mb: 3 }}>
+            <Box sx={{ position: 'relative', display: 'inline-flex' }}>
+              <CircularProgress
+                variant="determinate"
+                value={quizResult.percent}
+                size={80}
+                thickness={5}
+              />
+              <Box
+                sx={{
+                  position: 'absolute',
+                  inset: 0,
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                }}
+              >
+                <Typography variant="caption" component="div" color="text.secondary">
+                  {quizResult.percent}%
+                </Typography>
+              </Box>
+            </Box>
+            <Box>
+              <Typography variant="h5">
+                {quizResult.correct}/{quizResult.total} · {quizResult.percent}%
+              </Typography>
+              <Typography variant="body2" color="text.secondary">
+                {selectedLesson.title}
+              </Typography>
+            </Box>
+          </Box>
+
+          <Button variant="outlined" onClick={handleRetake} sx={{ mb: 3 }}>
+            Retake
+          </Button>
+
+          <Divider sx={{ mb: 3 }} />
+
+          {quizResult.perQuestion.map((pq, idx) => {
+            const q = selectedLesson.questions.find((sq) => sq.id === pq.questionId);
+            return (
+              <Box key={pq.questionId} sx={{ mb: 3 }}>
+                <Typography variant="subtitle2" color="text.secondary" sx={{ mb: 0.5 }}>
+                  Question {idx + 1}
+                </Typography>
+                <Typography variant="body1" sx={{ mb: 1 }}>
+                  {pq.prompt}
+                </Typography>
+                <Alert severity={pq.isCorrect ? 'success' : 'error'} sx={{ mb: 1 }}>
+                  <Typography variant="body2">
+                    Your answer: {pq.userAnswer}
+                    {q ? `. ${q.choices[pq.userAnswer]}` : ''}
+                  </Typography>
+                  {!pq.isCorrect && (
+                    <Typography variant="body2">
+                      Correct answer: {pq.correctAnswer}
+                      {q ? `. ${q.choices[pq.correctAnswer]}` : ''}
+                    </Typography>
+                  )}
+                </Alert>
+                <Typography variant="body2" sx={{ fontStyle: 'italic' }}>
+                  {pq.explanation}
+                </Typography>
+                {idx < quizResult.perQuestion.length - 1 && <Divider sx={{ mt: 2 }} />}
+              </Box>
+            );
+          })}
+        </Box>
+      )}
+
+      <Dialog open={pendingLessonId !== null} onClose={handleCancelSwitch}>
+        <DialogTitle>Switch Lesson?</DialogTitle>
+        <DialogContent>
+          <DialogContentText>
+            Your current quiz progress will be lost. Switch to the new lesson?
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={handleCancelSwitch}>Cancel</Button>
+          <Button onClick={handleConfirmSwitch} variant="contained">
+            Switch
+          </Button>
+        </DialogActions>
+      </Dialog>
     </Container>
   );
 }


### PR DESCRIPTION
## Summary
- Adds `QuizRunner` pure component with RadioGroup answer selection, immediate Alert feedback, explanation reveal before Next, and LinearProgress showing question N of total
- Replaces `Exam.tsx` stub with full lesson selector (AL-001 · Title format), `?lesson=ID` URL preselection, mid-quiz Dialog confirmation on lesson switch, CircularProgress score card (X/N · NN%), per-question review, Retake button, and score persistence via `useProgress()` → `store.setLastExamScore`

Closes #35

## Test plan
- [ ] Select a lesson from the dropdown; verify format `XX-NNN · Title`
- [ ] Navigate to `/exam?lesson=al-001`; verify correct lesson is preselected
- [ ] Start quiz, answer questions; verify correct/incorrect Alert + explanation before Next
- [ ] Switch lesson mid-quiz; verify Dialog appears and cancel/confirm work correctly
- [ ] Complete quiz; verify CircularProgress + score card with per-question review renders
- [ ] Click Retake; verify quiz resets to select phase
- [ ] Verify `lastExamScores` written to localStorage after completion

🤖 Generated with [Claude Code](https://claude.com/claude-code)