### PR TITLE
fix(ci): broaden perms + drop repoToken for Firebase deploy

### DIFF
--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -1,0 +1,40 @@
+name: Deploy main to Firebase (manual)
+
+# Safety-valve workflow: build and deploy current main to Firebase Hosting
+# on demand. Useful when the inline deploy inside qa-build-test.yml errored
+# but the merge already happened, leaving main ahead of what's live.
+#
+# Trigger: gh workflow run deploy-main.yml --ref main
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  checks: write
+  deployments: write
+  statuses: write
+
+jobs:
+  build_and_deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: web-app/package-lock.json
+
+      - name: Build
+        working-directory: web-app
+        run: npm ci && npm run build
+
+      - uses: FirebaseExtended/action-hosting-deploy@v0
+        with:
+          firebaseServiceAccount: '${{ secrets.FIREBASE_SERVICE_ACCOUNT_SUPRUN_CA }}'
+          channelId: live
+          projectId: suprun-ca

--- a/.github/workflows/qa-build-test.yml
+++ b/.github/workflows/qa-build-test.yml
@@ -13,6 +13,9 @@ on:
 permissions:
   pull-requests: write
   contents: write
+  checks: write
+  deployments: write
+  statuses: write
 
 jobs:
   qa-merge-deploy:
@@ -82,9 +85,12 @@ jobs:
         run: npm run build
 
       - name: Deploy to Firebase Hosting
+        # No repoToken: we deploy to `live` channel only — no PR preview comment
+        # needed. Avoids the "Resource not accessible by integration" failure
+        # that happens when the action tries to write a check/comment using
+        # GITHUB_TOKEN after the PR is already merged.
         uses: FirebaseExtended/action-hosting-deploy@v0
         with:
-          repoToken: '${{ secrets.GITHUB_TOKEN }}'
           firebaseServiceAccount: '${{ secrets.FIREBASE_SERVICE_ACCOUNT_SUPRUN_CA }}'
           channelId: live
           projectId: suprun-ca


### PR DESCRIPTION
## Summary

Two deploys today merged cleanly but errored on the Firebase deploy step with "Resource not accessible by integration". Main is currently ahead of what's live on ppl-study-suprun-ca.web.app (still serving the initial scaffold bundle).

**Fix:**
- Broaden workflow permissions: `checks: write`, `deployments: write`, `statuses: write`
- Drop `repoToken` from the Firebase action — we deploy to `live` channel only, so PR-preview commenting is unused
- Re-add `deploy-main.yml` as a `workflow_dispatch` safety valve for when the inline deploy fails

## Closes
—

## Test plan
- [ ] Label this PR `ready-for-qa` → full chain runs → build + merge + **deploy must succeed this time**
- [ ] Verify site at https://ppl-study-suprun-ca.web.app/ serves a NEW JS bundle hash (not `index-cUpQj6Hj.js`)
- [ ] Also runnable via `gh workflow run deploy-main.yml --ref main` after merge