### PR TITLE
[PPL-46] Mobile usability fixes: hamburger nav, 48px touch targets, responsive buttons

### DIFF
--- a/web-app/src/components/Nav.tsx
+++ b/web-app/src/components/Nav.tsx
@@ -1,7 +1,16 @@
+import { useState } from 'react';
 import AppBar from '@mui/material/AppBar';
+import Drawer from '@mui/material/Drawer';
+import IconButton from '@mui/material/IconButton';
+import List from '@mui/material/List';
+import ListItemButton from '@mui/material/ListItemButton';
+import ListItemText from '@mui/material/ListItemText';
 import Toolbar from '@mui/material/Toolbar';
 import Typography from '@mui/material/Typography';
 import Button from '@mui/material/Button';
+import useMediaQuery from '@mui/material/useMediaQuery';
+import { useTheme } from '@mui/material/styles';
+import MenuIcon from '@mui/icons-material/Menu';
 import { Link as RouterLink } from 'react-router-dom';
 
 const NAV_LINKS = [
@@ -12,17 +21,52 @@ const NAV_LINKS = [
 ];
 
 export default function Nav() {
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
+  const [drawerOpen, setDrawerOpen] = useState(false);
+
   return (
     <AppBar position="static" sx={{ backgroundColor: '#0a1628' }}>
       <Toolbar>
         <Typography variant="h6" sx={{ flexGrow: 1, color: '#f5a623', fontWeight: 700 }}>
           PPL Study
         </Typography>
-        {NAV_LINKS.map(({ label, to }) => (
-          <Button key={to} component={RouterLink} to={to} sx={{ color: '#ffffff' }}>
-            {label}
-          </Button>
-        ))}
+        {isMobile ? (
+          <>
+            <IconButton
+              color="inherit"
+              onClick={() => setDrawerOpen(true)}
+              aria-label="open navigation menu"
+            >
+              <MenuIcon />
+            </IconButton>
+            <Drawer
+              anchor="right"
+              open={drawerOpen}
+              onClose={() => setDrawerOpen(false)}
+              PaperProps={{ sx: { backgroundColor: '#0d1f3c', minWidth: 200 } }}
+            >
+              <List>
+                {NAV_LINKS.map(({ label, to }) => (
+                  <ListItemButton
+                    key={to}
+                    component={RouterLink}
+                    to={to}
+                    onClick={() => setDrawerOpen(false)}
+                  >
+                    <ListItemText primary={label} sx={{ color: '#ffffff' }} />
+                  </ListItemButton>
+                ))}
+              </List>
+            </Drawer>
+          </>
+        ) : (
+          NAV_LINKS.map(({ label, to }) => (
+            <Button key={to} component={RouterLink} to={to} sx={{ color: '#ffffff' }}>
+              {label}
+            </Button>
+          ))
+        )}
       </Toolbar>
     </AppBar>
   );

--- a/web-app/src/pages/LessonDetail.tsx
+++ b/web-app/src/pages/LessonDetail.tsx
@@ -74,13 +74,14 @@ export default function LessonDetail() {
 
       <AudioPlayer src={lesson.audio} />
 
-      <Box sx={{ mt: 2, mb: 3, display: 'flex', gap: 2, flexWrap: 'wrap' }}>
+      <Box sx={{ mt: 2, mb: 3, display: 'flex', gap: 2, flexDirection: { xs: 'column', sm: 'row' }, flexWrap: 'wrap' }}>
         <Button
           variant="outlined"
           size="small"
           href={lesson.visual}
           target="_blank"
           rel="noopener noreferrer"
+          sx={{ width: { xs: '100%', sm: 'auto' } }}
         >
           View Visual
         </Button>
@@ -88,6 +89,7 @@ export default function LessonDetail() {
           variant="outlined"
           size="small"
           onClick={() => navigate(`/lessons/${lesson.topic}/${lesson.slug}/quiz`)}
+          sx={{ width: { xs: '100%', sm: 'auto' } }}
         >
           Take Practice Quiz
         </Button>
@@ -114,6 +116,7 @@ export default function LessonDetail() {
         color="primary"
         onClick={handleMarkComplete}
         disabled={completed}
+        sx={{ width: { xs: '100%', sm: 'auto' } }}
       >
         {completed ? 'Completed' : 'Mark Complete'}
       </Button>

--- a/web-app/src/theme.ts
+++ b/web-app/src/theme.ts
@@ -17,6 +17,30 @@ const theme = createTheme({
   typography: {
     fontFamily: "'Roboto', 'Helvetica', 'Arial', sans-serif",
   },
+  components: {
+    MuiButton: {
+      styleOverrides: {
+        root: {
+          minHeight: 48,
+        },
+      },
+    },
+    MuiIconButton: {
+      styleOverrides: {
+        root: {
+          minWidth: 48,
+          minHeight: 48,
+        },
+      },
+    },
+    MuiCheckbox: {
+      styleOverrides: {
+        root: {
+          padding: 12,
+        },
+      },
+    },
+  },
 });
 
 export default theme;


### PR DESCRIPTION
Closes #46

## Changes

- **Nav.tsx**: Added `useMediaQuery(theme.breakpoints.down('sm'))` — on mobile renders an `IconButton` + `MenuIcon` that opens an MUI `Drawer` with all nav links as `ListItemButton` entries (drawer background `#0d1f3c`); existing `Button` row preserved on `sm+`
- **theme.ts**: Added `components` overrides — `MuiButton` `minHeight: 48px`, `MuiIconButton` `minWidth/minHeight: 48px`, `MuiCheckbox` `padding: 12px` for 48px touch targets; navy/amber dark theme preserved
- **LessonDetail.tsx**: Action button row (View Visual, Take Practice Quiz) uses `flexDirection: { xs: 'column', sm: 'row' }` and `width: { xs: '100%', sm: 'auto' }`; Mark Complete button also full-width on xs

## Test Plan

- [ ] On a mobile viewport (<600px), Nav shows hamburger icon; tapping it opens a right-side drawer with all four nav links on dark `#0d1f3c` background; tapping a link closes the drawer and navigates
- [ ] On desktop (≥600px), Nav shows the original horizontal button row unchanged
- [ ] Buttons and icon buttons have at least 48×48px touch targets
- [ ] On a lesson detail page at mobile width, the View Visual, Take Practice Quiz, and Mark Complete buttons stack vertically and span full width
- [ ] `npm run build` passes with zero TypeScript errors ✅