### PR TITLE
[PPL-49] Clickable source chips with canonical TC/Justice Laws URLs

### DIFF
--- a/web-app/src/components/SourceList.tsx
+++ b/web-app/src/components/SourceList.tsx
@@ -1,6 +1,8 @@
 import Box from '@mui/material/Box';
 import Chip from '@mui/material/Chip';
+import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
+import { SOURCE_URLS } from '../lib/sources';
 
 interface SourceListProps {
   sources: string[];
@@ -24,15 +26,35 @@ export default function SourceList({ sources }: SourceListProps) {
         Sources
       </Typography>
       <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
-        {sources.map((src) => (
-          <Chip
-            key={src}
-            label={src}
-            size="small"
-            variant="outlined"
-            sx={{ color: 'text.secondary', borderColor: 'text.disabled' }}
-          />
-        ))}
+        {sources.map((src) => {
+          const url = SOURCE_URLS[src];
+          if (url) {
+            return (
+              <Chip
+                key={src}
+                component="a"
+                href={url}
+                target="_blank"
+                rel="noopener noreferrer"
+                clickable
+                label={src}
+                size="small"
+                variant="outlined"
+                sx={{ color: 'text.secondary', borderColor: 'text.disabled' }}
+              />
+            );
+          }
+          return (
+            <Tooltip key={src} title="No public link">
+              <Chip
+                label={src}
+                size="small"
+                variant="outlined"
+                sx={{ color: 'text.secondary', borderColor: 'text.disabled' }}
+              />
+            </Tooltip>
+          );
+        })}
       </Box>
     </Box>
   );

--- a/web-app/src/lib/sources.ts
+++ b/web-app/src/lib/sources.ts
@@ -1,0 +1,9 @@
+export const SOURCE_URLS: Record<string, string> = {
+  'CARs Part VI': 'https://laws-lois.justice.gc.ca/eng/regulations/SOR-96-433/',
+  'CARs 602.114-602.117': 'https://laws-lois.justice.gc.ca/eng/regulations/SOR-96-433/',
+  'TP 12880E': '',
+  'TP 9994': '',
+  'TP 13014': '',
+  'AIM RAC 2.0': '',
+  'VNC Chart Legend': '',
+};


### PR DESCRIPTION
## Summary
- Create `web-app/src/lib/sources.ts` exporting `SOURCE_URLS: Record<string, string>` mapping 7 citation IDs (collected from all `lessons/air-law/*.md` and `lessons/navigation/*.md` frontmatter plus spec-required TP 13014) to canonical Justice Laws / Transport Canada URLs; CARs entries link to `laws-lois.justice.gc.ca`, TP/AIM/VNC entries use empty string (no stable public link)
- Update `web-app/src/components/SourceList.tsx` to render known citations as clickable MUI `Chip` (`component="a"`, `href`, `target="_blank"`, `rel="noopener noreferrer"`, `clickable`) and unknown citations as plain `Chip` wrapped in `Tooltip title="No public link"`
- `npm run build` passes with zero TypeScript errors

## Test plan
- [ ] Open a lesson with `CARs Part VI` or `CARs 602.114-602.117` source — chip should be clickable and open Justice Laws in new tab
- [ ] Open a lesson with `TP 12880E`, `AIM RAC 2.0`, `VNC Chart Legend`, `TP 9994` — chip should show tooltip "No public link" on hover
- [ ] `npm run build` passes

Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)