### PR TITLE
[PPL-48] Apply lesson reading standards

### DIFF
--- a/web-app/src/pages/LessonDetail.tsx
+++ b/web-app/src/pages/LessonDetail.tsx
@@ -16,10 +16,53 @@ import { useProgress } from '../lib/progress';
 const mdOptions = {
   overrides: {
     h1: { component: Typography, props: { variant: 'h4', gutterBottom: true, sx: { mt: 3 } } },
-    h2: { component: Typography, props: { variant: 'h5', gutterBottom: true, sx: { mt: 3 } } },
-    h3: { component: Typography, props: { variant: 'h6', gutterBottom: true, sx: { mt: 2 } } },
+    h2: { component: Typography, props: { variant: 'h5', gutterBottom: true, sx: { mt: 4, mb: 1 } } },
+    h3: { component: Typography, props: { variant: 'h6', gutterBottom: true, sx: { mt: 3, mb: 1 } } },
     p: { component: Typography, props: { variant: 'body1', paragraph: true } },
     li: { component: Typography, props: { component: 'li', variant: 'body1', sx: { mb: 0.5 } } },
+    code: {
+      component: Box,
+      props: {
+        component: 'code',
+        sx: {
+          fontFamily: 'monospace',
+          fontSize: '0.875em',
+          bgcolor: 'rgba(255,255,255,0.08)',
+          px: 0.75,
+          py: 0.25,
+          borderRadius: 0.5,
+        },
+      },
+    },
+    pre: {
+      component: Box,
+      props: {
+        component: 'pre',
+        sx: {
+          bgcolor: 'background.paper',
+          p: 2,
+          borderRadius: 1,
+          overflowX: 'auto',
+          maxWidth: '100%',
+          my: 2,
+          '& code': { bgcolor: 'transparent', p: 0 },
+        },
+      },
+    },
+    blockquote: {
+      component: Box,
+      props: {
+        component: 'blockquote',
+        sx: {
+          borderLeft: '3px solid',
+          borderColor: 'primary.main',
+          pl: 2,
+          ml: 0,
+          my: 2,
+          color: 'text.secondary',
+        },
+      },
+    },
   },
 };
 
@@ -55,7 +98,7 @@ export default function LessonDetail() {
   }
 
   return (
-    <Container maxWidth="md" sx={{ py: 4 }}>
+    <Container maxWidth={false} sx={{ maxWidth: 700, mx: 'auto', px: { xs: 2, sm: 3 }, py: 4 }}>
       <Box sx={{ mb: 1, display: 'flex', gap: 1, flexWrap: 'wrap', alignItems: 'center' }}>
         <Chip
           label={lesson.topic.replace(/-/g, ' ')}
@@ -68,26 +111,38 @@ export default function LessonDetail() {
         )}
       </Box>
 
-      <Typography variant="h3" gutterBottom sx={{ mt: 2 }}>
+      <Typography
+        variant="h3"
+        gutterBottom
+        sx={{ mt: 2, typography: { xs: 'h4', md: 'h3' } }}
+      >
         {lesson.title}
       </Typography>
 
       <AudioPlayer src={lesson.audio} />
 
-      <Box sx={{ mt: 2, mb: 3, display: 'flex', gap: 2, flexWrap: 'wrap' }}>
+      <Box
+        sx={{
+          mt: 2,
+          mb: 3,
+          display: 'flex',
+          flexDirection: { xs: 'column', sm: 'row' },
+          gap: 2,
+        }}
+      >
         <Button
           variant="outlined"
-          size="small"
           href={lesson.visual}
           target="_blank"
           rel="noopener noreferrer"
+          sx={{ minHeight: 44 }}
         >
           View Visual
         </Button>
         <Button
           variant="outlined"
-          size="small"
           onClick={() => navigate(`/lessons/${lesson.topic}/${lesson.slug}/quiz`)}
+          sx={{ minHeight: 44 }}
         >
           Take Practice Quiz
         </Button>

--- a/web-app/src/theme.ts
+++ b/web-app/src/theme.ts
@@ -1,6 +1,6 @@
 import { createTheme } from '@mui/material/styles';
 
-const theme = createTheme({
+let theme = createTheme({
   palette: {
     mode: 'dark',
     background: {
@@ -16,6 +16,41 @@ const theme = createTheme({
   },
   typography: {
     fontFamily: "'Roboto', 'Helvetica', 'Arial', sans-serif",
+    body1: {
+      lineHeight: 1.75,
+    },
+  },
+});
+
+theme = createTheme(theme, {
+  typography: {
+    h3: {
+      [theme.breakpoints.down('sm')]: {
+        fontSize: '1.75rem',
+      },
+    },
+    h4: {
+      [theme.breakpoints.down('sm')]: {
+        fontSize: '1.5rem',
+      },
+    },
+    h5: {
+      [theme.breakpoints.down('sm')]: {
+        fontSize: '1.25rem',
+      },
+    },
+    h6: {
+      [theme.breakpoints.down('sm')]: {
+        fontSize: '1.1rem',
+      },
+    },
+  },
+  components: {
+    MuiContainer: {
+      defaultProps: {
+        maxWidth: 'lg' as const,
+      },
+    },
   },
 });
 


### PR DESCRIPTION
Closes #48

## Changes
- **theme.ts**: `body1.lineHeight: 1.75` for comfortable reading; two-pass `createTheme` adds responsive font-size step-downs for h3/h4/h5/h6 at xs (≤600px); `MuiContainer.defaultProps.maxWidth: 'lg'`.
- **LessonDetail.tsx**: 700px reading-width container (`maxWidth={false}` + sx); markdown overrides for `code` (inline monospace chip, rgba(255,255,255,0.08) bg), `pre` (background.paper, overflowX auto, resets code bg inside), `blockquote` (3px primary left border, text.secondary); h2 mt:4/mb:1 and h3 mt:3/mb:1 for ≥24px vertical rhythm; action button row `flexDirection: { xs: 'column', sm: 'row' }` with 44px touch targets; lesson title responsive via `sx={{ typography: { xs: 'h4', md: 'h3' } }}`.

## Test Plan
- [ ] `npm run build` passes with zero TypeScript errors ✓
- [ ] 375px: title renders as h4, buttons stack vertically, no horizontal page scroll, inline code has chip appearance
- [ ] 1280px: title renders as h3, buttons side-by-side, reading column ≤700px centred
- [ ] blockquote shows amber left border with muted body text
- [ ] fenced code blocks scroll horizontally within their box; page does not scroll horizontally

🤖 Generated with [Claude Code](https://claude.com/claude-code)