### PR TITLE
[PPL-48] Apply lesson reading standards for mobile + desktop

### DIFF
--- a/web-app/src/pages/LessonDetail.tsx
+++ b/web-app/src/pages/LessonDetail.tsx
@@ -16,10 +16,52 @@ import { useProgress } from '../lib/progress';
 const mdOptions = {
   overrides: {
     h1: { component: Typography, props: { variant: 'h4', gutterBottom: true, sx: { mt: 3 } } },
-    h2: { component: Typography, props: { variant: 'h5', gutterBottom: true, sx: { mt: 3 } } },
-    h3: { component: Typography, props: { variant: 'h6', gutterBottom: true, sx: { mt: 2 } } },
+    h2: { component: Typography, props: { variant: 'h5', gutterBottom: true, sx: { mt: 4 } } },
+    h3: { component: Typography, props: { variant: 'h6', gutterBottom: true, sx: { mt: 3 } } },
     p: { component: Typography, props: { variant: 'body1', paragraph: true } },
     li: { component: Typography, props: { component: 'li', variant: 'body1', sx: { mb: 0.5 } } },
+    code: {
+      component: Box,
+      props: {
+        component: 'code',
+        sx: {
+          fontFamily: 'monospace',
+          fontSize: '0.875em',
+          bgcolor: 'rgba(255,255,255,0.08)',
+          px: 0.75,
+          py: 0.25,
+          borderRadius: 1,
+        },
+      },
+    },
+    pre: {
+      component: Box,
+      props: {
+        component: 'pre',
+        sx: {
+          bgcolor: 'background.paper',
+          p: 2,
+          borderRadius: 1,
+          overflowX: 'auto',
+          my: 2,
+          '& code': { bgcolor: 'transparent', p: 0 },
+        },
+      },
+    },
+    blockquote: {
+      component: Box,
+      props: {
+        component: 'blockquote',
+        sx: {
+          borderLeft: '3px solid',
+          borderColor: 'primary.main',
+          pl: 2,
+          ml: 0,
+          my: 2,
+          color: 'text.secondary',
+        },
+      },
+    },
   },
 };
 
@@ -33,7 +75,7 @@ export default function LessonDetail() {
 
   if (!lesson) {
     return (
-      <Container maxWidth="md" sx={{ py: 6 }}>
+      <Container maxWidth={false} sx={{ maxWidth: 700, mx: 'auto', px: { xs: 2, sm: 3 }, py: 6 }}>
         <Typography variant="h4" gutterBottom>
           Lesson not found
         </Typography>
@@ -55,7 +97,7 @@ export default function LessonDetail() {
   }
 
   return (
-    <Container maxWidth="md" sx={{ py: 4 }}>
+    <Container maxWidth={false} sx={{ maxWidth: 700, mx: 'auto', px: { xs: 2, sm: 3 }, py: 4 }}>
       <Box sx={{ mb: 1, display: 'flex', gap: 1, flexWrap: 'wrap', alignItems: 'center' }}>
         <Chip
           label={lesson.topic.replace(/-/g, ' ')}

--- a/web-app/src/theme.ts
+++ b/web-app/src/theme.ts
@@ -1,5 +1,7 @@
 import { createTheme } from '@mui/material/styles';
 
+const { breakpoints } = createTheme();
+
 const theme = createTheme({
   palette: {
     mode: 'dark',
@@ -16,6 +18,24 @@ const theme = createTheme({
   },
   typography: {
     fontFamily: "'Roboto', 'Helvetica', 'Arial', sans-serif",
+    body1: {
+      lineHeight: 1.75,
+    },
+    h3: {
+      [breakpoints.down('md')]: { fontSize: '1.875rem' },
+      [breakpoints.down('sm')]: { fontSize: '1.375rem' },
+    },
+    h4: {
+      [breakpoints.down('md')]: { fontSize: '1.5rem' },
+      [breakpoints.down('sm')]: { fontSize: '1.25rem' },
+    },
+    h5: {
+      [breakpoints.down('md')]: { fontSize: '1.25rem' },
+      [breakpoints.down('sm')]: { fontSize: '1.125rem' },
+    },
+    h6: {
+      [breakpoints.down('sm')]: { fontSize: '1rem' },
+    },
   },
   components: {
     MuiButton: {


### PR DESCRIPTION
Closes #48

## Changes
- **theme.ts**: Added `body1.lineHeight: 1.75`; responsive font-size overrides for h3 (xs: 1.375rem, md: 1.875rem), h4 (xs: 1.25rem, md: 1.5rem), h5 (xs: 1.125rem, md: 1.25rem), h6 (xs: 1rem) using `createTheme()` breakpoints pre-extraction.
- **LessonDetail.tsx**: Both Container instances (`main` + `404` branch) changed to `maxWidth={false}` with `sx={{ maxWidth: 700, mx: 'auto', px: { xs: 2, sm: 3 } }}`; mdOptions.overrides extended with `code` (inline monospace chip, rgba bg), `pre` (background.paper, overflowX auto, resets nested code bg), `blockquote` (3px primary.main left border, pl:2, text.secondary); h2 mt tightened to 4, h3 to 3.

## Test plan
- [ ] `npm run build` passes with zero TypeScript errors ✓
- [ ] 375px: body text line-height is comfortable (1.75), headings step down in size, reading column fits within viewport, no horizontal scroll
- [ ] 1280px: reading column caps at ~700px and is centred, h3 title at full md size
- [ ] Inline `code` shows monospace chip with subtle dark background
- [ ] Fenced code blocks (`pre`) have dark paper background and scroll horizontally within their box
- [ ] `blockquote` shows amber left border with muted text
- [ ] Action button row and mark-complete logic untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)