### PR TITLE
[PPL-49] Clickable source citations with URL map

### DIFF
--- a/web-app/src/components/SourceList.tsx
+++ b/web-app/src/components/SourceList.tsx
@@ -1,6 +1,8 @@
 import Box from '@mui/material/Box';
 import Chip from '@mui/material/Chip';
+import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
+import { SOURCE_URLS } from '../lib/sources';
 
 interface SourceListProps {
   sources: string[];
@@ -24,15 +26,35 @@ export default function SourceList({ sources }: SourceListProps) {
         Sources
       </Typography>
       <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
-        {sources.map((src) => (
-          <Chip
-            key={src}
-            label={src}
-            size="small"
-            variant="outlined"
-            sx={{ color: 'text.secondary', borderColor: 'text.disabled' }}
-          />
-        ))}
+        {sources.map((src) => {
+          const url = SOURCE_URLS[src];
+          if (url) {
+            return (
+              <Chip
+                key={src}
+                component="a"
+                href={url}
+                target="_blank"
+                rel="noopener noreferrer"
+                clickable
+                label={src}
+                size="small"
+                variant="outlined"
+                sx={{ color: 'text.secondary', borderColor: 'text.disabled' }}
+              />
+            );
+          }
+          return (
+            <Tooltip key={src} title="No public link">
+              <Chip
+                label={src}
+                size="small"
+                variant="outlined"
+                sx={{ color: 'text.secondary', borderColor: 'text.disabled' }}
+              />
+            </Tooltip>
+          );
+        })}
       </Box>
     </Box>
   );

--- a/web-app/src/lib/sources.ts
+++ b/web-app/src/lib/sources.ts
@@ -1,0 +1,9 @@
+export const SOURCE_URLS: Record<string, string> = {
+  'CARs Part VI': 'https://laws-lois.justice.gc.ca/eng/regulations/SOR-96-433/',
+  'CARs 602.114-602.117': 'https://laws-lois.justice.gc.ca/eng/regulations/SOR-96-433/',
+  'TP 12880E': '',
+  'TP 9994': '',
+  'TP 13014': '',
+  'AIM RAC 2.0': '',
+  'VNC Chart Legend': '',
+};


### PR DESCRIPTION
Closes #49

## Changes
- Create `web-app/src/lib/sources.ts` exporting `SOURCE_URLS: Record<string, string>` with 7 citation keys collected from `lessons/air-law/*.md` and `lessons/navigation/*.md` frontmatter (plus spec-required `TP 13014`). `CARs Part VI` and `CARs 602.114-602.117` map to the Justice Laws CARs page; all TP, AIM, and VNC entries map to `''` (no stable Transport Canada / Justice Laws public link exists).
- Modify `web-app/src/components/SourceList.tsx` to import `SOURCE_URLS` and render: clickable MUI `Chip` (`component="a"`, `href`, `target="_blank"`, `rel="noopener noreferrer"`, `clickable`) for non-empty URLs; plain `Chip` wrapped in `<Tooltip title="No public link">` otherwise.
- No changes to lesson frontmatter, `types.ts`, `LessonDetail.tsx`, or `docs/lesson-schema.md`.

## Test plan
- [ ] Open a lesson with `CARs Part VI` or `CARs 602.114-602.117` — chip is clickable and opens Justice Laws in a new tab
- [ ] Open a lesson with `TP 12880E`, `AIM RAC 2.0`, `VNC Chart Legend`, or `TP 9994` — hovering shows tooltip "No public link"
- [ ] `npm run build` passes with zero TypeScript errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)