### PR TITLE
[PPL-61] Theme token layers — surfaceRaised, onAccent; migrate hex literals

### DIFF
--- a/web-app/src/components/Nav.tsx
+++ b/web-app/src/components/Nav.tsx
@@ -26,9 +26,9 @@ export default function Nav() {
   const [drawerOpen, setDrawerOpen] = useState(false);
 
   return (
-    <AppBar position="static" sx={{ backgroundColor: '#0a1628' }}>
+    <AppBar position="static" sx={{ backgroundColor: 'background.default' }}>
       <Toolbar>
-        <Typography variant="h6" sx={{ flexGrow: 1, color: '#f5a623', fontWeight: 700 }}>
+        <Typography variant="h6" sx={{ flexGrow: 1, color: 'primary.main', fontWeight: 700 }}>
           PPL Study
         </Typography>
         {isMobile ? (
@@ -44,7 +44,7 @@ export default function Nav() {
               anchor="right"
               open={drawerOpen}
               onClose={() => setDrawerOpen(false)}
-              PaperProps={{ sx: { backgroundColor: '#0d1f3c', minWidth: 200 } }}
+              PaperProps={{ sx: { backgroundColor: 'background.surfaceRaised', minWidth: 200 } }}
             >
               <List>
                 {NAV_LINKS.map(({ label, to }) => (
@@ -54,7 +54,7 @@ export default function Nav() {
                     to={to}
                     onClick={() => setDrawerOpen(false)}
                   >
-                    <ListItemText primary={label} sx={{ color: '#ffffff' }} />
+                    <ListItemText primary={label} sx={{ color: 'text.primary' }} />
                   </ListItemButton>
                 ))}
               </List>
@@ -62,7 +62,7 @@ export default function Nav() {
           </>
         ) : (
           NAV_LINKS.map(({ label, to }) => (
-            <Button key={to} component={RouterLink} to={to} sx={{ color: '#ffffff' }}>
+            <Button key={to} component={RouterLink} to={to} color="inherit">
               {label}
             </Button>
           ))

--- a/web-app/src/pages/LessonDetail.tsx
+++ b/web-app/src/pages/LessonDetail.tsx
@@ -60,7 +60,7 @@ export default function LessonDetail() {
         <Chip
           label={lesson.topic.replace(/-/g, ' ')}
           size="small"
-          sx={{ textTransform: 'capitalize', bgcolor: 'primary.main', color: '#000' }}
+          sx={{ textTransform: 'capitalize', bgcolor: 'primary.main', color: 'text.onAccent' }}
         />
         <Chip label={`${lesson.duration_min} min`} size="small" variant="outlined" />
         {completed && (

--- a/web-app/src/theme.ts
+++ b/web-app/src/theme.ts
@@ -1,17 +1,30 @@
 import { createTheme } from '@mui/material/styles';
 
+declare module '@mui/material/styles' {
+  interface TypeBackground {
+    surfaceRaised: string;
+  }
+  interface TypeText {
+    onAccent: string;
+  }
+}
+
 const theme = createTheme({
   palette: {
     mode: 'dark',
     background: {
       default: '#0a1628',
       paper: '#0d1f3c',
+      surfaceRaised: '#0d1f3c',
     },
     primary: {
       main: '#f5a623',
     },
     secondary: {
       main: '#ffffff',
+    },
+    text: {
+      onAccent: '#000000',
     },
   },
   typography: {


### PR DESCRIPTION
## Summary
- Added TypeScript module augmentation in `theme.ts` declaring `TypeBackground.surfaceRaised` and `TypeText.onAccent`
- Registered `palette.background.surfaceRaised: '#0d1f3c'` and `palette.text.onAccent: '#000000'` in the MUI palette
- Migrated 5 hex literals in `Nav.tsx` to theme tokens (`background.default`, `primary.main`, `background.surfaceRaised`, `text.primary`, `color="inherit"`)
- Migrated topic Chip `color: '#000'` in `LessonDetail.tsx` to `'text.onAccent'`

## Test plan
- [x] `grep -rn '#[0-9a-fA-F]' web-app/src/ --include='*.tsx'` returns zero results
- [x] `npm run build` passes with zero TypeScript errors
- [ ] Visual check: `/`, `/lessons`, `/lessons/air-law/airspace-classifications` render unchanged

Closes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)