### PR TITLE
[PPL-59] Full typography scale + LessonDetail content styling

### DIFF
--- a/web-app/src/pages/LessonDetail.tsx
+++ b/web-app/src/pages/LessonDetail.tsx
@@ -20,6 +20,80 @@ const mdOptions = {
     h3: { component: Typography, props: { variant: 'h6', gutterBottom: true, sx: { mt: 2 } } },
     p: { component: Typography, props: { variant: 'body1', paragraph: true } },
     li: { component: Typography, props: { component: 'li', variant: 'body1', sx: { mb: 0.5 } } },
+    code: {
+      component: Box,
+      props: {
+        component: 'code',
+        sx: {
+          fontFamily: 'monospace',
+          fontSize: '0.875em',
+          bgcolor: 'rgba(255,255,255,0.08)',
+          px: 0.75,
+          py: 0.125,
+          borderRadius: '4px',
+        },
+      },
+    },
+    pre: {
+      component: Box,
+      props: {
+        component: 'pre',
+        sx: {
+          bgcolor: 'rgba(255,255,255,0.05)',
+          border: '1px solid',
+          borderColor: 'divider',
+          borderRadius: 1,
+          p: 2,
+          my: 2,
+          overflow: 'auto',
+          fontFamily: 'monospace',
+          fontSize: '0.875rem',
+          lineHeight: 1.6,
+        },
+      },
+    },
+    blockquote: {
+      component: Box,
+      props: {
+        component: 'blockquote',
+        sx: {
+          borderLeft: '4px solid',
+          borderColor: 'primary.main',
+          pl: 2,
+          ml: 0,
+          my: 2,
+          color: 'text.secondary',
+          fontStyle: 'italic',
+        },
+      },
+    },
+    table: {
+      component: Box,
+      props: {
+        component: 'table',
+        sx: {
+          width: '100%',
+          borderCollapse: 'collapse',
+          my: 2,
+          fontSize: '0.875rem',
+          '& th, & td': {
+            border: '1px solid',
+            borderColor: 'divider',
+            px: 1.5,
+            py: 1,
+            textAlign: 'left',
+          },
+          '& th': {
+            bgcolor: 'rgba(255,255,255,0.06)',
+            fontWeight: 600,
+          },
+        },
+      },
+    },
+    hr: {
+      component: Divider,
+      props: { sx: { my: 3 } },
+    },
   },
 };
 
@@ -55,7 +129,7 @@ export default function LessonDetail() {
   }
 
   return (
-    <Container maxWidth="md" sx={{ py: 4 }}>
+    <Container maxWidth={false} sx={{ maxWidth: 700, mx: 'auto', px: { xs: 2, sm: 3 }, py: 4 }}>
       <Box sx={{ mb: 1, display: 'flex', gap: 1, flexWrap: 'wrap', alignItems: 'center' }}>
         <Chip
           label={lesson.topic.replace(/-/g, ' ')}

--- a/web-app/src/theme.ts
+++ b/web-app/src/theme.ts
@@ -1,6 +1,6 @@
 import { createTheme } from '@mui/material/styles';
 
-const theme = createTheme({
+const baseTheme = createTheme({
   palette: {
     mode: 'dark',
     background: {
@@ -13,9 +13,6 @@ const theme = createTheme({
     secondary: {
       main: '#ffffff',
     },
-  },
-  typography: {
-    fontFamily: "'Roboto', 'Helvetica', 'Arial', sans-serif",
   },
   components: {
     MuiButton: {
@@ -39,6 +36,76 @@ const theme = createTheme({
           padding: 12,
         },
       },
+    },
+  },
+});
+
+const theme = createTheme(baseTheme, {
+  typography: {
+    fontFamily: "'Roboto', 'Helvetica', 'Arial', sans-serif",
+    h1: {
+      fontSize: '3rem',
+      fontWeight: 300,
+      lineHeight: 1.167,
+      [baseTheme.breakpoints.down('sm')]: {
+        fontSize: '2.5rem',
+      },
+    },
+    h2: {
+      fontSize: '2.125rem',
+      fontWeight: 300,
+      lineHeight: 1.235,
+      [baseTheme.breakpoints.down('sm')]: {
+        fontSize: '1.875rem',
+      },
+    },
+    h3: {
+      fontSize: '1.75rem',
+      fontWeight: 400,
+      lineHeight: 1.235,
+      [baseTheme.breakpoints.down('sm')]: {
+        fontSize: '1.5rem',
+      },
+    },
+    h4: {
+      fontSize: '1.5rem',
+      fontWeight: 400,
+      lineHeight: 1.334,
+      [baseTheme.breakpoints.down('sm')]: {
+        fontSize: '1.375rem',
+      },
+    },
+    h5: {
+      fontSize: '1.25rem',
+      fontWeight: 400,
+      lineHeight: 1.6,
+    },
+    h6: {
+      fontSize: '1.125rem',
+      fontWeight: 500,
+      lineHeight: 1.6,
+    },
+    body1: {
+      fontSize: '1rem',
+      fontWeight: 400,
+      lineHeight: 1.5,
+    },
+    body2: {
+      fontSize: '0.875rem',
+      fontWeight: 400,
+      lineHeight: 1.43,
+    },
+    caption: {
+      fontSize: '0.75rem',
+      fontWeight: 400,
+      lineHeight: 1.66,
+    },
+    overline: {
+      fontSize: '0.75rem',
+      fontWeight: 400,
+      lineHeight: 2.66,
+      letterSpacing: '0.08em',
+      textTransform: 'uppercase' as const,
     },
   },
 });


### PR DESCRIPTION
## Summary

- Add explicit `fontSize`/`fontWeight`/`lineHeight` for all MUI typography variants (h1–h6, body1, body2, caption, overline) in `theme.ts`, with `[theme.breakpoints.down('sm')]` responsive overrides for h1–h4
- Update `LessonDetail` main `Container` to `maxWidth={false}` with `maxWidth: 700, mx: 'auto', px: {xs:2, sm:3}` for a tighter reading column
- Extend `mdOptions.overrides` with dark-theme-appropriate `Box` components for `code`, `pre`, `blockquote`, `table`, and `hr` using `rgba` backgrounds and MUI theme tokens

## Test plan

- [x] `npm run build` passes with zero TypeScript errors
- [ ] Visual check: lesson detail page renders code blocks, blockquotes, and tables correctly in dark mode
- [ ] Visual check: heading sizes scale down on mobile (≤600 px viewport)
- [ ] No regressions on other pages (Home, LessonsIndex, Plan)

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)