### PR TITLE
[PPL-49] Fill in stable TC/Justice Laws URLs for source citations

### DIFF
--- a/web-app/src/lib/sources.ts
+++ b/web-app/src/lib/sources.ts
@@ -1,9 +1,9 @@
 export const SOURCE_URLS: Record<string, string> = {
   'CARs Part VI': 'https://laws-lois.justice.gc.ca/eng/regulations/SOR-96-433/',
-  'CARs 602.114-602.117': 'https://laws-lois.justice.gc.ca/eng/regulations/SOR-96-433/',
-  'TP 12880E': '',
+  'CARs 602.114-602.117': 'https://laws-lois.justice.gc.ca/eng/regulations/SOR-96-433/section-602.114.html',
+  'TP 12880E': 'https://tc.canada.ca/en/aviation/publications/study-reference-guide-written-examinations-private-pilot-licence-aeroplane-tp-12880',
   'TP 9994': '',
-  'TP 13014': '',
-  'AIM RAC 2.0': '',
+  'TP 13014': 'https://tc.canada.ca/en/aviation/publications/civil-aviation-sample-examination-recreational-pilot-permit-private-pilot-licence-aeroplane-tp-13014',
+  'AIM RAC 2.0': 'https://tc.canada.ca/en/aviation/publications/transport-canada-aeronautical-information-manual-tc-aim-tp-14371',
   'VNC Chart Legend': '',
 };


### PR DESCRIPTION
Closes #49

## Changes
- `web-app/src/lib/sources.ts` — replace four empty-string URL values with verified HTTPS URLs (all HTTP-200 confirmed):
  - `'CARs 602.114-602.117'` → section-level Justice Laws anchor `laws-lois.justice.gc.ca/…/section-602.114.html`
  - `'TP 12880E'` → `tc.canada.ca` study reference guide page for TP 12880
  - `'TP 13014'` → `tc.canada.ca` sample examination questions page for RPP/PPL
  - `'AIM RAC 2.0'` → `tc.canada.ca` TC AIM (TP 14371) publication page
- `'TP 9994'` and `'VNC Chart Legend'` remain `''` — no stable public link found on tc.canada.ca, laws-lois.justice.gc.ca, or navcanada.ca.
- No other files modified.

## Test plan
- [ ] Open a lesson with `CARs 602.114-602.117` — chip opens the specific section anchor on Justice Laws
- [ ] Open a lesson with `TP 12880E`, `TP 13014`, or `AIM RAC 2.0` — chip opens the correct tc.canada.ca page in a new tab
- [ ] `TP 9994` and `VNC Chart Legend` still show tooltip "No public link"
- [ ] `npm run build` passes with zero TypeScript errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)