### PR TITLE
[PPL-62] Add heading-rose aviation motif and tighten hero copy

### DIFF
--- a/web-app/src/components/HeroMotif.tsx
+++ b/web-app/src/components/HeroMotif.tsx
@@ -1,0 +1,72 @@
+/** Heading-rose aviation motif — decorative, aria-hidden */
+export default function HeroMotif() {
+  const cx = 200;
+  const cy = 200;
+  const outerR = 190;
+
+  const ticks = Array.from({ length: 36 }, (_, i) => {
+    const angle = i * 10;
+    const rad = ((angle - 90) * Math.PI) / 180;
+    const isCardinal = i % 9 === 0;
+    const isMajor = i % 3 === 0;
+    const innerR = isCardinal ? 148 : isMajor ? 165 : 178;
+    return {
+      x1: cx + outerR * Math.cos(rad),
+      y1: cy + outerR * Math.sin(rad),
+      x2: cx + innerR * Math.cos(rad),
+      y2: cy + innerR * Math.sin(rad),
+      isCardinal,
+      isMajor,
+    };
+  });
+
+  const cardinals = [
+    { angle: 0, label: 'N' },
+    { angle: 90, label: 'E' },
+    { angle: 180, label: 'S' },
+    { angle: 270, label: 'W' },
+  ];
+
+  return (
+    <svg
+      viewBox="0 0 400 400"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden="true"
+      style={{ width: '100%', height: '100%' }}
+    >
+      <circle cx={cx} cy={cy} r={outerR} fill="none" stroke="#f5a623" strokeWidth="1.5" />
+      <circle cx={cx} cy={cy} r={130} fill="none" stroke="#f5a623" strokeWidth="0.75" />
+      <circle cx={cx} cy={cy} r={68} fill="none" stroke="#f5a623" strokeWidth="0.5" />
+      {ticks.map(({ x1, y1, x2, y2, isCardinal, isMajor }, i) => (
+        <line
+          key={i}
+          x1={x1} y1={y1} x2={x2} y2={y2}
+          stroke="#f5a623"
+          strokeWidth={isCardinal ? 2 : isMajor ? 1.2 : 0.6}
+        />
+      ))}
+      {cardinals.map(({ angle, label }) => {
+        const rad = ((angle - 90) * Math.PI) / 180;
+        const r = 113;
+        return (
+          <text
+            key={label}
+            x={cx + r * Math.cos(rad)}
+            y={cy + r * Math.sin(rad)}
+            textAnchor="middle"
+            dominantBaseline="central"
+            fill="#f5a623"
+            fontSize="20"
+            fontWeight="700"
+            fontFamily="monospace"
+          >
+            {label}
+          </text>
+        );
+      })}
+      <line x1={cx} y1={cy - 58} x2={cx} y2={cy + 58} stroke="#f5a623" strokeWidth="0.5" />
+      <line x1={cx - 58} y1={cy} x2={cx + 58} y2={cy} stroke="#f5a623" strokeWidth="0.5" />
+      <circle cx={cx} cy={cy} r={4} fill="#f5a623" />
+    </svg>
+  );
+}

--- a/web-app/src/pages/Home.tsx
+++ b/web-app/src/pages/Home.tsx
@@ -8,6 +8,7 @@ import Container from '@mui/material/Container';
 import LinearProgress from '@mui/material/LinearProgress';
 import Typography from '@mui/material/Typography';
 
+import HeroMotif from '../components/HeroMotif';
 import { CURRICULUM, TOPIC_LABELS, TOPICS } from '../lib/curriculum';
 import { getAllLessons } from '../lib/lesson-loader';
 import { useProgress } from '../lib/progress';
@@ -34,14 +35,29 @@ export default function Home() {
   return (
     <>
       {/* Hero — full-width, above fold on 375 px mobile */}
-      <Box sx={{ pt: { xs: 6, md: 10 }, pb: { xs: 4, md: 6 } }}>
-        <Container maxWidth="lg">
+      <Box sx={{ position: 'relative', overflow: 'hidden', pt: { xs: 6, md: 10 }, pb: { xs: 4, md: 6 } }}>
+        {/* Heading-rose motif — decorative background */}
+        <Box
+          sx={{
+            position: 'absolute',
+            top: '50%',
+            right: { xs: '-10%', md: '2%' },
+            transform: 'translateY(-50%)',
+            width: { xs: 280, md: 420 },
+            height: { xs: 280, md: 420 },
+            opacity: 0.08,
+            pointerEvents: 'none',
+          }}
+        >
+          <HeroMotif />
+        </Box>
+        <Container maxWidth="lg" sx={{ position: 'relative' }}>
           <Typography
             variant="h3"
             component="h1"
             sx={{ fontWeight: 700, mb: 2, lineHeight: 1.2, fontSize: { xs: '1.875rem', md: '3rem' } }}
           >
-            Study for the Canadian PPL written exam, 20 minutes a day
+            Pass the Canadian PPL written exam — 20 minutes a day
           </Typography>
           <Typography
             variant="subtitle1"
@@ -49,7 +65,7 @@ export default function Home() {
             color="text.secondary"
             sx={{ mb: 3, maxWidth: 560 }}
           >
-            Structured lessons aligned to the Transport Canada PPL Aeroplane Written Exam syllabus.
+            Structured lessons covering PSTAR and the full Transport Canada PPL syllabus.
           </Typography>
           <Button
             component={RouterLink}
@@ -67,9 +83,9 @@ export default function Home() {
       <Box sx={{ bgcolor: 'background.paper', py: 2 }}>
         <Container maxWidth="lg">
           <Box sx={{ display: 'flex', gap: { xs: 2, md: 4 }, flexWrap: 'wrap', justifyContent: 'center' }}>
-            <Typography variant="body2" color="text.secondary">Transport Canada syllabus</Typography>
-            <Typography variant="body2" color="text.secondary">60 structured lessons</Typography>
-            <Typography variant="body2" color="text.secondary">Target 80%+ pass rate</Typography>
+            <Typography variant="body2" color="text.secondary">Covers PSTAR &amp; PPL written exam</Typography>
+            <Typography variant="body2" color="text.secondary">Transport Canada syllabus aligned</Typography>
+            <Typography variant="body2" color="text.secondary">Target 80%+ on your written</Typography>
           </Box>
         </Container>
       </Box>


### PR DESCRIPTION
Closes #62

## Summary
- Adds inline heading-rose SVG motif (extracted to `HeroMotif.tsx`) positioned absolutely in the hero `Box` with `opacity: 0.08`, using only theme colours `#0a1628`/`#0d1f3c`/`#f5a623`
- Tightens headline to 10 words: *"Pass the Canadian PPL written exam — 20 minutes a day"*
- Tightens subtitle to 11 words referencing PSTAR and Transport Canada syllabus
- Rewrites credibility strip to explicitly name PSTAR and Transport Canada syllabus

## Test plan
- [ ] `npm run build` passes with no TS errors (verified)
- [ ] Hero fits above fold on 375×667 (motif is `position:absolute`, overflow hidden, CTA unrestricted)
- [ ] `hasProgress` section and topic cards unchanged
- [ ] No new npm packages introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)