### PR TITLE
[PPL-60] Replace hamburger/drawer with BottomNavigation on mobile

### DIFF
--- a/web-app/src/App.tsx
+++ b/web-app/src/App.tsx
@@ -1,5 +1,5 @@
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
-import { ThemeProvider, CssBaseline } from '@mui/material';
+import { ThemeProvider, CssBaseline, Box } from '@mui/material';
 import theme from './theme';
 import Nav from './components/Nav';
 import Home from './pages/Home';
@@ -14,13 +14,15 @@ export default function App() {
       <CssBaseline />
       <BrowserRouter>
         <Nav />
-        <Routes>
-          <Route path="/" element={<Home />} />
-          <Route path="/lessons" element={<LessonsIndex />} />
-          <Route path="/lessons/:topic/:slug" element={<LessonDetail />} />
-          <Route path="/exam" element={<Exam />} />
-          <Route path="/plan" element={<Plan />} />
-        </Routes>
+        <Box sx={{ pb: { xs: 7, sm: 7, md: 0 } }}>
+          <Routes>
+            <Route path="/" element={<Home />} />
+            <Route path="/lessons" element={<LessonsIndex />} />
+            <Route path="/lessons/:topic/:slug" element={<LessonDetail />} />
+            <Route path="/exam" element={<Exam />} />
+            <Route path="/plan" element={<Plan />} />
+          </Routes>
+        </Box>
       </BrowserRouter>
     </ThemeProvider>
   );

--- a/web-app/src/components/Nav.tsx
+++ b/web-app/src/components/Nav.tsx
@@ -1,73 +1,87 @@
-import { useState } from 'react';
+import BottomNavigation from '@mui/material/BottomNavigation';
+import BottomNavigationAction from '@mui/material/BottomNavigationAction';
 import AppBar from '@mui/material/AppBar';
-import Drawer from '@mui/material/Drawer';
-import IconButton from '@mui/material/IconButton';
-import List from '@mui/material/List';
-import ListItemButton from '@mui/material/ListItemButton';
-import ListItemText from '@mui/material/ListItemText';
+import Paper from '@mui/material/Paper';
 import Toolbar from '@mui/material/Toolbar';
 import Typography from '@mui/material/Typography';
 import Button from '@mui/material/Button';
 import useMediaQuery from '@mui/material/useMediaQuery';
 import { useTheme } from '@mui/material/styles';
-import MenuIcon from '@mui/icons-material/Menu';
-import { Link as RouterLink } from 'react-router-dom';
+import HomeIcon from '@mui/icons-material/Home';
+import MenuBookIcon from '@mui/icons-material/MenuBook';
+import QuizIcon from '@mui/icons-material/Quiz';
+import MapIcon from '@mui/icons-material/Map';
+import { Link as RouterLink, useLocation, useNavigate } from 'react-router-dom';
 
 const NAV_LINKS = [
-  { label: 'Home', to: '/' },
-  { label: 'Browse Lessons', to: '/lessons' },
-  { label: 'Practice Exam', to: '/exam' },
-  { label: 'Study Plan', to: '/plan' },
+  { label: 'Home', shortLabel: 'Home', to: '/', icon: <HomeIcon /> },
+  { label: 'Browse Lessons', shortLabel: 'Browse', to: '/lessons', icon: <MenuBookIcon /> },
+  { label: 'Practice Exam', shortLabel: 'Exam', to: '/exam', icon: <QuizIcon /> },
+  { label: 'Study Plan', shortLabel: 'Plan', to: '/plan', icon: <MapIcon /> },
 ];
+
+function isActiveRoute(pathname: string, to: string): boolean {
+  return to === '/' ? pathname === '/' : pathname === to || pathname.startsWith(to + '/');
+}
 
 export default function Nav() {
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
-  const [drawerOpen, setDrawerOpen] = useState(false);
+  const location = useLocation();
+  const navigate = useNavigate();
+
+  const activeIndex = NAV_LINKS.findIndex(({ to }) => isActiveRoute(location.pathname, to));
 
   return (
-    <AppBar position="static" sx={{ backgroundColor: 'background.default' }}>
-      <Toolbar>
-        <Typography variant="h6" sx={{ flexGrow: 1, color: 'primary.main', fontWeight: 700 }}>
-          PPL Study
-        </Typography>
-        {isMobile ? (
-          <>
-            <IconButton
-              color="inherit"
-              onClick={() => setDrawerOpen(true)}
-              aria-label="open navigation menu"
-            >
-              <MenuIcon />
-            </IconButton>
-            <Drawer
-              anchor="right"
-              open={drawerOpen}
-              onClose={() => setDrawerOpen(false)}
-              PaperProps={{ sx: { backgroundColor: 'background.surfaceRaised', minWidth: 200 } }}
-            >
-              <List>
-                {NAV_LINKS.map(({ label, to }) => (
-                  <ListItemButton
-                    key={to}
-                    component={RouterLink}
-                    to={to}
-                    onClick={() => setDrawerOpen(false)}
-                  >
-                    <ListItemText primary={label} sx={{ color: 'text.primary' }} />
-                  </ListItemButton>
-                ))}
-              </List>
-            </Drawer>
-          </>
-        ) : (
-          NAV_LINKS.map(({ label, to }) => (
-            <Button key={to} component={RouterLink} to={to} color="inherit">
-              {label}
-            </Button>
-          ))
-        )}
-      </Toolbar>
-    </AppBar>
+    <>
+      <AppBar position="static" sx={{ backgroundColor: 'background.default' }}>
+        <Toolbar>
+          <Typography variant="h6" sx={{ flexGrow: 1, color: 'primary.main', fontWeight: 700 }}>
+            PPL Study
+          </Typography>
+          {!isMobile &&
+            NAV_LINKS.map(({ label, to }) => {
+              const active = isActiveRoute(location.pathname, to);
+              return (
+                <Button
+                  key={to}
+                  component={RouterLink}
+                  to={to}
+                  sx={{
+                    color: active ? 'primary.main' : 'inherit',
+                    borderBottom: '2px solid',
+                    borderBottomColor: active ? 'primary.main' : 'transparent',
+                    borderRadius: 0,
+                  }}
+                >
+                  {label}
+                </Button>
+              );
+            })}
+        </Toolbar>
+      </AppBar>
+      {isMobile && (
+        <Paper
+          elevation={3}
+          sx={{
+            position: 'fixed',
+            bottom: 0,
+            left: 0,
+            right: 0,
+            zIndex: theme.zIndex.appBar,
+            pb: 'env(safe-area-inset-bottom)',
+          }}
+        >
+          <BottomNavigation
+            value={activeIndex}
+            onChange={(_, newValue: number) => navigate(NAV_LINKS[newValue].to)}
+          >
+            {NAV_LINKS.map(({ shortLabel, icon }) => (
+              <BottomNavigationAction key={shortLabel} label={shortLabel} icon={icon} />
+            ))}
+          </BottomNavigation>
+        </Paper>
+      )}
+    </>
   );
 }


### PR DESCRIPTION
## Summary
- Mobile (`isMobile`): replaces hamburger + Drawer with fixed MUI `BottomNavigation` (Home/Browse/Exam/Plan) using `@mui/icons-material` icons, with `paddingBottom: env(safe-area-inset-bottom)` and `zIndex: theme.zIndex.appBar`
- Desktop: adds `useLocation`-based active-route styling — `primary.main` color + 2px bottom border on the matching nav `Button`
- `App.tsx`: wraps `<Routes>` in `<Box sx={{ pb: { xs: 7, sm: 7, md: 0 } }}>` to prevent content from being hidden behind the bottom nav
- Zero hex literals in `Nav.tsx`

## Test plan
- [ ] Mobile viewport: BottomNavigation visible at bottom, tapping each item navigates correctly
- [ ] Desktop viewport: active nav button shows amber color + bottom border matching current route
- [ ] iOS/Safari: safe-area-inset-bottom respected so nav doesn't overlap home indicator
- [ ] `npm run build` passes with no TypeScript errors

Closes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)