### PR TITLE
[PPL-60] Modernize nav: mobile bottom nav + desktop active indicator

### DIFF
--- a/web-app/src/App.tsx
+++ b/web-app/src/App.tsx
@@ -1,5 +1,5 @@
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
-import { ThemeProvider, CssBaseline } from '@mui/material';
+import { ThemeProvider, CssBaseline, Box } from '@mui/material';
 import theme from './theme';
 import Nav from './components/Nav';
 import Home from './pages/Home';
@@ -14,13 +14,15 @@ export default function App() {
       <CssBaseline />
       <BrowserRouter>
         <Nav />
-        <Routes>
-          <Route path="/" element={<Home />} />
-          <Route path="/lessons" element={<LessonsIndex />} />
-          <Route path="/lessons/:topic/:slug" element={<LessonDetail />} />
-          <Route path="/exam" element={<Exam />} />
-          <Route path="/plan" element={<Plan />} />
-        </Routes>
+        <Box sx={{ pb: { xs: 7, sm: 7, md: 0 } }}>
+          <Routes>
+            <Route path="/" element={<Home />} />
+            <Route path="/lessons" element={<LessonsIndex />} />
+            <Route path="/lessons/:topic/:slug" element={<LessonDetail />} />
+            <Route path="/exam" element={<Exam />} />
+            <Route path="/plan" element={<Plan />} />
+          </Routes>
+        </Box>
       </BrowserRouter>
     </ThemeProvider>
   );

--- a/web-app/src/components/Nav.tsx
+++ b/web-app/src/components/Nav.tsx
@@ -1,73 +1,94 @@
-import { useState } from 'react';
+import BottomNavigation from '@mui/material/BottomNavigation';
+import BottomNavigationAction from '@mui/material/BottomNavigationAction';
 import AppBar from '@mui/material/AppBar';
-import Drawer from '@mui/material/Drawer';
-import IconButton from '@mui/material/IconButton';
-import List from '@mui/material/List';
-import ListItemButton from '@mui/material/ListItemButton';
-import ListItemText from '@mui/material/ListItemText';
+import Paper from '@mui/material/Paper';
 import Toolbar from '@mui/material/Toolbar';
 import Typography from '@mui/material/Typography';
 import Button from '@mui/material/Button';
 import useMediaQuery from '@mui/material/useMediaQuery';
 import { useTheme } from '@mui/material/styles';
-import MenuIcon from '@mui/icons-material/Menu';
-import { Link as RouterLink } from 'react-router-dom';
+import HomeIcon from '@mui/icons-material/Home';
+import MenuBookIcon from '@mui/icons-material/MenuBook';
+import QuizIcon from '@mui/icons-material/Quiz';
+import ChecklistIcon from '@mui/icons-material/Checklist';
+import { Link as RouterLink, useLocation, useNavigate } from 'react-router-dom';
 
 const NAV_LINKS = [
-  { label: 'Home', to: '/' },
-  { label: 'Browse Lessons', to: '/lessons' },
-  { label: 'Practice Exam', to: '/exam' },
-  { label: 'Study Plan', to: '/plan' },
+  { label: 'Home', to: '/', icon: <HomeIcon /> },
+  { label: 'Browse Lessons', to: '/lessons', icon: <MenuBookIcon /> },
+  { label: 'Practice Exam', to: '/exam', icon: <QuizIcon /> },
+  { label: 'Study Plan', to: '/plan', icon: <ChecklistIcon /> },
 ];
+
+const BOTTOM_NAV_LABELS = ['Home', 'Browse', 'Exam', 'Plan'];
+
+function isActiveRoute(pathname: string, to: string): boolean {
+  return to === '/' ? pathname === '/' : pathname === to || pathname.startsWith(to + '/');
+}
 
 export default function Nav() {
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
-  const [drawerOpen, setDrawerOpen] = useState(false);
+  const location = useLocation();
+  const navigate = useNavigate();
+
+  const activeIndex = NAV_LINKS.findIndex(({ to }) => isActiveRoute(location.pathname, to));
 
   return (
-    <AppBar position="static" sx={{ backgroundColor: 'background.default' }}>
-      <Toolbar>
-        <Typography variant="h6" sx={{ flexGrow: 1, color: 'primary.main', fontWeight: 700 }}>
-          PPL Study
-        </Typography>
-        {isMobile ? (
-          <>
-            <IconButton
-              color="inherit"
-              onClick={() => setDrawerOpen(true)}
-              aria-label="open navigation menu"
-            >
-              <MenuIcon />
-            </IconButton>
-            <Drawer
-              anchor="right"
-              open={drawerOpen}
-              onClose={() => setDrawerOpen(false)}
-              PaperProps={{ sx: { backgroundColor: 'background.surfaceRaised', minWidth: 200 } }}
-            >
-              <List>
-                {NAV_LINKS.map(({ label, to }) => (
-                  <ListItemButton
-                    key={to}
-                    component={RouterLink}
-                    to={to}
-                    onClick={() => setDrawerOpen(false)}
-                  >
-                    <ListItemText primary={label} sx={{ color: 'text.primary' }} />
-                  </ListItemButton>
-                ))}
-              </List>
-            </Drawer>
-          </>
-        ) : (
-          NAV_LINKS.map(({ label, to }) => (
-            <Button key={to} component={RouterLink} to={to} color="inherit">
-              {label}
-            </Button>
-          ))
-        )}
-      </Toolbar>
-    </AppBar>
+    <>
+      <AppBar position="static" sx={{ backgroundColor: 'background.default' }}>
+        <Toolbar>
+          <Typography variant="h6" sx={{ flexGrow: 1, color: 'primary.main', fontWeight: 700 }}>
+            PPL Study
+          </Typography>
+          {!isMobile &&
+            NAV_LINKS.map(({ label, to }) => {
+              const active = isActiveRoute(location.pathname, to);
+              return (
+                <Button
+                  key={to}
+                  component={RouterLink}
+                  to={to}
+                  color="inherit"
+                  sx={
+                    active
+                      ? {
+                          color: 'primary.main',
+                          borderBottom: '2px solid',
+                          borderBottomColor: 'primary.main',
+                          borderRadius: 0,
+                        }
+                      : { borderRadius: 0 }
+                  }
+                >
+                  {label}
+                </Button>
+              );
+            })}
+        </Toolbar>
+      </AppBar>
+      {isMobile && (
+        <Paper
+          elevation={3}
+          sx={{
+            position: 'fixed',
+            bottom: 0,
+            left: 0,
+            right: 0,
+            zIndex: theme.zIndex.appBar,
+            pb: 'env(safe-area-inset-bottom)',
+          }}
+        >
+          <BottomNavigation
+            value={activeIndex}
+            onChange={(_, newValue: number) => navigate(NAV_LINKS[newValue].to)}
+          >
+            {NAV_LINKS.map(({ icon }, i) => (
+              <BottomNavigationAction key={NAV_LINKS[i].to} label={BOTTOM_NAV_LABELS[i]} icon={icon} />
+            ))}
+          </BottomNavigation>
+        </Paper>
+      )}
+    </>
   );
 }

--- a/web-app/src/components/Nav.tsx
+++ b/web-app/src/components/Nav.tsx
@@ -55,10 +55,10 @@ export default function Nav() {
                       ? {
                           color: 'primary.main',
                           borderBottom: '2px solid',
-                          borderBottomColor: 'primary.main',
+                          borderColor: 'primary.main',
                           borderRadius: 0,
                         }
-                      : { borderRadius: 0 }
+                      : undefined
                   }
                 >
                   {label}


### PR DESCRIPTION
Closes #60

## Changes
- **Mobile**: replaces hamburger + Drawer with fixed MUI `BottomNavigation` (Home/Browse/Exam/Plan) using HomeIcon, MenuBookIcon, QuizIcon, ChecklistIcon; positioned `fixed` at bottom with `zIndex: theme.zIndex.appBar` and `paddingBottom: env(safe-area-inset-bottom)`
- **Desktop**: `useLocation`-based active-route detection; active `Button` gets `sx={{ color: 'primary.main', borderBottom: '2px solid', borderColor: 'primary.main', borderRadius: 0 }}`
- **Theme tokens**: all hex literals removed — `background.default`, `primary.main`, `background.paper`, `text.primary`, `color="inherit"` used throughout
- **App.tsx**: `<Routes>` wrapped in `<Box sx={{ pb: { xs: 7, sm: 7, md: 0 } }}>` to prevent content overlap with bottom nav

## Test Plan
- [ ] Mobile viewport: BottomNavigation visible at bottom; tapping each item navigates correctly
- [ ] Desktop viewport: active nav button shows primary color + 2px bottom border
- [ ] iOS Safari: `env(safe-area-inset-bottom)` respected so nav clears home indicator
- [ ] `npm run build` passes with zero TypeScript errors
- [ ] `grep '#[0-9a-fA-F]' web-app/src/components/Nav.tsx` returns zero matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)