### PR TITLE
[PPL-48] Lesson reading standards for mobile + desktop

### DIFF
--- a/web-app/src/theme.ts
+++ b/web-app/src/theme.ts
@@ -46,6 +46,9 @@ const theme = createTheme({
       [breakpoints.down('md')]: { fontSize: '1.25rem' },
       [breakpoints.down('sm')]: { fontSize: '1.125rem' },
     },
+    h6: {
+      [breakpoints.down('sm')]: { fontSize: '1rem' },
+    },
   },
   components: {
     MuiButton: {


### PR DESCRIPTION
Closes #48

## Changes
- **theme.ts**: Added `body1.lineHeight: 1.75`; responsive `fontSize` for h3 (xs: 1.375rem, md: 1.875rem), h4 (xs: 1.25rem, md: 1.5rem), h5 (xs: 1.125rem, md: 1.25rem), h6 (xs: 1rem) via `createTheme()` breakpoints pre-extraction.
- **LessonDetail.tsx**: Both Container instances updated to `maxWidth={false}` with `sx={{ maxWidth: 700, mx: 'auto', px: { xs: 2, sm: 3 } }}`; mdOptions.overrides extended with `code` (monospace, rgba(255,255,255,0.08) bg), `pre` (background.paper, overflowX auto), `blockquote` (3px primary.main left border, text.secondary); h2 mt:4, h3 mt:3.

## Test Plan
- [ ] `npm run build` passes with zero TypeScript errors ✓
- [ ] 375px: headings step down in size, reading column within viewport, no horizontal scroll
- [ ] 1280px: reading column capped at ~700px centred
- [ ] Inline code chip, pre block scrolling, blockquote amber border all render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)