### PR TITLE
[PPL-49] Populate SOURCE_URLS with TC/Justice Laws links

### DIFF
--- a/web-app/src/lib/sources.ts
+++ b/web-app/src/lib/sources.ts
@@ -2,8 +2,6 @@ export const SOURCE_URLS: Record<string, string> = {
   'CARs Part VI': 'https://laws-lois.justice.gc.ca/eng/regulations/SOR-96-433/',
   'CARs 602.114-602.117': 'https://laws-lois.justice.gc.ca/eng/regulations/SOR-96-433/section-602.114.html',
   'TP 12880E': 'https://tc.canada.ca/en/aviation/publications/study-reference-guide-written-examinations-private-pilot-licence-aeroplane-tp-12880',
-  'TP 9994': '',
   'TP 13014': 'https://tc.canada.ca/en/aviation/publications/civil-aviation-sample-examination-recreational-pilot-permit-private-pilot-licence-aeroplane-tp-13014',
   'AIM RAC 2.0': 'https://tc.canada.ca/en/aviation/publications/transport-canada-aeronautical-information-manual-tc-aim-tp-14371',
-  'VNC Chart Legend': '',
 };


### PR DESCRIPTION
Closes #49

## Changes
- `web-app/src/lib/sources.ts`: remove `'TP 9994'` and `'VNC Chart Legend'` keys entirely (no stable public URL on `tc.canada.ca`, `laws-lois.justice.gc.ca`, or `navcanada.ca`) — `SourceList` tooltip fallback fires for unknown keys, same user-facing behaviour as `''` but cleaner.
- All other keys already have verified HTTPS URLs from prior work (PR #65): `CARs Part VI`, `CARs 602.114-602.117` (section anchor), `TP 12880E`, `TP 13014`, `AIM RAC 2.0`.

## Test plan
- [ ] Load a lesson with `TP 9994` or `VNC Chart Legend` in sources — chip shows tooltip "No public link"
- [ ] Load a lesson with `CARs 602.114-602.117` — chip opens Justice Laws section anchor in new tab
- [ ] Load a lesson with `TP 12880E`, `TP 13014`, `AIM RAC 2.0` — chips open correct tc.canada.ca pages
- [ ] `npm run build` passes with zero TypeScript errors