### PR TITLE
[PPL-79] Add Air Law lessons AL-004 through AL-008

### DIFF
--- a/lessons/air-law/004-altimeter-settings.md
+++ b/lessons/air-law/004-altimeter-settings.md
@@ -1,0 +1,144 @@
+---
+id: AL-004
+topic: air-law
+order: 4
+slug: altimeter-settings
+title: "Altimeter Settings"
+duration_min: 20
+status: published
+audio: null
+visual: null
+sources:
+  - CARs 602.35
+  - TP 12880E
+  - AIM RAC 9.11
+questions:
+  - id: q1
+    prompt: "Below the transition altitude in Canada, a VFR pilot should set the altimeter to:"
+    choices:
+      A: "29.92 inHg (standard pressure)"
+      B: "The current QNH reported by ATC or ATIS for the nearest station"
+      C: "The field elevation of the departure aerodrome"
+      D: "Zero, so the altimeter reads height above ground"
+    answer: B
+    explanation: "Below the transition altitude (18,000 feet ASL in Canada), pilots set QNH — the current local altimeter setting corrected to sea level. This makes the altimeter read altitude ASL. Standard pressure (29.92 inHg / QNE) is used at and above the transition altitude. Source: CARs 602.35, TP 12880E Chapter 8."
+  - id: q2
+    prompt: "What is the transition altitude in Canada?"
+    choices:
+      A: "12,500 feet ASL"
+      B: "14,000 feet ASL"
+      C: "18,000 feet ASL"
+      D: "10,000 feet ASL"
+    answer: C
+    explanation: "Canada's transition altitude is 18,000 feet ASL — the same altitude at which Class A airspace begins. At and above this level, all aircraft set their altimeters to standard pressure (29.92 inHg / 1013.25 hPa) and altimeter readings are called flight levels. Source: CARs 602.35, TP 12880E Chapter 8."
+  - id: q3
+    prompt: "A pilot sets the altimeter to 29.92 inHg (1013.25 hPa). This is known as:"
+    choices:
+      A: "QNH"
+      B: "QFE"
+      C: "QNE"
+      D: "QTE"
+    answer: C
+    explanation: "QNE is the ICAO Q-code for the standard pressure setting of 29.92 inHg (1013.25 hPa). When using QNE the altimeter reads pressure altitude, which is expressed as a flight level (e.g., FL180 = 18,000 feet on standard pressure). Used in Canada at and above 18,000 feet ASL. Source: CARs 602.35, AIM RAC 9.11."
+  - id: q4
+    prompt: "What does an altimeter set to QFE indicate to the pilot?"
+    choices:
+      A: "Altitude above sea level based on standard pressure"
+      B: "Altitude above sea level based on current local pressure"
+      C: "Height above the aerodrome reference elevation"
+      D: "True altitude corrected for non-standard temperature"
+    answer: C
+    explanation: "QFE is the station pressure at aerodrome elevation. When the altimeter is set to QFE, it reads zero on the runway and indicates height above the aerodrome. QFE is rarely used in Canadian civil operations but may appear on PPL written exam questions. Source: AIM RAC 9.11, TP 12880E Chapter 8."
+  - id: q5
+    prompt: "You are cruising at 8,500 feet ASL and receive an updated altimeter setting of 29.74 inHg from ATC. Your altimeter was previously set to 29.92 inHg. After resetting, your indicated altitude will:"
+    choices:
+      A: "Increase, because the new setting is higher"
+      B: "Decrease, because the new setting is lower than standard"
+      C: "Remain the same — altimeter setting does not change indicated altitude"
+      D: "Increase temporarily, then return to 8,500 feet"
+    answer: B
+    explanation: "Pressure is lower than standard (29.74 vs 29.92), so resetting will cause the indicated altitude to decrease. A lower altimeter setting means the air pressure at your location is lower than you had set — the altimeter adjusts down. The rule: high to low, look out below. If you fly into lower pressure without resetting, your true altitude is lower than indicated. Source: CARs 602.35, TP 12880E Chapter 8."
+---
+
+# Lesson AL-004: Altimeter Settings
+
+**Section:** Air Law  
+**Lesson number:** 004  
+**Estimated time:** 20 minutes  
+**Source:** CARs 602.35, TP 12880E Chapter 8, AIM RAC 9.11
+
+---
+
+## Narration Script
+
+Welcome to Lesson AL-004. Today we cover altimeter settings — a topic that spans Air Law, navigation, and general knowledge. Understand this well and you'll have an edge on questions throughout the exam.
+
+---
+
+**Why the Altimeter Needs a Setting**
+
+An altimeter works by measuring atmospheric pressure. As altitude increases, pressure decreases. The altimeter converts pressure into an altitude reading — but that conversion depends on knowing the reference pressure at sea level. If you just used a fixed reference, your altitude reading would be wrong whenever actual sea level pressure differed from that reference.
+
+That's why pilots set an altimeter. By dialling in the current sea level pressure at a nearby station, the altimeter gives you a reading that accurately represents your altitude above sea level — regardless of what the weather is doing.
+
+---
+
+**Q-Codes: QNH, QNE, QFE**
+
+Aviation inherited a set of three-letter Q-codes from radiotelegraphy. Three of them describe altimeter settings.
+
+**QNH** — This is the setting you use most often. QNH is the current sea level pressure at the nearest reporting station, corrected for temperature and altitude. When you set QNH, your altimeter reads altitude above sea level (ASL). Below the transition altitude in Canada — below 18,000 feet ASL — you must use QNH. ATC will give you an altimeter setting when you call them, and it's also in the ATIS broadcast at controlled aerodromes.
+
+**QNE** — This is standard pressure: 29.92 inHg, or 1013.25 hPa in millibars. When you set QNE, your altimeter reads pressure altitude, not true altitude above sea level. At and above the transition altitude (18,000 feet ASL in Canada), all aircraft — IFR and VFR — must use QNE. Readings are then expressed as flight levels: FL180, FL200, FL240. A flight level is the QNE altitude divided by 100. FL180 means 18,000 feet on standard pressure.
+
+**QFE** — QFE is the pressure at the aerodrome reference point. Set QFE, and the altimeter reads zero on the runway and shows height above the aerodrome. QFE is rarely used in Canadian civil operations, but it appears in training documents and on exam questions, so know the definition.
+
+---
+
+**Transition Altitude**
+
+Canada's transition altitude is 18,000 feet ASL. This is where Class A airspace begins. At and above 18,000 feet ASL, all pilots switch to standard pressure (QNE = 29.92 inHg). Below 18,000 feet ASL, use QNH from the nearest reporting station.
+
+The logic behind a transition altitude is standardization. At high altitudes where multiple aircraft share the same airspace, everyone using standard pressure means altitudes are comparable. Two aircraft assigned FL200 and FL220 are separated by 2,000 feet of pressure altitude regardless of the local weather. This makes ATC separation reliable.
+
+---
+
+**The "High to Low, Look Out Below" Rule**
+
+When you fly from a high pressure area into a lower pressure area without updating your altimeter, your indicated altitude will be higher than your true altitude. The altimeter thinks you're higher than you are — which means the ground is closer than you realize. This is especially dangerous over high terrain.
+
+The memory phrase: **high to low, look out below**. Flying into lower pressure = your true altitude is lower than indicated. Always update your altimeter with the current setting when crossing into a new region with different pressure.
+
+The reverse is also true: flying from low to high pressure, your true altitude is slightly above what the altimeter indicates — that's a safer error direction, but you should still update regularly.
+
+---
+
+**Practical Altimeter Setting Procedures**
+
+Before departure, set your altimeter to the current QNH. Most controlled aerodromes broadcast this on ATIS (Automated Terminal Information Service). You can also get it from ATC ground control or clearance delivery.
+
+In flight, update your altimeter setting when ATC passes you a new one, or at least every 100 nautical miles if you don't receive an update. When climbing through 18,000 feet ASL into Class A (for IFR aircraft), switch to 29.92 inHg (QNE).
+
+For VFR pilots in Canada, you'll stay well below the transition altitude — but you'll be tested on what happens up there.
+
+---
+
+**Common Exam Errors**
+
+Students sometimes confuse QNH and QNE. Remember: QNH is the current local setting, changes constantly, and gives altitude ASL. QNE is fixed at 29.92, used above 18,000 feet, and gives pressure altitude in flight levels.
+
+Another trap: the question may ask what happens to indicated altitude when you increase or decrease the altimeter setting. Increasing the setting (turning the Kollsman knob to a higher number) increases the indicated altitude. Decreasing the setting decreases the indicated altitude.
+
+---
+
+## Quick Reference Table
+
+| Code | Setting | Reads | Used When |
+|------|---------|-------|-----------|
+| QNH | Current local sea-level pressure | Altitude ASL | Below 18,000 ft ASL (transition altitude) |
+| QNE | Standard pressure — 29.92 inHg / 1013.25 hPa | Pressure altitude (Flight Levels) | At or above 18,000 ft ASL |
+| QFE | Pressure at aerodrome elevation | Height above aerodrome | Rarely used in Canadian civil ops |
+
+---
+
+*End of Lesson AL-004.*

--- a/lessons/air-law/005-right-of-way-rules.md
+++ b/lessons/air-law/005-right-of-way-rules.md
@@ -1,0 +1,182 @@
+---
+id: AL-005
+topic: air-law
+order: 5
+slug: right-of-way-rules
+title: "Right-of-Way Rules"
+duration_min: 20
+status: published
+audio: null
+visual: null
+sources:
+  - CARs 602.19
+  - CARs 602.20
+  - CARs 602.21
+  - TP 12880E
+questions:
+  - id: q1
+    prompt: "Two powered aircraft are converging at the same altitude. Aircraft A is to the left of Aircraft B, and they are on a collision course. Who must give way?"
+    choices:
+      A: "Aircraft A, because it is on the left"
+      B: "Aircraft B, because it is on the right"
+      C: "The faster aircraft"
+      D: "The aircraft in controlled airspace"
+    answer: A
+    explanation: "When two aircraft are converging at the same altitude, the aircraft that has the other on its right must give way. Aircraft A sees Aircraft B on its right — Aircraft A is the give-way aircraft. Aircraft B sees Aircraft A on its left and holds course. Source: CARs 602.19(2)."
+  - id: q2
+    prompt: "A glider and a powered aircraft are both approaching an aerodrome to land. Which aircraft has the right of way?"
+    choices:
+      A: "The powered aircraft, because it has an engine and can manoeuvre more quickly"
+      B: "The glider, because unpowered aircraft take priority over powered aircraft"
+      C: "Whichever aircraft is lower"
+      D: "Whichever aircraft called in first on CTAF"
+    answer: B
+    explanation: "Unpowered aircraft — gliders, balloons, and airships — take priority over powered aircraft in the right-of-way hierarchy. The pilot of the powered aircraft must give way to the glider. Source: CARs 602.19(1), TP 12880E."
+  - id: q3
+    prompt: "You are overtaking another aircraft from behind. Which direction should you pass, and who yields?"
+    choices:
+      A: "Pass to the left; the aircraft being overtaken yields"
+      B: "Pass to the right; you as the overtaking aircraft yield"
+      C: "Pass to the left; you as the overtaking aircraft yield"
+      D: "Pass either side; both aircraft yield equally"
+    answer: B
+    explanation: "An overtaking aircraft must pass to the right of the aircraft being overtaken, and the overtaking aircraft has the obligation to keep clear. The aircraft being overtaken has right of way and should maintain its heading and speed. Source: CARs 602.21, TP 12880E."
+  - id: q4
+    prompt: "Two aircraft are approaching head-on and a collision risk exists. Both pilots should:"
+    choices:
+      A: "The higher aircraft climbs; the lower aircraft descends"
+      B: "Both aircraft turn right"
+      C: "The aircraft on the right turns right; the aircraft on the left turns left"
+      D: "Both aircraft slow down and wait for ATC instructions"
+    answer: B
+    explanation: "When aircraft are approaching head-on and there is a risk of collision, both pilots must turn right. This ensures both aircraft turn away from each other in the same direction, creating separation. Source: CARs 602.20, TP 12880E."
+  - id: q5
+    prompt: "An aircraft is on final approach to land at an aerodrome. A second aircraft is taxiing on the runway. Who has the right of way?"
+    choices:
+      A: "The taxiing aircraft, because it is already on the aerodrome surface"
+      B: "The landing aircraft, because aircraft on approach have priority over aircraft on the ground"
+      C: "Neither — both must hold position until ATC resolves the conflict"
+      D: "The aircraft with the higher gross weight"
+    answer: B
+    explanation: "An aircraft on approach to land, or in the process of landing, has the right of way over all other aircraft in flight or on the ground. The taxiing aircraft must yield. An aircraft that is lower on approach also has priority over a higher aircraft. Source: CARs 602.19(3), TP 12880E."
+---
+
+# Lesson AL-005: Right-of-Way Rules
+
+**Section:** Air Law  
+**Lesson number:** 005  
+**Estimated time:** 20 minutes  
+**Source:** CARs 602.19–602.21, TP 12880E
+
+---
+
+## Narration Script
+
+Welcome to Lesson AL-005. Today we cover the right-of-way rules — how pilots determine who yields to whom when aircraft are on conflicting paths. These rules appear on the PPL exam in scenario questions, so understanding the hierarchy and each specific case is essential.
+
+---
+
+**Why Right-of-Way Rules Exist**
+
+Pilots are ultimately responsible for seeing and avoiding other aircraft. In uncontrolled airspace, there is no ATC issuing separation. Even in controlled airspace, ATC may not catch every conflict. The right-of-way rules provide a clear, universally known framework: when two aircraft are on a collision course, one must give way, and both pilots need to know in advance which one that is.
+
+The CARs establish these rules in sections 602.19 through 602.21. Let's walk through the key scenarios.
+
+---
+
+**The Aircraft Category Hierarchy**
+
+The first principle in CARs 602.19 is a hierarchy based on aircraft type. In a conflict between different categories of aircraft, the lower category on this list must give way to the higher one:
+
+1. Balloons (highest priority — give way to nothing)
+2. Gliders
+3. Airships
+4. Aircraft towing other aircraft or objects
+5. Powered aircraft (lowest in the hierarchy)
+
+So if you are flying a powered airplane and you see a glider on a converging course, you must give way to the glider. The glider does not manoeuvre for you. This hierarchy exists because some aircraft have much less ability to manoeuvre — a balloon cannot turn on demand, and a glider cannot add thrust.
+
+---
+
+**Converging Aircraft — Same Category**
+
+When two aircraft of the same category are converging at approximately the same altitude, the aircraft that has the other on its right must give way. This is the standard right-of-way rule for converging aircraft.
+
+Think of it this way: if you look to your right and see an aircraft that might collide with you, you are the give-way aircraft. The other pilot, who sees you on their left, has the right of way and should hold their course.
+
+This is analogous to maritime rules and road rules in many countries: give way to traffic on your right.
+
+Source: CARs 602.19(2).
+
+---
+
+**Head-On Approach**
+
+When two aircraft are approaching head-on and a collision risk exists, both aircraft must alter course to the right. Both turn right simultaneously. This creates a natural separation — each aircraft moves away from the other's path in the same direction.
+
+This rule applies when aircraft are approaching directly toward each other. Source: CARs 602.20.
+
+---
+
+**Overtaking**
+
+An aircraft that is overtaking another — approaching from behind, within 70 degrees of the other aircraft's tail — must pass to the right of the aircraft being overtaken. The overtaking aircraft yields; the aircraft being overtaken holds its course and speed.
+
+The critical point: the overtaking aircraft has the obligation to keep clear until it is well clear of the other aircraft. The aircraft being overtaken should not alter its course or speed unless it detects a conflict developing. Source: CARs 602.21.
+
+---
+
+**Landing Aircraft Priority**
+
+An aircraft that is on final approach to land or in the process of landing has the right of way over all other aircraft. This includes:
+
+- Aircraft taxiing on the aerodrome surface
+- Aircraft in flight at higher altitude
+- Aircraft that called in on CTAF before the landing aircraft
+
+An aircraft at a lower point on final approach has priority over an aircraft at a higher point. If two aircraft are both on approach at different altitudes, the lower aircraft has right of way. The higher aircraft must not attempt to overtake or cut off the lower one.
+
+Source: CARs 602.19(3).
+
+---
+
+**Emergency Aircraft**
+
+An aircraft declaring an emergency — distress (MAYDAY) or urgency (PAN-PAN) — has absolute priority over all other aircraft. All other pilots must yield and cooperate with ATC instructions to clear the way.
+
+---
+
+**The Duty to See and Avoid**
+
+Right-of-way rules determine who yields, but they do not remove the obligation of the right-of-way aircraft to avoid a collision if one is imminent. If the give-way aircraft is not manoeuvring in time, the right-of-way aircraft must take action. The goal of the rules is to avoid collisions — if following the rule results in a collision, both pilots failed.
+
+CARs 602.19 states that no person shall operate an aircraft in such proximity to another aircraft as to create a collision hazard. Right-of-way rules refine who must manoeuvre first; they do not excuse passive collision.
+
+---
+
+**Exam Pattern**
+
+On the exam, right-of-way questions usually present a scenario: two aircraft types, a specific geometry (converging, head-on, overtaking), and ask who yields. Work through each scenario in order:
+
+1. Are the aircraft in different categories? Apply the category hierarchy.
+2. Is one on approach to land? Landing aircraft has priority.
+3. Are they converging? Right-of-way goes to the aircraft on the left (the other aircraft is on its right, so it yields).
+4. Head-on? Both turn right.
+5. Overtaking? Overtaking aircraft passes right, yields.
+
+---
+
+## Quick Reference Table
+
+| Scenario | Who Gives Way |
+|----------|--------------|
+| Powered aircraft vs. glider (converging) | Powered aircraft |
+| Two powered aircraft converging | Aircraft with the other on its right gives way |
+| Head-on approach | Both turn right |
+| Overtaking | Overtaking aircraft passes right, yields |
+| Aircraft on approach to land | All others yield to the landing aircraft |
+| Emergency aircraft | All aircraft yield |
+
+---
+
+*End of Lesson AL-005.*

--- a/lessons/air-law/006-aerodrome-traffic-circuit.md
+++ b/lessons/air-law/006-aerodrome-traffic-circuit.md
@@ -1,0 +1,185 @@
+---
+id: AL-006
+topic: air-law
+order: 6
+slug: aerodrome-traffic-circuit
+title: "Aerodrome Traffic Circuit"
+duration_min: 20
+status: published
+audio: null
+visual: null
+sources:
+  - CARs 602.96
+  - CARs 602.105
+  - TP 12880E
+  - AIM RAC 4.5
+questions:
+  - id: q1
+    prompt: "In Canada, the standard aerodrome traffic circuit direction is:"
+    choices:
+      A: "Right-hand turns, unless otherwise indicated"
+      B: "Left-hand turns, unless otherwise indicated"
+      C: "Determined by the pilot-in-command based on wind"
+      D: "Clockwise when viewed from above"
+    answer: B
+    explanation: "The standard circuit in Canada uses left-hand turns on all legs. A right-hand circuit may be established at specific aerodromes and will be indicated by aerodrome markings, the CFS (Canada Flight Supplement), or a NOTAM. Source: CARs 602.96, AIM RAC 4.5."
+  - id: q2
+    prompt: "The standard circuit altitude for light aircraft at most Canadian aerodromes is:"
+    choices:
+      A: "500 feet AGL"
+      B: "800 feet AGL"
+      C: "1,000 feet AGL"
+      D: "1,500 feet AGL"
+    answer: C
+    explanation: "The standard circuit altitude for light aircraft is 1,000 feet AGL. Some aerodromes or larger aircraft use 1,500 feet AGL. Pilots should check the Canada Flight Supplement and any NOTAMs for aerodrome-specific circuit altitudes. Source: AIM RAC 4.5, TP 12880E."
+  - id: q3
+    prompt: "Which leg of the circuit runs parallel to the runway in the opposite direction of landing?"
+    choices:
+      A: "Crosswind leg"
+      B: "Base leg"
+      C: "Downwind leg"
+      D: "Upwind leg"
+    answer: C
+    explanation: "The downwind leg runs parallel to the runway in the direction opposite to landing. The aircraft is flying with the wind on its tail (or at least away from the runway). After downwind, the pilot turns onto base leg, then onto final. Source: AIM RAC 4.5, TP 12880E."
+  - id: q4
+    prompt: "You are arriving at an uncontrolled aerodrome to land. The standard joining procedure at the circuit altitude is to:"
+    choices:
+      A: "Enter directly on final approach from outside the circuit area"
+      B: "Fly over the aerodrome at circuit altitude and join the crosswind leg"
+      C: "Join the downwind leg at 45 degrees on the upwind side of the runway"
+      D: "Join the downwind leg at a 45-degree angle to the mid-point of the downwind leg, from the non-traffic side"
+    answer: D
+    explanation: "The recommended joining procedure in Canada is to approach the mid-point of the downwind leg at a 45-degree angle from the non-traffic (upwind) side of the runway. This avoids conflicts with aircraft already in the circuit and gives the joining pilot a clear view of the whole pattern. Source: AIM RAC 4.5."
+  - id: q5
+    prompt: "A right-hand circuit is in use at an aerodrome. Compared to the standard left-hand circuit, which statement is correct?"
+    choices:
+      A: "The circuit altitude is different — right-hand circuits use 1,500 feet AGL"
+      B: "The pilot makes all turns to the right instead of to the left"
+      C: "The landing direction is reversed"
+      D: "Right-hand circuits are only used at night"
+    answer: B
+    explanation: "In a right-hand circuit all turns are to the right — including the crosswind turn, downwind turn, base turn, and turn to final. The circuit altitude and landing direction remain the same. Right-hand circuits are published in the CFS or indicated by aerodrome markings. Source: CARs 602.96, AIM RAC 4.5."
+---
+
+# Lesson AL-006: Aerodrome Traffic Circuit
+
+**Section:** Air Law  
+**Lesson number:** 006  
+**Estimated time:** 20 minutes  
+**Source:** CARs 602.96, CARs 602.105, TP 12880E, AIM RAC 4.5
+
+---
+
+## Narration Script
+
+Welcome to Lesson AL-006. Today we cover the aerodrome traffic circuit — the standard rectangular pattern flown around an aerodrome for take-off and landing. This is fundamental PPL knowledge and appears on the written exam in questions about joining procedures, circuit direction, and standard leg names.
+
+---
+
+**What the Circuit Is**
+
+The aerodrome traffic circuit — sometimes called the traffic pattern — is a standardized rectangular flight path around the runway. Every pilot at an aerodrome follows the same circuit, which creates predictability: everyone is flying the same legs in the same direction at the same altitude. This predictability is what allows multiple aircraft to use an aerodrome safely without ATC in many cases.
+
+---
+
+**The Legs of the Circuit**
+
+A standard circuit has five named legs. Knowing each name and its relationship to the runway is essential.
+
+**Upwind leg** — The upwind leg is the initial climb-out segment after take-off. The aircraft is flying in the same direction as it just landed or took off, directly away from the runway. It is called "upwind" because the aircraft is flying into (or with the nose into) the wind — runway alignment is typically into the prevailing wind.
+
+**Crosswind leg** — After reaching a suitable altitude (usually around 500 feet AGL during departure), the pilot turns 90 degrees. The aircraft is now flying perpendicular to the runway. This turn is made away from the runway on the upwind side.
+
+**Downwind leg** — The aircraft turns again, now flying parallel to the runway in the opposite direction from landing. The aircraft is at circuit altitude — typically 1,000 feet AGL for light aircraft. The pilot runs through pre-landing checks on the downwind leg. ATIS, altimeter setting, fuel, undercarriage if applicable.
+
+**Base leg** — After passing the threshold end of the landing runway, the pilot turns 90 degrees again. The aircraft is now flying perpendicular to the runway, toward the runway. This is the transition leg between downwind and final. Flaps are extended on base.
+
+**Final approach** — The final turn brings the aircraft aligned with the runway. Final approach is made into the wind. The pilot manages descent rate, airspeed, and alignment to arrive at the threshold and land.
+
+---
+
+**Standard Circuit Direction**
+
+In Canada, the default circuit direction is left-hand turns. "Left-hand circuit" means all turns in the circuit are to the left. On the upwind leg after take-off, the pilot turns left onto crosswind. At the end of crosswind, turns left onto downwind. At the end of downwind, turns left onto base. From base, turns left onto final.
+
+A right-hand circuit can be established at specific aerodromes for terrain clearance, noise abatement, obstacle avoidance, or other reasons. Right-hand circuits are published in the Canada Flight Supplement (CFS) or indicated by a right-hand traffic indicator at the aerodrome. A right-hand circuit uses right turns on all legs.
+
+Source: CARs 602.96, AIM RAC 4.5.
+
+---
+
+**Standard Circuit Altitude**
+
+The standard circuit altitude for light aircraft is 1,000 feet AGL. Some aerodromes — typically those with larger turbine aircraft or specific terrain concerns — may use 1,500 feet AGL. Always check the CFS entry and any applicable NOTAMs for the specific aerodrome.
+
+The circuit altitude applies to the downwind, base, and portions of crosswind legs. The pilot climbs to circuit altitude by the time they are established on crosswind, maintains it through the downwind leg, then begins descending on base or final.
+
+---
+
+**Joining the Circuit**
+
+If you are arriving at an aerodrome, you need to join the circuit in a way that does not conflict with aircraft already flying the pattern. The recommended joining procedure in Canada is to approach the mid-point of the downwind leg at 45 degrees from the non-traffic side.
+
+The non-traffic side is the upwind side of the runway — the side away from the circuit. You approach from outside the circuit area, cross into the downwind leg at a 45-degree angle, and blend with the existing circuit flow. This approach gives you maximum visibility of the circuit: you can see any aircraft on final, base, and downwind as you join.
+
+Another accepted procedure is the overhead join: fly over the aerodrome at circuit altitude (or above), observe the circuit, cross to the upwind side, then descend and join the crosswind leg.
+
+Source: AIM RAC 4.5.
+
+---
+
+**Uncontrolled Aerodromes — Radio Calls**
+
+At uncontrolled aerodromes with a Mandatory Frequency (MF) or Common Traffic Advisory Frequency (CTAF), pilots are required to make radio position reports at specific points in the circuit. Typical reporting points:
+
+- Joining downwind (state runway and circuit direction if applicable)
+- Turning base
+- On final
+
+These calls alert other traffic to your position and intentions. You are not requesting permission — there is no ATC at an uncontrolled aerodrome — you are broadcasting your position.
+
+Even at non-mandatory uncontrolled aerodromes, making radio calls on the CTAF is good practice and strongly recommended.
+
+---
+
+**Non-Standard Circuits — Key Indicators**
+
+You may encounter a right-hand circuit indicated by one or more of:
+
+- The CFS aerodrome entry (look for the word "Right" after the circuit direction)
+- A right-hand traffic pattern indicator (L-shaped or T-shaped marker) on the aerodrome surface
+- A NOTAM for the aerodrome
+- ATC instruction at a controlled aerodrome
+
+If the CFS indicates a right-hand circuit for a specific runway, that is the mandatory direction.
+
+---
+
+**Common Exam Questions**
+
+The exam often tests:
+- The standard circuit direction (left-hand, unless otherwise indicated)
+- The standard circuit altitude (1,000 feet AGL for light aircraft)
+- Which leg is parallel to the runway going opposite to landing (downwind)
+- The recommended joining procedure (45-degree entry to mid-downwind from non-traffic side)
+- Who has right-of-way on final approach (lower aircraft)
+
+---
+
+## Quick Reference
+
+| Leg | Description |
+|-----|-------------|
+| Upwind | Departure, same direction as runway heading |
+| Crosswind | 90° turn, perpendicular to runway |
+| Downwind | Parallel to runway, opposite direction to landing; circuit altitude |
+| Base | 90° turn toward runway |
+| Final | Aligned with runway, into wind, descending to land |
+
+**Standard direction:** Left-hand turns  
+**Standard altitude:** 1,000 ft AGL (light aircraft)  
+**Standard joining procedure:** 45° entry to mid-downwind from non-traffic side
+
+---
+
+*End of Lesson AL-006.*

--- a/lessons/air-law/007-radio-communications.md
+++ b/lessons/air-law/007-radio-communications.md
@@ -1,0 +1,193 @@
+---
+id: AL-007
+topic: air-law
+order: 7
+slug: radio-communications
+title: "Radio Communications"
+duration_min: 20
+status: published
+audio: null
+visual: null
+sources:
+  - CARs 602.136
+  - CARs 602.138
+  - TP 12880E
+  - AIM COM 5.0
+questions:
+  - id: q1
+    prompt: "Using the ICAO phonetic alphabet, how do you correctly say the aircraft registration C-FXYZ on initial radio contact?"
+    choices:
+      A: "Charlie Foxtrot X-ray Yankee Zulu"
+      B: "Seefox Zulu"
+      C: "See Eff Ecks Why Zee"
+      D: "Charlie Fox X-ray Yankee Zero"
+    answer: A
+    explanation: "The ICAO phonetic alphabet spells each letter using a standardized word: C = Charlie, F = Foxtrot, X = X-ray, Y = Yankee, Z = Zulu. On initial contact you use the full phonetic spelling of each letter. Source: AIM COM 5.0, TP 12880E."
+  - id: q2
+    prompt: "ATC issues you a clearance: 'Cessna Golf Bravo Romeo, cleared to land runway 27, wind 260 at 12.' You must read back:"
+    choices:
+      A: "Nothing — a simple radio acknowledgement ('roger') is sufficient for landing clearances"
+      B: "The runway number and your call sign at minimum"
+      C: "The full clearance verbatim, including wind"
+      D: "Only the wind information, since you accepted the clearance"
+    answer: B
+    explanation: "CARs 602.136 requires that a pilot read back any ATC clearance to enter, land on, take off from, or hold short of a runway. The read-back must include the runway designation and the aircraft call sign. Wind is not required in the readback but the runway and call sign are mandatory. Source: CARs 602.136."
+  - id: q3
+    prompt: "At an uncontrolled aerodrome, you are on a 3-mile final for runway 10. The correct radio call is:"
+    choices:
+      A: "'[Aerodrome name] traffic, [aircraft type] C-[registration], 3-mile final runway 10, [aerodrome name].'"
+      B: "'Request landing clearance, [aerodrome name] tower.'"
+      C: "'[Aircraft type] C-[registration] is inbound for landing.'"
+      D: "'All stations, [registration], on final, runway 10.'"
+    answer: A
+    explanation: "At uncontrolled aerodromes, the standard position report format is: aerodrome name, aircraft type and call sign, position and intentions, aerodrome name again. The final word ('aerodrome name') is a safeguard so a pilot who hears only the end of the call knows which aerodrome is being discussed. Source: AIM COM 5.0."
+  - id: q4
+    prompt: "ATC says 'Standby' in response to your radio call. This means:"
+    choices:
+      A: "Your request is approved — proceed as requested"
+      B: "ATC has not heard your transmission and you must repeat it"
+      C: "ATC has acknowledged your call and will respond shortly; do not take action yet"
+      D: "ATC is unable to accommodate your request"
+    answer: C
+    explanation: "'Standby' means the controller has heard your call and will get back to you — it is an acknowledgement that does not authorize any action. Do not proceed with a request simply because ATC said standby. Wait for a full response. Source: AIM COM 5.0."
+  - id: q5
+    prompt: "Which of the following is the correct phraseology when you have fully understood an ATC transmission?"
+    choices:
+      A: "Copy"
+      B: "Roger"
+      C: "Wilco"
+      D: "Affirmative"
+    answer: B
+    explanation: "'Roger' means 'I have received all of your last transmission' — it confirms you heard and understood the message. 'Wilco' means 'I understand and will comply' (used when given an instruction). 'Affirmative' means 'yes'. 'Copy' is informal and not standard ICAO phraseology. Use 'Roger' to confirm receipt of a message, 'Wilco' to confirm you will carry out an instruction. Source: AIM COM 5.0."
+---
+
+# Lesson AL-007: Radio Communications
+
+**Section:** Air Law  
+**Lesson number:** 007  
+**Estimated time:** 20 minutes  
+**Source:** CARs 602.136, CARs 602.138, TP 12880E, AIM COM 5.0
+
+---
+
+## Narration Script
+
+Welcome to Lesson AL-007. Today we cover radio communications — the phonetic alphabet, standard phraseology, the readback rules, and common exam traps. Radio communication is a testable topic and a practical skill you will use on every flight.
+
+---
+
+**Why Standard Radio Phraseology Exists**
+
+Radio communications in aviation are standardized across the world. All pilots and controllers use the same words, the same phonetic alphabet, and the same message structure. This standardization reduces misunderstanding and errors. When a controller clears an aircraft to "runway two-seven," there is no ambiguity about what was said. When a pilot reads back a clearance, both parties confirm the message was received correctly.
+
+Non-standard language — colloquialisms, shortened forms, non-standard words — increases the chance of a miscommunication. The exam tests your knowledge of standard phrases specifically because misusing them is a safety risk.
+
+---
+
+**The ICAO Phonetic Alphabet**
+
+Aviation uses the ICAO phonetic alphabet to spell out letters that might be confused over the radio. Letters that sound similar — B and D, M and N, F and S — become distinct words.
+
+| Letter | Word | Letter | Word |
+|--------|------|--------|------|
+| A | Alpha | N | November |
+| B | Bravo | O | Oscar |
+| C | Charlie | P | Papa |
+| D | Delta | Q | Quebec |
+| E | Echo | R | Romeo |
+| F | Foxtrot | S | Sierra |
+| G | Golf | T | Tango |
+| H | Hotel | U | Uniform |
+| I | India | V | Victor |
+| J | Juliet | W | Whiskey |
+| K | Kilo | X | X-ray |
+| L | Lima | Y | Yankee |
+| M | Mike | Z | Zulu |
+
+Aircraft registrations in Canada begin with the prefix C (Charlie), followed by a hyphen and four letters. On initial contact with ATC, use the full phonetic spelling of each letter. On subsequent calls in the same session, ATC may abbreviate your call sign — follow their lead.
+
+Numbers are said digit-by-digit in most contexts: altitude 8,500 is "eight thousand five hundred"; heading 270 is "two seven zero"; runway 09 is "runway zero nine" or "runway niner" (note: nine is pronounced "niner" in aviation to avoid confusion with the German word for "no").
+
+---
+
+**Standard Phraseology — Key Words**
+
+A handful of words carry precise meanings in aviation radio work. Misusing them is an exam error and a real-world hazard.
+
+**Roger** — "I have received all of your last transmission." Use Roger to confirm you heard and understood a message. Roger does not mean you will comply — just that you received it.
+
+**Wilco** — "Will comply." Use Wilco when ATC has given you an instruction and you are confirming you will carry it out. Wilco implies you also understood, so using both Roger and Wilco together is redundant — just say Wilco.
+
+**Affirmative / Negative** — "Yes" and "No" in standard phraseology. Do not use "yeah," "yep," "no way," or other informal words.
+
+**Standby** — ATC has heard your call and will respond. Do not take action based on standby alone.
+
+**Unable** — The pilot or controller is not able to comply with a request. If ATC issues an instruction you cannot safely carry out, say "Unable, [reason]."
+
+**Say Again** — You did not receive the last transmission clearly. Use "Say again" (not "Repeat" — repeat has a different military connotation).
+
+---
+
+**Call Sign Format**
+
+On initial contact, identify the station you are calling, then yourself:
+
+> "[Station name], [aircraft type] [full call sign], [position/request]."
+
+Example:
+> "Ottawa Radio, Cessna C-GABC, 20 miles east, request flight following."
+
+After two-way contact is established, you may use the abbreviated call sign if the controller has used it.
+
+---
+
+**Position Reports at Uncontrolled Aerodromes**
+
+At uncontrolled aerodromes with a Mandatory Frequency (MF) or CTAF, standard position reports follow this format:
+
+> "[Aerodrome name] traffic, [aircraft type] [call sign], [position and altitude], [intentions], [aerodrome name]."
+
+The aerodrome name appears at both the beginning and end of the call. This ensures a pilot who catches only the end of the transmission knows which aerodrome is involved.
+
+Required reporting points include: 10 nautical miles inbound (if applicable), entering the circuit, turning base, on final. The exact requirements depend on whether the aerodrome has an MF or CTAF designation.
+
+---
+
+**Readback Requirements — CARs 602.136**
+
+CARs 602.136 specifies what must be read back. A pilot must read back ATC instructions that include:
+
+- Runway in use (take-off, landing, crossing, holding short)
+- Clearances to hold position or enter a runway
+- Taxi routes when they include a runway crossing
+- Altimeter settings
+- Altitude and heading assignments
+
+A runway clearance readback must include the runway designation and the aircraft call sign. The controller listens to the readback to confirm receipt. If your readback is wrong, the controller will correct you. If you do not read back, the controller may prompt you.
+
+Source: CARs 602.136.
+
+---
+
+**Communication Failure Procedures**
+
+If your radio fails in flight:
+
+- Squawk 7600 on the transponder (radio failure code).
+- At a controlled aerodrome, look for light gun signals from the control tower.
+- Light gun signals: steady green = cleared to land; flashing green = cleared to approach; steady red = give way, continue circling; flashing red = aerodrome unsafe, do not land; flashing white = return to start position; alternating red and green = exercise extreme caution.
+
+If you have radio failure en route in uncontrolled airspace, navigate, land at the nearest suitable aerodrome, and notify ATC of the failure.
+
+---
+
+**Common Exam Traps**
+
+- "Roger" does not mean you will comply — "Wilco" does.
+- You must read back runway clearances. A simple "Roger" is insufficient for a landing, take-off, or crossing clearance.
+- "Say again" is correct; "Repeat" is not standard in civilian aviation.
+- At uncontrolled aerodromes you are not requesting clearance — you are broadcasting your position and intentions.
+
+---
+
+*End of Lesson AL-007.*

--- a/lessons/air-law/008-atc-services-clearances.md
+++ b/lessons/air-law/008-atc-services-clearances.md
@@ -1,0 +1,193 @@
+---
+id: AL-008
+topic: air-law
+order: 8
+slug: atc-services-clearances
+title: "ATC Services and Clearances"
+duration_min: 20
+status: published
+audio: null
+visual: null
+sources:
+  - CARs 602.31
+  - CARs 602.32
+  - CARs 602.136
+  - TP 12880E
+  - AIM RAC 1.0
+questions:
+  - id: q1
+    prompt: "Which ATC unit provides separation and traffic services to aircraft flying between airports at en route altitudes?"
+    choices:
+      A: "Ground control"
+      B: "Aerodrome control tower"
+      C: "Area Control Centre (ACC)"
+      D: "Terminal Control Unit (TCU)"
+    answer: C
+    explanation: "The Area Control Centre (ACC) provides ATC services to en route aircraft in controlled airspace. In Canada there are several ACCs (e.g., Toronto ACC, Edmonton ACC). The tower handles the immediate aerodrome environment, the TCU handles the terminal area, and the ACC handles en route. Source: AIM RAC 1.0, TP 12880E."
+  - id: q2
+    prompt: "ATC issues the following clearance: 'C-GABC, cleared to land runway 28, hold short of taxiway Charlie after landing.' You must:"
+    choices:
+      A: "Acknowledge with 'Roger' and land as cleared"
+      B: "Read back the landing clearance and the hold-short instruction including your call sign"
+      C: "Read back only the runway number"
+      D: "Accept the clearance silently and flash your landing lights"
+    answer: B
+    explanation: "CARs 602.136 requires a full readback of clearances that include a runway and any hold-short instructions. The readback must include the runway, the hold-short point, and your call sign. 'Roger' alone is not sufficient for a runway clearance. Source: CARs 602.136."
+  - id: q3
+    prompt: "You receive an ATC clearance you are not able to comply with safely. The correct response is:"
+    choices:
+      A: "Comply anyway — ATC clearances are legally mandatory and must always be followed"
+      B: "Respond 'Unable' and state the reason, then negotiate an alternative"
+      C: "Comply and file a report after landing"
+      D: "Squawk 7700 and declare an emergency"
+    answer: B
+    explanation: "A pilot is not required to comply with an ATC clearance that would jeopardize safety. The correct response is 'Unable, [reason].' ATC will then issue an amended clearance. Safety always takes precedence over ATC compliance — this is explicitly recognized in CARs 602.31. Source: CARs 602.31, TP 12880E."
+  - id: q4
+    prompt: "A VFR aircraft departs a controlled aerodrome and enters Class C airspace. Which ATC unit handles this aircraft in the terminal area?"
+    choices:
+      A: "Ground control"
+      B: "Clearance delivery"
+      C: "Terminal Control Unit (TCU) or Approach Control"
+      D: "Flight Service Station (FSS)"
+    answer: C
+    explanation: "After departure from the aerodrome environment, the terminal area is handled by the Terminal Control Unit (TCU) or Approach Control. This unit manages the airspace surrounding a major airport (typically Class C), providing separation and traffic services. Once beyond the terminal area, the aircraft may be handed off to the Area Control Centre. Source: AIM RAC 1.0."
+  - id: q5
+    prompt: "An aircraft receives a clearance to 'hold short of runway 28.' The pilot reads back 'Hold short runway 28, C-GABC.' ATC does not correct the readback. Who bears responsibility if the aircraft subsequently crosses runway 28 without a clearance?"
+    choices:
+      A: "ATC bears full responsibility because they issued the clearance"
+      B: "The pilot-in-command bears responsibility — the pilot is always ultimately responsible for compliance with clearances"
+      C: "Shared equally between pilot and ATC"
+      D: "The aerodrome authority, because runway incursions are their liability"
+    answer: B
+    explanation: "The pilot-in-command is ultimately responsible for compliance with ATC instructions and for the safety of the aircraft. A correct readback confirms the instruction was received — it does not transfer responsibility to ATC if the pilot subsequently fails to comply. Source: CARs 602.31, TP 12880E."
+---
+
+# Lesson AL-008: ATC Services and Clearances
+
+**Section:** Air Law  
+**Lesson number:** 008  
+**Estimated time:** 20 minutes  
+**Source:** CARs 602.31, CARs 602.32, CARs 602.136, TP 12880E, AIM RAC 1.0
+
+---
+
+## Narration Script
+
+Welcome to Lesson AL-008. Today we cover ATC services and clearances — what services are available, which unit provides which service, and the rules around accepting and complying with ATC clearances. This topic connects directly to the radio communication material in AL-007 and is essential for the exam.
+
+---
+
+**What Air Traffic Control Does**
+
+Air Traffic Control exists to prevent collisions between aircraft, and between aircraft and obstructions on the movement area of an aerodrome. ATC issues clearances and instructions to manage the flow of traffic. In controlled airspace, no aircraft may operate without an ATC clearance.
+
+Canada's ATC system is operated by NAV CANADA, a private non-share capital corporation. It operates control towers, terminal control units, area control centres, and flight service stations across the country.
+
+Source: AIM RAC 1.0.
+
+---
+
+**The ATC Units and What They Do**
+
+**Aerodrome Control Tower (TWR)** — The tower controls the movement of aircraft on the runway, taxiways, and in the immediate aerodrome environment. The tower issues taxi instructions, take-off and landing clearances, and maintains awareness of all traffic in the circuit. Frequencies: typically 118–132 MHz VHF. Positions within the tower include ground control (taxiing), local control (runway and circuit), and clearance delivery (pre-departure IFR clearances).
+
+**Terminal Control Unit (TCU) / Approach Control (APP)** — The TCU manages the terminal area surrounding a major airport, typically encompassing Class C airspace. After take-off, the tower hands the aircraft off to the TCU. The TCU provides separation in the climb and manages arriving aircraft during the approach and descent. VFR pilots operating in Class C are in contact with the TCU.
+
+**Area Control Centre (ACC)** — The ACC handles en route aircraft in controlled airspace. Canada has several ACCs — including Toronto, Montréal, Edmonton, Vancouver, Gander, and Moncton. Once a departure aircraft is clear of the terminal area, the TCU hands it off to the ACC. En route IFR aircraft are under ACC control for most of their flight.
+
+**Flight Service Station (FSS)** — FSSs are not ATC units but provide important services: weather briefings, flight plan filing, MF advisory services at uncontrolled aerodromes, and SAR alerting. Pilots at uncontrolled aerodromes with an MF report position to the FSS, which provides traffic advisories. The FSS does not issue clearances.
+
+---
+
+**The Clearance Concept**
+
+A clearance is an ATC authorization for an aircraft to proceed under specified conditions. Clearances do not guarantee separation from all traffic — they authorize the pilot to proceed while ATC maintains separation within its area of responsibility.
+
+Clearances are not commands in the absolute sense. A pilot may deviate from a clearance when necessary to avoid an immediate threat to safety. CARs 602.31 acknowledges this: a pilot may deviate from an ATC clearance to the extent necessary to deal with an emergency.
+
+---
+
+**Compliance with ATC Instructions — CARs 602.31**
+
+CARs 602.31 requires that a pilot operating in controlled airspace must comply with ATC instructions. However, the pilot-in-command retains authority over and responsibility for the operation of the aircraft.
+
+If a clearance would compromise safety, the pilot must say "Unable" and state the reason. ATC will issue an amended clearance. Safety takes priority.
+
+After an emergency deviation from an ATC clearance, the pilot must notify ATC as soon as practicable.
+
+---
+
+**Clearance Components — The CRAFT Acronym**
+
+IFR clearances in Canada are commonly structured around the CRAFT acronym. While you will fly VFR as a PPL holder, understanding clearance structure is testable:
+
+- **C** — Clearance limit (the point to which you are cleared, typically the destination)
+- **R** — Route (airways or direct routing)
+- **A** — Altitude (maintain, expect)
+- **F** — Frequency (departure frequency to contact after take-off)
+- **T** — Transponder code (squawk code assigned)
+
+VFR aircraft typically do not receive full CRAFT clearances but may receive runway clearances, class C entry clearances, and traffic advisories.
+
+---
+
+**Readback Requirements — CARs 602.136**
+
+When ATC issues a clearance to take off, land, enter, cross, or hold short of a runway, the pilot must read back the clearance. The readback must include:
+
+- The runway designation
+- Any hold-short instructions
+- The aircraft call sign
+
+The purpose is to close the communication loop. If the readback is incorrect, the controller will immediately correct it. A clearance that is not read back correctly has not been confirmed.
+
+A simple "Roger" is not sufficient for a runway clearance. This is one of the most common exam questions in this area.
+
+Source: CARs 602.136.
+
+---
+
+**The Tower–TCU–ACC Handoff Sequence**
+
+Understanding how a controlled flight moves through the system helps with exam scenario questions.
+
+1. Pre-departure: pilot contacts clearance delivery (at larger aerodromes) or ground control to receive taxi instructions.
+2. Ground control: issues taxi instructions to the runway.
+3. Tower (local control): issues take-off clearance. The aircraft is under tower control in the circuit and immediate departure area.
+4. After departure, the tower instructs the pilot to contact the TCU/approach control. The TCU handles the aircraft in the terminal area.
+5. Once clear of the terminal area, the TCU hands off to the ACC for en route handling.
+6. On arrival, the sequence reverses: ACC → TCU → tower.
+
+VFR pilots do not follow this sequence unless they are operating in Class C airspace or requesting traffic following services. At a controlled aerodrome, VFR pilots contact the tower directly.
+
+---
+
+**Flight Following — Radar Traffic Advisories**
+
+VFR pilots can request radar traffic advisory service (sometimes called "flight following") from ATC. ATC issues a squawk code, identifies the aircraft on radar, and provides traffic advisories when workload permits. This is a workload-permitting service — ATC is not obligated to provide it, and it can be terminated at any time.
+
+Flight following does not constitute ATC separation services for VFR aircraft. The pilot remains responsible for see-and-avoid.
+
+---
+
+**Common Exam Questions**
+
+- Which ATC unit handles en route aircraft? ACC.
+- Which unit handles aircraft in the Class C terminal area? TCU / Approach Control.
+- What do you read back for a landing clearance? Runway, call sign (and any hold-short instruction if given).
+- Can you deviate from an ATC clearance? Yes, if required for safety — then notify ATC as soon as practicable.
+
+---
+
+## Quick Reference
+
+| ATC Unit | Role |
+|----------|------|
+| Aerodrome Control Tower (TWR) | Runway, taxiway, aerodrome circuit |
+| Terminal Control Unit (TCU) | Terminal area (Class C), arrivals and departures |
+| Area Control Centre (ACC) | En route controlled airspace |
+| Flight Service Station (FSS) | Weather, flight plans, MF advisory — not ATC |
+
+---
+
+*End of Lesson AL-008.*


### PR DESCRIPTION
## Summary

- Adds 5 new lesson files: AL-004 altimeter settings, AL-005 right-of-way rules, AL-006 aerodrome traffic circuit, AL-007 radio communications, AL-008 ATC services and clearances
- All lessons follow the canonical frontmatter schema with 5 questions each citing CARs sections and TP references (no FAA/FARs)
- All 10 lesson files pass `scripts/validate-lesson-schema.sh` (0 failures)

## Test plan

- [x] `scripts/validate-lesson-schema.sh` — 0 failures across all 10 lessons
- [ ] Reviewer: spot-check CARs citations (602.19–602.21 right-of-way, 602.35 altimeter settings, 602.96 circuit, 602.136 readback, 602.31 ATC compliance)
- [ ] Reviewer: verify question answer keys are correct and explanations are accurate

Closes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)