### PR TITLE
[PPL-78] Set audio URLs for Air Law lessons AL-004 through AL-008

### DIFF
--- a/lessons/air-law/004-altimeter-settings.md
+++ b/lessons/air-law/004-altimeter-settings.md
@@ -6,7 +6,7 @@ slug: altimeter-settings
 title: "Altimeter Settings"
 duration_min: 20
 status: published
-audio: null
+audio: https://media.suprun.workers.dev/ppl/lessons/air-law/004-altimeter-settings.m4a
 visual: null
 sources:
   - CARs 602.35

--- a/lessons/air-law/005-right-of-way-rules.md
+++ b/lessons/air-law/005-right-of-way-rules.md
@@ -6,7 +6,7 @@ slug: right-of-way-rules
 title: "Right-of-Way Rules"
 duration_min: 20
 status: published
-audio: null
+audio: https://media.suprun.workers.dev/ppl/lessons/air-law/005-right-of-way-rules.m4a
 visual: null
 sources:
   - CARs 602.19

--- a/lessons/air-law/006-aerodrome-traffic-circuit.md
+++ b/lessons/air-law/006-aerodrome-traffic-circuit.md
@@ -6,7 +6,7 @@ slug: aerodrome-traffic-circuit
 title: "Aerodrome Traffic Circuit"
 duration_min: 20
 status: published
-audio: null
+audio: https://media.suprun.workers.dev/ppl/lessons/air-law/006-aerodrome-traffic-circuit.m4a
 visual: null
 sources:
   - CARs 602.96

--- a/lessons/air-law/007-radio-communications.md
+++ b/lessons/air-law/007-radio-communications.md
@@ -6,7 +6,7 @@ slug: radio-communications
 title: "Radio Communications"
 duration_min: 20
 status: published
-audio: null
+audio: https://media.suprun.workers.dev/ppl/lessons/air-law/007-radio-communications.m4a
 visual: null
 sources:
   - CARs 602.136

--- a/lessons/air-law/008-atc-services-clearances.md
+++ b/lessons/air-law/008-atc-services-clearances.md
@@ -6,7 +6,7 @@ slug: atc-services-clearances
 title: "ATC Services and Clearances"
 duration_min: 20
 status: published
-audio: null
+audio: https://media.suprun.workers.dev/ppl/lessons/air-law/008-atc-services-clearances.m4a
 visual: null
 sources:
   - CARs 602.31


### PR DESCRIPTION
## Summary

- Sets `audio:` frontmatter in lessons AL-004 through AL-008 from `null` to the Cloudflare R2 public URL
- Narration m4a files were generated via macOS `say` + ffmpeg (AAC 64k) and uploaded to the `suprun-media` R2 bucket
- All five audio URLs verified HTTP 200:
  - `https://media.suprun.workers.dev/ppl/lessons/air-law/004-altimeter-settings.m4a`
  - `https://media.suprun.workers.dev/ppl/lessons/air-law/005-right-of-way-rules.m4a`
  - `https://media.suprun.workers.dev/ppl/lessons/air-law/006-aerodrome-traffic-circuit.m4a`
  - `https://media.suprun.workers.dev/ppl/lessons/air-law/007-radio-communications.m4a`
  - `https://media.suprun.workers.dev/ppl/lessons/air-law/008-atc-services-clearances.m4a`

## Test plan

- [ ] `scripts/validate-lesson-schema.sh` — 10/10 OK, 0 failures
- [ ] `curl -I` each audio URL confirms HTTP 200
- [ ] `npm run build` in `web-app/` builds cleanly (no TS errors)

Closes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)