### PR TITLE
[#26] README, LICENSE, CONTRIBUTING, CODE_OF_CONDUCT

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,35 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to making participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing opinions, viewpoints, and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project maintainers at [contact information]. All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at https://www.contributor-covenant.org/version/2_1/code_of_conduct.html
+
+[homepage]: https://www.contributor-covenant.org

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,111 @@
+# Contributing to PPL Study
+
+Thank you for helping improve PPL Study! This guide explains how to add lessons, fix content, or contribute code.
+
+## Adding or Correcting a Lesson
+
+### Lesson File Format
+
+Lessons live in `lessons/{topic}/{NNN}-{slug}.md` (e.g., `lessons/air-law/001-airspace-classifications.md`).
+
+Every lesson follows the schema defined in [docs/lesson-schema.md](./docs/lesson-schema.md). **Do not deviate from this schema.**
+
+### Required Fields
+
+- `id`: Lesson identifier (e.g., `AL-001` for Air Law lesson 1)
+- `topic`: Category (e.g., `air-law`, `meteorology`)
+- `order`: Numeric order within the topic
+- `slug`: URL-friendly name (lowercase, hyphens, no spaces)
+- `title`: Human-readable lesson title
+- `duration_min`: Expected study time (usually 20 minutes)
+- `status`: One of `draft`, `published`
+- `audio`: URL to `.m4a` narration file (or `null` if not yet recorded)
+- `sources`: List of Transport Canada sources (TP or CARs references)
+- `questions`: 3–5 practice questions with answers
+
+### Factual Accuracy Rules
+
+**CRITICAL:** Every claim in a lesson must be sourced to Transport Canada materials.
+
+- Use **TP** (Transport Publications) numbers when citing specific documents
+  - Example: `TP 12880E` (Pilot's Handbook)
+  - Example: `TP 10252` (CNO Aerodrome information)
+- Use **CARs** (Canadian Aviation Regulations) for regulatory citations
+  - Example: `CARs 602.35` (Altimeter requirements)
+  - Example: `CARs Part I, Section 402.13` (Engine failure procedures)
+- Link to **AIM RAC** (Aeronautical Information Manual — Rules of the Air & Air Traffic Services) when relevant
+- **No unsourced statements.** If you cannot cite the regulation or Transport Canada handbook, do not include it.
+
+### Before Submitting
+
+1. Ensure the lesson YAML parses correctly
+2. Run the validation script:
+   ```bash
+   scripts/validate-lesson-schema.sh lessons/{topic}/{NNN}-{slug}.md
+   ```
+3. Verify all sources (TP/CARs numbers) are correct and cited in Transport Canada publications
+4. Test the web app locally:
+   ```bash
+   cd web-app && npm run dev
+   ```
+
+## Contributing Code
+
+### Setup
+
+```bash
+git clone https://github.com/svv2014/ppl-study.git
+cd ppl-study
+cd web-app
+npm install
+npm run dev
+```
+
+### Tech Stack
+
+- **React** 18 with TypeScript
+- **Vite** 6 (fast bundler)
+- **MUI** 7 (Material Design components)
+- **Audio:** Web Audio API + HTML5 `<audio>`
+
+### Running Tests & Builds
+
+```bash
+# TypeScript type check
+npm run type-check
+
+# Build for production
+npm run build
+
+# Validate all lessons
+scripts/validate-lesson-schema.sh
+```
+
+### Code Style
+
+- Use TypeScript — no `any` types without justification
+- Format with Prettier (configured in `.prettierrc`)
+- Follow MUI component patterns — keep UI simple and accessible
+- Write comments only for **why**, not what — good naming explains the code
+
+### Pull Request Process
+
+1. Create a feature branch: `git checkout -b fix/issue-NNN-description`
+2. Make your changes (lessons, web app, or scripts)
+3. Run type check and build locally
+4. Push and open a PR linked to the relevant GitHub issue
+5. CI will run automated tests and validation
+6. Await human review (label: `review-approved`)
+7. Merge via the AISDLC automation
+
+## Reporting Issues
+
+Found a bug or have a feature request? Open an [issue](https://github.com/svv2014/ppl-study/issues) with:
+
+- **Bug reports:** Steps to reproduce, expected behavior, actual behavior
+- **Feature requests:** What problem does it solve? Why is it important?
+- **Factual errors:** Which TP/CARs reference should we cite instead?
+
+---
+
+**Questions?** Check [docs/](./docs) or open a discussion.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Vadym Suprun
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,106 @@
+# PPL Study — Canadian Pilot License Exam Prep
+
+A structured, audio-first curriculum for Transport Canada PPL (Aeroplane) written exam preparation. Each lesson is a 20-minute audio module with practice questions and linked regulatory sources.
+
+**Target:** Transport Canada PPL written exam (passing grade 60%, target 80%+)  
+**Audience:** Student pilots preparing for the Canadian pilot license  
+**Format:** Audio-first lessons with visual support and practice questions
+
+## Features
+
+- **20-minute audio lessons** — Kokoro-narrated, scientifically paced for retention
+- **Audio-first design** — Study while driving, flying, or commuting
+- **Regulatory references** — Every fact linked to TP (Transport Publications) or CARs (Canadian Aviation Regulations)
+- **Practice questions** — 3–5 multi-choice questions per lesson with explanations
+- **Web app** — React SPA for lesson playback and practice tests
+- **Lessons by topic:**
+  - Air Law
+  - Human Performance & Limitations
+  - Meteorology
+  - Navigation
+  - Aircraft Technical Knowledge
+  - Flight Planning & Performance
+
+## Quick Start
+
+### Run the Web App Locally
+
+```bash
+cd web-app
+npm install
+npm run dev
+```
+
+The web app will be available at `http://localhost:5173`.
+
+### Project Structure
+
+```
+ppl-study/
+├── lessons/              # Lesson content (Markdown + audio)
+│   ├── air-law/
+│   ├── human-performance/
+│   ├── meteorology/
+│   └── ...
+├── web-app/             # React + Vite + TypeScript web application
+├── docs/                # Guides and schema documentation
+│   ├── lesson-schema.md # Lesson format specification
+│   └── curriculum-plan.md
+└── scripts/             # Build & deployment scripts
+```
+
+## Contributing
+
+Want to add lessons, fix content, or improve the web app? See [CONTRIBUTING.md](./CONTRIBUTING.md).
+
+### Lesson Format
+
+Lessons follow a strict schema:
+
+```yaml
+---
+id: AL-001
+topic: air-law
+order: 1
+slug: airspace-classifications
+title: "Airspace Classifications"
+duration_min: 20
+status: published
+audio: https://media.suprun.workers.dev/ppl/lessons/air-law/001-airspace-classifications.m4a
+visual: null
+sources:
+  - CARs Part I, Section 101.01
+  - TP 12880E "Pilot's Handbook of Aeronautical Knowledge"
+questions:
+  - id: q1
+    prompt: "Class B airspace requires..."
+    choices: [...]
+```
+
+See [docs/lesson-schema.md](./docs/lesson-schema.md) for the full schema.
+
+### Factual Accuracy Rules
+
+- **Every regulation reference must cite a source:** TP number (Transport Publications) or CARs section
+- **No unsourced claims:** If you can't cite Transport Canada, CAA, or peer-reviewed aviation publications, don't include it
+- **Canadian focus:** This is PPL (Canada), not FAA. Use Transport Canada materials exclusively
+
+## Tech Stack
+
+- **Web App:** React 18 + TypeScript + Vite 6 + MUI 7
+- **Narration:** Kokoro TTS (ai-echo voice profile)
+- **Media Storage:** Cloudflare R2
+- **CI/CD:** GitHub Actions
+
+## License
+
+[MIT](./LICENSE) — Educational content. Contributed lessons remain the copyright of their authors unless transferred.
+
+## Questions?
+
+Open an [issue](https://github.com/svv2014/ppl-study/issues) or check [docs/](./docs) for guidance.
+
+---
+
+**Made by:** Vadym Suprun & contributors  
+**Updated:** 2026-04-20


### PR DESCRIPTION
Resolves #26 by adding all required documentation for public open-source repo.

## What's Added

- **README.md** — Project overview, quick start, structure, contribution guide
- **LICENSE** — MIT license (copyright Vadym Suprun)
- **CONTRIBUTING.md** — Lesson format, factual accuracy rules, code guidelines
- **CODE_OF_CONDUCT.md** — Contributor Covenant v2.1

All acceptance criteria from #26 met. Lesson content unchanged. CLAUDE.md kept internal.