### PR TITLE
[PPL-86] Standardize lesson audio on Kokoro am_echo + document contract

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,6 +48,12 @@ ppl-study/
 └── orchestrator/     ASDLC-compatible dev cycle (GitHub issue automation)
 ```
 
+## Audio Generation
+
+Lesson narration is generated with Kokoro TTS (voice `am_echo`, speed 1.1) and hosted on Cloudflare R2.
+See **`docs/audio-standards.md`** for the canonical parameters, R2 path convention, generation command, and idempotency rule.
+See `docs/audio-hosting.md` for infrastructure and upload details.
+
 ## Critical Rules
 
 - All lesson content must be factually accurate against Transport Canada sources

--- a/docs/audio-standards.md
+++ b/docs/audio-standards.md
@@ -1,0 +1,59 @@
+# Audio Standards — PPL Study
+
+## TTS Model and Voice
+
+All lesson narration is generated with **Kokoro** using the following canonical parameters:
+
+| Parameter | Value |
+|---|---|
+| Model | `mlx-community/Kokoro-82M-bf16` |
+| Voice | `am_echo` |
+| Speed | `1.1` |
+| Output format | AAC/M4A, 64 kbps |
+
+These parameters are fixed for the project. Do not mix voices or models between lessons — consistency across the audio library matters for listener experience.
+
+## R2 Path Convention
+
+Audio files are hosted on Cloudflare R2 under the `suprun-media` bucket. The R2 key mirrors the lesson markdown path exactly:
+
+```
+lessons/{topic}/{NNN}-{slug}.md  →  ppl/lessons/{topic}/{NNN}-{slug}.m4a
+```
+
+Public URL pattern:
+```
+https://media.suprun.workers.dev/ppl/lessons/{topic}/{NNN}-{slug}.m4a
+```
+
+Examples:
+
+| Lesson file | R2 key | Public URL |
+|---|---|---|
+| `lessons/air-law/001-airspace-classifications.md` | `ppl/lessons/air-law/001-airspace-classifications.m4a` | `https://media.suprun.workers.dev/ppl/lessons/air-law/001-airspace-classifications.m4a` |
+| `lessons/navigation/001-vfr-charts.md` | `ppl/lessons/navigation/001-vfr-charts.m4a` | `https://media.suprun.workers.dev/ppl/lessons/navigation/001-vfr-charts.m4a` |
+
+See `docs/audio-hosting.md` for infrastructure details, credentials location, and verification steps.
+
+## Canonical Generation Command
+
+To regenerate audio for a single lesson manually:
+
+```bash
+scripts/generate-lesson-audio.sh lessons/air-law/001-airspace-classifications.md
+```
+
+The script:
+1. Strips YAML frontmatter from the lesson `.md` file
+2. Pipes the lesson body to Kokoro via `mlx_audio` with `am_echo` at speed 1.1
+3. Encodes output to `.m4a` at 64 kbps AAC
+4. Delegates upload to `scripts/upload-lesson-audio.sh`
+5. Prints the resulting public URL
+
+## Idempotency Rule
+
+**Skip if already set:** If the `audio:` frontmatter field in a lesson file is already a non-null URL, do not regenerate — the audio is considered authoritative. Overwriting a published URL risks breaking existing listener sessions.
+
+**Exception — AL-001:** Lesson `AL-001` (`lessons/air-law/001-airspace-classifications.md`) must be regenerated unconditionally when re-running the batch, as the initial recording predates these standards and used a different voice.
+
+To force regeneration of a lesson that already has an audio URL, delete or null out the `audio:` field before running the script.

--- a/lessons/air-law/002-controlled-vs-uncontrolled.md
+++ b/lessons/air-law/002-controlled-vs-uncontrolled.md
@@ -6,7 +6,7 @@ slug: controlled-vs-uncontrolled
 title: "Controlled vs Uncontrolled Airspace"
 duration_min: 20
 status: complete
-audio: null
+audio: https://media.suprun.workers.dev/ppl/lessons/air-law/002-controlled-vs-uncontrolled.m4a
 visual: /visuals/al002-controlled-vs-uncontrolled.html
 sources:
   - CARs Part VI

--- a/lessons/air-law/003-vfr-weather-minimums.md
+++ b/lessons/air-law/003-vfr-weather-minimums.md
@@ -6,7 +6,7 @@ slug: vfr-weather-minimums
 title: "VFR Weather Minimums"
 duration_min: 20
 status: complete
-audio: null
+audio: https://media.suprun.workers.dev/ppl/lessons/air-law/003-vfr-weather-minimums.m4a
 visual: /visuals/al003-vfr-weather-minimums.html
 sources:
   - CARs 602.114-602.117

--- a/lessons/navigation/001-vfr-charts.md
+++ b/lessons/navigation/001-vfr-charts.md
@@ -6,7 +6,7 @@ slug: vfr-charts
 title: "VFR Aeronautical Charts — Reading the Map"
 duration_min: 20
 status: complete
-audio: null
+audio: https://media.suprun.workers.dev/ppl/lessons/navigation/001-vfr-charts.m4a
 visual: /visuals/nav001-vfr-charts.html
 sources:
   - TP 12880E

--- a/lessons/navigation/002-lat-lon-map-reading.md
+++ b/lessons/navigation/002-lat-lon-map-reading.md
@@ -6,7 +6,7 @@ slug: lat-lon-map-reading
 title: "Latitude, Longitude, and Map Reading"
 duration_min: 20
 status: complete
-audio: null
+audio: https://media.suprun.workers.dev/ppl/lessons/navigation/002-lat-lon-map-reading.m4a
 visual: null
 sources:
   - TP 12880E

--- a/scripts/generate-lesson-audio.sh
+++ b/scripts/generate-lesson-audio.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# generate-lesson-audio.sh — generate narration audio for a single lesson.
+#
+# Usage:
+#   scripts/generate-lesson-audio.sh <lesson.md>
+#
+# Strips YAML frontmatter, pipes the lesson body through Kokoro TTS
+# (mlx-community/Kokoro-82M-bf16, voice am_echo, speed 1.1), encodes to .m4a
+# at 64 kbps AAC, uploads via scripts/upload-lesson-audio.sh, and prints the
+# public URL.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+    awk '/^#!/ {next} /^#/ {print substr($0, 3); next} {exit}' "$0"
+    exit 0
+fi
+
+if [[ $# -ne 1 ]]; then
+    echo "Usage: $0 <lesson.md>" >&2
+    exit 2
+fi
+
+LESSON_MD="$1"
+
+if [[ ! -f "$LESSON_MD" ]]; then
+    echo "Lesson file not found: $LESSON_MD" >&2
+    exit 1
+fi
+
+# Derive output paths (alongside the .md file)
+LESSON_BASE="${LESSON_MD%.md}"
+LESSON_WAV="${LESSON_BASE}.wav"
+LESSON_M4A="${LESSON_BASE}.m4a"
+
+# Strip YAML frontmatter (content between the two leading --- markers)
+TMPBODY=$(mktemp /tmp/lesson-body-XXXXXX.txt)
+trap 'rm -f "$TMPBODY" "$LESSON_WAV" "$LESSON_M4A"' EXIT
+
+python3 - "$LESSON_MD" "$TMPBODY" <<'PYEOF'
+import sys
+
+lesson_path, out_path = sys.argv[1], sys.argv[2]
+with open(lesson_path, encoding="utf-8") as f:
+    content = f.read()
+
+if not content.startswith("---"):
+    body = content
+else:
+    close = content.find("\n---", 3)
+    if close == -1:
+        sys.exit("ERROR: frontmatter block never closed in " + lesson_path)
+    body = content[close + 4:].lstrip("\n")
+
+with open(out_path, "w", encoding="utf-8") as f:
+    f.write(body)
+PYEOF
+
+echo "Generating audio for: $LESSON_MD" >&2
+
+# Run Kokoro TTS via mlx_audio CLI; --join_audio produces a single wav file.
+# Text is passed via stdin (omitting --text) to avoid shell argument-length limits.
+# Requires Python 3.10+ for mlx_audio type-union syntax; prefer python3.12
+PYTHON3=$(command -v python3.12 || command -v python3.11 || command -v python3.10 || echo python3)
+"$PYTHON3" -m mlx_audio.tts.generate \
+    --model "mlx-community/Kokoro-82M-bf16" \
+    --voice "am_echo" \
+    --speed 1.1 \
+    --file_prefix "$LESSON_BASE" \
+    --audio_format wav \
+    --join_audio \
+    < "$TMPBODY" \
+    2>&1 | grep -v "^$" >&2 || true
+
+# The CLI writes {LESSON_BASE}.wav when --join_audio is used
+if [[ ! -f "$LESSON_WAV" ]]; then
+    echo "ERROR: TTS did not produce $LESSON_WAV" >&2
+    exit 1
+fi
+
+# Encode wav → m4a at 64 kbps AAC
+ffmpeg -y -i "$LESSON_WAV" -c:a aac -b:a 64k "$LESSON_M4A" \
+    -hide_banner -loglevel error >&2
+
+rm -f "$LESSON_WAV"
+
+# Upload and capture the public URL
+PUBLIC_URL="$("$SCRIPT_DIR/upload-lesson-audio.sh" "$LESSON_M4A" "$LESSON_MD")"
+
+echo "$PUBLIC_URL"


### PR DESCRIPTION
## Summary

- **docs/audio-standards.md** — Documents the canonical TTS parameters: Kokoro `mlx-community/Kokoro-82M-bf16`, voice `am_echo`, speed 1.1, AAC/M4A 64 kbps, R2 path convention, canonical generation command, and idempotency rule (skip if audio URL is non-null; AL-001 regenerates unconditionally per issue)
- **scripts/generate-lesson-audio.sh** — New script that strips YAML frontmatter, runs Kokoro TTS via `mlx_audio` CLI with canonical params, encodes to `.m4a` at 64 kbps AAC via ffmpeg, delegates upload to `scripts/upload-lesson-audio.sh`, and prints the public URL
- **Audio URLs set** for AL-002, AL-003, NAV-001, NAV-002; AL-001 regenerated with canonical voice
- **CLAUDE.md** updated with an Audio Generation section cross-referencing `docs/audio-standards.md`

## Test plan

- [x] `scripts/validate-lesson-schema.sh` passes (10/10 lessons OK)
- [x] All 5 lesson audio files uploaded and accessible at `https://media.suprun.workers.dev/ppl/lessons/...`
- [x] `audio:` frontmatter field updated only — no lesson body content modified

Closes #86

🤖 Generated with [Claude Code](https://claude.com/claude-code)