### PR TITLE
[PPL-98] Add visuals for AL-004–AL-008

### DIFF
--- a/lessons/air-law/004-altimeter-settings.md
+++ b/lessons/air-law/004-altimeter-settings.md
@@ -7,7 +7,7 @@ title: "Altimeter Settings"
 duration_min: 20
 status: published
 audio: https://media.suprun.workers.dev/ppl/lessons/air-law/004-altimeter-settings.m4a
-visual: null
+visual: /visuals/al004-altimeter-settings.html
 sources:
   - CARs 602.35
   - TP 12880E

--- a/lessons/air-law/005-right-of-way-rules.md
+++ b/lessons/air-law/005-right-of-way-rules.md
@@ -7,7 +7,7 @@ title: "Right-of-Way Rules"
 duration_min: 20
 status: published
 audio: https://media.suprun.workers.dev/ppl/lessons/air-law/005-right-of-way-rules.m4a
-visual: null
+visual: /visuals/al005-right-of-way-rules.html
 sources:
   - CARs 602.19
   - CARs 602.20

--- a/lessons/air-law/006-aerodrome-traffic-circuit.md
+++ b/lessons/air-law/006-aerodrome-traffic-circuit.md
@@ -7,7 +7,7 @@ title: "Aerodrome Traffic Circuit"
 duration_min: 20
 status: published
 audio: https://media.suprun.workers.dev/ppl/lessons/air-law/006-aerodrome-traffic-circuit.m4a
-visual: null
+visual: /visuals/al006-aerodrome-traffic-circuit.html
 sources:
   - CARs 602.96
   - CARs 602.105

--- a/lessons/air-law/007-radio-communications.md
+++ b/lessons/air-law/007-radio-communications.md
@@ -7,7 +7,7 @@ title: "Radio Communications"
 duration_min: 20
 status: published
 audio: https://media.suprun.workers.dev/ppl/lessons/air-law/007-radio-communications.m4a
-visual: null
+visual: /visuals/al007-radio-communications.html
 sources:
   - CARs 602.136
   - CARs 602.138

--- a/lessons/air-law/008-atc-services-clearances.md
+++ b/lessons/air-law/008-atc-services-clearances.md
@@ -7,7 +7,7 @@ title: "ATC Services and Clearances"
 duration_min: 20
 status: published
 audio: https://media.suprun.workers.dev/ppl/lessons/air-law/008-atc-services-clearances.m4a
-visual: null
+visual: /visuals/al008-atc-services-clearances.html
 sources:
   - CARs 602.31
   - CARs 602.32

--- a/web-app/public/visuals/al004-altimeter-settings.html
+++ b/web-app/public/visuals/al004-altimeter-settings.html
@@ -1,0 +1,113 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>AL-004: Altimeter Settings</title>
+<style>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body { background: #0d1b2a; color: #e8edf2; font-family: 'Segoe UI', system-ui, sans-serif; padding: 32px; max-width: 900px; margin: auto; }
+  h1 { font-size: 22px; color: #f0c040; letter-spacing: 1px; margin-bottom: 6px; }
+  .subtitle { font-size: 13px; color: #7a9ab5; margin-bottom: 32px; letter-spacing: 0.5px; }
+  .section-label { font-size: 11px; color: #7a9ab5; letter-spacing: 1px; text-transform: uppercase; margin-bottom: 8px; font-weight: 600; }
+  table { width: 100%; border-collapse: collapse; font-size: 13px; margin-bottom: 28px; }
+  th { background: #1a2d3d; color: #7a9ab5; padding: 9px 12px; text-align: left; font-size: 11px; text-transform: uppercase; letter-spacing: 0.5px; }
+  td { padding: 10px 12px; border-bottom: 1px solid #1a2d3d; vertical-align: top; }
+  .code { font-size: 18px; font-weight: 800; color: #f0c040; }
+  .setting-val { font-weight: 600; color: #e8edf2; }
+  .reads-val { color: #80e0e0; }
+  .when-val { color: #c8d8e8; font-size: 12px; }
+
+  .altitude-bar { display: flex; flex-direction: column; margin-bottom: 28px; border-radius: 10px; overflow: hidden; border: 1.5px solid #1a2d3d; }
+  .alt-row { display: grid; grid-template-columns: 160px 1fr; align-items: stretch; border-bottom: 1px solid rgba(255,255,255,0.05); }
+  .alt-row:last-child { border-bottom: none; }
+  .alt-label { padding: 14px 16px; background: #1a2d3d; }
+  .alt-ft { font-size: 14px; font-weight: 700; color: #f0c040; }
+  .alt-desc { font-size: 11px; color: #7a9ab5; margin-top: 3px; }
+  .alt-content { padding: 14px 16px; }
+  .alt-content .badge { display: inline-block; border-radius: 4px; padding: 3px 10px; font-size: 12px; font-weight: 700; margin-bottom: 6px; }
+  .qne-badge { background: rgba(240,192,64,0.15); color: #f0c040; border: 1px solid rgba(240,192,64,0.4); }
+  .qnh-badge { background: rgba(80,160,255,0.12); color: #80b8ff; border: 1px solid rgba(80,160,255,0.3); }
+  .alt-content p { font-size: 12px; color: #c8d8e8; margin-top: 4px; }
+
+  .hook-box { background: #1a2a1a; border: 1.5px solid #2d5a2d; border-radius: 10px; padding: 18px 22px; }
+  .hook-box h2 { font-size: 12px; color: #80c880; text-transform: uppercase; letter-spacing: 1px; margin-bottom: 12px; }
+  .hook-row { display: flex; gap: 10px; margin-bottom: 8px; align-items: flex-start; }
+  .hook-badge { background: #2d5a2d; color: #80c880; font-size: 10px; font-weight: 800; padding: 2px 8px; border-radius: 10px; white-space: nowrap; flex-shrink: 0; margin-top: 2px; }
+  .hook-text { font-size: 13px; color: #c8d8c8; line-height: 1.5; }
+  .hook-text strong { color: #f0c040; }
+</style>
+</head>
+<body>
+
+<h1>AL-004 — Altimeter Settings</h1>
+<p class="subtitle">Transport Canada · CARs 602.35, TP 12880E Ch.8, AIM RAC 9.11 · PPL Written Exam</p>
+
+<!-- Q-code reference table -->
+<div class="section-label">Q-Code Reference</div>
+<table>
+  <thead>
+    <tr>
+      <th>Code</th>
+      <th>Setting</th>
+      <th>Reads</th>
+      <th>Used When</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><span class="code">QNH</span></td>
+      <td class="setting-val">Current local sea-level pressure<br><small style="color:#7a9ab5;">Changes constantly — get from ATIS or ATC</small></td>
+      <td class="reads-val">Altitude ASL</td>
+      <td class="when-val">Below 18,000 ft ASL (transition altitude) — standard VFR setting</td>
+    </tr>
+    <tr>
+      <td><span class="code">QNE</span></td>
+      <td class="setting-val">Standard pressure<br><small style="color:#7a9ab5;">29.92 inHg / 1013.25 hPa — fixed value</small></td>
+      <td class="reads-val">Pressure altitude (Flight Levels)</td>
+      <td class="when-val">At or above 18,000 ft ASL — FL180, FL200, FL240…</td>
+    </tr>
+    <tr>
+      <td><span class="code">QFE</span></td>
+      <td class="setting-val">Pressure at aerodrome elevation</td>
+      <td class="reads-val">Height above aerodrome (zero on runway)</td>
+      <td class="when-val">Rarely used in Canadian civil ops — know the definition for the exam</td>
+    </tr>
+  </tbody>
+</table>
+
+<!-- Altitude transition diagram -->
+<div class="section-label">Transition Altitude — 18,000 ft ASL</div>
+<div class="altitude-bar">
+  <div class="alt-row">
+    <div class="alt-label">
+      <div class="alt-ft">≥ 18,000 ft ASL</div>
+      <div class="alt-desc">Class A airspace<br>Flight Levels</div>
+    </div>
+    <div class="alt-content">
+      <span class="badge qne-badge">QNE — 29.92 inHg</span>
+      <p>All aircraft use standard pressure. Altimeter reads <strong style="color:#f0c040;">pressure altitude</strong>. Expressed as FL180, FL200, etc. IFR only above this level.</p>
+    </div>
+  </div>
+  <div class="alt-row">
+    <div class="alt-label">
+      <div class="alt-ft">&lt; 18,000 ft ASL</div>
+      <div class="alt-desc">VFR operations<br>Altitude ASL</div>
+    </div>
+    <div class="alt-content">
+      <span class="badge qnh-badge">QNH — local sea-level pressure</span>
+      <p>Use the current altimeter setting from the nearest station. Altimeter reads <strong style="color:#80b8ff;">altitude above sea level</strong>. Update when crossing regions.</p>
+    </div>
+  </div>
+</div>
+
+<!-- Memory hook -->
+<div class="hook-box">
+  <h2>Memory Hooks</h2>
+  <div class="hook-row"><span class="hook-badge">High → Low</span><span class="hook-text">Flying into lower pressure without resetting: your <strong>true altitude is lower</strong> than indicated — the ground is closer than you think. <strong>"High to low, look out below."</strong></span></div>
+  <div class="hook-row"><span class="hook-badge">Setting Up</span><span class="hook-text">Turning the Kollsman knob <strong>higher</strong> increases indicated altitude. Turning it <strong>lower</strong> decreases indicated altitude.</span></div>
+  <div class="hook-row"><span class="hook-badge">QNH vs QNE</span><span class="hook-text">QNH changes constantly (local weather); QNE is always <strong>29.92 inHg</strong> (standard, fixed).</span></div>
+</div>
+
+</body>
+</html>

--- a/web-app/public/visuals/al005-right-of-way-rules.html
+++ b/web-app/public/visuals/al005-right-of-way-rules.html
@@ -1,0 +1,143 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>AL-005: Right-of-Way Rules</title>
+<style>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body { background: #0d1b2a; color: #e8edf2; font-family: 'Segoe UI', system-ui, sans-serif; padding: 32px; max-width: 900px; margin: auto; }
+  h1 { font-size: 22px; color: #f0c040; letter-spacing: 1px; margin-bottom: 6px; }
+  .subtitle { font-size: 13px; color: #7a9ab5; margin-bottom: 32px; letter-spacing: 0.5px; }
+  .section-label { font-size: 11px; color: #7a9ab5; letter-spacing: 1px; text-transform: uppercase; margin-bottom: 8px; font-weight: 600; }
+
+  /* Hierarchy pyramid */
+  .hierarchy { display: flex; flex-direction: column; gap: 4px; margin-bottom: 28px; }
+  .hier-row { display: flex; align-items: center; gap: 12px; padding: 10px 16px; border-radius: 6px; }
+  .hier-num { font-size: 11px; font-weight: 800; color: #7a9ab5; width: 20px; flex-shrink: 0; }
+  .hier-label { font-size: 14px; font-weight: 700; flex: 1; }
+  .hier-note { font-size: 11px; color: #7a9ab5; }
+  .priority-1 { background: #1a1005; border-left: 4px solid #f0c040; }
+  .priority-2 { background: #0f1a0f; border-left: 4px solid #80e080; }
+  .priority-3 { background: #0a1520; border-left: 4px solid #7a9ab5; }
+  .priority-4 { background: #0a1520; border-left: 4px solid #5a7a95; }
+  .priority-5 { background: #0a1520; border-left: 4px solid #3a5a75; }
+  .priority-1 .hier-label { color: #f0c040; }
+  .priority-2 .hier-label { color: #80e080; }
+  .priority-3 .hier-label, .priority-4 .hier-label, .priority-5 .hier-label { color: #e8edf2; }
+  .gives-way-tag { font-size: 10px; background: rgba(255,80,80,0.12); color: #ff9090; border: 1px solid rgba(255,80,80,0.25); border-radius: 4px; padding: 2px 7px; font-weight: 700; }
+  .right-of-way-tag { font-size: 10px; background: rgba(80,200,80,0.12); color: #80e080; border: 1px solid rgba(80,200,80,0.25); border-radius: 4px; padding: 2px 7px; font-weight: 700; }
+
+  table { width: 100%; border-collapse: collapse; font-size: 13px; margin-bottom: 28px; }
+  th { background: #1a2d3d; color: #7a9ab5; padding: 9px 12px; text-align: left; font-size: 11px; text-transform: uppercase; letter-spacing: 0.5px; }
+  td { padding: 10px 12px; border-bottom: 1px solid #1a2d3d; vertical-align: top; }
+  .scenario-col { font-weight: 600; color: #e8edf2; }
+  .gives-way-col { color: #ff9090; font-weight: 700; }
+  .rule-col { font-size: 12px; color: #7a9ab5; }
+
+  .hook-box { background: #1a2a1a; border: 1.5px solid #2d5a2d; border-radius: 10px; padding: 18px 22px; }
+  .hook-box h2 { font-size: 12px; color: #80c880; text-transform: uppercase; letter-spacing: 1px; margin-bottom: 12px; }
+  .hook-row { display: flex; gap: 10px; margin-bottom: 8px; align-items: flex-start; }
+  .hook-badge { background: #2d5a2d; color: #80c880; font-size: 10px; font-weight: 800; padding: 2px 8px; border-radius: 10px; white-space: nowrap; flex-shrink: 0; margin-top: 2px; }
+  .hook-text { font-size: 13px; color: #c8d8c8; line-height: 1.5; }
+  .hook-text strong { color: #f0c040; }
+</style>
+</head>
+<body>
+
+<h1>AL-005 — Right-of-Way Rules</h1>
+<p class="subtitle">Transport Canada · CARs 602.19–602.21, TP 12880E · PPL Written Exam</p>
+
+<!-- Aircraft category hierarchy -->
+<div class="section-label">Aircraft Category Hierarchy — Higher = More Right-of-Way</div>
+<div class="hierarchy">
+  <div class="hier-row priority-1">
+    <span class="hier-num">1</span>
+    <span class="hier-label">Balloons</span>
+    <span class="right-of-way-tag">Right of Way over All</span>
+    <span class="hier-note">Cannot manoeuvre on demand</span>
+  </div>
+  <div class="hier-row priority-2">
+    <span class="hier-num">2</span>
+    <span class="hier-label">Gliders</span>
+    <span class="right-of-way-tag">Over Airships, Tow, Powered</span>
+    <span class="hier-note">No engine — limited manoeuvring</span>
+  </div>
+  <div class="hier-row priority-3">
+    <span class="hier-num">3</span>
+    <span class="hier-label">Airships</span>
+    <span class="hier-note">Over towing aircraft and powered aircraft</span>
+  </div>
+  <div class="hier-row priority-4">
+    <span class="hier-num">4</span>
+    <span class="hier-label">Aircraft towing other aircraft or objects</span>
+    <span class="hier-note">Over powered aircraft only</span>
+  </div>
+  <div class="hier-row priority-5">
+    <span class="hier-num">5</span>
+    <span class="hier-label">Powered Aircraft</span>
+    <span class="gives-way-tag">Lowest Priority — Yields to All Above</span>
+  </div>
+</div>
+
+<!-- Scenario table -->
+<div class="section-label">Scenario Quick Reference — CARs 602.19–602.21</div>
+<table>
+  <thead>
+    <tr>
+      <th>Scenario</th>
+      <th>Who Gives Way</th>
+      <th>Rule / Source</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td class="scenario-col">Powered aircraft vs. glider (converging)</td>
+      <td class="gives-way-col">Powered aircraft</td>
+      <td class="rule-col">Category hierarchy — CARs 602.19(1)</td>
+    </tr>
+    <tr>
+      <td class="scenario-col">Two powered aircraft converging at same altitude</td>
+      <td class="gives-way-col">Aircraft that has the other on its right</td>
+      <td class="rule-col">Give way to traffic on your right — CARs 602.19(2)</td>
+    </tr>
+    <tr>
+      <td class="scenario-col">Head-on approach (collision risk)</td>
+      <td class="gives-way-col">Both aircraft turn right</td>
+      <td class="rule-col">Both turn simultaneously — CARs 602.20</td>
+    </tr>
+    <tr>
+      <td class="scenario-col">Overtaking (from behind, within 70° of tail)</td>
+      <td class="gives-way-col">Overtaking aircraft — passes to the right, yields</td>
+      <td class="rule-col">Being-overtaken aircraft holds course — CARs 602.21</td>
+    </tr>
+    <tr>
+      <td class="scenario-col">Aircraft on final approach / landing</td>
+      <td class="gives-way-col">All other aircraft yield to the landing aircraft</td>
+      <td class="rule-col">Lower on approach = higher priority — CARs 602.19(3)</td>
+    </tr>
+    <tr>
+      <td class="scenario-col">Two aircraft on approach at different altitudes</td>
+      <td class="gives-way-col">Higher aircraft yields to the lower aircraft</td>
+      <td class="rule-col">CARs 602.19(3)</td>
+    </tr>
+    <tr>
+      <td class="scenario-col">Aircraft declaring emergency (MAYDAY / PAN-PAN)</td>
+      <td class="gives-way-col">All other aircraft yield — absolute priority</td>
+      <td class="rule-col">Emergency overrides all other rules</td>
+    </tr>
+  </tbody>
+</table>
+
+<!-- Exam decision flow -->
+<div class="hook-box">
+  <h2>Exam Decision Flow — Work Through in Order</h2>
+  <div class="hook-row"><span class="hook-badge">Step 1</span><span class="hook-text">Different aircraft categories? Apply <strong>category hierarchy</strong> — powered aircraft yields to glider, balloon, etc.</span></div>
+  <div class="hook-row"><span class="hook-badge">Step 2</span><span class="hook-text">Is one aircraft on <strong>approach to land</strong>? Landing aircraft has priority over all others.</span></div>
+  <div class="hook-row"><span class="hook-badge">Step 3</span><span class="hook-text">Same category, <strong>converging</strong>? The aircraft that has the other on its RIGHT gives way.</span></div>
+  <div class="hook-row"><span class="hook-badge">Step 4</span><span class="hook-text"><strong>Head-on</strong>? Both aircraft turn right — simultaneously.</span></div>
+  <div class="hook-row"><span class="hook-badge">Step 5</span><span class="hook-text"><strong>Overtaking</strong>? Overtaking aircraft passes to the right and yields. Being-overtaken holds course.</span></div>
+</div>
+
+</body>
+</html>

--- a/web-app/public/visuals/al006-aerodrome-traffic-circuit.html
+++ b/web-app/public/visuals/al006-aerodrome-traffic-circuit.html
@@ -1,0 +1,209 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>AL-006: Aerodrome Traffic Circuit</title>
+<style>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body { background: #0d1b2a; color: #e8edf2; font-family: 'Segoe UI', system-ui, sans-serif; padding: 32px; max-width: 900px; margin: auto; }
+  h1 { font-size: 22px; color: #f0c040; letter-spacing: 1px; margin-bottom: 6px; }
+  .subtitle { font-size: 13px; color: #7a9ab5; margin-bottom: 32px; letter-spacing: 0.5px; }
+  .section-label { font-size: 11px; color: #7a9ab5; letter-spacing: 1px; text-transform: uppercase; margin-bottom: 8px; font-weight: 600; }
+
+  /* Circuit diagram using CSS grid */
+  .circuit-container { background: #0a1520; border: 1.5px solid #1a2d3d; border-radius: 10px; padding: 24px; margin-bottom: 28px; }
+  .circuit-diagram { display: grid; grid-template-columns: 1fr 180px 1fr; grid-template-rows: auto auto auto auto auto; gap: 0; max-width: 600px; margin: 0 auto; }
+
+  /* Runway */
+  .runway-cell { grid-column: 2; grid-row: 3; display: flex; align-items: center; justify-content: center; }
+  .runway { background: #2a3a4a; border: 2px solid #f0c040; border-radius: 4px; padding: 8px 16px; text-align: center; font-size: 11px; font-weight: 800; color: #f0c040; letter-spacing: 2px; width: 100%; }
+  .runway-arrows { font-size: 14px; display: block; margin-top: 2px; color: #7a9ab5; }
+
+  /* Leg labels */
+  .leg-cell { display: flex; align-items: center; justify-content: center; padding: 8px; }
+  .leg-label { text-align: center; }
+  .leg-name { font-size: 13px; font-weight: 700; color: #f0c040; display: block; }
+  .leg-detail { font-size: 11px; color: #7a9ab5; display: block; margin-top: 3px; line-height: 1.4; }
+  .leg-arrow { font-size: 20px; color: #80b8ff; display: block; margin-bottom: 4px; }
+
+  /* Direction arrows along legs */
+  .arrow-h { display: flex; align-items: center; justify-content: center; padding: 4px 0; }
+  .arrow-v { display: flex; align-items: center; justify-content: center; }
+  .line-h { height: 2px; background: #80b8ff; flex: 1; }
+  .line-v { width: 2px; background: #80b8ff; flex: 1; min-height: 40px; }
+  .arrowhead { color: #80b8ff; font-size: 14px; }
+
+  /* Grid positions for legs */
+  .upwind { grid-column: 2; grid-row: 5; }
+  .crosswind { grid-column: 3; grid-row: 2; }
+  .downwind { grid-column: 2; grid-row: 1; }
+  .base { grid-column: 1; grid-row: 2; }
+  .final { grid-column: 2; grid-row: 4; }
+
+  .corner-tr { grid-column: 3; grid-row: 1; display: flex; align-items: flex-end; justify-content: flex-start; padding: 4px; color: #80b8ff; font-size: 16px; }
+  .corner-br { grid-column: 3; grid-row: 5; display: flex; align-items: flex-start; justify-content: flex-start; padding: 4px; color: #80b8ff; font-size: 16px; }
+  .corner-tl { grid-column: 1; grid-row: 1; display: flex; align-items: flex-end; justify-content: flex-end; padding: 4px; color: #80b8ff; font-size: 16px; }
+  .corner-bl { grid-column: 1; grid-row: 5; display: flex; align-items: flex-start; justify-content: flex-end; padding: 4px; color: #80b8ff; font-size: 16px; }
+
+  .diagram-note { text-align: center; font-size: 11px; color: #7a9ab5; margin-top: 12px; }
+
+  /* Legs reference table */
+  table { width: 100%; border-collapse: collapse; font-size: 13px; margin-bottom: 28px; }
+  th { background: #1a2d3d; color: #7a9ab5; padding: 9px 12px; text-align: left; font-size: 11px; text-transform: uppercase; letter-spacing: 0.5px; }
+  td { padding: 10px 12px; border-bottom: 1px solid #1a2d3d; vertical-align: top; }
+  .leg-name-col { font-weight: 700; color: #f0c040; }
+  .leg-order { display: inline-block; width: 20px; height: 20px; border-radius: 50%; background: #1a2d3d; color: #7a9ab5; font-size: 10px; font-weight: 800; text-align: center; line-height: 20px; margin-right: 6px; }
+
+  /* Standards panel */
+  .standards-grid { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 12px; margin-bottom: 28px; }
+  .std-card { background: #1a2d3d; border-radius: 8px; padding: 14px 16px; }
+  .std-card h3 { font-size: 11px; color: #7a9ab5; text-transform: uppercase; letter-spacing: 0.5px; margin-bottom: 8px; }
+  .std-value { font-size: 16px; font-weight: 800; color: #f0c040; }
+  .std-note { font-size: 11px; color: #7a9ab5; margin-top: 4px; }
+
+  .hook-box { background: #1a2a1a; border: 1.5px solid #2d5a2d; border-radius: 10px; padding: 18px 22px; }
+  .hook-box h2 { font-size: 12px; color: #80c880; text-transform: uppercase; letter-spacing: 1px; margin-bottom: 12px; }
+  .hook-row { display: flex; gap: 10px; margin-bottom: 8px; align-items: flex-start; }
+  .hook-badge { background: #2d5a2d; color: #80c880; font-size: 10px; font-weight: 800; padding: 2px 8px; border-radius: 10px; white-space: nowrap; flex-shrink: 0; margin-top: 2px; }
+  .hook-text { font-size: 13px; color: #c8d8c8; line-height: 1.5; }
+  .hook-text strong { color: #f0c040; }
+
+  @media (max-width: 600px) { .standards-grid { grid-template-columns: 1fr; } }
+</style>
+</head>
+<body>
+
+<h1>AL-006 — Aerodrome Traffic Circuit</h1>
+<p class="subtitle">Transport Canada · CARs 602.96, 602.105, TP 12880E, AIM RAC 4.5 · PPL Written Exam</p>
+
+<!-- Circuit diagram -->
+<div class="section-label">Standard Left-Hand Circuit (all turns to the left)</div>
+<div class="circuit-container">
+  <div class="circuit-diagram">
+    <!-- Row 1: Downwind label + corners -->
+    <div class="corner-tl">↙</div>
+    <div class="leg-cell downwind">
+      <div class="leg-label">
+        <span class="leg-name">⬅ DOWNWIND</span>
+        <span class="leg-detail">Parallel to runway<br>Opposite direction to landing<br>1,000 ft AGL · pre-landing checks</span>
+      </div>
+    </div>
+    <div class="corner-tr">↙</div>
+
+    <!-- Row 2: Base label + crosswind label -->
+    <div class="leg-cell base">
+      <div class="leg-label">
+        <span class="leg-name">BASE ↓</span>
+        <span class="leg-detail">90° to runway<br>Toward runway<br>Extend flaps</span>
+      </div>
+    </div>
+    <div></div><!-- empty runway column row 2 -->
+    <div class="leg-cell crosswind">
+      <div class="leg-label">
+        <span class="leg-name">CROSSWIND ↑</span>
+        <span class="leg-detail">90° to runway<br>Away from runway<br>Climb to circuit altitude</span>
+      </div>
+    </div>
+
+    <!-- Row 3: Runway -->
+    <div></div>
+    <div class="runway-cell">
+      <div class="runway">RUNWAY<span class="runway-arrows">▲ ▼</span></div>
+    </div>
+    <div></div>
+
+    <!-- Row 4: Final label -->
+    <div></div>
+    <div class="leg-cell final">
+      <div class="leg-label">
+        <span class="leg-name">FINAL ↓</span>
+        <span class="leg-detail">Aligned with runway<br>Into wind · descending<br>to land</span>
+      </div>
+    </div>
+    <div></div>
+
+    <!-- Row 5: Upwind label + corners -->
+    <div class="corner-bl">↖</div>
+    <div class="leg-cell upwind">
+      <div class="leg-label">
+        <span class="leg-name">UPWIND ➡</span>
+        <span class="leg-detail">After take-off · climb-out<br>Same direction as runway</span>
+      </div>
+    </div>
+    <div class="corner-br">↖</div>
+  </div>
+  <p class="diagram-note">Left-hand circuit shown. Arrows indicate direction of aircraft travel. All turns to the LEFT.</p>
+</div>
+
+<!-- Standards -->
+<div class="section-label">Circuit Standards</div>
+<div class="standards-grid">
+  <div class="std-card">
+    <h3>Standard Direction</h3>
+    <div class="std-value">Left-Hand</div>
+    <div class="std-note">All turns to the left unless CFS, NOTAM, or ATC specifies right-hand</div>
+  </div>
+  <div class="std-card">
+    <h3>Circuit Altitude</h3>
+    <div class="std-value">1,000 ft AGL</div>
+    <div class="std-note">Light aircraft. Some aerodromes use 1,500 ft AGL — check CFS</div>
+  </div>
+  <div class="std-card">
+    <h3>Standard Join</h3>
+    <div class="std-value">45° Mid-Downwind</div>
+    <div class="std-note">From non-traffic (upwind) side, 45° angle to mid-point of downwind</div>
+  </div>
+</div>
+
+<!-- Legs table -->
+<div class="section-label">Circuit Legs — In Order</div>
+<table>
+  <thead>
+    <tr><th>Order</th><th>Leg</th><th>Description</th><th>Key Actions</th></tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><span style="color:#f0c040;font-weight:800;">1</span></td>
+      <td class="leg-name-col">Upwind</td>
+      <td>Departure, same direction as runway heading, climbing</td>
+      <td style="font-size:12px;color:#7a9ab5;">Initial climb-out, retract flaps</td>
+    </tr>
+    <tr>
+      <td><span style="color:#f0c040;font-weight:800;">2</span></td>
+      <td class="leg-name-col">Crosswind</td>
+      <td>Perpendicular to runway, away from aerodrome</td>
+      <td style="font-size:12px;color:#7a9ab5;">Continue climb to circuit altitude</td>
+    </tr>
+    <tr>
+      <td><span style="color:#f0c040;font-weight:800;">3</span></td>
+      <td class="leg-name-col">Downwind</td>
+      <td>Parallel to runway, opposite direction to landing, at circuit altitude</td>
+      <td style="font-size:12px;color:#7a9ab5;">ATIS/altimeter, fuel, pre-landing checks</td>
+    </tr>
+    <tr>
+      <td><span style="color:#f0c040;font-weight:800;">4</span></td>
+      <td class="leg-name-col">Base</td>
+      <td>Perpendicular to runway, toward the runway</td>
+      <td style="font-size:12px;color:#7a9ab5;">Reduce speed, extend flaps, begin descent</td>
+    </tr>
+    <tr>
+      <td><span style="color:#f0c040;font-weight:800;">5</span></td>
+      <td class="leg-name-col">Final</td>
+      <td>Aligned with runway, into wind, descending to land</td>
+      <td style="font-size:12px;color:#7a9ab5;">Manage descent rate, airspeed, alignment</td>
+    </tr>
+  </tbody>
+</table>
+
+<!-- Memory hooks -->
+<div class="hook-box">
+  <h2>Key Facts for the Exam</h2>
+  <div class="hook-row"><span class="hook-badge">Direction</span><span class="hook-text"><strong>Left-hand turns</strong> are the Canadian standard. Right-hand only when published in CFS, NOTAM, or directed by ATC.</span></div>
+  <div class="hook-row"><span class="hook-badge">Altitude</span><span class="hook-text">Standard altitude is <strong>1,000 ft AGL</strong> for light aircraft. Always check the CFS for aerodrome-specific info.</span></div>
+  <div class="hook-row"><span class="hook-badge">Downwind</span><span class="hook-text">The leg that runs <strong>parallel to the runway in the opposite direction to landing</strong>. This is the "which leg" question on the exam.</span></div>
+  <div class="hook-row"><span class="hook-badge">Joining</span><span class="hook-text">Recommended join: <strong>45° to mid-downwind from the non-traffic side</strong> (the upwind side of the runway).</span></div>
+</div>
+
+</body>
+</html>

--- a/web-app/public/visuals/al007-radio-communications.html
+++ b/web-app/public/visuals/al007-radio-communications.html
@@ -1,0 +1,198 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>AL-007: Radio Communications</title>
+<style>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body { background: #0d1b2a; color: #e8edf2; font-family: 'Segoe UI', system-ui, sans-serif; padding: 32px; max-width: 900px; margin: auto; }
+  h1 { font-size: 22px; color: #f0c040; letter-spacing: 1px; margin-bottom: 6px; }
+  .subtitle { font-size: 13px; color: #7a9ab5; margin-bottom: 32px; letter-spacing: 0.5px; }
+  .section-label { font-size: 11px; color: #7a9ab5; letter-spacing: 1px; text-transform: uppercase; margin-bottom: 8px; font-weight: 600; }
+
+  /* Phonetic alphabet — two-column grid */
+  .alphabet-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 3px; margin-bottom: 28px; border-radius: 8px; overflow: hidden; border: 1.5px solid #1a2d3d; }
+  .alpha-row { display: grid; grid-template-columns: 36px 1fr; align-items: center; padding: 7px 12px; background: #0d1b2a; border-bottom: 1px solid rgba(255,255,255,0.04); }
+  .alpha-row:nth-child(even) { background: #0a1520; }
+  .alpha-letter { font-size: 16px; font-weight: 800; color: #f0c040; }
+  .alpha-word { font-size: 13px; color: #e8edf2; }
+
+  /* Phraseology table */
+  table { width: 100%; border-collapse: collapse; font-size: 13px; margin-bottom: 28px; }
+  th { background: #1a2d3d; color: #7a9ab5; padding: 9px 12px; text-align: left; font-size: 11px; text-transform: uppercase; letter-spacing: 0.5px; }
+  td { padding: 10px 12px; border-bottom: 1px solid #1a2d3d; vertical-align: top; }
+  .word-col { font-weight: 800; color: #f0c040; font-size: 14px; }
+  .meaning-col { color: #e8edf2; }
+  .trap-col { font-size: 12px; color: #ff9090; }
+
+  /* Light gun table */
+  .gun-table td:first-child { font-weight: 700; }
+  .gun-green { color: #80e080; }
+  .gun-red { color: #ff9090; }
+  .gun-white { color: #e8edf2; }
+  .gun-alt { color: #f0c040; }
+
+  .hook-box { background: #1a2a1a; border: 1.5px solid #2d5a2d; border-radius: 10px; padding: 18px 22px; }
+  .hook-box h2 { font-size: 12px; color: #80c880; text-transform: uppercase; letter-spacing: 1px; margin-bottom: 12px; }
+  .hook-row { display: flex; gap: 10px; margin-bottom: 8px; align-items: flex-start; }
+  .hook-badge { background: #2d5a2d; color: #80c880; font-size: 10px; font-weight: 800; padding: 2px 8px; border-radius: 10px; white-space: nowrap; flex-shrink: 0; margin-top: 2px; }
+  .hook-text { font-size: 13px; color: #c8d8c8; line-height: 1.5; }
+  .hook-text strong { color: #f0c040; }
+
+  @media (max-width: 500px) { .alphabet-grid { grid-template-columns: 1fr; } }
+</style>
+</head>
+<body>
+
+<h1>AL-007 — Radio Communications</h1>
+<p class="subtitle">Transport Canada · CARs 602.136, 602.138, TP 12880E, AIM COM 5.0 · PPL Written Exam</p>
+
+<!-- ICAO phonetic alphabet -->
+<div class="section-label">ICAO Phonetic Alphabet</div>
+<div class="alphabet-grid">
+  <div class="alpha-row"><span class="alpha-letter">A</span><span class="alpha-word">Alpha</span></div>
+  <div class="alpha-row"><span class="alpha-letter">N</span><span class="alpha-word">November</span></div>
+  <div class="alpha-row"><span class="alpha-letter">B</span><span class="alpha-word">Bravo</span></div>
+  <div class="alpha-row"><span class="alpha-letter">O</span><span class="alpha-word">Oscar</span></div>
+  <div class="alpha-row"><span class="alpha-letter">C</span><span class="alpha-word">Charlie</span></div>
+  <div class="alpha-row"><span class="alpha-letter">P</span><span class="alpha-word">Papa</span></div>
+  <div class="alpha-row"><span class="alpha-letter">D</span><span class="alpha-word">Delta</span></div>
+  <div class="alpha-row"><span class="alpha-letter">Q</span><span class="alpha-word">Quebec</span></div>
+  <div class="alpha-row"><span class="alpha-letter">E</span><span class="alpha-word">Echo</span></div>
+  <div class="alpha-row"><span class="alpha-letter">R</span><span class="alpha-word">Romeo</span></div>
+  <div class="alpha-row"><span class="alpha-letter">F</span><span class="alpha-word">Foxtrot</span></div>
+  <div class="alpha-row"><span class="alpha-letter">S</span><span class="alpha-word">Sierra</span></div>
+  <div class="alpha-row"><span class="alpha-letter">G</span><span class="alpha-word">Golf</span></div>
+  <div class="alpha-row"><span class="alpha-letter">T</span><span class="alpha-word">Tango</span></div>
+  <div class="alpha-row"><span class="alpha-letter">H</span><span class="alpha-word">Hotel</span></div>
+  <div class="alpha-row"><span class="alpha-letter">U</span><span class="alpha-word">Uniform</span></div>
+  <div class="alpha-row"><span class="alpha-letter">I</span><span class="alpha-word">India</span></div>
+  <div class="alpha-row"><span class="alpha-letter">V</span><span class="alpha-word">Victor</span></div>
+  <div class="alpha-row"><span class="alpha-letter">J</span><span class="alpha-word">Juliet</span></div>
+  <div class="alpha-row"><span class="alpha-letter">W</span><span class="alpha-word">Whiskey</span></div>
+  <div class="alpha-row"><span class="alpha-letter">K</span><span class="alpha-word">Kilo</span></div>
+  <div class="alpha-row"><span class="alpha-letter">X</span><span class="alpha-word">X-ray</span></div>
+  <div class="alpha-row"><span class="alpha-letter">L</span><span class="alpha-word">Lima</span></div>
+  <div class="alpha-row"><span class="alpha-letter">Y</span><span class="alpha-word">Yankee</span></div>
+  <div class="alpha-row"><span class="alpha-letter">M</span><span class="alpha-word">Mike</span></div>
+  <div class="alpha-row"><span class="alpha-letter">Z</span><span class="alpha-word">Zulu</span></div>
+</div>
+
+<!-- Standard phraseology -->
+<div class="section-label">Standard Phraseology — Key Words</div>
+<table>
+  <thead>
+    <tr><th>Word</th><th>Meaning</th><th>Common Exam Trap</th></tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td class="word-col">Roger</td>
+      <td class="meaning-col">I have received all of your last transmission</td>
+      <td class="trap-col">Does NOT mean you will comply — use Wilco for that</td>
+    </tr>
+    <tr>
+      <td class="word-col">Wilco</td>
+      <td class="meaning-col">Understood and will comply</td>
+      <td class="trap-col">Implies Roger — don't say both</td>
+    </tr>
+    <tr>
+      <td class="word-col">Affirmative</td>
+      <td class="meaning-col">Yes</td>
+      <td class="trap-col">Don't use "yeah", "yep", or informal equivalents</td>
+    </tr>
+    <tr>
+      <td class="word-col">Negative</td>
+      <td class="meaning-col">No</td>
+      <td class="trap-col">Don't use "nope" or informal equivalents</td>
+    </tr>
+    <tr>
+      <td class="word-col">Standby</td>
+      <td class="meaning-col">ATC has heard your call — wait for a response</td>
+      <td class="trap-col">Does NOT authorize any action — wait for full clearance</td>
+    </tr>
+    <tr>
+      <td class="word-col">Unable</td>
+      <td class="meaning-col">Cannot comply with the instruction</td>
+      <td class="trap-col">Always state a reason: "Unable, terrain"</td>
+    </tr>
+    <tr>
+      <td class="word-col">Say Again</td>
+      <td class="meaning-col">Please repeat your last transmission</td>
+      <td class="trap-col">"Repeat" is NOT standard civilian phraseology — use "Say Again"</td>
+    </tr>
+  </tbody>
+</table>
+
+<!-- Readback requirement -->
+<div class="section-label">Runway Clearance Readback — CARs 602.136</div>
+<table>
+  <thead>
+    <tr><th>Clearance Type</th><th>Mandatory Readback Elements</th></tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td style="font-weight:600;">Take-off / Landing / Crossing / Hold-short clearance</td>
+      <td><span style="color:#f0c040;font-weight:700;">Runway designation + Aircraft call sign</span> + any hold-short instruction</td>
+    </tr>
+    <tr>
+      <td style="font-weight:600;">Taxi route including runway crossing</td>
+      <td>Full taxi route including the runway(s) to be crossed</td>
+    </tr>
+    <tr>
+      <td style="font-weight:600;">Altitude/heading assignment, altimeter setting</td>
+      <td>The assigned value + call sign</td>
+    </tr>
+  </tbody>
+</table>
+
+<!-- Light gun signals -->
+<div class="section-label">Light Gun Signals (Radio Failure — Squawk 7600)</div>
+<table class="gun-table">
+  <thead>
+    <tr><th>Signal</th><th>For Aircraft in Flight</th><th>For Aircraft on Ground</th></tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td class="gun-green">Steady Green</td>
+      <td>Cleared to land</td>
+      <td>Cleared for take-off</td>
+    </tr>
+    <tr>
+      <td class="gun-green">Flashing Green</td>
+      <td>Cleared to approach</td>
+      <td>Cleared to taxi</td>
+    </tr>
+    <tr>
+      <td class="gun-red">Steady Red</td>
+      <td>Give way, continue circling</td>
+      <td>Stop</td>
+    </tr>
+    <tr>
+      <td class="gun-red">Flashing Red</td>
+      <td>Aerodrome unsafe — do not land</td>
+      <td>Taxi clear of runway in use</td>
+    </tr>
+    <tr>
+      <td class="gun-white">Flashing White</td>
+      <td>Return to start position</td>
+      <td>Return to starting point on aerodrome</td>
+    </tr>
+    <tr>
+      <td class="gun-alt">Alternating Red &amp; Green</td>
+      <td colspan="2">Exercise extreme caution</td>
+    </tr>
+  </tbody>
+</table>
+
+<!-- Exam traps -->
+<div class="hook-box">
+  <h2>Common Exam Traps</h2>
+  <div class="hook-row"><span class="hook-badge">Roger ≠ Comply</span><span class="hook-text">"Roger" confirms you received the message. <strong>"Wilco"</strong> means you will comply. A landing clearance requires a full readback — not just "Roger".</span></div>
+  <div class="hook-row"><span class="hook-badge">Say Again</span><span class="hook-text">Use <strong>"Say Again"</strong> — not "Repeat". "Repeat" has a specific military meaning (fire again) and is non-standard in civilian aviation.</span></div>
+  <div class="hook-row"><span class="hook-badge">Uncontrolled</span><span class="hook-text">At uncontrolled aerodromes you are <strong>broadcasting position and intentions</strong>, not requesting clearance. No ATC present.</span></div>
+  <div class="hook-row"><span class="hook-badge">Niner</span><span class="hook-text">The digit 9 is pronounced <strong>"niner"</strong> in aviation to avoid confusion with the German word for "no" (nein).</span></div>
+</div>
+
+</body>
+</html>

--- a/web-app/public/visuals/al008-atc-services-clearances.html
+++ b/web-app/public/visuals/al008-atc-services-clearances.html
@@ -1,0 +1,194 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>AL-008: ATC Services and Clearances</title>
+<style>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body { background: #0d1b2a; color: #e8edf2; font-family: 'Segoe UI', system-ui, sans-serif; padding: 32px; max-width: 900px; margin: auto; }
+  h1 { font-size: 22px; color: #f0c040; letter-spacing: 1px; margin-bottom: 6px; }
+  .subtitle { font-size: 13px; color: #7a9ab5; margin-bottom: 32px; letter-spacing: 0.5px; }
+  .section-label { font-size: 11px; color: #7a9ab5; letter-spacing: 1px; text-transform: uppercase; margin-bottom: 8px; font-weight: 600; }
+
+  /* ATC units cards */
+  .units-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; margin-bottom: 28px; }
+  .unit-card { background: #1a2d3d; border-radius: 8px; padding: 16px; border-left: 4px solid #1a2d3d; }
+  .unit-card.twr { border-left-color: #f0c040; }
+  .unit-card.tcu { border-left-color: #80b8ff; }
+  .unit-card.acc { border-left-color: #80e080; }
+  .unit-card.fss { border-left-color: #7a9ab5; }
+  .unit-abbr { font-size: 18px; font-weight: 800; margin-bottom: 2px; }
+  .twr .unit-abbr { color: #f0c040; }
+  .tcu .unit-abbr { color: #80b8ff; }
+  .acc .unit-abbr { color: #80e080; }
+  .fss .unit-abbr { color: #7a9ab5; }
+  .unit-name { font-size: 12px; color: #7a9ab5; margin-bottom: 8px; }
+  .unit-role { font-size: 13px; color: #e8edf2; line-height: 1.5; }
+  .unit-detail { font-size: 11px; color: #7a9ab5; margin-top: 6px; line-height: 1.4; }
+  .not-atc { display: inline-block; font-size: 10px; background: rgba(150,150,150,0.12); color: #aaa; border: 1px solid rgba(150,150,150,0.25); border-radius: 4px; padding: 1px 6px; margin-bottom: 4px; }
+
+  /* Handoff sequence */
+  .handoff { display: flex; flex-direction: column; gap: 0; margin-bottom: 28px; border-radius: 10px; overflow: hidden; border: 1.5px solid #1a2d3d; }
+  .handoff-row { display: grid; grid-template-columns: 36px 160px 1fr; align-items: center; padding: 11px 16px; gap: 12px; border-bottom: 1px solid rgba(255,255,255,0.05); }
+  .handoff-row:last-child { border-bottom: none; }
+  .step-num { font-size: 11px; font-weight: 800; color: #7a9ab5; text-align: center; }
+  .step-unit { font-weight: 700; font-size: 13px; }
+  .step-twr { color: #f0c040; }
+  .step-tcu { color: #80b8ff; }
+  .step-acc { color: #80e080; }
+  .step-gnd { color: #c8b870; }
+  .step-cd { color: #d0a050; }
+  .step-desc { font-size: 12px; color: #c8d8e8; }
+  .dep-row { background: #0a1a0a; }
+  .arr-row { background: #0a0a1a; }
+  .header-row { background: #1a2d3d; }
+  .header-row .step-desc { color: #7a9ab5; font-weight: 700; font-size: 11px; text-transform: uppercase; letter-spacing: 0.5px; }
+
+  /* CRAFT table */
+  table { width: 100%; border-collapse: collapse; font-size: 13px; margin-bottom: 28px; }
+  th { background: #1a2d3d; color: #7a9ab5; padding: 9px 12px; text-align: left; font-size: 11px; text-transform: uppercase; letter-spacing: 0.5px; }
+  td { padding: 10px 12px; border-bottom: 1px solid #1a2d3d; vertical-align: top; }
+  .craft-letter { font-size: 20px; font-weight: 800; color: #f0c040; width: 36px; }
+  .craft-word { font-weight: 700; color: #e8edf2; }
+  .craft-desc { font-size: 12px; color: #7a9ab5; margin-top: 3px; }
+
+  .hook-box { background: #1a2a1a; border: 1.5px solid #2d5a2d; border-radius: 10px; padding: 18px 22px; }
+  .hook-box h2 { font-size: 12px; color: #80c880; text-transform: uppercase; letter-spacing: 1px; margin-bottom: 12px; }
+  .hook-row { display: flex; gap: 10px; margin-bottom: 8px; align-items: flex-start; }
+  .hook-badge { background: #2d5a2d; color: #80c880; font-size: 10px; font-weight: 800; padding: 2px 8px; border-radius: 10px; white-space: nowrap; flex-shrink: 0; margin-top: 2px; }
+  .hook-text { font-size: 13px; color: #c8d8c8; line-height: 1.5; }
+  .hook-text strong { color: #f0c040; }
+
+  @media (max-width: 550px) { .units-grid { grid-template-columns: 1fr; } }
+</style>
+</head>
+<body>
+
+<h1>AL-008 — ATC Services and Clearances</h1>
+<p class="subtitle">Transport Canada · CARs 602.31, 602.32, 602.136, TP 12880E, AIM RAC 1.0 · PPL Written Exam</p>
+
+<!-- ATC units -->
+<div class="section-label">ATC Units — Who Does What</div>
+<div class="units-grid">
+  <div class="unit-card twr">
+    <div class="unit-abbr">TWR</div>
+    <div class="unit-name">Aerodrome Control Tower</div>
+    <div class="unit-role">Controls runways, taxiways, and the immediate aerodrome environment</div>
+    <div class="unit-detail">Issues taxi instructions, take-off &amp; landing clearances, circuit control. Sub-positions: Ground, Local, Clearance Delivery.</div>
+  </div>
+  <div class="unit-card tcu">
+    <div class="unit-abbr">TCU / APP</div>
+    <div class="unit-name">Terminal Control Unit / Approach Control</div>
+    <div class="unit-role">Controls the terminal area surrounding a major airport (typically Class C airspace)</div>
+    <div class="unit-detail">Handles departures after tower handoff; manages arrivals during approach. VFR in Class C contacts TCU.</div>
+  </div>
+  <div class="unit-card acc">
+    <div class="unit-abbr">ACC</div>
+    <div class="unit-name">Area Control Centre</div>
+    <div class="unit-role">Controls en route aircraft in controlled airspace</div>
+    <div class="unit-detail">Canada has ACCs in Toronto, Montréal, Edmonton, Vancouver, Gander, Moncton. Handles IFR (and VFR on request) between terminal areas.</div>
+  </div>
+  <div class="unit-card fss">
+    <div class="unit-abbr">FSS</div>
+    <div class="unit-name">Flight Service Station</div>
+    <span class="not-atc">NOT an ATC unit</span>
+    <div class="unit-role">Weather briefings, flight plan filing, MF advisory at uncontrolled aerodromes, SAR alerting</div>
+    <div class="unit-detail">Does not issue clearances. Provides traffic advisories at MF aerodromes.</div>
+  </div>
+</div>
+
+<!-- Handoff sequence -->
+<div class="section-label">Tower → TCU → ACC Handoff Sequence</div>
+<div class="handoff">
+  <div class="handoff-row header-row dep-row">
+    <div></div>
+    <div class="step-desc" style="grid-column: 2 / span 2;">DEPARTURE</div>
+  </div>
+  <div class="handoff-row dep-row">
+    <div class="step-num">1</div>
+    <div class="step-unit step-cd">Clearance Delivery / Ground</div>
+    <div class="step-desc">Pre-departure: taxi instructions, IFR clearance (CRAFT) at larger aerodromes</div>
+  </div>
+  <div class="handoff-row dep-row">
+    <div class="step-num">2</div>
+    <div class="step-unit step-twr">Tower (TWR)</div>
+    <div class="step-desc">Take-off clearance. Aircraft under tower control in circuit and immediate departure area</div>
+  </div>
+  <div class="handoff-row dep-row">
+    <div class="step-num">3</div>
+    <div class="step-unit step-tcu">TCU / Approach</div>
+    <div class="step-desc">Tower instructs pilot to contact TCU. Handles aircraft climbing through terminal area (Class C)</div>
+  </div>
+  <div class="handoff-row dep-row">
+    <div class="step-num">4</div>
+    <div class="step-unit step-acc">ACC</div>
+    <div class="step-desc">Clear of terminal area: TCU hands off to ACC for en route phase</div>
+  </div>
+  <div class="handoff-row header-row arr-row">
+    <div></div>
+    <div class="step-desc" style="grid-column: 2 / span 2;">ARRIVAL (reverse sequence)</div>
+  </div>
+  <div class="handoff-row arr-row">
+    <div class="step-num">↓</div>
+    <div class="step-unit step-acc">ACC</div>
+    <div class="step-desc">En route → hands off to TCU as aircraft approaches terminal area</div>
+  </div>
+  <div class="handoff-row arr-row">
+    <div class="step-num">↓</div>
+    <div class="step-unit step-tcu">TCU / Approach</div>
+    <div class="step-desc">Vectors aircraft for approach, hands off to tower for final</div>
+  </div>
+  <div class="handoff-row arr-row">
+    <div class="step-num">↓</div>
+    <div class="step-unit step-twr">Tower (TWR)</div>
+    <div class="step-desc">Landing clearance, taxi to parking via Ground</div>
+  </div>
+</div>
+
+<!-- CRAFT acronym -->
+<div class="section-label">CRAFT Acronym — IFR Clearance Structure</div>
+<table>
+  <thead>
+    <tr><th>Letter</th><th>Element</th><th>Example</th></tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td class="craft-letter">C</td>
+      <td><span class="craft-word">Clearance limit</span><div class="craft-desc">The point to which you are cleared (usually destination)</div></td>
+      <td style="font-size:12px;color:#7a9ab5;">…cleared to CYOW…</td>
+    </tr>
+    <tr>
+      <td class="craft-letter">R</td>
+      <td><span class="craft-word">Route</span><div class="craft-desc">Airways, waypoints, or direct routing</div></td>
+      <td style="font-size:12px;color:#7a9ab5;">…via V300 direct…</td>
+    </tr>
+    <tr>
+      <td class="craft-letter">A</td>
+      <td><span class="craft-word">Altitude</span><div class="craft-desc">Cleared altitude; expect altitude en route</div></td>
+      <td style="font-size:12px;color:#7a9ab5;">…maintain FL180, expect FL220…</td>
+    </tr>
+    <tr>
+      <td class="craft-letter">F</td>
+      <td><span class="craft-word">Frequency</span><div class="craft-desc">Departure frequency to contact after take-off</div></td>
+      <td style="font-size:12px;color:#7a9ab5;">…departure 132.4…</td>
+    </tr>
+    <tr>
+      <td class="craft-letter">T</td>
+      <td><span class="craft-word">Transponder</span><div class="craft-desc">Squawk code assigned by ATC</div></td>
+      <td style="font-size:12px;color:#7a9ab5;">…squawk 4521</td>
+    </tr>
+  </tbody>
+</table>
+
+<!-- Key rules -->
+<div class="hook-box">
+  <h2>Key Rules — CARs 602.31 &amp; 602.136</h2>
+  <div class="hook-row"><span class="hook-badge">Unable</span><span class="hook-text">If a clearance would compromise safety, respond <strong>"Unable, [reason]"</strong>. ATC will issue an amended clearance. Safety always overrides ATC compliance.</span></div>
+  <div class="hook-row"><span class="hook-badge">Readback</span><span class="hook-text">Runway clearances must be read back: <strong>runway designation + call sign</strong> + any hold-short instruction. "Roger" alone is not sufficient.</span></div>
+  <div class="hook-row"><span class="hook-badge">En Route = ACC</span><span class="hook-text">The <strong>Area Control Centre</strong> handles en route IFR aircraft. Terminal area = TCU. Aerodrome = Tower. FSS is not ATC.</span></div>
+  <div class="hook-row"><span class="hook-badge">Responsibility</span><span class="hook-text">A correct readback confirms the instruction was received — it does <strong>not</strong> transfer responsibility. The pilot-in-command is always ultimately responsible.</span></div>
+</div>
+
+</body>
+</html>


### PR DESCRIPTION
## Summary

- Creates standalone dark-aviation HTML visuals for lessons AL-004 through AL-008 in `web-app/public/visuals/`
- Updates `visual:` frontmatter in each of the five lesson files from `null` to the root-relative path
- All five visuals conform to `docs/visuals-standards.md`: palette `#0d1b2a`/`#f0c040`/`#7a9ab5`/`#1a2d3d`, 32px body padding, `max-width` with `margin: auto`, no external resources, semantic HTML, accessible colour pairing

Closes #98

## Visuals produced

| Lesson | File | Content |
|--------|------|---------|
| AL-004 | `al004-altimeter-settings.html` | QNH/QNE/QFE reference table, transition altitude diagram, memory hooks |
| AL-005 | `al005-right-of-way-rules.html` | Aircraft category hierarchy, scenario quick-reference table, exam decision flow |
| AL-006 | `al006-aerodrome-traffic-circuit.html` | CSS circuit diagram with all 5 legs labelled, standards cards, legs table |
| AL-007 | `al007-radio-communications.html` | Full ICAO phonetic alphabet grid, standard phraseology table, light gun signals |
| AL-008 | `al008-atc-services-clearances.html` | ATC units cards, Tower→TCU→ACC handoff sequence, CRAFT acronym table |

## Test plan

- [ ] Open each HTML file directly in a browser (`file://`) and verify correct rendering
- [ ] Check that colour palette matches canonical sample `al001-airspace-classifications.html`
- [ ] Confirm `visual:` frontmatter in all five lesson files points to the correct path
- [ ] Verify no external resources (no `<link>`, no `<script src>`, no `https://` img sources)

🤖 Generated with [Claude Code](https://claude.com/claude-code)