### PR TITLE
[PPL-108] Add hover accent and border styles to lesson cards

### DIFF
--- a/web-app/src/pages/LessonsIndex.tsx
+++ b/web-app/src/pages/LessonsIndex.tsx
@@ -60,7 +60,7 @@ export default function LessonsIndex() {
 
                 if (!lesson) {
                   return (
-                    <Card key={slot.id} variant="outlined" sx={{ opacity: 0.5 }}>
+                    <Card key={slot.id} variant="outlined" sx={{ opacity: 0.5, borderLeft: '3px solid rgba(255,255,255,0.12)' }}>
                       <CardContent sx={{ pb: '12px !important' }}>
                         <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 0.5 }}>
                           <Chip label={slot.id} size="small" variant="outlined" color="default" sx={{ fontFamily: 'monospace', fontWeight: 600 }} />
@@ -80,7 +80,17 @@ export default function LessonsIndex() {
                   <Card
                     key={slot.id}
                     variant="outlined"
-                    sx={{ opacity: done ? 0.7 : 1 }}
+                    sx={{
+                      opacity: done ? 0.7 : 1,
+                      borderLeft: '3px solid',
+                      borderColor: done ? 'success.main' : 'primary.main',
+                      willChange: 'transform',
+                      transition: 'all 0.15s ease',
+                      '&:hover': {
+                        transform: 'translateY(-2px)',
+                        boxShadow: '0 4px 20px rgba(245, 166, 35, 0.2)',
+                      },
+                    }}
                   >
                     <CardActionArea
                       component={RouterLink}


### PR DESCRIPTION
Closes #108

## Changes
- Planning stub cards: added `borderLeft: '3px solid rgba(255,255,255,0.12)'` alongside existing `opacity: 0.5` for a subtle visual separator
- Authored lesson cards: replaced single `opacity` sx prop with full style object including:
  - Left border accent (`success.main` when done, `primary.main` otherwise)
  - `willChange: 'transform'` and `transition: 'all 0.15s ease'` for smooth animation
  - `&:hover` lift effect: `translateY(-2px)` + warm amber glow shadow
- Planning stubs have **no** hover styles (static only)

## Test Plan
- [ ] `npm run build` in `web-app/` passes with no TypeScript errors ✓
- [ ] Authored lesson cards show left border accent (primary color by default, success when completed)
- [ ] Hovering an authored card produces a subtle lift + amber glow shadow
- [ ] Planning stub cards show a faint left border but no hover effect
- [ ] No regressions to CardActionArea, CardContent, Chip, or Typography