### PR TITLE
[PPL-103] Add Space Grotesk display font for h1-h4 headings

### DIFF
--- a/web-app/package-lock.json
+++ b/web-app/package-lock.json
@@ -11,6 +11,7 @@
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",
         "@fontsource/roboto": "^5.0.5",
+        "@fontsource/space-grotesk": "^5.0.5",
         "@mui/icons-material": "^7.3.9",
         "@mui/material": "^7.3.9",
         "js-yaml": "^4.1.0",
@@ -910,6 +911,15 @@
       "version": "5.2.10",
       "resolved": "https://registry.npmjs.org/@fontsource/roboto/-/roboto-5.2.10.tgz",
       "integrity": "sha512-8HlA5FtSfz//oFSr2eL7GFXAiE7eIkcGOtx7tjsLKq+as702x9+GU7K95iDeWFapHC4M2hv9RrpXKRTGGBI8Zg==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource/space-grotesk": {
+      "version": "5.2.10",
+      "resolved": "https://registry.npmjs.org/@fontsource/space-grotesk/-/space-grotesk-5.2.10.tgz",
+      "integrity": "sha512-XNXEbT74OIITPqw2H6HXwPDp85fy43uxfBwFR5PU+9sLnjuLj12KlhVM9nZVN6q6dlKjkuN8JisW/OBxwxgUew==",
       "license": "OFL-1.1",
       "funding": {
         "url": "https://github.com/sponsors/ayuhito"
@@ -2731,24 +2741,6 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/yaml": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
-      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
-      }
     }
   }
 }

--- a/web-app/package.json
+++ b/web-app/package.json
@@ -6,6 +6,7 @@
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.1",
     "@fontsource/roboto": "^5.0.5",
+    "@fontsource/space-grotesk": "^5.0.5",
     "@mui/icons-material": "^7.3.9",
     "@mui/material": "^7.3.9",
     "js-yaml": "^4.1.0",

--- a/web-app/src/main.tsx
+++ b/web-app/src/main.tsx
@@ -4,6 +4,9 @@ import '@fontsource/roboto/300.css';
 import '@fontsource/roboto/400.css';
 import '@fontsource/roboto/500.css';
 import '@fontsource/roboto/700.css';
+import '@fontsource/space-grotesk/400.css';
+import '@fontsource/space-grotesk/600.css';
+import '@fontsource/space-grotesk/700.css';
 import App from './App';
 
 const root = ReactDOM.createRoot(document.getElementById('root')!);

--- a/web-app/src/theme.ts
+++ b/web-app/src/theme.ts
@@ -30,6 +30,7 @@ const theme = createTheme({
   typography: {
     fontFamily: "'Roboto', 'Helvetica', 'Arial', sans-serif",
     h1: {
+      fontFamily: "'Space Grotesk', 'Roboto', 'Helvetica', sans-serif",
       fontSize: '1.875rem',
       fontWeight: 700,
       lineHeight: 1.2,
@@ -38,6 +39,7 @@ const theme = createTheme({
       },
     },
     h2: {
+      fontFamily: "'Space Grotesk', 'Roboto', 'Helvetica', sans-serif",
       fontSize: '1.5rem',
       fontWeight: 700,
       lineHeight: 1.25,
@@ -46,6 +48,7 @@ const theme = createTheme({
       },
     },
     h3: {
+      fontFamily: "'Space Grotesk', 'Roboto', 'Helvetica', sans-serif",
       fontSize: '1.375rem',
       fontWeight: 600,
       lineHeight: 1.3,
@@ -54,6 +57,7 @@ const theme = createTheme({
       },
     },
     h4: {
+      fontFamily: "'Space Grotesk', 'Roboto', 'Helvetica', sans-serif",
       fontSize: '1.25rem',
       fontWeight: 600,
       lineHeight: 1.35,


### PR DESCRIPTION
Closes #103

## Changes

- Added `@fontsource/space-grotesk` (^5.0.5) to `web-app/package.json` dependencies, self-hosted via fontsource (no Google Fonts CDN)
- Imported Space Grotesk weight variants (400, 600, 700) in `web-app/src/main.tsx` after existing Roboto imports
- Added `fontFamily: "'Space Grotesk', 'Roboto', 'Helvetica', sans-serif"` to `h1`, `h2`, `h3`, and `h4` variants in `web-app/src/theme.ts`; no other typography values changed

## Test Plan

- [ ] `npm run build` passes with no TypeScript errors
- [ ] Space Grotesk WOFF2 files appear in `dist/assets/` (confirmed: latin-400, latin-600, latin-700, latin-ext variants)
- [ ] h1–h4 headings render in Space Grotesk in the browser; h5/h6/body1/body2/caption unaffected
- [ ] No regressions in existing Roboto body text

🤖 Generated with [Claude Code](https://claude.com/claude-code)