### PR TITLE
[PPL-116] Rename Practice Exam to Practice Quiz and show visible lesson selector

### DIFF
--- a/web-app/src/components/Nav.tsx
+++ b/web-app/src/components/Nav.tsx
@@ -16,7 +16,7 @@ import { Link as RouterLink, useLocation, useNavigate } from 'react-router-dom';
 const NAV_LINKS = [
   { label: 'Home', shortLabel: 'Home', to: '/', icon: <HomeIcon /> },
   { label: 'Browse Lessons', shortLabel: 'Browse', to: '/lessons', icon: <MenuBookIcon /> },
-  { label: 'Practice Exam', shortLabel: 'Exam', to: '/exam', icon: <QuizIcon /> },
+  { label: 'Practice Quiz', shortLabel: 'Quiz', to: '/exam', icon: <QuizIcon /> },
   { label: 'Study Plan', shortLabel: 'Plan', to: '/plan', icon: <ChecklistIcon /> },
 ];
 

--- a/web-app/src/pages/Exam.tsx
+++ b/web-app/src/pages/Exam.tsx
@@ -11,10 +11,6 @@ import DialogContent from '@mui/material/DialogContent';
 import DialogContentText from '@mui/material/DialogContentText';
 import DialogTitle from '@mui/material/DialogTitle';
 import Divider from '@mui/material/Divider';
-import FormControl from '@mui/material/FormControl';
-import InputLabel from '@mui/material/InputLabel';
-import MenuItem from '@mui/material/MenuItem';
-import Select from '@mui/material/Select';
 import Typography from '@mui/material/Typography';
 import { getAllLessons } from '../lib/lesson-loader';
 import { useProgress } from '../lib/progress';
@@ -90,7 +86,7 @@ export default function Exam() {
     return (
       <Container maxWidth="md" sx={{ py: 4 }}>
         <Typography variant="h4" sx={{ mb: 3 }}>
-          Practice Exam
+          Practice Quiz
         </Typography>
         <Alert severity="info">No lessons with quiz questions found.</Alert>
       </Container>
@@ -100,24 +96,21 @@ export default function Exam() {
   return (
     <Container maxWidth="md" sx={{ py: 4 }}>
       <Typography variant="h4" sx={{ mb: 3 }}>
-        Practice Exam
+        Practice Quiz
       </Typography>
 
-      <FormControl fullWidth sx={{ mb: 3 }}>
-        <InputLabel id="lesson-select-label">Lesson</InputLabel>
-        <Select
-          labelId="lesson-select-label"
-          value={selectedLessonId}
-          label="Lesson"
-          onChange={(e) => handleLessonChange(e.target.value)}
-        >
-          {lessons.map((l) => (
-            <MenuItem key={l.id} value={l.id}>
-              {formatLessonLabel(l.id, l.title)}
-            </MenuItem>
-          ))}
-        </Select>
-      </FormControl>
+      <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1, mb: 3 }}>
+        {lessons.map((l) => (
+          <Button
+            key={l.id}
+            variant={selectedLessonId === l.id ? 'contained' : 'outlined'}
+            size="small"
+            onClick={() => handleLessonChange(l.id)}
+          >
+            {formatLessonLabel(l.id, l.title)}
+          </Button>
+        ))}
+      </Box>
 
       {phase === 'select' && selectedLesson && (
         <Box>


### PR DESCRIPTION
Closes #116

## Changes
- `Nav.tsx`: Renamed nav label from 'Practice Exam' to 'Practice Quiz' (desktop button and mobile bottom-nav short label)
- `Exam.tsx`: Renamed both Typography h4 headings from 'Practice Exam' to 'Practice Quiz'
- `Exam.tsx`: Replaced `FormControl`/`Select` dropdown with a flex-wrap grid of MUI `Button` elements — one per lesson with questions, using `variant="contained"` for the selected lesson and `variant="outlined"` for others. Each button calls `handleLessonChange(l.id)` and displays `formatLessonLabel(id, title)`.
- Removed unused `FormControl`, `InputLabel`, `MenuItem`, `Select` imports from `Exam.tsx`
- Preserved all existing state logic: `selectedLessonId`, `handleLessonChange`, `pendingLessonId` mid-quiz confirmation Dialog, and the Start Quiz button

## Test Plan
- [ ] Nav shows "Practice Quiz" label in both desktop and mobile views
- [ ] `/exam` page heading reads "Practice Quiz"
- [ ] Empty-state heading (no lessons with questions) reads "Practice Quiz"
- [ ] Lesson selector shows all lessons with questions as visible buttons
- [ ] Selected lesson button is highlighted (`contained` variant)
- [ ] Clicking a lesson button during a quiz shows the mid-quiz confirmation dialog
- [ ] Start Quiz button still works correctly
- [ ] `npm run build` passes with no TS errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)