### PR TITLE
[PPL-110] Add info palette color; apply to chips, progress bar, blockquote

### DIFF
--- a/web-app/src/components/AudioPlayer.tsx
+++ b/web-app/src/components/AudioPlayer.tsx
@@ -13,7 +13,7 @@ export default function AudioPlayer({ src }: AudioPlayerProps) {
         label="Audio: In production"
         size="small"
         variant="outlined"
-        sx={{ color: 'primary.main', borderColor: 'primary.main' }}
+        color="info"
       />
     );
   }

--- a/web-app/src/components/QuizRunner.tsx
+++ b/web-app/src/components/QuizRunner.tsx
@@ -47,7 +47,7 @@ export default function QuizRunner({ questions, onComplete }: QuizRunnerProps) {
         <Typography variant="body2" color="text.secondary" sx={{ mb: 0.5 }}>
           Question {currentIndex + 1} of {questions.length}
         </Typography>
-        <LinearProgress variant="determinate" value={progress} />
+        <LinearProgress variant="determinate" value={progress} color="info" />
       </Box>
 
       <Typography variant="h6" sx={{ mb: 2 }}>

--- a/web-app/src/pages/LessonDetail.tsx
+++ b/web-app/src/pages/LessonDetail.tsx
@@ -54,7 +54,7 @@ const mdOptions = {
         component: 'blockquote',
         sx: {
           borderLeft: '3px solid',
-          borderColor: 'primary.main',
+          borderColor: 'info.main',
           pl: 2,
           ml: 0,
           my: 2,
@@ -104,7 +104,7 @@ export default function LessonDetail() {
           size="small"
           sx={{ textTransform: 'capitalize', bgcolor: 'primary.main', color: 'text.onAccent' }}
         />
-        <Chip label={`${lesson.duration_min} min`} size="small" variant="outlined" />
+        <Chip label={`${lesson.duration_min} min`} size="small" variant="outlined" color="info" />
         {completed && (
           <Chip label="Completed" size="small" color="success" variant="outlined" />
         )}

--- a/web-app/src/pages/LessonsIndex.tsx
+++ b/web-app/src/pages/LessonsIndex.tsx
@@ -96,7 +96,7 @@ export default function LessonsIndex() {
                             color="primary"
                             sx={{ fontFamily: 'monospace', fontWeight: 600 }}
                           />
-                          <Chip label={`${lesson.duration_min} min`} size="small" variant="outlined" />
+                          <Chip label={`${lesson.duration_min} min`} size="small" variant="outlined" color="info" />
                           <Chip {...chipProps} size="small" />
                           {lesson.audio ? (
                             <Chip label="▶ Audio" size="small" color="warning" />

--- a/web-app/src/theme.ts
+++ b/web-app/src/theme.ts
@@ -23,6 +23,9 @@ const theme = createTheme({
     secondary: {
       main: '#ffffff',
     },
+    info: {
+      main: '#4fc3f7',
+    },
     text: {
       onAccent: '#000000',
     },


### PR DESCRIPTION
## Summary
- Adds `info: { main: '#4fc3f7' }` to the MUI theme palette in `theme.ts`
- Applies `color="info"` to QuizRunner `LinearProgress` (line 50)
- Replaces manual `sx={{ color: 'primary.main', borderColor: 'primary.main' }}` on AudioPlayer "Audio: In production" `Chip` with `color="info"`
- Applies `color="info"` to LessonDetail duration `Chip` (line 68)
- Changes blockquote `borderColor` from `primary.main` to `info.main` in `mdOptions` (LessonDetail)
- Applies `color="info"` to LessonsIndex duration `Chip` (line 99)

Build verified: `npm run build` passes with no TypeScript errors.

Closes #110

## Test plan
- [ ] Run `npm run build` in `web-app/` — should succeed with no TS errors
- [ ] Open Lessons list — duration chips should render in info blue (#4fc3f7)
- [ ] Open a lesson without audio — "Audio: In production" chip should use info color
- [ ] Open a lesson with a blockquote in the body — left border should be info blue
- [ ] Start a quiz — progress bar should render in info blue

🤖 Generated with [Claude Code](https://claude.com/claude-code)