### PR TITLE
[PPL-106] Make AppBar sticky with frosted-glass background

### DIFF
--- a/web-app/src/components/Nav.tsx
+++ b/web-app/src/components/Nav.tsx
@@ -34,10 +34,10 @@ export default function Nav() {
 
   return (
     <>
-      <AppBar position="static" sx={{ backgroundColor: 'background.default' }}>
+      <AppBar position="sticky" sx={{ backgroundColor: 'rgba(10,22,40,0.85)', backdropFilter: 'blur(12px)', borderBottom: '1px solid rgba(255,255,255,0.06)' }}>
         <Toolbar>
           <Typography variant="h6" sx={{ flexGrow: 1, color: 'primary.main', fontWeight: 700 }}>
-            PPL Study
+            <span aria-hidden="true">✈ </span>PPL Study
           </Typography>
           {!isMobile &&
             NAV_LINKS.map(({ label, to }) => {


### PR DESCRIPTION
Closes #106

## Changes

- Changed `AppBar` `position` from `static` to `sticky` so the nav bar stays visible while scrolling
- Replaced opaque background with frosted-glass style: `rgba(10,22,40,0.85)` fill + `blur(12px)` backdrop filter + subtle bottom border `rgba(255,255,255,0.06)`
- Added `<span aria-hidden="true">✈ </span>` prefix to the wordmark for visual flair

Only `web-app/src/components/Nav.tsx` was modified. Drawer, nav links, NAV_LINKS, theme.ts, App.tsx, and lesson content are untouched.

## Test Plan

- [ ] Load the web app and scroll down a long lesson page — AppBar should remain pinned at the top
- [ ] Verify frosted-glass blur is visible where page content scrolls behind the bar
- [ ] Confirm ✈ icon appears in the wordmark and is not read by screen readers
- [ ] Confirm Drawer background, wordmark color (#f5a623), and button colors (#ffffff) are unchanged
- [ ] Check on mobile — BottomNavigation should still appear correctly at bottom

🤖 Generated with [Claude Code](https://claude.com/claude-code)