### PR TITLE
[PPL-105] Add HeroMotif compass rose to home hero

### DIFF
--- a/web-app/package-lock.json
+++ b/web-app/package-lock.json
@@ -2731,24 +2731,6 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/yaml": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
-      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
-      }
     }
   }
 }

--- a/web-app/src/components/HeroMotif.tsx
+++ b/web-app/src/components/HeroMotif.tsx
@@ -1,20 +1,22 @@
-import { useTheme } from '@mui/material/styles';
+const AMBER = '#f5a623';
 
-/** Heading-rose aviation motif — decorative, aria-hidden */
-export default function HeroMotif() {
-  const theme = useTheme();
-  const primary = theme.palette.primary.main;
+interface Props {
+  width?: number;
+  height?: number;
+}
 
-  const cx = 200;
-  const cy = 200;
-  const outerR = 190;
+/** Compass-rose aviation motif — decorative, aria-hidden */
+export default function HeroMotif({ width = 340, height = 340 }: Props) {
+  const cx = 100;
+  const cy = 100;
+  const outerR = 95;
 
   const ticks = Array.from({ length: 36 }, (_, i) => {
     const angle = i * 10;
     const rad = ((angle - 90) * Math.PI) / 180;
     const isCardinal = i % 9 === 0;
     const isMajor = i % 3 === 0;
-    const innerR = isCardinal ? 148 : isMajor ? 165 : 178;
+    const innerR = isCardinal ? 74 : isMajor ? 82.5 : 89;
     return {
       x1: cx + outerR * Math.cos(rad),
       y1: cy + outerR * Math.sin(rad),
@@ -34,25 +36,30 @@ export default function HeroMotif() {
 
   return (
     <svg
-      viewBox="0 0 400 400"
+      viewBox="0 0 200 200"
       xmlns="http://www.w3.org/2000/svg"
       aria-hidden="true"
-      style={{ width: '100%', height: '100%' }}
+      width={width}
+      height={height}
+      opacity={0.2}
     >
-      <circle cx={cx} cy={cy} r={outerR} fill="none" stroke={primary} strokeWidth="1.5" />
-      <circle cx={cx} cy={cy} r={130} fill="none" stroke={primary} strokeWidth="0.75" />
-      <circle cx={cx} cy={cy} r={68} fill="none" stroke={primary} strokeWidth="0.5" />
+      <circle cx={cx} cy={cy} r={outerR} fill="none" stroke={AMBER} strokeWidth="0.75" />
+      <circle cx={cx} cy={cy} r={65} fill="none" stroke={AMBER} strokeWidth="0.4" />
+      <circle cx={cx} cy={cy} r={34} fill="none" stroke={AMBER} strokeWidth="0.25" />
       {ticks.map(({ x1, y1, x2, y2, isCardinal, isMajor }, i) => (
         <line
           key={i}
-          x1={x1} y1={y1} x2={x2} y2={y2}
-          stroke={primary}
-          strokeWidth={isCardinal ? 2 : isMajor ? 1.2 : 0.6}
+          x1={x1}
+          y1={y1}
+          x2={x2}
+          y2={y2}
+          stroke={AMBER}
+          strokeWidth={isCardinal ? 1 : isMajor ? 0.6 : 0.3}
         />
       ))}
       {cardinals.map(({ angle, label }) => {
         const rad = ((angle - 90) * Math.PI) / 180;
-        const r = 113;
+        const r = 56.5;
         return (
           <text
             key={label}
@@ -60,8 +67,8 @@ export default function HeroMotif() {
             y={cy + r * Math.sin(rad)}
             textAnchor="middle"
             dominantBaseline="central"
-            fill={primary}
-            fontSize="20"
+            fill={AMBER}
+            fontSize="10"
             fontWeight="700"
             fontFamily="monospace"
           >
@@ -69,9 +76,12 @@ export default function HeroMotif() {
           </text>
         );
       })}
-      <line x1={cx} y1={cy - 58} x2={cx} y2={cy + 58} stroke={primary} strokeWidth="0.5" />
-      <line x1={cx - 58} y1={cy} x2={cx + 58} y2={cy} stroke={primary} strokeWidth="0.5" />
-      <circle cx={cx} cy={cy} r={4} fill={primary} />
+      <line x1={cx} y1={cy - 29} x2={cx} y2={cy + 29} stroke={AMBER} strokeWidth="0.25" />
+      <line x1={cx - 29} y1={cy} x2={cx + 29} y2={cy} stroke={AMBER} strokeWidth="0.25" />
+      <circle cx={cx} cy={cy} r={2} fill={AMBER} />
+      {/* Horizon-line accent at 55 % / 58 % of viewBox height */}
+      <line x1={0} y1={110} x2={200} y2={110} stroke={AMBER} strokeWidth="0.75" strokeOpacity={0.3} />
+      <line x1={0} y1={116} x2={200} y2={116} stroke={AMBER} strokeWidth="0.75" strokeOpacity={0.3} />
     </svg>
   );
 }

--- a/web-app/src/pages/Home.tsx
+++ b/web-app/src/pages/Home.tsx
@@ -38,14 +38,12 @@ export default function Home() {
       <Box sx={{ position: 'relative', overflow: 'hidden', pt: { xs: 6, md: 10 }, pb: { xs: 4, md: 6 } }}>
         {/* Heading-rose motif — decorative background */}
         <Box
+          aria-hidden="true"
           sx={{
             position: 'absolute',
             top: '50%',
             right: { xs: '-10%', md: '2%' },
             transform: 'translateY(-50%)',
-            width: { xs: 280, md: 420 },
-            height: { xs: 280, md: 420 },
-            opacity: 0.08,
             pointerEvents: 'none',
           }}
         >
@@ -63,9 +61,22 @@ export default function Home() {
             variant="subtitle1"
             component="p"
             color="text.secondary"
-            sx={{ mb: 3, maxWidth: 560 }}
+            sx={{ mb: 1, maxWidth: 560 }}
           >
             Structured lessons covering PSTAR and the full Transport Canada PPL syllabus.
+          </Typography>
+          <Typography
+            component="p"
+            sx={{
+              mb: 2,
+              fontFamily: 'monospace',
+              fontSize: '0.625rem',
+              letterSpacing: '0.15em',
+              color: 'text.secondary',
+              opacity: 0.75,
+            }}
+          >
+            TRANSPORT CANADA PPL
           </Typography>
           <Button
             component={RouterLink}


### PR DESCRIPTION
## Summary
- Rewrites `HeroMotif.tsx`: viewBox `0 0 200 200`, 340 px default size, `opacity={0.2}`, amber `#f5a623` hardcoded (removes `useTheme` dependency), horizon-line accent at 55 %/58 % viewBox height with `strokeOpacity 0.3`
- Updates `Home.tsx`: removes Box-level opacity/explicit sizing (SVG self-sizes at 340 px), adds `aria-hidden` to wrapper Box, adds TRANSPORT CANADA PPL small-caps monospaced label between tagline and CTA

Closes #105

## Test plan
- [ ] `tsc --noEmit` passes (verified locally — zero errors)
- [ ] Compass rose visible at low opacity on hero section, centred-right
- [ ] Horizon lines visible as thin parallel amber lines across the motif
- [ ] TRANSPORT CANADA PPL label renders below tagline in monospace, does not push CTA off-screen at 375 px mobile
- [ ] No layout shift on hero text/CTA compared to prior state

🤖 Generated with [Claude Code](https://claude.com/claude-code)