### PR TITLE
[PPL-113] Increase source citation chip tap target to 44px

### DIFF
--- a/web-app/src/components/SourceList.tsx
+++ b/web-app/src/components/SourceList.tsx
@@ -40,7 +40,7 @@ export default function SourceList({ sources }: SourceListProps) {
                 label={src}
                 size="small"
                 variant="outlined"
-                sx={{ color: 'text.secondary', borderColor: 'text.disabled' }}
+                sx={{ color: 'text.secondary', borderColor: 'text.disabled', minHeight: 44, py: '10px' }}
               />
             );
           }
@@ -50,7 +50,7 @@ export default function SourceList({ sources }: SourceListProps) {
                 label={src}
                 size="small"
                 variant="outlined"
-                sx={{ color: 'text.secondary', borderColor: 'text.disabled' }}
+                sx={{ color: 'text.secondary', borderColor: 'text.disabled', minHeight: 44, py: '10px' }}
               />
             </Tooltip>
           );


### PR DESCRIPTION
Closes #113

## Changes

- Added `minHeight: 44` and `py: '10px'` to the `sx` prop on both `Chip` components in `SourceList.tsx`
- Clickable (anchor) chip and tooltip-wrapped (non-clickable) chip both receive the same tap target sizing
- All existing visual styles (colour, border, font, border-radius) are preserved
- No theme changes, no new files, no dependency changes

## Test Plan

- [ ] Open a lesson detail page that includes source citations
- [ ] Verify chips render with the correct colours and border style (no visual regression)
- [ ] On a mobile viewport or touch device, confirm the chips have a comfortable 44 px minimum tap height
- [ ] Verify `tsc --noEmit` passes (confirmed clean in CI)