### PR TITLE
[PPL-112] fix: wrap markdown tables in horizontally scrollable Box

### DIFF
--- a/web-app/src/pages/LessonDetail.tsx
+++ b/web-app/src/pages/LessonDetail.tsx
@@ -7,11 +7,19 @@ import Chip from '@mui/material/Chip';
 import Container from '@mui/material/Container';
 import Divider from '@mui/material/Divider';
 import Typography from '@mui/material/Typography';
-import { useState } from 'react';
+import { useState, type ReactNode } from 'react';
 import AudioPlayer from '../components/AudioPlayer';
 import SourceList from '../components/SourceList';
 import { getLessonBySlug } from '../lib/lesson-loader';
 import { useProgress } from '../lib/progress';
+
+function MarkdownTable({ children }: { children?: ReactNode }) {
+  return (
+    <Box sx={{ overflowX: 'auto', width: '100%', my: 1 }}>
+      <table>{children}</table>
+    </Box>
+  );
+}
 
 const mdOptions = {
   overrides: {
@@ -48,6 +56,7 @@ const mdOptions = {
         },
       },
     },
+    table: { component: MarkdownTable },
     blockquote: {
       component: Box,
       props: {


### PR DESCRIPTION
## Summary

- Adds a `MarkdownTable` wrapper component that renders markdown `<table>` elements inside a `<Box sx={{ overflowX: 'auto', width: '100%', my: 1 }}>` container
- Prevents table content from overflowing viewport on narrow mobile screens
- Follows the existing `pre` override pattern in `mdOptions.overrides`

Closes #112

## Test plan

- [ ] Open a lesson page that includes a markdown table on a narrow viewport (≤ 375 px)
- [ ] Confirm the table scrolls horizontally instead of overflowing the page
- [ ] Confirm `tsc --noEmit` passes (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)