### PR TITLE
[PPL-104] Add AL-011 CARs Structure lesson

### DIFF
--- a/lessons/air-law/011-cars-structure.md
+++ b/lessons/air-law/011-cars-structure.md
@@ -1,0 +1,212 @@
+---
+id: AL-011
+topic: air-law
+order: 11
+slug: cars-structure
+title: "CARs Structure"
+duration_min: 20
+status: complete
+audio: null
+visual: null
+sources:
+  - TP 12880E
+  - Aeronautics Act
+  - CARs Part I
+  - CARs Part VI
+questions:
+  - id: q1
+    prompt: "Which Part of the CARs contains the general operating and flight rules that govern day-to-day VFR flying?"
+    choices:
+      A: "Part II — Aeronautical Products and Services"
+      B: "Part IV — Personnel Licensing and Training"
+      C: "Part VI — General Operating and Flight Rules"
+      D: "Part VII — Commercial Air Services"
+    answer: C
+    explanation: "Part VI covers General Operating and Flight Rules — the section that governs day-to-day VFR flight including airspace entry, VFR weather minimums, altimeter settings, right-of-way, and flight plans. Part IV deals with pilot licensing; Part VII covers commercial operations. Source: CARs Part VI."
+  - id: q2
+    prompt: "A regulation states \"see the applicable Standard.\" What is the relationship between a CARs Standard and the Regulation it supports?"
+    choices:
+      A: "Standards replace the Regulation and are the only binding authority"
+      B: "Standards provide the technical detail and specific numbers; the Regulation sets the legal obligation"
+      C: "Standards and Regulations have equal legal authority and are interchangeable"
+      D: "Standards are voluntary guidelines that pilots may choose to follow"
+    answer: B
+    explanation: "Regulations set the obligation — they say what must be done. Standards provide the technical specifications referenced by that Regulation, such as exact dimensions, limits, or procedures. When a Regulation incorporates a Standard by reference, the Standard becomes legally binding. The Regulation is the law; the Standard is its technical arm. Source: Aeronautics Act, CARs Part I."
+  - id: q3
+    prompt: "Under what federal statute are the Canadian Aviation Regulations made?"
+    choices:
+      A: "Canadian Air Transport Security Act"
+      B: "Navigation Protection Act"
+      C: "Aeronautics Act"
+      D: "Canada Transportation Act"
+    answer: C
+    explanation: "The Aeronautics Act (R.S.C., 1985, c. A-2) is the parent statute that authorizes the Governor in Council to make the Canadian Aviation Regulations. All CARs are subordinate legislation enacted under the Aeronautics Act's authority. Without the Aeronautics Act, the CARs would have no legal basis. Source: Aeronautics Act preamble."
+  - id: q4
+    prompt: "A pilot needs to look up the rule on altimeter settings before a cross-country flight. In which Sub-Part of the CARs would they find this?"
+    choices:
+      A: "Sub-Part 601 — Air Traffic Control Services"
+      B: "Sub-Part 602 — General Operating and Flight Rules"
+      C: "Sub-Part 603 — Aerodromes"
+      D: "Sub-Part 604 — Private Operators"
+    answer: B
+    explanation: "Sub-Part 602 contains the General Operating and Flight Rules and is the primary reference for most PPL exam topics: altimeter settings (CAR 602.35–602.38), VFR weather minimums (CAR 602.115–602.116), right-of-way, and flight plans. Sub-Part 601 covers ATC services; 603 covers aerodrome operations; 604 covers private operators. Source: CARs Part VI, Sub-Part 602."
+  - id: q5
+    prompt: "What is the difference between Part IV and Part V of the CARs?"
+    choices:
+      A: "Part IV covers airspace classifications; Part V covers aerodrome standards"
+      B: "Part IV covers personnel licensing and training; Part V covers airworthiness of aircraft"
+      C: "Part IV covers commercial air services; Part V covers private operations"
+      D: "Part IV covers IFR operations; Part V covers VFR operations"
+    answer: B
+    explanation: "Part IV (Personnel Licensing and Training) contains the rules for pilot licences, medical certificates, and training requirements. Part V (Airworthiness) covers aircraft design, manufacture, maintenance, and airworthiness certificates. Pilot qualifications live in Part IV; aircraft certificates live in Part V. This distinction is a common source of exam confusion. Source: CARs Parts IV and V."
+---
+
+# Lesson AL-011: CARs Structure
+
+**Section:** Air Law  
+**Lesson number:** 011  
+**Estimated time:** 20 minutes  
+**Source:** Aeronautics Act (R.S.C., 1985, c. A-2), CARs Part I, CARs Part VI, TP 12880E
+
+---
+
+## Narration Script
+
+Welcome to Lesson 11 of Air Law. This lesson is about the rulebook itself — the Canadian Aviation Regulations, how they're organized, and how to find the rule you're looking for. If you've ever flipped through the CARs and felt lost, this lesson will give you a map.
+
+---
+
+### The Aeronautics Act: The Parent Statute
+
+Before there were CARs, there was the Aeronautics Act. Everything starts here.
+
+The Aeronautics Act (Revised Statutes of Canada, 1985, chapter A-2) is the federal statute — an Act of Parliament — that gives the government the legal authority to regulate aviation in Canada. It empowers the Governor in Council to make regulations, and it authorizes the Minister of Transport to set standards, issue certificates, and enforce compliance.
+
+The Canadian Aviation Regulations — the CARs — are what lawyers call subordinate legislation, also called delegated legislation. They don't come directly from Parliament. Instead, they are made under the authority granted by the Aeronautics Act. Think of the Aeronautics Act as the enabling law and the CARs as the detailed rules made under it. If the Aeronautics Act ever said "no regulations on this topic," the CARs couldn't cover it.
+
+This matters for the exam because questions sometimes ask which authority governs Canadian aviation. The answer is always rooted in the Aeronautics Act.
+
+---
+
+### The CARs: Eight Parts
+
+The Canadian Aviation Regulations are organized into eight Parts. Each Part covers a distinct subject area. Here is the structure you need to know:
+
+**Part I — General Provisions**  
+Administrative definitions, interpretation rules, and the general framework. This is where you find what terms mean across the entire regulation. When a later section says "aircraft" or "pilot-in-command," Part I defines those terms.
+
+**Part II — Aeronautical Products and Aeronautical Information Services**  
+Rules about aircraft design, manufacturing, and the information services that support aviation — including the publication of aeronautical charts and the Canada Flight Supplement. Less directly relevant to the PPL written exam, but important context.
+
+**Part III — Aerodromes, Airports and Heliports**  
+Standards and requirements for the physical infrastructure: runways, lighting, markings, and safety at aerodromes. Airport operators and Transport Canada inspectors spend most of their time in Part III.
+
+**Part IV — Personnel Licensing and Training**  
+This is where your pilot licence lives. Part IV covers who can act as a pilot, what licence is required for which operation, medical certificate requirements, recency requirements, and training standards. If a question asks about licence privileges, currency requirements, or training, the answer comes from Part IV.
+
+**Part V — Airworthiness**  
+Part V governs the aircraft itself: design standards, manufacture, maintenance, inspections, and the certificates that authorize an aircraft to fly. A Certificate of Airworthiness, a Maintenance Release, and the rules for who can sign off on maintenance — all Part V. This is distinct from Part IV, which governs the human. Part IV is about the person; Part V is about the machine.
+
+**Part VI — General Operating and Flight Rules**  
+This is the most important Part for the PPL written exam. Part VI governs day-to-day flying operations: the rules of the air, VFR weather minimums, altimeter settings, airspace entry requirements, right-of-way rules, flight plans, emergency procedures. If a question is about what a VFR pilot must do during flight, the answer is almost certainly in Part VI.
+
+**Part VII — Commercial Air Services**  
+Rules for airlines, air taxis, aerial work, and flight training units operating commercially. Beyond the scope of the PPL written exam, but knowing it exists helps you understand why your flight school operates under different (more demanding) rules than a private pilot flying their own aircraft.
+
+**Part VIII — Air Navigation Services**  
+Rules governing the providers of ATC, weather briefing, and other services that support the airspace system. Mostly applies to NAV CANADA and Transport Canada, not individual pilots.
+
+---
+
+### Part VI in Detail: Sub-Parts 601 through 604
+
+Since Part VI is where most of your exam questions live, let's go one level deeper. Part VI is divided into Sub-Parts numbered in the 600 series:
+
+**Sub-Part 601 — Air Traffic Control Services and Airspace**  
+Sub-Part 601 deals with the airspace system itself: definitions of airspace classes (A through G), requirements to enter each class, transponder requirements, and ATC clearance procedures. When you studied airspace classifications, those rules came from Sub-Part 601.
+
+**Sub-Part 602 — General Operating and Flight Rules**  
+Sub-Part 602 is the main event. This is where you find:
+- Altimeter setting requirements (when to use QNH, transition altitudes)
+- VFR weather minimums for each airspace class
+- Right-of-way rules (who gives way to whom)
+- Formation and acrobatic flight restrictions
+- Fuel requirements for VFR flight
+- Low-level flight restrictions
+- Flight plans and flight itineraries
+- Emergency procedures and distress signals
+
+When a question cites "CAR 602-something," that's Sub-Part 602. This sub-part comes up more often on the exam than any other. Know it well.
+
+**Sub-Part 603 — Aerodromes**  
+Sub-Part 603 governs pilot behaviour at and around aerodromes: aerodrome traffic circuit procedures, landing and take-off rules, right-of-way on the movement area. Think of it as the rules for operating on and around airport property from the pilot's perspective.
+
+**Sub-Part 604 — Private Operators**  
+Sub-Part 604 applies to private operators — defined as operations for pleasure or recreation in private aircraft. Private operators must register with Transport Canada and meet certain operational standards, though these are less demanding than commercial standards in Part VII.
+
+---
+
+### How to Read a CARs Citation
+
+You will encounter CARs citations throughout your training and on the exam. Understanding the format takes about 30 seconds to learn and will save you minutes of confusion.
+
+The format is: **CAR [Section Number]**
+
+For example: **CAR 602.19**
+
+Breaking that down:
+- **6** — Part VI (General Operating and Flight Rules)
+- **02** — Sub-Part 602 (General Operating and Flight Rules within Part VI)
+- **19** — Section 19 within Sub-Part 602
+
+So CAR 602.19 means Part VI, Sub-Part 602, section 19. You do not need to memorize individual section numbers for the exam, but you do need to understand that a "602" citation lives in Part VI, covers general flight operations, and is not about licensing (Part IV) or airworthiness (Part V).
+
+Another example: CAR 401.03 is in Part IV (personnel licensing), Sub-Part 401, section 3.
+
+The pattern holds across the entire regulation. The first digit tells you the Part; the three-digit number tells you the Sub-Part; the number after the decimal is the section.
+
+---
+
+### Regulations vs. Standards
+
+The CARs contain two distinct types of rules: **Regulations** and **Standards**. Both are legally binding, but they serve different purposes and are written at different levels of detail.
+
+**Regulations** state the legal obligation. They answer "what must be done?" A Regulation might say: an aircraft must comply with the noise standards set out in the applicable Standard. That sentence tells you the obligation exists, but it doesn't give you the numbers.
+
+**Standards** provide the technical specifications. They answer "exactly how must it be done?" The Standard referenced by that Regulation would list the precise decibel levels, test conditions, and measurement methods. Standards are published separately from the main Regulations text, but when a Regulation incorporates a Standard by reference, that Standard has the same legal force as the Regulation itself.
+
+For the pilot exam, the practical takeaway is this: if you're reading a Regulation and it says "see the applicable Standard," the Standard is not optional guidance. It is the specific technical rule that makes the Regulation operational.
+
+This two-tier structure lets Transport Canada update technical specifications (Standards) without going through the full regulatory process each time. Regulations are harder to amend; Standards are more agile. You will see this pattern often in Part V (Airworthiness Standards), Part VI references to noise and instrument standards, and Part IV licensing requirements.
+
+---
+
+## Quick Reference
+
+| Part | Subject | Exam Relevance |
+|------|---------|----------------|
+| I | General Provisions / Definitions | Background |
+| II | Aeronautical Products & Information | Low |
+| III | Aerodromes, Airports, Heliports | Low–Medium |
+| IV | Personnel Licensing & Training | **High** (licences, recency) |
+| V | Airworthiness | **High** (aircraft documents, maintenance) |
+| VI | General Operating & Flight Rules | **Very High** (most VFR rules) |
+| VII | Commercial Air Services | Low (PPL context) |
+| VIII | Air Navigation Services | Low |
+
+**Part VI Sub-Parts:**
+
+| Sub-Part | Subject |
+|----------|---------|
+| 601 | ATC Services and Airspace (classes, entry requirements) |
+| **602** | **General Operating & Flight Rules (altimeters, wx minimums, right-of-way, flight plans)** |
+| 603 | Aerodromes (circuit, landing/takeoff rules) |
+| 604 | Private Operators |
+
+**Citation shortcut:** CAR 602.35 → Part VI, Sub-Part 602, section 35.
+
+**Regulations vs. Standards:** Regulations = the obligation. Standards = the technical numbers. Both legally binding when cross-referenced.
+
+---
+
+*End of Lesson AL-011.*


### PR DESCRIPTION
## Summary
- Creates `lessons/air-law/011-cars-structure.md` with valid YAML frontmatter and full lesson body
- Covers: Aeronautics Act as parent statute, CARs Parts I–VIII, Sub-Parts 601–604 within Part VI, citation format (CAR 602.x), and Standards vs. Regulations distinction
- Includes 5 practice questions with choices A–D, answers, and explanations

## Test plan
- [ ] YAML frontmatter parses correctly via existing lesson-loader
- [ ] `getLessonBySlug('air-law', 'cars-structure')` resolves the lesson
- [ ] `tsc --noEmit` passes in `web-app/` (verified: exit 0)
- [ ] All 5 practice questions present with correct structure

Closes #104

🤖 Generated with [Claude Code](https://claude.com/claude-code)