### PR TITLE
[PPL-114] Add skip-navigation link for keyboard accessibility

### DIFF
--- a/web-app/src/App.tsx
+++ b/web-app/src/App.tsx
@@ -13,6 +13,25 @@ export default function App() {
     <ThemeProvider theme={theme}>
       <CssBaseline />
       <BrowserRouter>
+        <Box
+          component="a"
+          href="#main-content"
+          sx={{
+            position: 'absolute',
+            top: -9999,
+            left: -9999,
+            zIndex: 9999,
+            p: 1,
+            bgcolor: 'background.paper',
+            color: 'text.primary',
+            '&:focus': {
+              top: 8,
+              left: 8,
+            },
+          }}
+        >
+          Skip to main content
+        </Box>
         <Nav />
         <Box sx={{ pb: { xs: 7, sm: 7, md: 0 } }}>
           <Routes>

--- a/web-app/src/pages/Exam.tsx
+++ b/web-app/src/pages/Exam.tsx
@@ -84,7 +84,7 @@ export default function Exam() {
 
   if (lessons.length === 0) {
     return (
-      <Container maxWidth="md" sx={{ py: 4 }}>
+      <Container id="main-content" tabIndex={-1} maxWidth="md" sx={{ py: 4 }}>
         <Typography variant="h4" sx={{ mb: 3 }}>
           Practice Quiz
         </Typography>
@@ -94,7 +94,7 @@ export default function Exam() {
   }
 
   return (
-    <Container maxWidth="md" sx={{ py: 4 }}>
+    <Container id="main-content" tabIndex={-1} maxWidth="md" sx={{ py: 4 }}>
       <Typography variant="h4" sx={{ mb: 3 }}>
         Practice Quiz
       </Typography>

--- a/web-app/src/pages/Home.tsx
+++ b/web-app/src/pages/Home.tsx
@@ -35,7 +35,7 @@ export default function Home() {
   return (
     <>
       {/* Hero — full-width, above fold on 375 px mobile */}
-      <Box sx={{ position: 'relative', overflow: 'hidden', pt: { xs: 6, md: 10 }, pb: { xs: 4, md: 6 } }}>
+      <Box id="main-content" tabIndex={-1} sx={{ position: 'relative', overflow: 'hidden', pt: { xs: 6, md: 10 }, pb: { xs: 4, md: 6 } }}>
         {/* Heading-rose motif — decorative background */}
         <Box
           aria-hidden="true"

--- a/web-app/src/pages/LessonDetail.tsx
+++ b/web-app/src/pages/LessonDetail.tsx
@@ -75,7 +75,7 @@ export default function LessonDetail() {
 
   if (!lesson) {
     return (
-      <Container maxWidth={false} sx={{ maxWidth: 700, mx: 'auto', px: { xs: 2, sm: 3 }, py: 6 }}>
+      <Container id="main-content" tabIndex={-1} maxWidth={false} sx={{ maxWidth: 700, mx: 'auto', px: { xs: 2, sm: 3 }, py: 6 }}>
         <Typography variant="h4" gutterBottom>
           Lesson not found
         </Typography>
@@ -97,7 +97,7 @@ export default function LessonDetail() {
   }
 
   return (
-    <Container maxWidth={false} sx={{ maxWidth: 700, mx: 'auto', px: { xs: 2, sm: 3 }, py: 4 }}>
+    <Container id="main-content" tabIndex={-1} maxWidth={false} sx={{ maxWidth: 700, mx: 'auto', px: { xs: 2, sm: 3 }, py: 4 }}>
       <Box sx={{ mb: 1, display: 'flex', gap: 1, flexWrap: 'wrap', alignItems: 'center' }}>
         <Chip
           label={lesson.topic.replace(/-/g, ' ')}

--- a/web-app/src/pages/LessonsIndex.tsx
+++ b/web-app/src/pages/LessonsIndex.tsx
@@ -29,7 +29,7 @@ export default function LessonsIndex() {
   }, []);
 
   return (
-    <Container maxWidth="md" sx={{ py: 4 }}>
+    <Container id="main-content" tabIndex={-1} maxWidth="md" sx={{ py: 4 }}>
       <Typography variant="h4" gutterBottom>
         Browse Lessons
       </Typography>

--- a/web-app/src/pages/Plan.tsx
+++ b/web-app/src/pages/Plan.tsx
@@ -48,7 +48,7 @@ export default function Plan() {
   }
 
   return (
-    <Container maxWidth="md" sx={{ py: 4 }}>
+    <Container id="main-content" tabIndex={-1} maxWidth="md" sx={{ py: 4 }}>
       {/* ── Page header ── */}
       <Box sx={{ mb: 4 }}>
         <Typography variant="h4" gutterBottom>


### PR DESCRIPTION
## Summary
- Adds a visually-hidden skip link (`Box component='a' href='#main-content'`) as the first focusable element in the DOM, immediately before `<Nav />` in `App.tsx`
- Adds `id="main-content"` and `tabIndex={-1}` to the outermost layout element of all five page components (`Home`, `LessonsIndex`, `LessonDetail`, `Exam`, `Plan`)
- No new CSS files, packages, or components introduced — uses MUI `sx` prop only

## Test plan
- [ ] Tab to the page — first focus target should be the skip link
- [ ] Press Enter on skip link — focus jumps to `#main-content` skipping the nav
- [ ] Verify on all five routes: `/`, `/lessons`, `/lessons/:topic/:slug`, `/exam`, `/plan`
- [ ] Confirm skip link is invisible until focused (positioned off-screen)

Closes #114

🤖 Generated with [Claude Code](https://claude.com/claude-code)