### PR TITLE
[PPL-107] Add lesson AL-012: Pilot Licences and Recency Requirements

### DIFF
--- a/lessons/air-law/012-pilot-licences-recency.md
+++ b/lessons/air-law/012-pilot-licences-recency.md
@@ -1,0 +1,221 @@
+---
+id: AL-012
+topic: air-law
+order: 12
+slug: pilot-licences-recency
+title: "Pilot Licences and Recency Requirements"
+duration_min: 20
+status: complete
+sources:
+  - CAR 401.05
+  - CAR 421.26
+  - CAR 404.04
+  - TP 12880E
+questions:
+  - id: q1
+    prompt: "Under CAR 421.26, what is the minimum total flight time required to qualify for a Private Pilot Licence (Aeroplane)?"
+    choices:
+      A: "40 hours"
+      B: "45 hours"
+      C: "50 hours"
+      D: "65 hours"
+    answer: B
+    explanation: "CAR 421.26 requires a minimum of 45 hours total flight time, which must include at least 17 hours of dual flight instruction and at least 12 hours of supervised solo flight time (with 5 of those solo hours being cross-country). Source: CAR 421.26(2)(c)."
+  - id: q2
+    prompt: "Under CAR 401.05, to act as PIC of an aircraft carrying passengers, a pilot must have completed at least how many takeoffs and landings in the preceding six months?"
+    choices:
+      A: "3 takeoffs and 3 landings"
+      B: "5 takeoffs and 5 landings in the preceding 90 days"
+      C: "5 takeoffs and 5 landings in the preceding 6 months"
+      D: "10 takeoffs and 10 landings in the preceding 12 months"
+    answer: C
+    explanation: "CAR 401.05(1) requires a pilot acting as PIC with passengers on board to have completed at least 5 takeoffs and 5 landings in the same category and class of aircraft within the 6 months preceding the flight. The 90-day window is an FAA standard, not Canadian. Source: CAR 401.05(1)."
+  - id: q3
+    prompt: "A pilot receives a Category 3 medical at age 43. How long is that medical valid?"
+    choices:
+      A: "12 months"
+      B: "24 months"
+      C: "36 months"
+      D: "60 months"
+    answer: B
+    explanation: "Under CAR 404.04, a Category 3 Medical Certificate is valid for 60 months if the holder was under 40 years of age on the date of the examination, and for 24 months if the holder was 40 years of age or older. At age 43, the validity is 24 months. Source: CAR 404.04."
+  - id: q4
+    prompt: "A student tells you they completed a Biennial Flight Review last month and are therefore current to carry passengers in Canada. Which of the following is correct?"
+    choices:
+      A: "They are correct — a BFR grants two years of passenger-carrying currency"
+      B: "They are partially correct — a BFR counts toward CAR 401.05 recency only for aircraft used during the review"
+      C: "A Biennial Flight Review has no regulatory standing in Canada — it is an FAA requirement only"
+      D: "Canadian regulations require a BFR every 24 months to maintain PPL privileges"
+    answer: C
+    explanation: "The Biennial Flight Review (BFR) is an FAA requirement under 14 CFR 61.56 and does not exist in Canadian aviation regulations. Canada uses a recency standard under CAR 401.05 (5 takeoffs and landings in the preceding 6 months). There is no equivalent BFR requirement in the CARs — PPL privileges do not lapse on a fixed time cycle. Source: CAR 401.05; note absence of BFR equivalent in CARs."
+  - id: q5
+    prompt: "Which of the following correctly describes the privileges of a Canadian Private Pilot Licence (Aeroplane) holder?"
+    choices:
+      A: "Act as PIC on any aircraft and carry passengers for hire"
+      B: "Act as PIC of a single-engine aeroplane and carry passengers, but not for hire or reward"
+      C: "Act as co-pilot only — a PPL does not allow PIC privileges"
+      D: "Act as PIC on any multi-engine aeroplane with no restriction"
+    answer: B
+    explanation: "A PPL (Aeroplane) holder may act as PIC of a single-engine aeroplane (up to 5,700 kg MCTOW) and carry passengers, but may not carry passengers for hire or reward — that requires a CPL. A PPL may act as co-pilot on a multi-engine aircraft if qualified, but PIC solo privileges are limited to single-engine without additional ratings. Source: CAR 401.28, TP 12880E Chapter 2."
+---
+
+# Lesson AL-012: Pilot Licences and Recency Requirements
+
+**Section:** Air Law  
+**Lesson number:** 012  
+**Estimated time:** 20 minutes  
+**Source:** CAR 401.05, CAR 421.26, CAR 404.04, TP 12880E Chapter 2
+
+---
+
+## Narration Script
+
+Welcome to Lesson AL-012. Today we cover the Canadian pilot licence system — the ladder of qualifications from your very first solo to an airline cockpit — and the recency requirements that keep your privileges active once you have them. These topics are tested directly on the PPL written exam, so pay close attention to the specific numbers.
+
+---
+
+**The Canadian Licence Ladder**
+
+Canada has a clear progression of pilot qualifications. From the bottom up:
+
+First: the Student Pilot Permit, or SPP. This is not a licence — it is a permit that authorizes a student to fly solo under the supervision of a flight instructor. With an SPP you cannot carry passengers, and every solo flight is authorized individually by your instructor. The SPP has no minimum age requirement written into the permit itself, but you must be at least 14 years old to fly solo.
+
+Second: the Recreational Pilot Permit, or RPP. The RPP is a step above the SPP. An RPP holder can fly solo without instructor supervision and carry one passenger — but only in Canada, only in Visual Meteorological Conditions, and only in aircraft with a maximum takeoff weight of 1,200 kg or less. No flight into controlled airspace, no night flying, no cross-country beyond 25 nautical miles from the departure aerodrome unless additional requirements are met.
+
+Third: the Private Pilot Licence, or PPL. This is your target for this exam. A PPL (Aeroplane) holder can act as pilot-in-command of a single-engine aeroplane and carry passengers — but not for payment. The PPL has no limits on geographic range or controlled airspace access (within ratings and endorsements). It is the foundation for recreational and personal flying.
+
+Fourth: the Commercial Pilot Licence, or CPL. A CPL allows you to fly for hire and reward — to be paid to carry passengers or cargo. Most professional flying careers start here.
+
+Fifth: the Airline Transport Pilot Licence, or ATPL. The ATPL is the highest licence and is required to act as PIC on air carrier operations — scheduled airlines, large aircraft flown commercially.
+
+---
+
+**PPL Requirements: What CAR 421.26 Requires**
+
+To be issued a Private Pilot Licence (Aeroplane), CAR 421.26 requires:
+
+Minimum age: 17 years.
+
+Medical: a valid Category 3 Medical Certificate.
+
+Knowledge: you must pass the Transport Canada PPL written examination. Note that the PSTAR — Pre-Solo Standard Test of Air Regulations — is a separate prerequisite for solo flight, not the PPL written exam itself.
+
+Flight time: a minimum of 45 hours total, which must include:
+- At least 17 hours of dual flight instruction (you and an instructor together in the aircraft)
+- At least 12 hours of supervised solo flight time, of which at least 5 hours must be solo cross-country
+- Within that solo cross-country time, at least one cross-country flight of at least 150 nautical miles, with full-stop landings at two points different from the departure aerodrome
+
+Flight test: you must pass the Transport Canada PPL Aeroplane flight test administered by a designated examiner.
+
+The 45-hour minimum is just that — a minimum. Most students require more. But 45 hours is the legal floor.
+
+---
+
+**PPL Privileges and Limitations**
+
+With a PPL (Aeroplane) in hand, you may:
+
+- Act as pilot-in-command of a single-engine aeroplane with a maximum certificated takeoff weight not exceeding 5,700 kilograms
+- Carry passengers (but not for hire or reward)
+- Fly in Canada and, with appropriate validation, in many foreign countries
+
+You may NOT:
+
+- Be paid to carry passengers or cargo — that requires a CPL
+- Fly multi-engine aircraft as PIC without the multi-engine class rating
+- Fly at night without the night rating
+- Fly in IMC without an IFR rating
+
+---
+
+**SPP Scope: A Closer Look**
+
+The Student Pilot Permit authorizes solo flight only. An SPP holder:
+
+- May not carry any passengers
+- May not fly at night
+- Must have an endorsement from their instructor for each solo flight or series of flights
+- Is limited to the aircraft category, class, and type for which they have been authorized
+- Operates under the direct supervision of a licensed flight instructor even when flying alone
+
+The SPP is a training tool, not a standalone pilot credential.
+
+---
+
+**Category 3 Medical: CAR 404.04**
+
+A Category 3 Medical Certificate is the minimum required for private pilot operations. Under CAR 404.04, its validity depends on the holder's age at the time of the medical examination:
+
+- Under 40 years of age at the time of exam: the certificate is valid for **60 months** (5 years).
+- 40 years of age or older at the time of exam: the certificate is valid for **24 months** (2 years).
+
+This is a hard cutoff at age 40. If your examination is conducted on your 39th birthday, your medical is valid for 60 months. If it is conducted on your 40th birthday, it is valid for 24 months.
+
+Category 1 and Category 2 medicals (required for commercial and airline operations) have stricter validity periods, but for the PPL, Category 3 is the standard.
+
+---
+
+**Recency Requirements: CAR 401.05**
+
+Having a licence is one thing. Being legally current to exercise its privileges is another.
+
+Under CAR 401.05(1), a pilot may not act as PIC of an aircraft with passengers on board unless, within the 6 months preceding the flight, they have completed at least 5 takeoffs and 5 landings in an aircraft of the same category and class.
+
+Let that sink in: 5 takeoffs and 5 landings in the preceding 6 months. That is all. Not a fixed-interval review. Not a checkride. Five landings in six months keeps your day passenger-carrying privileges current.
+
+For night passenger operations, CAR 401.05 adds an additional requirement: at least 5 takeoffs and 5 night landings in the preceding 6 months, in the same category and class.
+
+If you go more than 6 months without flying, you can still fly solo — your licence does not expire. But you cannot carry passengers until you meet the recency requirements again. Log five landings, and you are current.
+
+---
+
+**A Critical Point: The BFR Does Not Exist in Canada**
+
+This is one of the most common misconceptions among Canadian students who have also studied FAA materials.
+
+Under United States regulations (14 CFR 61.56), the FAA requires a Biennial Flight Review — commonly called a BFR — every 24 months. Without it, you lose your privilege to act as PIC.
+
+**There is no equivalent requirement in the Canadian Aviation Regulations.** No BFR. No periodic flight review requirement. Your PPL does not lapse on a 24-month clock. Your privileges continue so long as you hold a valid medical and meet the recency requirements in CAR 401.05. If you stop flying for two years and then complete 5 takeoffs and landings, your passenger-carrying currency is restored.
+
+If a Transport Canada exam question presents a "Biennial Flight Review" scenario in a Canadian context — the correct answer is that it has no regulatory basis in Canada.
+
+---
+
+**Putting It All Together: Exam Strategy**
+
+When the exam asks about pilot licences and recency, you will typically be tested on:
+
+1. Which licence type is required for a described operation (SPP can't carry passengers; PPL can't carry passengers for hire; CPL can)
+2. The specific flight hour minimums for PPL — 45 total, 17 dual, 12 solo, 5 solo cross-country
+3. The recency requirement — 5 takeoffs and landings in the preceding 6 months to carry passengers
+4. Category 3 medical validity — 60 months under 40, 24 months at 40 or older
+5. The BFR trap — it is an FAA requirement, not Canadian
+
+Work through each scenario methodically. Identify what operation is being described, then apply the correct regulation.
+
+---
+
+## Quick Reference Table
+
+| Licence / Permit | Can Carry Passengers? | For Hire? | Key Requirement |
+|---|---|---|---|
+| Student Pilot Permit (SPP) | No | No | Solo only, instructor supervision |
+| Recreational Pilot Permit (RPP) | 1 passenger | No | Max 1,200 kg, day VFR, within limits |
+| Private Pilot Licence (PPL) | Yes | No | 45 hrs total, Cat 3 medical, age 17 |
+| Commercial Pilot Licence (CPL) | Yes | Yes | Higher flight time, Cat 1 medical |
+| ATPL | Yes | Yes (airline PIC) | Highest qualification |
+
+| Requirement | Rule | Key Number |
+|---|---|---|
+| PPL minimum flight time | CAR 421.26 | 45 hours total |
+| PPL dual instruction | CAR 421.26 | 17 hours |
+| PPL solo time | CAR 421.26 | 12 hours (incl. 5 solo x-country) |
+| Passenger recency | CAR 401.05 | 5 T&L in preceding 6 months |
+| Night passenger recency | CAR 401.05 | 5 night T&L in preceding 6 months |
+| Cat 3 medical (under 40) | CAR 404.04 | 60 months |
+| Cat 3 medical (40 or older) | CAR 404.04 | 24 months |
+| Biennial Flight Review (BFR) | FAA only — 14 CFR 61.56 | **Not applicable in Canada** |
+
+---
+
+*End of Lesson AL-012.*


### PR DESCRIPTION
## Summary

- Creates `lessons/air-law/012-pilot-licences-recency.md` (AL-012, order 12)
- Covers Canadian licence ladder (SPP → RPP → PPL → CPL → ATPL), PPL minimums per CAR 421.26, recency per CAR 401.05, Category 3 medical validity per CAR 404.04, PPL privileges/limitations, and SPP scope
- Includes 5 practice questions with id/prompt/choices/answer/explanation
- Explicitly notes the BFR is an FAA-only requirement (14 CFR 61.56) with no equivalent in the CARs

Closes #107

## Test plan

- [ ] Frontmatter matches AL-001..AL-003 shape (id, topic, order, slug, title, duration_min, status, sources, questions)
- [ ] All 5 questions have id/prompt/choices/answer/explanation
- [ ] CAR citations are accurate (421.26, 401.05, 404.04)
- [ ] BFR is explicitly flagged as FAA-only
- [ ] Lesson is self-contained (no prior lesson required)

🤖 Generated with [Claude Code](https://claude.com/claude-code)