### PR TITLE
[PPL-109] Add AL-013 Aircraft Documents lesson

### DIFF
--- a/lessons/air-law/013-aircraft-documents.md
+++ b/lessons/air-law/013-aircraft-documents.md
@@ -1,0 +1,244 @@
+---
+id: AL-013
+topic: air-law
+order: 13
+slug: aircraft-documents
+title: "Aircraft Documents"
+duration_min: 20
+status: complete
+audio: null
+visual: null
+sources:
+  - CARs 605.03
+  - CARs 605.92
+  - CARs 605.93
+  - CARs 605.94
+  - CARs 605.95
+  - CARs 202.26
+  - TP 12880E
+questions:
+  - id: q1
+    prompt: "Under CAR 605.03, which of the following documents is NOT required to be carried on board a Canadian-registered private aircraft?"
+    choices:
+      A: "Certificate of Airworthiness"
+      B: "Certificate of Registration"
+      C: "Pilot's logbook"
+      D: "Journey Log"
+    answer: C
+    explanation: "CAR 605.03 requires five documents on board: Certificate of Airworthiness, Certificate of Registration, Journey Log, Radio Station Licence (if radio-equipped), and the Aircraft Flight Manual or POH. The pilot's personal logbook is not one of them — it is the pilot's own record kept separately. Source: CARs 605.03."
+  - id: q2
+    prompt: "Which government authority issues the Radio Station Licence required on board a Canadian aircraft?"
+    choices:
+      A: "Transport Canada (TC)"
+      B: "NAV CANADA"
+      C: "Innovation, Science and Economic Development Canada (ISED)"
+      D: "The Department of National Defence (DND)"
+    answer: C
+    explanation: "The Radio Station Licence is issued by Innovation, Science and Economic Development Canada (ISED) under the Radiocommunication Act — not by Transport Canada. TC issues the Certificate of Airworthiness and Certificate of Registration. ISED has authority over radio spectrum and station licensing. Source: Radiocommunication Act, CARs 605.03."
+  - id: q3
+    prompt: "A pilot notices an oil pressure gauge is reading erratically during a flight. After landing, the correct action under CAR 605.94 is to:"
+    choices:
+      A: "Record the defect in the Journey Log before the next flight"
+      B: "Report the defect verbally to an AME and depart if the AME says it is fine"
+      C: "Ignore it if the oil pressure was within limits throughout the flight"
+      D: "Remove the aircraft from service immediately without any documentation"
+    answer: A
+    explanation: "CAR 605.94 requires that a defect observed before, during, or after a flight be recorded in the Journey Log. The record must be made before the next flight. An Aircraft Maintenance Engineer (AME) must then review the entry and either issue a maintenance release clearing the defect or defer it under the Minimum Equipment List. A verbal report is not sufficient — it must be entered in writing. Source: CARs 605.94."
+  - id: q4
+    prompt: "A Certificate of Airworthiness (C of A) issued for a private aircraft:"
+    choices:
+      A: "Expires one year after the date of issue and must be renewed annually"
+      B: "Remains valid indefinitely as long as the aircraft is maintained in airworthy condition and a valid maintenance release has been issued after each required maintenance"
+      C: "Expires when the aircraft reaches its maximum certified hours"
+      D: "Is valid for two years, after which a new inspection is required to reissue it"
+    answer: B
+    explanation: "A Canadian C of A does not have an annual expiry date on its face. It remains valid indefinitely provided the aircraft continues to be maintained in accordance with CARs Part VI, a maintenance release has been issued after each required maintenance, and no modification has been made that voids the type certificate data. If the aircraft is found unairworthy or maintenance is overdue, the C of A is effectively suspended. Source: CARs 605.03, TP 12880E."
+  - id: q5
+    prompt: "After completing scheduled maintenance on an aircraft, an Aircraft Maintenance Engineer (AME) must:"
+    choices:
+      A: "Notify Transport Canada within 48 hours"
+      B: "Issue a Maintenance Release in the Journey Log certifying the aircraft is airworthy"
+      C: "Attach a signed placard to the instrument panel"
+      D: "File a maintenance report with NAV CANADA"
+    answer: B
+    explanation: "Under CAR 605.95, an AME must sign a Maintenance Release in the Journey Log after completing maintenance. This entry certifies that the work was done in accordance with the applicable standards and that the aircraft is airworthy for flight. No aircraft may be operated following maintenance until a valid Maintenance Release has been entered. There is no requirement to notify TC or NAV CANADA for routine maintenance. Source: CARs 605.95."
+---
+
+# Lesson AL-013: Aircraft Documents
+
+**Section:** Air Law  
+**Lesson number:** 013  
+**Estimated time:** 20 minutes  
+**Source:** CARs 605.03, CARs 605.92–605.95, TP 12880E
+
+---
+
+## Narration Script
+
+Welcome to Lesson AL-013. Today we cover aircraft documents — specifically, which five documents must be on board every flight, what each one means, who issues it, and what happens when something goes wrong. This topic is straightforward but appears consistently on the written exam, often in scenario form.
+
+---
+
+## The Five Required On-Board Documents — CAR 605.03
+
+CAR 605.03 lists the documents that must be carried on board a Canadian registered aircraft during every flight. There are five:
+
+1. **Certificate of Airworthiness (C of A)**
+2. **Certificate of Registration (C of R)**
+3. **Journey Log**
+4. **Radio Station Licence**
+5. **Aircraft Flight Manual (AFM) or Pilot's Operating Handbook (POH)**
+
+A common exam trick is to list the pilot's personal logbook and ask whether it is required on board. It is not — the logbook is the pilot's personal record and has no place in this list.
+
+Let's look at each document in detail.
+
+---
+
+## 1. Certificate of Airworthiness (C of A)
+
+**What it is:** The C of A is the formal declaration that the aircraft type and this specific aircraft meet the airworthiness standards required for flight. It is issued by Transport Canada under the authority of the Aeronautics Act.
+
+**Who issues it:** Transport Canada.
+
+**Validity:** A Canadian C of A does not carry an annual expiry date. It remains valid indefinitely — provided:
+
+- The aircraft is maintained in accordance with the applicable maintenance schedule under CARs Part VI.
+- A valid Maintenance Release has been issued after every required maintenance.
+- No modification has been made to the aircraft that voids the type certificate.
+- The aircraft has not sustained damage that renders it unairworthy.
+
+If any of these conditions is not met, the aircraft is not airworthy and must not be flown, regardless of what the C of A says on paper. The C of A is a status document — it reflects a history of compliance, not a guarantee of current condition.
+
+**Common exam point:** The C of A never "expires" on a fixed calendar date. It is suspended (effectively void) when the aircraft goes out of airworthy condition. Students sometimes confuse this with the pilot's medical, which has a fixed expiry. The C of A works differently.
+
+---
+
+## 2. Certificate of Registration (C of R)
+
+**What it is:** The C of R identifies the aircraft and its registered owner. It links the aircraft's unique Canadian registration marks (the C-G or C-F prefix and four-letter suffix painted on the fuselage) to a specific individual or corporation.
+
+**Who issues it:** Transport Canada, Civil Aviation Registry.
+
+**Key points:**
+- The C of R must reflect the current owner. If the aircraft is sold, the new owner must apply for a new C of R before operating the aircraft.
+- The registration marks on the aircraft must match the C of R.
+- The C of R does not expire on a set date but becomes invalid if the aircraft changes hands without a new application.
+
+---
+
+## 3. Journey Log
+
+**What it is:** The Journey Log is the aircraft's operational record. Every flight must be recorded in it, along with defects, maintenance, and maintenance releases.
+
+**Regulatory basis:** CARs 605.92 requires that a Journey Log be kept for every Canadian registered aircraft. The pilot-in-command is responsible for ensuring entries are made.
+
+**What must be recorded — CAR 605.93:**
+
+Per CAR 605.93, each Journey Log entry for a flight must include:
+
+- Date of the flight
+- Departure and destination aerodromes
+- Names of crew members and their functions
+- Times of departure and arrival (or flight time)
+- Total flight time
+
+For an aircraft used in commercial air services or requiring a multi-crew complement, additional entries may be required. For a private flight in a single-engine piston aircraft, the items above are the core requirements.
+
+---
+
+## 4. Defect Recording — CAR 605.94
+
+**The rule:** CAR 605.94 requires that any technical defect observed **before, during, or after a flight** must be entered in the Journey Log before the next flight.
+
+This is a critical safety rule. If a pilot notices an unusual noise, an instrument discrepancy, an oil leak, or any other airworthiness concern, the defect must be written down — not communicated verbally and not deferred informally.
+
+**Why it matters:** The Journey Log entry creates a written record that an AME (Aircraft Maintenance Engineer) must review. The AME must either:
+
+1. Certify that the defect does not affect airworthiness and issue a Maintenance Release, or
+2. Repair the defect and then issue a Maintenance Release, or
+3. Defer the defect in accordance with a Minimum Equipment List (MEL) if one exists for the aircraft.
+
+**An aircraft must not depart with an unresolved defect entry in the Journey Log unless it has been cleared by a Maintenance Release or deferred under an MEL.**
+
+Exam tip: "The AME said it was fine verbally" is not acceptable. It must be documented in the Journey Log.
+
+---
+
+## 5. Maintenance Release — CAR 605.95
+
+**What it is:** A Maintenance Release is a signed entry in the Journey Log made by an AME after completing maintenance on the aircraft. It certifies that the work was performed in accordance with the applicable airworthiness standards and that the aircraft is in an airworthy condition.
+
+**Regulatory basis:** CAR 605.95 requires an AME to issue a Maintenance Release after any required maintenance is completed. No aircraft may be operated following maintenance until a valid Maintenance Release has been entered in the Journey Log.
+
+**Key point:** The Maintenance Release is the AME's certification that the aircraft is airworthy. The pilot should check that a Maintenance Release is present before flying an aircraft that has had recent maintenance.
+
+---
+
+## 6. Radio Station Licence
+
+**What it is:** A licence authorizing the operation of the aircraft's radio transmitter, issued under the Radiocommunication Act.
+
+**Who issues it:** **Innovation, Science and Economic Development Canada (ISED)** — not Transport Canada. This is a common exam trap. ISED (formerly known as Industry Canada) is the federal department responsible for radio spectrum licensing in Canada. All radio stations — including aircraft radio stations — are licensed by ISED, not TC.
+
+**Key points:**
+- Required on board whenever the aircraft is equipped with a radio transmitter.
+- The licence identifies the aircraft, the type of radio equipment authorized, and the call sign.
+- Transport Canada issues aviation documents (C of A, C of R). ISED issues the Radio Station Licence. These are different federal authorities.
+
+---
+
+## 7. Aircraft Flight Manual / Pilot's Operating Handbook (POH)
+
+**What it is:** The AFM or POH is the manufacturer's approved flight handbook for the specific aircraft type. It contains:
+
+- Aircraft limitations (Vne, Vfe, Vlo, maximum weights, etc.)
+- Normal and emergency procedures
+- Performance charts (takeoff distance, climb, cruise, landing)
+- Weight and balance data
+- Systems descriptions
+
+**Who issues it:** The manufacturer, approved by Transport Canada as part of the type certification process. The AFM/POH specific to the aircraft (with the aircraft's serial number on the limitations section for certified aircraft) must be on board.
+
+**Key point:** The AFM is a legal document, not just a reference guide. The limitations section defines what the aircraft is certified to do. Operating outside the AFM limitations can void the C of A.
+
+---
+
+## TC vs. ISED: Knowing the Difference
+
+This distinction appears repeatedly on Transport Canada exams:
+
+| Document | Issuing Authority |
+|----------|------------------|
+| Certificate of Airworthiness | Transport Canada |
+| Certificate of Registration | Transport Canada |
+| Radio Station Licence | ISED (Innovation, Science and Economic Development Canada) |
+| AFM/POH | Manufacturer (approved by TC) |
+
+Transport Canada's authority flows from the Aeronautics Act. ISED's authority over radio licensing flows from the Radiocommunication Act. They are separate legislative frameworks.
+
+---
+
+## Summary: The Five Documents at a Glance
+
+| Document | Issued By | When Invalid |
+|----------|-----------|--------------|
+| Certificate of Airworthiness | Transport Canada | Aircraft out of airworthy condition / maintenance overdue |
+| Certificate of Registration | Transport Canada | Aircraft ownership changed without re-registration |
+| Journey Log | N/A (aircraft record) | Must be kept current per CAR 605.92 |
+| Radio Station Licence | ISED | Licence not held or expired |
+| AFM / POH | Manufacturer (TC-approved) | Wrong manual or aircraft-specific data missing |
+
+---
+
+## Common Exam Traps
+
+- **Pilot's logbook is NOT on the list.** The pilot's logbook belongs to the pilot, not the aircraft.
+- **The C of A does not expire on a fixed date** — it is suspended when the aircraft goes out of airworthy condition.
+- **Defects must be written in the Journey Log** — a verbal report to an AME does not satisfy CAR 605.94.
+- **Radio Station Licence = ISED**, not Transport Canada.
+- **A Maintenance Release is required** in the Journey Log after any maintenance before the next flight.
+
+---
+
+*End of Lesson AL-013.*


### PR DESCRIPTION
## Summary
- Creates `lessons/air-law/013-aircraft-documents.md` (AL-013) covering all five required on-board documents per CAR 605.03
- Content covers: C of A, C of R, Journey Log, Radio Station Licence, and AFM/POH with issuing authorities and validity conditions
- Covers Journey Log entry requirements (CAR 605.93), defect recording (CAR 605.94), and Maintenance Release (CAR 605.95)
- Includes TC vs ISED distinction for Radio Station Licence
- 5 practice questions with correct CARs citations

## Test plan
- [ ] Verify frontmatter fields match schema: id AL-013, topic air-law, order 13, slug aircraft-documents, status complete, audio/visual null
- [ ] Verify all 5 regulatory claims cite correct CARs sections (605.03, 605.92–605.95)
- [ ] Verify TC vs ISED distinction is accurate
- [ ] Verify 5 practice questions have id/prompt/choices/answer/explanation

Closes #109

🤖 Generated with [Claude Code](https://claude.com/claude-code)