### PR TITLE
[PPL-101] Add AL-009 VFR Flight Plans and Itineraries lesson

### DIFF
--- a/lessons/air-law/009-flight-plans-itineraries.md
+++ b/lessons/air-law/009-flight-plans-itineraries.md
@@ -1,0 +1,282 @@
+---
+id: AL-009
+topic: air-law
+order: 9
+slug: flight-plans-itineraries
+title: "VFR Flight Plans and Itineraries"
+duration_min: 20
+status: complete
+audio: null
+visual: null
+sources:
+  - CARs 602.73
+  - CARs 602.75
+  - CARs 602.78
+  - CARs 602.79
+  - TP 12880E
+  - AIM SAR 1.0
+questions:
+  - id: q1
+    prompt: "What is the primary difference between a VFR flight plan and a VFR flight itinerary under the CARs?"
+    choices:
+      A: "A flight plan is for IFR flights; an itinerary is for VFR flights"
+      B: "A flight plan is filed with an ATS unit; an itinerary is filed with a responsible person"
+      C: "A flight plan is only required for international flights; an itinerary is required for domestic flights"
+      D: "A flight plan requires a transponder; an itinerary does not"
+    answer: B
+    explanation: "The fundamental distinction is who receives the document. A VFR flight plan is filed with an Air Traffic Services (ATS) unit — typically an FSS, ADIS, or control tower. The ATS unit monitors the flight and initiates SAR alerting if the plan is not closed. A flight itinerary is filed with a responsible person (a private individual), who is then obligated to notify authorities if the pilot does not return by the stated SARTIME. Source: CARs 602.73, 602.75."
+  - id: q2
+    prompt: "Under CAR 602.73, a VFR flight plan is required when a pilot intends to fly:"
+    choices:
+      A: "Any local flight within 10 NM of the departure aerodrome"
+      B: "Any flight conducted at night within controlled airspace"
+      C: "A cross-country flight that will proceed beyond the departure aerodrome's local area, including flights over routes where forced landing options are limited"
+      D: "Only flights departing Canada for a foreign destination"
+    answer: C
+    explanation: "CAR 602.73 requires a VFR flight plan for flights that will proceed beyond the local area, particularly where the route involves terrain or conditions where a forced landing would be hazardous (over water, mountainous terrain, sparsely populated areas). International departures also require a flight plan, but this is not the only trigger. Local pleasure flights that remain in the immediate area may satisfy requirements with a flight itinerary instead. Source: CARs 602.73, TP 12880E."
+  - id: q3
+    prompt: "What is a SARTIME, and what happens if a pilot does not close their VFR flight plan by that time?"
+    choices:
+      A: "SARTIME is a suggested arrival time; no action is taken if it is missed"
+      B: "SARTIME is the time by which the pilot must close the flight plan; if not closed, the ATS unit begins overdue alerting and notifies the JRCC"
+      C: "SARTIME is the ATC-assigned departure time; failure to depart by SARTIME cancels the clearance"
+      D: "SARTIME is the latest time a VFR flight may continue in daylight; exceeding it requires filing an amended plan"
+    answer: B
+    explanation: "SARTIME (Search and Rescue Time) is the time a pilot commits to when filing a flight plan — the time by which they will close the plan upon landing. CAR 602.78 requires the pilot to close the flight plan no later than the SARTIME. If the plan is not closed, CAR 602.79 requires the ATS unit to begin overdue procedures: attempts are made to locate the aircraft, and if unsuccessful, the Joint Rescue Coordination Centre (JRCC) is notified to initiate SAR. Source: CARs 602.78, 602.79."
+  - id: q4
+    prompt: "A pilot has filed and opened a VFR flight plan for a cross-country flight. After landing at the destination, the pilot's immediate obligation is to:"
+    choices:
+      A: "File a new flight plan for the return trip before doing anything else"
+      B: "Close the flight plan with an ATS unit before or at the stated SARTIME"
+      C: "Notify Transport Canada by email within 24 hours of landing"
+      D: "Contact the departure FSS and confirm the flight was uneventful"
+    answer: B
+    explanation: "Under CAR 602.78, a pilot must close their VFR flight plan no later than the SARTIME. Closing is done by contacting an ATS unit — the destination FSS, ADIS (1-800-WXBRIEF), or any available FSS by phone or radio. Failure to close triggers SAR alerting under CAR 602.79. Notifying the departure FSS after arrival is not required — you contact any available ATS unit to close. Source: CARs 602.78."
+  - id: q5
+    prompt: "A pilot files a VFR flight itinerary under CAR 602.75 with a responsible person before a backcountry flight. The responsible person's legal obligation is to:"
+    choices:
+      A: "File a copy of the itinerary with the nearest ATC unit before the flight departs"
+      B: "Monitor the pilot's position using ADS-B throughout the flight"
+      C: "Notify a person in charge of a rescue coordination centre, a peace officer, or a search and rescue organization if the pilot does not return or report in by the stated SARTIME"
+      D: "Contact the pilot by phone every hour until the flight is complete"
+    answer: C
+    explanation: "Under CARs 602.75, a person who receives a VFR flight itinerary becomes a 'responsible person' with a legal obligation: if the pilot does not return or contact them by the SARTIME specified in the itinerary, the responsible person must notify a rescue coordination centre, a peace officer, or a search and rescue organization. The responsible person does not need to contact ATC before the flight or monitor the flight continuously — their obligation is activated only if the SARTIME is missed. Source: CARs 602.75."
+---
+
+# Lesson AL-009: VFR Flight Plans and Itineraries
+
+**Section:** Air Law  
+**Lesson number:** 009  
+**Estimated time:** 20 minutes  
+**Source:** CARs 602.73, CARs 602.75, CARs 602.78, CARs 602.79, TP 12880E, AIM SAR 1.0
+
+---
+
+## Narration Script
+
+Welcome to Lesson AL-009. Today we cover VFR flight plans and flight itineraries — what they are, when each is required, how to file and close them, and what happens when a pilot goes overdue. This topic comes up directly on the written exam and is a real-world skill every Canadian VFR pilot needs.
+
+---
+
+**Why These Documents Exist**
+
+Before you depart on any cross-country or extended flight, Transport Canada requires you to leave a record of your intentions with someone who can call for help if you don't arrive. This is the foundation of Canada's search and rescue system.
+
+There are two tools for doing this: the **VFR flight plan** and the **VFR flight itinerary**. They serve the same ultimate purpose — ensuring someone knows where to look if you go missing — but they work differently and have different legal implications.
+
+---
+
+**Flight Plan vs. Flight Itinerary: The Core Distinction**
+
+The most important thing to know for the exam:
+
+| | VFR Flight Plan | VFR Flight Itinerary |
+|---|---|---|
+| Filed with | An ATS unit (FSS, ADIS, tower) | A responsible person (private individual) |
+| Monitored by | Air Traffic Services | The designated responsible person |
+| Must be opened | Yes — contact ATS after departure | No formal opening required |
+| Must be closed | Yes — contact ATS on arrival | No formal closing with ATS |
+| SAR triggered by | ATS, under CARs 602.79 | Responsible person notifying authorities |
+| Best for | Longer cross-country, remote routes, international | Shorter domestic flights, local area ops |
+
+A flight plan puts the responsibility for SAR alerting on ATS. An itinerary puts it on a private individual.
+
+Source: CARs 602.73, 602.75.
+
+---
+
+**When Is a Flight Plan Required? — CAR 602.73**
+
+Under CAR 602.73, a VFR pilot must file a flight plan when:
+
+- The flight will proceed **beyond the local area** of the departure aerodrome, particularly over routes where forced landing options are limited — including over water, mountainous terrain, or sparsely populated areas.
+- The flight **departs Canada** for a foreign destination. Any international VFR flight requires a flight plan.
+- The specific route or conditions mean that help could not reasonably be expected within a short time if the aircraft went down.
+
+The regulatory intent is to ensure that whenever a forced landing in a remote area is a realistic risk, someone in the formal ATS system knows your plan and will call for help if you don't arrive.
+
+Local VFR flights that remain within the immediate area of the departure aerodrome — where a return or landing is always close at hand — may satisfy Transport Canada's intent with a flight itinerary filed with a responsible person rather than with ATS.
+
+Source: CARs 602.73, TP 12880E.
+
+---
+
+**When Is a Flight Itinerary Acceptable? — CAR 602.75**
+
+Under CAR 602.75, a VFR flight itinerary filed with a **responsible person** satisfies the notification requirement for domestic flights that do not require a formal flight plan.
+
+The responsible person may be a family member, a friend, a fixed-base operator, or anyone who agrees to take action if you don't return. Critically, the responsible person takes on a legal obligation: if you do not contact them or return by the stated SARTIME, they must notify:
+
+- A rescue coordination centre (JRCC — Joint Rescue Coordination Centre), or
+- A peace officer (RCMP, local police), or
+- A search and rescue organization.
+
+The responsible person is not simply a "just in case" contact. Under the CARs, they have a duty to act.
+
+Source: CARs 602.75.
+
+---
+
+**VFR Flight Plan Format — Required Fields**
+
+A VFR flight plan must contain the following information when filed with ATS:
+
+1. **Flight rules** — VFR (or CVFR, DVFR for special rules)
+2. **Aircraft type** — e.g., C172, PA28
+3. **Aircraft registration** — full call sign (e.g., C-GABC)
+4. **True airspeed** — planned cruising airspeed
+5. **Departure aerodrome and time** — ICAO code and estimated departure time (UTC)
+6. **Cruising altitude**
+7. **Route** — airways, direct routings, waypoints
+8. **Destination aerodrome** — ICAO code
+9. **Estimated time en route (ETE)** — hours and minutes
+10. **Alternate aerodrome** (if applicable)
+11. **Fuel endurance** — in hours and minutes (determines how long ATS should wait before escalating)
+12. **Persons on board (POB)**
+13. **Emergency equipment** — survival gear, ELT type, life rafts, etc.
+14. **Pilot-in-command name and contact information**
+15. **Aircraft colour and markings** — helps searchers identify the aircraft
+
+Fuel endurance is not the same as flight time. It is how long the aircraft can remain airborne on its fuel load — a key input for SAR planning.
+
+Source: TP 12880E, AIM RAC 3.0.
+
+---
+
+**How to File a VFR Flight Plan**
+
+In Canada, a VFR flight plan can be filed by:
+
+- **Phone** — Call the nearest Flight Service Station (FSS). The FSS will take the plan over the phone and enter it into the system.
+- **ADIS (Automated Departure Information Service)** — Call the NAV CANADA toll-free ADIS number. ADIS accepts, opens, and closes VFR flight plans.
+- **Radio** — On the ground or in the air, contact an FSS on the appropriate frequency.
+- **Online** — NAV CANADA's online flight planning portal allows VFR flight plan filing.
+
+File the plan before departure. Do not depart and then try to file — the system depends on the plan being in place before you leave.
+
+---
+
+**Opening a VFR Flight Plan**
+
+Filing a flight plan does not open it. You must contact ATS after departure to open the plan.
+
+To open: contact the departure FSS (or any available FSS) by radio or phone and state:
+> *"[FSS name], C-GABC, opening VFR flight plan, departed [aerodrome] at [time UTC]."*
+
+If you filed with ADIS, the ADIS system may accept an opening call on the same number.
+
+Some pilots forget to open their plan after takeoff. A filed but un-opened plan creates a gap — ATS doesn't know you've actually departed. Always open.
+
+---
+
+**SARTIME: The Key Concept**
+
+SARTIME — Search and Rescue Time — is the single most important concept in this lesson for the exam.
+
+SARTIME is the time you commit to when filing your flight plan. It represents the time by which you will have **closed** the flight plan on the ground. It is essentially your deadline.
+
+SARTIME = Estimated time of departure + Estimated time en route + a reasonable buffer (typically 30 minutes, set by the pilot).
+
+Example: You depart at 14:00 UTC with a 2-hour flight. You might set SARTIME for 16:30 UTC, giving yourself 30 minutes after ETA to land and close the plan.
+
+**Under CAR 602.78**: you must close the flight plan no later than the SARTIME.
+
+If you extend your flight or stop en route, you must update your SARTIME before the original one expires. Contact any ATS unit to revise it.
+
+---
+
+**Closing a VFR Flight Plan**
+
+Closing is done by contacting any ATS unit — not necessarily the departure FSS. Options:
+
+- Call the destination FSS by radio or phone.
+- Call ADIS.
+- Contact the destination tower, if it has FSS services.
+
+State: *"[FSS name], closing VFR flight plan C-GABC, landed [aerodrome] at [time UTC], persons on board all safe."*
+
+Forgetting to close is a common and serious error. SAR resources have been dispatched for pilots who simply forgot to close their plan. Closing is not optional.
+
+---
+
+**SAR Activation Timeline — CARs 602.78 and 602.79**
+
+What happens if a flight plan is not closed?
+
+**Under CAR 602.79**, when the SARTIME passes without a close:
+
+1. The ATS unit (FSS) begins **overdue procedures** — attempts to contact the pilot by radio, phone, and through aerodromes along the route.
+2. ATS contacts the destination aerodrome and intermediate aerodromes to determine if the aircraft has landed without closing.
+3. If the aircraft cannot be located, ATS notifies the **Joint Rescue Coordination Centre (JRCC)**.
+4. JRCC initiates a SAR response — aircraft, Coast Guard, or ground teams as appropriate.
+
+The timeline from SARTIME to JRCC notification depends on how quickly the ATS unit can rule out simpler explanations. The process begins immediately when the SARTIME passes.
+
+Source: CARs 602.78, 602.79.
+
+---
+
+**Itinerary Responsibilities — CAR 602.75**
+
+A flight itinerary filed with a responsible person must contain similar information to a flight plan: aircraft type and registration, route, departure and destination, ETE, fuel endurance, POB, and the SARTIME by which the responsible person should expect contact.
+
+The responsible person's obligation is activated when the SARTIME passes without contact. They must notify:
+- The JRCC (1-800 number for the applicable region), or
+- A peace officer (RCMP, municipal or provincial police), or
+- A search and rescue organization.
+
+The responsible person cannot simply wait and hope. The duty to notify is a legal obligation under CAR 602.75, not a suggestion.
+
+Choosing the right responsible person matters. The person must be contactable, understand the obligation they are accepting, and be willing to make the call if needed. A responsible person who doesn't understand the system — or who waits too long — delays SAR response.
+
+---
+
+**Common Exam Questions**
+
+- What is the difference between a flight plan and an itinerary? Flight plan → ATS unit; itinerary → responsible person.
+- What is SARTIME? The time by which you must close your flight plan. Missed SARTIME triggers SAR alerting.
+- How do you open a flight plan? Contact ATS after departure and state that you are opening the plan.
+- Who receives a flight itinerary? A responsible person — not ATC.
+- What must a responsible person do if SARTIME is missed? Notify JRCC, police, or a SAR organization.
+
+---
+
+## Quick Reference
+
+| Step | Flight Plan | Flight Itinerary |
+|------|-------------|-----------------|
+| File before departure | With FSS, ADIS, or tower | With a responsible person |
+| Open after departure | Yes — contact ATS | No formal opening |
+| Close on arrival | Yes — contact ATS by SARTIME | No formal close |
+| SAR triggered by | ATS (CAR 602.79) | Responsible person notifying JRCC/police |
+| Overdue action | ATS → JRCC automatically | Responsible person's legal obligation |
+
+**Key CARs:**
+- **602.73** — When a VFR flight plan is required
+- **602.75** — Flight itinerary requirements and responsible person obligation
+- **602.78** — Pilot must close flight plan by SARTIME
+- **602.79** — ATS overdue and SAR alerting procedures
+
+---
+
+*End of Lesson AL-009.*


### PR DESCRIPTION
## Summary

- Creates `lessons/air-law/009-flight-plans-itineraries.md` (AL-009, order 9)
- Covers flight plan vs itinerary distinction, CAR 602.73/602.75 when each is required, SARTIME mechanics, flight plan format fields, filing/opening/closing procedures, SAR activation timeline (CAR 602.78/602.79), and responsible person obligations under itinerary
- Includes 5 practice questions with explanations citing CARs sections
- `status: complete`, `audio: null`, `visual: null` — matches AL-011 convention

## Test plan

- [ ] Verify YAML frontmatter parses correctly (id, topic, order, slug, title, duration_min, status, sources, questions)
- [ ] Confirm lesson loader picks up file at `lessons/air-law/009-flight-plans-itineraries.md`
- [ ] Check that all 5 questions have id, prompt, choices (A–D), answer, and explanation
- [ ] Review regulatory citations (CARs 602.73, 602.75, 602.78, 602.79) for accuracy

Closes #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)