### PR TITLE
[PPL-102] Add AL-010 NOTAMs lesson

### DIFF
--- a/lessons/air-law/010-notams.md
+++ b/lessons/air-law/010-notams.md
@@ -1,0 +1,352 @@
+---
+id: AL-010
+topic: air-law
+order: 10
+slug: notams
+title: "NOTAMs"
+duration_min: 20
+status: complete
+audio: null
+visual: null
+sources:
+  - TP 12880E
+  - CAR 602.72
+  - AIM RAC 2.0
+questions:
+  - id: q1
+    prompt: "What is the difference between a Class I and a Class II NOTAM in Canada?"
+    choices:
+      A: "Class I NOTAMs cover aerodromes; Class II NOTAMs cover airways and en-route airspace"
+      B: "Class I NOTAMs are of immediate operational significance and distributed directly to pilots in real time; Class II NOTAMs are non-immediate and published in the Canada Flight Supplement"
+      C: "Class I NOTAMs are issued by Transport Canada; Class II NOTAMs are issued by NAV CANADA"
+      D: "Class I NOTAMs are valid for up to 24 hours; Class II NOTAMs are valid for up to 7 days"
+    answer: B
+    explanation: "Canada divides NOTAMs into two classes based on urgency. Class I NOTAMs have immediate operational significance — they involve conditions that affect flight safety right now — and are distributed directly to affected pilots and ATS units in real time through telecommunications. Class II NOTAMs are non-immediate in nature and are published in the Canada Flight Supplement (CFS) and the Notice to Airmen (NOF) publication. Both classes must be checked during preflight. Source: AIM RAC 2.0, TP 12880E."
+  - id: q2
+    prompt: "A NOTAM indicates a VOR is unserviceable. Which Q-code subject area does this fall under?"
+    choices:
+      A: "OB — Obstacle"
+      B: "AF — Aerodrome lighting"
+      C: "NV — Navaid unserviceable"
+      D: "AG — Aerodrome ground movement"
+    answer: C
+    explanation: "NOTAM Q-codes use a two-letter subject identifier to categorize the affected facility or service. The prefix 'N' represents navigation-related subjects, and 'NV' specifically denotes a navaid (VOR, NDB, DME, etc.) that is unserviceable or degraded. 'OB' is used for obstacle-related NOTAMs, 'AF' covers aerodrome lighting, and 'AG' covers aerodrome ground movement areas. Understanding Q-code subjects helps pilots quickly filter NOTAMs for items relevant to their flight. Source: AIM RAC 2.0."
+  - id: q3
+    prompt: "Where can a pilot access current NOTAMs during preflight planning (list two methods)?"
+    choices:
+      A: "Only through a licensed dispatcher and the tower frequency"
+      B: "NAV CANADA NOTAMplus (notamplus.navcanada.ca) and 1-800-WX-BRIEF (NAV CANADA flight information service)"
+      C: "Transport Canada website and the airport manager's office"
+      D: "Environment Canada weather briefing and the en-route control centre"
+    answer: B
+    explanation: "NAV CANADA provides two primary access methods for NOTAMs during preflight: (1) NOTAMplus at notamplus.navcanada.ca — the online self-briefing portal where pilots can query NOTAMs by aerodrome, FIR, and time period; and (2) 1-800-WX-BRIEF — the NAV CANADA toll-free telephone flight information service staffed by Flight Service Specialists who provide NOTAMs as part of a standard weather briefing. The Canada Flight Supplement (CFS) contains Class II NOTAMs in published form. Source: AIM RAC 2.0, TP 12880E."
+  - id: q4
+    prompt: "Decode this abbreviated NOTAM: !YYZ A0093/26 NOTAMN — YYZ RWY 05/23 CLSD 0604210600 TIL 0604211400 — what does it say?"
+    choices:
+      A: "Toronto Pearson (YYZ) runway 05/23 is closed from 06 April 2026 at 0600 UTC until 06 April 2026 at 1400 UTC"
+      B: "Toronto Pearson (YYZ) runway 05/23 is closed from April 21 at 0600 local until April 21 at 1400 local"
+      C: "Toronto Pearson (YYZ) taxiway 05/23 is closed from 06 April 2026 at 0600 UTC until 06 April 2026 at 1400 UTC"
+      D: "Toronto Pearson (YYZ) runway 05/23 is closed for 93 minutes starting 26 April 2026"
+    answer: A
+    explanation: "Breaking down the NOTAM: '!YYZ' is the issuing office (Toronto area FIR); 'A0093/26' is the NOTAM number (sequential number 93, year 2026); 'NOTAMN' means this is a new NOTAM (not a replacement or cancellation); 'YYZ' is the affected aerodrome (Toronto Pearson); 'RWY 05/23 CLSD' means runway 05/23 is closed; '0604210600' is the effective time in format YYMMDDHHMM — year 26, month 04, day 21, time 0600 UTC; 'TIL 0604211400' means until the same date at 1400 UTC. The runway is closed for 8 hours on 21 April 2026. All NOTAM times are UTC. Source: AIM RAC 2.0."
+  - id: q5
+    prompt: "Under which CAR section is a pilot required to obtain and use current aeronautical information before flight?"
+    choices:
+      A: "CAR 602.68 — Fuel requirements"
+      B: "CAR 602.72 — Preflight information"
+      C: "CAR 602.73 — VFR flight plan requirements"
+      D: "CAR 801.03 — Aviation document booklet"
+    answer: B
+    explanation: "CAR 602.72 is the preflight information regulation. It requires the pilot-in-command to obtain and use all available aeronautical information pertinent to the intended flight before departure. This includes NOTAMs, weather reports and forecasts, fuel requirements, and any other information necessary for the safe conduct of the flight. Failure to check NOTAMs before departure — and then encountering a closed runway, unserviceable navaid, or restricted airspace that was NOTAMed — is a regulatory violation under this section. Source: CAR 602.72."
+---
+
+# Lesson AL-010: NOTAMs
+
+**Section:** Air Law  
+**Lesson number:** 010  
+**Estimated time:** 20 minutes  
+**Source:** TP 12880E, CAR 602.72, AIM RAC 2.0
+
+---
+
+## Narration Script
+
+Welcome to Lesson AL-010. This lesson covers NOTAMs — Notices to Airmen — what they are, how Canada's system is organized, how to read them, where to find them before flight, and what the regulations require you to do with them. NOTAMs appear on every Transport Canada written exam and are a daily part of real-world flight planning.
+
+---
+
+**What Is a NOTAM?**
+
+A NOTAM — Notice to Airmen — is a notice distributed by telecommunication that contains information essential to flight safety concerning the establishment, condition, or change in any aeronautical facility, service, procedure, or hazard.
+
+In plain language: a NOTAM tells you about something in the aviation system that has changed or is temporarily different from what appears on charts or in standard publications. Examples include:
+
+- A runway is closed for maintenance
+- A VOR is unserviceable
+- A parachute drop zone is active
+- New construction cranes create an obstacle near an aerodrome
+- A navigational aid is operating with reduced power
+- Airspace is temporarily restricted for a special event
+
+NOTAMs fill the gap between permanent publications (charts, AIP, CFS) and real-time conditions. They are time-sensitive: most NOTAMs have a defined effective period (start and end time, both in UTC).
+
+Source: AIM RAC 2.0.
+
+---
+
+**Canada's Two NOTAM Classes**
+
+Canada classifies NOTAMs into two categories based on urgency and distribution method:
+
+**Class I NOTAM**
+
+- Contains information of **immediate operational significance**
+- Distributed **directly to affected pilots and ATS units** via telecommunications in real time
+- Issued by the appropriate ATS authority (NAV CANADA) and transmitted immediately
+- Examples: runway unexpectedly closed due to an accident, ILS suddenly unserviceable, unexpected airspace restriction effective immediately
+- You receive Class I NOTAMs through a flight service specialist briefing, the NOTAMplus system, or a radio broadcast from an FSS
+
+**Class II NOTAM**
+
+- Contains information that is **not of immediate operational significance** but still important for flight planning
+- Published in the **Canada Flight Supplement (CFS)** and the **Notice to Airmen (NOF)** publication
+- Issued on a scheduled publication cycle
+- Examples: planned construction activity starting in three weeks, a published instrument approach procedure being amended, a frequency change at a remote aerodrome
+- You review Class II NOTAMs when checking the current CFS edition or NOF publication
+
+Both classes are mandatory to review before flight under CAR 602.72. Class I NOTAMs are more urgent; Class II NOTAMs are planned in advance.
+
+Source: AIM RAC 2.0, TP 12880E.
+
+---
+
+**NOTAM Format — Field by Field**
+
+A standard NOTAM follows a structured format. Here is the anatomy of a typical Class I NOTAM:
+
+```
+!YYZ A0093/26 NOTAMN
+Q) CZYZ/QMRLC/IV/NBO/A/000/999/4338N07936W005
+A) CYYZ
+B) 2604210600
+C) 2604211400
+E) RWY 05/23 CLSD
+```
+
+Breaking down each line:
+
+**Header line: `!YYZ A0093/26 NOTAMN`**
+
+- `!YYZ` — issuing office (Toronto FIR / NOTAM Office)
+- `A0093/26` — NOTAM number: sequential number 0093 in year 2026
+- `NOTAMN` — NOTAM type: **N** = New, **R** = Replacement (supersedes a previous NOTAM), **C** = Cancellation
+
+**Q) line — The Q-Code line**
+
+The Q-line is the machine-readable summary. It contains five slash-delimited fields:
+
+`Q) FIR/QCODE/TRAFFIC/PURPOSE/SCOPE/LOWER/UPPER/CENTRE-RADIUS`
+
+- **FIR**: Flight Information Region affected (e.g., CZYZ = Toronto FIR)
+- **Q-code**: Two-letter subject identifier (see below)
+- **Traffic**: I = IFR, V = VFR, IV = both
+- **Purpose**: N = immediate safety, B = pre-flight briefing, O = ops, M = miscellaneous
+- **Scope**: A = aerodrome, E = en-route, W = warning, K = checklist
+- **Lower/Upper**: Flight levels affected (000/999 = all altitudes)
+- **Centre-Radius**: Latitude/longitude of the NOTAM centre and radius in NM
+
+**A) line** — Location (ICAO identifier of the affected aerodrome or navaid)
+
+**B) line** — Effective FROM date-time in `YYMMDDHHMM` format (UTC)
+
+**C) line** — Effective TO (PERM = permanent; ESTM = estimated)
+
+**D) line** — Schedule (optional — used when the NOTAM is not continuous within the B–C window; e.g., active only during daytime hours)
+
+**E) line** — Plain language text describing the NOTAM content
+
+The E) line is what pilots read for operational meaning. The Q-line allows automated filtering.
+
+Source: AIM RAC 2.0.
+
+---
+
+**Q-Code Subject Fields — Common Examples**
+
+The Q-code second character pair identifies the subject. Key ones to know for the exam:
+
+| Q-Code | Meaning |
+|--------|---------|
+| NV | Navaid — unserviceable (VOR, NDB, DME, ILS) |
+| OB | Obstacle — new or elevated obstruction |
+| AF | Aerodrome — lighting (approach lights, PAPI, VASIS) |
+| AG | Aerodrome — ground movement (taxiways, aprons, runways) |
+| MR | Runway — closed or restricted |
+| LT | Air traffic services — tower closed/hours changed |
+| XX | Plain language / catch-all (no specific code applies) |
+
+Knowing NV, OB, AF, and AG is particularly useful. An NV NOTAM before a flight tells you a navaid you were counting on may not be available. An OB NOTAM alerts you to new obstacles near the aerodrome that may not appear on your chart.
+
+Source: AIM RAC 2.0.
+
+---
+
+**How to Access NOTAMs Before Flight**
+
+There are three primary methods for accessing current NOTAMs in Canada:
+
+**1. NAV CANADA NOTAMplus (notamplus.navcanada.ca)**
+
+The online self-briefing portal. Pilots can:
+- Query NOTAMs by aerodrome ICAO code, FIR, or geographic area
+- Filter by time period and NOTAM type
+- Create a route briefing showing all NOTAMs along a planned route
+
+NOTAMplus is the most complete and current source. It is updated continuously as new NOTAMs are issued.
+
+**2. 1-800-WX-BRIEF — NAV CANADA Flight Information Service**
+
+The toll-free telephone service staffed by Flight Service Specialists (FSS). A standard weather briefing from an FSS includes a NOTAM briefing for your route and destination. You can request:
+- All NOTAMs for specific aerodromes
+- Route NOTAMs along your planned track
+- FIR-wide active NOTAMs
+
+The FSS specialist integrates NOTAMs with weather, pilot reports, and other flight information. This is useful when you want a single integrated briefing from a knowledgeable specialist.
+
+**3. Canada Flight Supplement (CFS) / CFPS**
+
+The CFS contains Class II NOTAMs and permanent notices. It is published on a regular cycle (every 56 days). Class II NOTAMs with planned effective dates appear here. The CFS is not real-time — always supplement CFS review with NOTAMplus or an FSS briefing to catch Class I NOTAMs.
+
+Source: AIM RAC 2.0, TP 12880E.
+
+---
+
+**CAR 602.72 — The Preflight Obligation**
+
+**CAR 602.72** is the regulatory foundation for NOTAM checking. It states:
+
+> *No pilot-in-command shall commence a flight unless the pilot-in-command has obtained and has available all available aeronautical information that is pertinent to the intended flight.*
+
+This means before every flight you must:
+
+1. Check and understand NOTAMs relevant to your departure aerodrome, route, destination, and any alternates
+2. Obtain weather reports and forecasts
+3. Verify fuel requirements
+4. Review any other information affecting the safety of the flight
+
+Failing to check NOTAMs before departure is a violation of CAR 602.72. If you operate in a closed runway or deactivated restricted area that was NOTAMed and you didn't check, you have broken this regulation regardless of whether an incident occurs.
+
+The obligation applies to every flight, not just IFR or cross-country flights. A local training flight is subject to CAR 602.72 just as much as a long cross-country.
+
+Source: CAR 602.72.
+
+---
+
+**Special NOTAM Series: SNOWTAM and ASHTAM**
+
+Beyond standard NOTAMs, Canada uses two specialized series for specific hazard categories:
+
+**SNOWTAM**
+
+A SNOWTAM is a special series NOTAM reporting the current condition of movement areas (runways, taxiways, aprons) affected by snow, ice, slush, or standing water. SNOWTAMs are issued by aerodrome operators and distributed via the NOTAM system.
+
+Key information in a SNOWTAM includes:
+- Which runway(s) are affected
+- Type of contamination (snow, ice, compacted snow, slush, water)
+- Depth of contamination
+- Braking action (good / medium / poor / nil)
+- Runway condition code (RCC) — a standardized numeric code (0–6)
+
+SNOWTAMs are critical for winter operations. Braking action affects accelerate-stop distance, crosswind limits, and landing roll. Always review the current SNOWTAM when operating at Canadian aerodromes in winter conditions.
+
+**ASHTAM**
+
+An ASHTAM is a special series NOTAM reporting volcanic ash cloud activity. It advises pilots of:
+- The location and extent of the volcanic ash cloud
+- Affected flight levels
+- Recommended avoidance routes
+
+ASHTAMs are particularly relevant for Pacific routes (Alaska, Kamchatka, Aleutian Islands) where volcanic activity can affect Canadian airspace. For most PPL-level VFR flying, ASHTAMs are rarely encountered, but you should know they exist and what they report.
+
+Source: AIM RAC 2.0.
+
+---
+
+**Worked Sample NOTAM Decode**
+
+Let us decode the following NOTAM field by field:
+
+```
+!YYZ A0093/26 NOTAMN
+Q) CZYZ/QMRLC/IV/NBO/A/000/999/4338N07936W005
+A) CYYZ
+B) 2604210600
+C) 2604211400
+E) RWY 05/23 CLSD
+```
+
+| Field | Value | Meaning |
+|-------|-------|---------|
+| `!YYZ` | Issuing office | Toronto NOTAM office |
+| `A0093/26` | NOTAM number | Number 93 of year 2026 |
+| `NOTAMN` | Type | New NOTAM (not a replacement or cancellation) |
+| `CZYZ` | FIR | Toronto FIR |
+| `QMRLC` | Q-code | MR = runway, LC = closed |
+| `IV` | Traffic | Affects both IFR and VFR traffic |
+| `NBO` | Purpose | Immediate safety, briefing, ops |
+| `A` | Scope | Aerodrome |
+| `000/999` | Altitude | All altitudes (ground to FL999) |
+| `CYYZ` | Location | Toronto Pearson International Airport |
+| `2604210600` | Effective from | 21 April 2026 at 0600 UTC |
+| `2604211400` | Effective to | 21 April 2026 at 1400 UTC |
+| `RWY 05/23 CLSD` | Plain text | Runway 05/23 is closed |
+
+**Operational meaning:** Toronto Pearson runway 05/23 will be closed from 0600 to 1400 UTC on 21 April 2026 (an 8-hour window). Pilots planning to depart, arrive, or practise circuits at CYYZ during this period must plan to use an alternative runway configuration. Note that all NOTAM times are UTC — not local.
+
+---
+
+**Common Exam Points**
+
+- CAR 602.72 requires preflight NOTAM check for **every** flight
+- Class I = immediate, distributed in real time; Class II = non-immediate, published in CFS
+- NOTAM times are always **UTC**
+- `NOTAMN` = New, `NOTAMR` = Replacement, `NOTAMC` = Cancellation
+- Q-code NV = navaid unserviceable; OB = obstacle; AF = aerodrome lighting; AG = ground movement
+- SNOWTAM = runway surface conditions (winter); ASHTAM = volcanic ash warning
+- NOTAMplus and 1-800-WX-BRIEF are the two primary real-time access methods
+
+---
+
+## Quick Reference
+
+| Item | Detail |
+|------|--------|
+| Regulatory requirement | CAR 602.72 — obtain all available aeronautical information before flight |
+| Class I NOTAM | Immediate operational significance, distributed in real time via telecom |
+| Class II NOTAM | Non-immediate, published in CFS/NOF |
+| NOTAM time standard | Always UTC (never local time) |
+| New / Replace / Cancel | NOTAMN / NOTAMR / NOTAMC |
+| Q-code NV | Navaid unserviceable |
+| Q-code OB | Obstacle |
+| Q-code AF | Aerodrome lighting |
+| Q-code AG | Aerodrome ground movement |
+| SNOWTAM | Runway surface condition report |
+| ASHTAM | Volcanic ash advisory |
+| Online access | NAV CANADA NOTAMplus (notamplus.navcanada.ca) |
+| Phone access | 1-800-WX-BRIEF |
+| Published source | Canada Flight Supplement (Class II) |
+
+**NOTAM format fields:**
+- `!ICAO` — issuing office
+- `XXXXXXXX/YY` — NOTAM number / year
+- `NOTAMN/R/C` — type
+- `Q)` — Q-code line (FIR, subject code, traffic, purpose, scope, altitudes, location)
+- `A)` — affected location (ICAO)
+- `B)` — effective from (UTC, format YYMMDDHHMM)
+- `C)` — effective to (UTC, PERM, or ESTM)
+- `D)` — schedule (optional)
+- `E)` — plain language text
+
+---
+
+*End of Lesson AL-010.*


### PR DESCRIPTION
## Summary

- Creates `lessons/air-law/010-notams.md` with full content for the AL-010 NOTAMs lesson
- Covers NOTAM definition/purpose, Class I vs Class II, NOTAM format (Q/A/B/C/D/E fields), Q-code subjects (NV, OB, AF, AG), access methods (NOTAMplus, 1-800-WX-BRIEF, CFS), CAR 602.72 preflight obligation, SNOWTAM and ASHTAM types, and a worked sample NOTAM decode
- Includes all 5 practice questions in frontmatter with 4 choices, correct answer, and explanation
- `getLessonBySlug('air-law', 'notams')` resolves correctly via existing lesson-loader

Closes #102

## Test plan

- [ ] Verify `lessons/air-law/010-notams.md` parses as valid YAML frontmatter
- [ ] Confirm `id: AL-010`, `slug: notams`, `topic: air-law`, `order: 10` match curriculum.ts entry
- [ ] Confirm all 5 questions present with A–D choices, answer, and explanation
- [ ] Review factual accuracy of CAR 602.72 citation and NOTAM format details

🤖 Generated with [Claude Code](https://claude.com/claude-code)