### PR TITLE
[PPL-141] Narration-only extraction + backfill existing lessons

### DIFF
--- a/docs/audio-standards.md
+++ b/docs/audio-standards.md
@@ -13,6 +13,24 @@ All lesson narration is generated with **Kokoro** using the following canonical 
 
 These parameters are fixed for the project. Do not mix voices or models between lessons — consistency across the audio library matters for listener experience.
 
+## Narration Extraction Rule
+
+Audio is generated from the **`## Narration Script`** section of each lesson file only — not the full lesson body. The script must:
+
+1. Locate the `## Narration Script` heading in the lesson body (after stripping YAML frontmatter).
+2. Extract all text from that heading up to (but not including) the next `## ` heading, or end-of-file.
+3. Strip all markdown formatting from the extracted text before passing it to Kokoro:
+   - Bold markers: `**text**` → `text`
+   - Italic markers: `*text*` → `text`
+   - Inline code: `` `text` `` → `text`
+   - Fenced code blocks: ` ```...``` ` → (removed)
+   - ATX headings: lines starting with `#` → plain text (strip the `# ` prefix)
+   - Horizontal rules: `---` lines → (removed)
+   - Table rows: lines containing `|` → (removed)
+   - Bullet markers: leading `- ` → (removed)
+
+If a lesson file has no `## Narration Script` section, the script exits with an error — do not fall back to narrating the whole lesson.
+
 ## R2 Path Convention
 
 Audio files are hosted on Cloudflare R2 under the `suprun-media` bucket. The R2 key mirrors the lesson markdown path exactly:
@@ -54,6 +72,6 @@ The script:
 
 **Skip if already set:** If the `audio:` frontmatter field in a lesson file is already a non-null URL, do not regenerate — the audio is considered authoritative. Overwriting a published URL risks breaking existing listener sessions.
 
-**Exception — AL-001:** Lesson `AL-001` (`lessons/air-law/001-airspace-classifications.md`) must be regenerated unconditionally when re-running the batch, as the initial recording predates these standards and used a different voice.
+**2026-04-21 cutoff — narration-extraction backfill:** Audio generated before 2026-04-21 was produced from the full lesson body, not the `## Narration Script` section. All 15 lessons existing on that date (AL-001 through AL-013, NAV-001, NAV-002) were regenerated with narration-only extraction as part of issue #141. Their `audio:` fields were nulled and re-set during that backfill. Any audio URL already present for these lessons after 2026-04-21 is considered authoritative under the narration-extraction standard.
 
 To force regeneration of a lesson that already has an audio URL, delete or null out the `audio:` field before running the script.

--- a/lessons/air-law/009-flight-plans-itineraries.md
+++ b/lessons/air-law/009-flight-plans-itineraries.md
@@ -6,7 +6,7 @@ slug: flight-plans-itineraries
 title: "VFR Flight Plans and Itineraries"
 duration_min: 20
 status: complete
-audio: null
+audio: https://media.suprun.workers.dev/ppl/lessons/air-law/009-flight-plans-itineraries.m4a
 visual: null
 sources:
   - CARs 602.73

--- a/lessons/air-law/010-notams.md
+++ b/lessons/air-law/010-notams.md
@@ -6,7 +6,7 @@ slug: notams
 title: "NOTAMs"
 duration_min: 20
 status: complete
-audio: null
+audio: https://media.suprun.workers.dev/ppl/lessons/air-law/010-notams.m4a
 visual: null
 sources:
   - TP 12880E

--- a/lessons/air-law/011-cars-structure.md
+++ b/lessons/air-law/011-cars-structure.md
@@ -6,7 +6,7 @@ slug: cars-structure
 title: "CARs Structure"
 duration_min: 20
 status: complete
-audio: null
+audio: https://media.suprun.workers.dev/ppl/lessons/air-law/011-cars-structure.m4a
 visual: null
 sources:
   - TP 12880E

--- a/lessons/air-law/012-pilot-licences-recency.md
+++ b/lessons/air-law/012-pilot-licences-recency.md
@@ -6,6 +6,7 @@ slug: pilot-licences-recency
 title: "Pilot Licences and Recency Requirements"
 duration_min: 20
 status: complete
+audio: https://media.suprun.workers.dev/ppl/lessons/air-law/012-pilot-licences-recency.m4a
 sources:
   - CAR 401.05
   - CAR 421.26

--- a/lessons/air-law/013-aircraft-documents.md
+++ b/lessons/air-law/013-aircraft-documents.md
@@ -6,7 +6,7 @@ slug: aircraft-documents
 title: "Aircraft Documents"
 duration_min: 20
 status: complete
-audio: null
+audio: https://media.suprun.workers.dev/ppl/lessons/air-law/013-aircraft-documents.m4a
 visual: null
 sources:
   - CARs 605.03

--- a/scripts/generate-lesson-audio.sh
+++ b/scripts/generate-lesson-audio.sh
@@ -57,12 +57,21 @@ else:
 
 # Extract only the Narration Script section (between ## Narration Script and the next ## heading)
 narration_match = re.search(r'^## Narration Script\s*\n(.*?)(?=\n## |\Z)', body, re.DOTALL | re.MULTILINE)
-if narration_match:
-    body = narration_match.group(1)
+if not narration_match:
+    sys.exit("ERROR: no '## Narration Script' section found in " + lesson_path)
+body = narration_match.group(1)
 
 # Strip markdown formatting
+# Fenced code blocks: ```...``` (multi-line)
+body = re.sub(r'```[^\n]*\n.*?```', '', body, flags=re.DOTALL)
 # Bold markers: **text** -> text
 body = re.sub(r'\*\*(.+?)\*\*', r'\1', body)
+# Italic markers: *text* -> text
+body = re.sub(r'\*(.+?)\*', r'\1', body)
+# Inline code: `text` -> text
+body = re.sub(r'`(.+?)`', r'\1', body)
+# ATX headings: strip leading # characters (e.g. ### Title -> Title)
+body = re.sub(r'^#{1,6}\s+', '', body, flags=re.MULTILINE)
 # Horizontal rules: --- on its own line
 body = re.sub(r'^---+\s*$', '', body, flags=re.MULTILINE)
 # Table rows: lines containing | ... |
@@ -107,5 +116,34 @@ rm -f "$LESSON_WAV"
 
 # Upload and capture the public URL
 PUBLIC_URL="$("$SCRIPT_DIR/upload-lesson-audio.sh" "$LESSON_M4A" "$LESSON_MD")"
+
+# Update the audio: frontmatter field in the lesson file
+python3 - "$LESSON_MD" "$PUBLIC_URL" <<'PYEOF'
+import sys, re
+
+lesson_path, url = sys.argv[1], sys.argv[2]
+with open(lesson_path, encoding="utf-8") as f:
+    content = f.read()
+
+if not content.startswith("---"):
+    sys.exit("ERROR: lesson has no YAML frontmatter: " + lesson_path)
+
+close = content.find("\n---", 3)
+if close == -1:
+    sys.exit("ERROR: frontmatter block never closed in " + lesson_path)
+
+frontmatter = content[3:close]
+rest = content[close:]
+
+if re.search(r'^audio:', frontmatter, re.MULTILINE):
+    # Replace existing audio: line (null, empty, or existing URL)
+    frontmatter = re.sub(r'^audio:.*$', f'audio: {url}', frontmatter, flags=re.MULTILINE)
+else:
+    # Append audio: field before closing ---
+    frontmatter = frontmatter.rstrip('\n') + f'\naudio: {url}\n'
+
+with open(lesson_path, "w", encoding="utf-8") as f:
+    f.write("---" + frontmatter + rest)
+PYEOF
 
 echo "$PUBLIC_URL"


### PR DESCRIPTION
## Summary

- **Narration Extraction Rule documented** in `docs/audio-standards.md` — new section after the TTS parameters table defines the `## Narration Script` extraction logic and the full list of markdown stripping rules (fenced code, bold, italic, inline code, headings, tables, bullets, horizontal rules).
- **Idempotency Rule revised** with 2026-04-21 cutoff clause explaining that all 15 pre-existing lessons were regenerated with narration-only audio as part of this issue's backfill.
- **`scripts/generate-lesson-audio.sh` fixed**:
  - Exits with an error if `## Narration Script` section is missing (no silent fallback to full lesson body).
  - Adds stripping of fenced code blocks, italic markers (`*text*`), inline backticks, and ATX headings.
  - Writes the public URL back into the `audio:` frontmatter field after a successful upload.
- **Backfill**: Nulled `audio:` field and regenerated narration-only `.m4a` for all 15 existing lessons (AL-001 through AL-013, NAV-001, NAV-002). Lessons without a prior `audio:` field (AL-012) had the field added. All 15 uploads confirmed on R2.

## Test plan

- [ ] Verify `audio:` frontmatter fields in all 15 lesson files contain live R2 URLs.
- [ ] Spot-check one audio file URL returns HTTP 200 with `content-type: audio/mp4`.
- [ ] Run `scripts/generate-lesson-audio.sh` against a lesson file with no `## Narration Script` section — confirm script exits non-zero with a clear error message.
- [ ] Run against a lesson file — confirm frontmatter `audio:` is updated without corrupting surrounding YAML.

Closes #141

🤖 Generated with [Claude Code](https://claude.com/claude-code)