### PR TITLE
[PPL-146] Add Study Playlist with auto-advancing audio player

### DIFF
--- a/web-app/src/App.tsx
+++ b/web-app/src/App.tsx
@@ -8,6 +8,7 @@ import LessonDetail from './pages/LessonDetail';
 import LessonQuiz from './pages/LessonQuiz';
 import Exam from './pages/Exam';
 import Plan from './pages/Plan';
+import Playlist from './pages/Playlist';
 
 export default function App() {
   return (
@@ -42,6 +43,8 @@ export default function App() {
             <Route path="/lessons/:topic/:slug/quiz" element={<LessonQuiz />} />
             <Route path="/exam" element={<Exam />} />
             <Route path="/plan" element={<Plan />} />
+            <Route path="/playlist" element={<Playlist />} />
+            <Route path="/playlist/:topic" element={<Playlist />} />
           </Routes>
         </Box>
       </BrowserRouter>

--- a/web-app/src/components/PlaylistPlayer.tsx
+++ b/web-app/src/components/PlaylistPlayer.tsx
@@ -1,0 +1,101 @@
+import { useEffect, useRef, useState } from 'react';
+import Box from '@mui/material/Box';
+import IconButton from '@mui/material/IconButton';
+import Typography from '@mui/material/Typography';
+import SkipPreviousIcon from '@mui/icons-material/SkipPrevious';
+import SkipNextIcon from '@mui/icons-material/SkipNext';
+import type { Lesson } from '../lib/types';
+import { TOPIC_LABELS } from '../lib/curriculum';
+
+interface PlaylistPlayerProps {
+  lessons: Lesson[];
+}
+
+export default function PlaylistPlayer({ lessons }: PlaylistPlayerProps) {
+  const [playlist] = useState<Lesson[]>(() => lessons.filter((l) => l.audio !== null));
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const audioRef = useRef<HTMLAudioElement>(null);
+
+  useEffect(() => {
+    const audio = audioRef.current;
+    if (!audio) return;
+    audio.load();
+    audio.play().catch(() => {});
+  }, [currentIndex]);
+
+  if (playlist.length === 0) return null;
+
+  const current = playlist[currentIndex];
+
+  function handlePrev() {
+    setCurrentIndex((i) => Math.max(0, i - 1));
+  }
+
+  function handleNext() {
+    setCurrentIndex((i) => Math.min(playlist.length - 1, i + 1));
+  }
+
+  function handleEnded() {
+    if (currentIndex < playlist.length - 1) {
+      setCurrentIndex((i) => i + 1);
+    }
+  }
+
+  return (
+    <Box sx={{ my: 2, width: '100%' }}>
+      <Typography
+        variant="caption"
+        color="text.secondary"
+        sx={{
+          display: 'block',
+          mb: 0.5,
+          textTransform: 'uppercase',
+          letterSpacing: 0.5,
+          fontSize: 11,
+        }}
+      >
+        Playlist
+      </Typography>
+      <Typography
+        variant="caption"
+        color="text.secondary"
+        sx={{ display: 'block', mb: 0.5, fontSize: 11 }}
+      >
+        {TOPIC_LABELS[current.topic] ?? current.topic}
+      </Typography>
+      <Typography variant="subtitle1" sx={{ mb: 1 }}>
+        {current.title}
+      </Typography>
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1 }}>
+        <IconButton
+          onClick={handlePrev}
+          disabled={currentIndex === 0}
+          aria-label="Previous lesson"
+          size="small"
+        >
+          <SkipPreviousIcon />
+        </IconButton>
+        <Typography variant="caption" color="text.secondary">
+          {currentIndex + 1} / {playlist.length}
+        </Typography>
+        <IconButton
+          onClick={handleNext}
+          disabled={currentIndex === playlist.length - 1}
+          aria-label="Next lesson"
+          size="small"
+        >
+          <SkipNextIcon />
+        </IconButton>
+      </Box>
+      <audio
+        ref={audioRef}
+        preload="none"
+        onEnded={handleEnded}
+        style={{ width: '100%', display: 'block' }}
+      >
+        <source src={current.audio!} type="audio/mp4" />
+        Your browser does not support the audio element.
+      </audio>
+    </Box>
+  );
+}

--- a/web-app/src/pages/Playlist.tsx
+++ b/web-app/src/pages/Playlist.tsx
@@ -1,0 +1,56 @@
+import { useNavigate, useParams } from 'react-router-dom';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Container from '@mui/material/Container';
+import Typography from '@mui/material/Typography';
+import PlaylistPlayer from '../components/PlaylistPlayer';
+import { getLessonsByTopic } from '../lib/lesson-loader';
+import { TOPICS, TOPIC_LABELS } from '../lib/curriculum';
+
+export default function Playlist() {
+  const { topic } = useParams<{ topic: string }>();
+  const navigate = useNavigate();
+
+  if (topic) {
+    const lessons = getLessonsByTopic(topic).filter(
+      (l) => l.status !== 'planning' && l.audio !== null,
+    );
+
+    return (
+      <Container maxWidth="md" sx={{ py: 4 }}>
+        <Typography variant="h4" gutterBottom>
+          {TOPIC_LABELS[topic] ?? topic} — Playlist
+        </Typography>
+        {lessons.length === 0 ? (
+          <Typography color="text.secondary">
+            No audio lessons are available for this topic yet.
+          </Typography>
+        ) : (
+          <PlaylistPlayer lessons={lessons} />
+        )}
+      </Container>
+    );
+  }
+
+  return (
+    <Container maxWidth="md" sx={{ py: 4 }}>
+      <Typography variant="h4" gutterBottom>
+        Study Playlist
+      </Typography>
+      <Typography variant="body1" color="text.secondary" sx={{ mb: 3 }}>
+        Select a topic to listen to all available audio lessons in order.
+      </Typography>
+      <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 2 }}>
+        {TOPICS.map((t) => (
+          <Button
+            key={t}
+            variant="outlined"
+            onClick={() => navigate(`/playlist/${t}`)}
+          >
+            {TOPIC_LABELS[t]}
+          </Button>
+        ))}
+      </Box>
+    </Container>
+  );
+}


### PR DESCRIPTION
## Summary

- Adds `PlaylistPlayer` component: stateful, auto-advancing audio player that cycles through a filtered list of lessons with audio, with prev/next controls and position indicator
- Adds `Playlist` page at `/playlist` (topic selector) and `/playlist/:topic` (direct playback) using `getLessonsByTopic` filtered to authored lessons with audio
- Adds routes `/playlist` and `/playlist/:topic` to `App.tsx`

## Changes

- `web-app/src/components/PlaylistPlayer.tsx` — new component
- `web-app/src/pages/Playlist.tsx` — new page
- `web-app/src/App.tsx` — added two routes

## Test plan

- [ ] Visit `/playlist` — confirm topic selector renders four topic buttons
- [ ] Click a topic with audio lessons — confirm `PlaylistPlayer` loads with position indicator
- [ ] Confirm prev/next buttons are disabled at list bounds
- [ ] Confirm audio auto-advances to next lesson on `onEnded`
- [ ] Visit a topic with no audio — confirm "no audio lessons available" notice displays
- [ ] `tsc --noEmit` passes cleanly

Closes #146

🤖 Generated with [Claude Code](https://claude.ai/claude-code)