### PR TITLE
[PPL-137] Theme foundation: IBM Plex fonts, design tokens, MUI overrides

### DIFF
--- a/web-app/package-lock.json
+++ b/web-app/package-lock.json
@@ -10,6 +10,8 @@
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",
+        "@fontsource/ibm-plex-mono": "^5.0.5",
+        "@fontsource/ibm-plex-sans": "^5.0.5",
         "@fontsource/roboto": "^5.0.5",
         "@fontsource/space-grotesk": "^5.0.5",
         "@mui/icons-material": "^7.3.9",
@@ -905,6 +907,24 @@
       ],
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@fontsource/ibm-plex-mono": {
+      "version": "5.2.7",
+      "resolved": "https://registry.npmjs.org/@fontsource/ibm-plex-mono/-/ibm-plex-mono-5.2.7.tgz",
+      "integrity": "sha512-MKAb8qV+CaiMQn2B0dIi1OV3565NYzp3WN5b4oT6LTkk+F0jR6j0ZN+5BKJiIhffDC3rtBULsYZE65+0018z9w==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource/ibm-plex-sans": {
+      "version": "5.2.8",
+      "resolved": "https://registry.npmjs.org/@fontsource/ibm-plex-sans/-/ibm-plex-sans-5.2.8.tgz",
+      "integrity": "sha512-eztSXjDhPhcpxNIiGTgMebdLP9qS4rWkysuE1V7c+DjOR0qiezaiDaTwQE7bTnG5HxAY/8M43XKDvs3cYq6ZYQ==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
       }
     },
     "node_modules/@fontsource/roboto": {

--- a/web-app/package.json
+++ b/web-app/package.json
@@ -5,6 +5,8 @@
   "dependencies": {
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.1",
+    "@fontsource/ibm-plex-mono": "^5.0.5",
+    "@fontsource/ibm-plex-sans": "^5.0.5",
     "@fontsource/roboto": "^5.0.5",
     "@fontsource/space-grotesk": "^5.0.5",
     "@mui/icons-material": "^7.3.9",

--- a/web-app/src/main.tsx
+++ b/web-app/src/main.tsx
@@ -1,12 +1,9 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import '@fontsource/roboto/300.css';
-import '@fontsource/roboto/400.css';
-import '@fontsource/roboto/500.css';
-import '@fontsource/roboto/700.css';
-import '@fontsource/space-grotesk/400.css';
-import '@fontsource/space-grotesk/600.css';
-import '@fontsource/space-grotesk/700.css';
+import '@fontsource/ibm-plex-sans/400.css';
+import '@fontsource/ibm-plex-sans/600.css';
+import '@fontsource/ibm-plex-mono/400.css';
+import '@fontsource/ibm-plex-mono/600.css';
 import App from './App';
 
 const root = ReactDOM.createRoot(document.getElementById('root')!);

--- a/web-app/src/theme.ts
+++ b/web-app/src/theme.ts
@@ -1,4 +1,5 @@
 import { createTheme } from '@mui/material/styles';
+import { colorTokens, typographyTokens, radiusTokens } from './tokens';
 
 declare module '@mui/material/styles' {
   interface TypeBackground {
@@ -7,97 +8,128 @@ declare module '@mui/material/styles' {
   interface TypeText {
     onAccent: string;
   }
+  interface Palette {
+    primaryMuted: string;
+  }
+  interface PaletteOptions {
+    primaryMuted?: string;
+  }
 }
 
 const theme = createTheme({
   palette: {
     mode: 'dark',
     background: {
-      default: '#0a1628',
-      paper: '#0d1f3c',
-      surfaceRaised: '#0d1f3c',
+      default: colorTokens.background.default,
+      paper: colorTokens.background.paper,
+      surfaceRaised: colorTokens.background.surfaceRaised,
     },
     primary: {
-      main: '#f5a623',
+      main: colorTokens.primary.main,
     },
     secondary: {
-      main: '#ffffff',
+      main: colorTokens.secondary.main,
     },
     info: {
-      main: '#4fc3f7',
+      main: colorTokens.info.main,
+    },
+    success: {
+      main: colorTokens.success.main,
     },
     text: {
-      onAccent: '#000000',
+      primary: colorTokens.text.primary,
+      secondary: colorTokens.text.secondary,
+      disabled: colorTokens.text.disabled,
+      onAccent: colorTokens.text.onAccent,
     },
+    divider: colorTokens.divider,
+    primaryMuted: colorTokens.primary.muted,
+  },
+  shape: {
+    borderRadius: radiusTokens.sm,
   },
   typography: {
-    fontFamily: "'Roboto', 'Helvetica', 'Arial', sans-serif",
+    fontFamily: typographyTokens.fontFamily.sans,
     h1: {
-      fontFamily: "'Space Grotesk', 'Roboto', 'Helvetica', sans-serif",
+      fontFamily: typographyTokens.fontFamily.sans,
       fontSize: '1.875rem',
-      fontWeight: 700,
+      fontWeight: typographyTokens.weight.bold,
       lineHeight: 1.2,
       '@media (min-width:900px)': {
         fontSize: '3rem',
       },
     },
     h2: {
-      fontFamily: "'Space Grotesk', 'Roboto', 'Helvetica', sans-serif",
+      fontFamily: typographyTokens.fontFamily.sans,
       fontSize: '1.5rem',
-      fontWeight: 700,
+      fontWeight: typographyTokens.weight.bold,
       lineHeight: 1.25,
       '@media (min-width:900px)': {
         fontSize: '2.25rem',
       },
     },
     h3: {
-      fontFamily: "'Space Grotesk', 'Roboto', 'Helvetica', sans-serif",
+      fontFamily: typographyTokens.fontFamily.sans,
       fontSize: '1.375rem',
-      fontWeight: 600,
+      fontWeight: typographyTokens.weight.semibold,
       lineHeight: 1.3,
       '@media (min-width:900px)': {
         fontSize: '1.875rem',
       },
     },
     h4: {
-      fontFamily: "'Space Grotesk', 'Roboto', 'Helvetica', sans-serif",
+      fontFamily: typographyTokens.fontFamily.sans,
       fontSize: '1.25rem',
-      fontWeight: 600,
+      fontWeight: typographyTokens.weight.semibold,
       lineHeight: 1.35,
       '@media (min-width:900px)': {
         fontSize: '1.5rem',
       },
     },
     h5: {
+      fontFamily: typographyTokens.fontFamily.sans,
       fontSize: '1.125rem',
-      fontWeight: 600,
+      fontWeight: typographyTokens.weight.semibold,
       lineHeight: 1.4,
       '@media (min-width:900px)': {
         fontSize: '1.25rem',
       },
     },
     h6: {
+      fontFamily: typographyTokens.fontFamily.sans,
       fontSize: '1rem',
-      fontWeight: 500,
+      fontWeight: typographyTokens.weight.semibold,
       lineHeight: 1.4,
       '@media (min-width:900px)': {
         fontSize: '1.125rem',
       },
     },
     body1: {
+      fontFamily: typographyTokens.fontFamily.sans,
       fontSize: '1rem',
-      fontWeight: 400,
+      fontWeight: typographyTokens.weight.regular,
       lineHeight: 1.75,
     },
     body2: {
+      fontFamily: typographyTokens.fontFamily.sans,
       fontSize: '0.875rem',
-      fontWeight: 400,
+      fontWeight: typographyTokens.weight.regular,
       lineHeight: 1.6,
     },
     caption: {
+      fontFamily: typographyTokens.fontFamily.sans,
       fontSize: '0.75rem',
-      fontWeight: 400,
+      fontWeight: typographyTokens.weight.regular,
       lineHeight: 1.5,
+    },
+    // Monospace variant for lesson IDs, CARs citations, and code
+    overline: {
+      fontFamily: typographyTokens.fontFamily.mono,
+      fontSize: '0.75rem',
+      fontWeight: typographyTokens.weight.regular,
+      lineHeight: 1.5,
+      letterSpacing: '0.08em',
+      textTransform: 'uppercase',
     },
   },
   components: {
@@ -105,6 +137,13 @@ const theme = createTheme({
       styleOverrides: {
         root: {
           minHeight: 48,
+          borderRadius: radiusTokens.md,
+          fontFamily: typographyTokens.fontFamily.sans,
+          fontWeight: typographyTokens.weight.semibold,
+          textTransform: 'none',
+        },
+        containedPrimary: {
+          color: colorTokens.text.onAccent,
         },
       },
     },
@@ -116,10 +155,64 @@ const theme = createTheme({
         },
       },
     },
+    MuiCard: {
+      styleOverrides: {
+        root: {
+          borderRadius: radiusTokens.md,
+          border: `1px solid ${colorTokens.divider}`,
+          backgroundImage: 'none',
+        },
+      },
+    },
+    MuiAppBar: {
+      styleOverrides: {
+        root: {
+          backgroundImage: 'none',
+          backgroundColor: colorTokens.background.paper,
+          borderBottom: `1px solid ${colorTokens.divider}`,
+          backdropFilter: 'blur(12px)',
+        },
+      },
+    },
     MuiCheckbox: {
       styleOverrides: {
         root: {
           padding: 12,
+        },
+      },
+    },
+    MuiChip: {
+      styleOverrides: {
+        root: {
+          fontFamily: typographyTokens.fontFamily.sans,
+          fontWeight: typographyTokens.weight.semibold,
+          borderRadius: radiusTokens.pill,
+        },
+      },
+    },
+    MuiTooltip: {
+      styleOverrides: {
+        tooltip: {
+          fontFamily: typographyTokens.fontFamily.sans,
+          fontSize: '0.75rem',
+          borderRadius: radiusTokens.sm,
+          backgroundColor: colorTokens.background.surfaceRaised,
+          border: `1px solid ${colorTokens.divider}`,
+        },
+      },
+    },
+    MuiLinearProgress: {
+      styleOverrides: {
+        root: {
+          borderRadius: radiusTokens.pill,
+          backgroundColor: colorTokens.primary.muted,
+        },
+      },
+    },
+    MuiPaper: {
+      styleOverrides: {
+        root: {
+          backgroundImage: 'none',
         },
       },
     },

--- a/web-app/src/tokens.ts
+++ b/web-app/src/tokens.ts
@@ -1,0 +1,49 @@
+// Design tokens for PPL Study — source of truth for all theme values.
+// No MUI blue #1976d2. Green reserved for correct/complete semantics only.
+
+export const colorTokens = {
+  background: {
+    default: '#0a1628',
+    paper: '#0d1f3c',
+    surfaceRaised: '#112244',
+  },
+  primary: {
+    main: '#f5a623',
+    muted: 'rgba(245,166,35,0.15)',
+  },
+  secondary: {
+    main: '#ffffff',
+  },
+  info: {
+    main: '#4fc3f7',
+  },
+  success: {
+    main: '#4caf50',
+  },
+  text: {
+    primary: '#ffffff',
+    secondary: 'rgba(255,255,255,0.65)',
+    disabled: 'rgba(255,255,255,0.35)',
+    onAccent: '#000000',
+  },
+  divider: 'rgba(255,255,255,0.12)',
+} as const;
+
+export const typographyTokens = {
+  fontFamily: {
+    sans: "'IBM Plex Sans', 'Roboto', 'Helvetica', 'Arial', sans-serif",
+    mono: "'IBM Plex Mono', 'Roboto Mono', 'Courier New', monospace",
+  },
+  weight: {
+    regular: 400,
+    semibold: 600,
+    bold: 700,
+  },
+} as const;
+
+export const radiusTokens = {
+  sm: 4,
+  md: 8,
+  lg: 12,
+  pill: 100,
+} as const;


### PR DESCRIPTION
Closes #137

## Phase 1 [Theme] only

This PR implements the theme foundation for the UI/UX redesign epic (#137). It does **not** touch Nav.tsx, lessons/, public/visuals/, or .github/workflows/ — those are separate child issues.

## Changes

- **`web-app/package.json`** — adds `@fontsource/ibm-plex-sans` and `@fontsource/ibm-plex-mono` (weights 400 and 600 only per font-budget constraint)
- **`web-app/src/tokens.ts`** (new) — exports `colorTokens`, `typographyTokens`, `radiusTokens`; no MUI blue `#1976d2`; green reserved for `success` (correct/complete only)
- **`web-app/src/theme.ts`** — consumes tokens.ts; switches body to IBM Plex Sans, code/numerics to IBM Plex Mono; adds MUI component overrides for Button, Card, AppBar, Chip, Tooltip, LinearProgress, Paper
- **`web-app/src/main.tsx`** — replaces Roboto/Space Grotesk font imports with IBM Plex Sans 400/600 and IBM Plex Mono 400/600

## Note: docs/pio-design-brief.md absent

The referenced `docs/pio-design-brief.md` was not present in the worktree. Token values were derived from `docs/design/2026-mobile-first-research.md` and the epic issue body (#137), which together contain the full color table, typography direction, and design constraints. The tokens implemented here are consistent with those sources.

## Remaining child work (tracked in epic #137)

- **[Nav]** Desktop side-rail + mobile bottom-nav
- **[ExamTrackProvider]** Context provider
- **[TopicMasteryCard]**, **[LessonProgressBar]**, **[ExamReadinessGauge]**
- **[QuizOption]**, **[SRSQueue]**, **[AudioPlayerV2]**, **[LessonCompleteScreen]**
- Phase 4 items (MockExamRunner, AirspaceDiagram, TrackSwitcher)

## Build

`npm run build` in `web-app/` passes ✓