### PR TITLE
[PPL-148] Add GK-001..GK-014 visual HTML files

### DIFF
--- a/lessons/general-knowledge/001-aircraft-parts-controls.md
+++ b/lessons/general-knowledge/001-aircraft-parts-controls.md
@@ -7,7 +7,7 @@ title: "Aircraft Parts and Controls"
 duration_min: 20
 status: complete
 audio: null
-visual: null
+visual: /visuals/gk001-aircraft-parts-controls.html
 sources:
   - TP 12880E Chapter 1
   - TP 12880E Chapter 2

--- a/lessons/general-knowledge/002-four-forces.md
+++ b/lessons/general-knowledge/002-four-forces.md
@@ -7,7 +7,7 @@ title: "Four Forces of Flight"
 duration_min: 20
 status: complete
 audio: null
-visual: null
+visual: /visuals/gk002-four-forces.html
 sources:
   - TP 12880E Chapter 3
   - TP 12880E Chapter 4

--- a/lessons/general-knowledge/003-piston-engines.md
+++ b/lessons/general-knowledge/003-piston-engines.md
@@ -7,7 +7,7 @@ title: "Piston Engines"
 duration_min: 20
 status: complete
 audio: null
-visual: null
+visual: /visuals/gk003-piston-engines.html
 sources:
   - TP 12880E Chapter 5
   - TP 12880E Chapter 6

--- a/lessons/general-knowledge/004-fuel-system.md
+++ b/lessons/general-knowledge/004-fuel-system.md
@@ -7,7 +7,7 @@ title: "Fuel System"
 duration_min: 20
 status: complete
 audio: null
-visual: null
+visual: /visuals/gk004-fuel-system.html
 sources:
   - TP 12880E Chapter 5
   - CARs 602.88

--- a/lessons/general-knowledge/005-electrical-system.md
+++ b/lessons/general-knowledge/005-electrical-system.md
@@ -7,7 +7,7 @@ title: "Electrical System"
 duration_min: 20
 status: complete
 audio: null
-visual: null
+visual: /visuals/gk005-electrical-system.html
 sources:
   - TP 12880E Chapter 5
   - TP 12880E Chapter 8

--- a/lessons/general-knowledge/006-pitot-static-instruments.md
+++ b/lessons/general-knowledge/006-pitot-static-instruments.md
@@ -7,7 +7,7 @@ title: "Pitot-Static System"
 duration_min: 20
 status: complete
 audio: null
-visual: null
+visual: /visuals/gk006-pitot-static-instruments.html
 sources:
   - TP 12880E Chapter 8
   - CARs 605.14

--- a/lessons/general-knowledge/007-gyroscopic-instruments.md
+++ b/lessons/general-knowledge/007-gyroscopic-instruments.md
@@ -7,7 +7,7 @@ title: "Gyroscopic Instruments"
 duration_min: 20
 status: complete
 audio: null
-visual: null
+visual: /visuals/gk007-gyroscopic-instruments.html
 sources:
   - TP 12880E Chapter 8
   - CARs 605.14

--- a/lessons/general-knowledge/008-engine-instruments.md
+++ b/lessons/general-knowledge/008-engine-instruments.md
@@ -7,7 +7,7 @@ title: "Engine Instruments"
 duration_min: 20
 status: complete
 audio: null
-visual: null
+visual: /visuals/gk008-engine-instruments.html
 sources:
   - TP 12880E Chapter 5
   - TP 12880E Chapter 8

--- a/lessons/general-knowledge/009-weight-and-balance.md
+++ b/lessons/general-knowledge/009-weight-and-balance.md
@@ -7,7 +7,7 @@ title: "Weight and Balance"
 duration_min: 20
 status: complete
 audio: null
-visual: null
+visual: /visuals/gk009-weight-and-balance.html
 sources:
   - TP 12880E Chapter 10
   - POH (aircraft-specific)

--- a/lessons/general-knowledge/010-performance-charts.md
+++ b/lessons/general-knowledge/010-performance-charts.md
@@ -7,7 +7,7 @@ title: "Performance Charts"
 duration_min: 20
 status: complete
 audio: null
-visual: null
+visual: /visuals/gk010-performance-charts.html
 sources:
   - TP 12880E Chapter 11
   - POH (aircraft-specific)

--- a/lessons/general-knowledge/011-takeoff-landing-perf.md
+++ b/lessons/general-knowledge/011-takeoff-landing-perf.md
@@ -7,7 +7,7 @@ title: "Takeoff and Landing Performance"
 duration_min: 20
 status: complete
 audio: null
-visual: null
+visual: /visuals/gk011-takeoff-landing-perf.html
 sources:
   - TP 12880E Chapter 11
   - CARs Part VI (Flight Operations)

--- a/lessons/general-knowledge/012-stalls-spins.md
+++ b/lessons/general-knowledge/012-stalls-spins.md
@@ -7,7 +7,7 @@ title: "Stalls and Spins"
 duration_min: 20
 status: complete
 audio: null
-visual: null
+visual: /visuals/gk012-stalls-spins.html
 sources:
   - TP 12880E Chapter 3
   - TP 12880E Chapter 12

--- a/lessons/general-knowledge/013-load-factor.md
+++ b/lessons/general-knowledge/013-load-factor.md
@@ -7,7 +7,7 @@ title: "Load Factor and Maneuvering Speed"
 duration_min: 20
 status: complete
 audio: null
-visual: null
+visual: /visuals/gk013-load-factor.html
 sources:
   - TP 12880E Chapter 3
   - TP 12880E Chapter 4

--- a/lessons/general-knowledge/014-preflight-inspection.md
+++ b/lessons/general-knowledge/014-preflight-inspection.md
@@ -7,7 +7,7 @@ title: "Pre-Flight Inspection and Maintenance"
 duration_min: 20
 status: complete
 audio: null
-visual: null
+visual: /visuals/gk014-preflight-inspection.html
 sources:
   - CARs Part V (Airworthiness)
   - CARs 605.03

--- a/web-app/public/visuals/gk001-aircraft-parts-controls.html
+++ b/web-app/public/visuals/gk001-aircraft-parts-controls.html
@@ -1,0 +1,169 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>GK-001: Aircraft Parts and Controls</title>
+<style>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body { background: #0d1b2a; color: #e8edf2; font-family: 'Segoe UI', system-ui, sans-serif; padding: 32px; }
+  h1 { font-size: 22px; color: #f0c040; letter-spacing: 1px; margin-bottom: 6px; }
+  .subtitle { font-size: 13px; color: #7a9ab5; margin-bottom: 32px; letter-spacing: 0.5px; }
+  .container { max-width: 900px; margin: 0 auto; }
+  .section-title { font-size: 14px; color: #f0c040; letter-spacing: 1px; text-transform: uppercase; margin-bottom: 14px; margin-top: 32px; }
+  .diagrams { display: grid; grid-template-columns: 1fr 1fr; gap: 24px; margin-bottom: 32px; }
+  .diagram-box { background: #1a2d3d; border: 1px solid #1a2d3d; border-radius: 8px; padding: 16px; }
+  .diagram-label { font-size: 12px; color: #7a9ab5; text-align: center; margin-bottom: 10px; letter-spacing: 0.5px; }
+  svg text { font-family: 'Segoe UI', system-ui, sans-serif; }
+  table { width: 100%; border-collapse: collapse; margin-bottom: 20px; }
+  th { background: #1a2d3d; color: #f0c040; font-size: 12px; text-align: left; padding: 10px 14px; letter-spacing: 0.5px; }
+  td { font-size: 13px; color: #e8edf2; padding: 9px 14px; border-bottom: 1px solid #1a2d3d; vertical-align: top; }
+  tr:last-child td { border-bottom: none; }
+  .tag-primary { display: inline-block; background: #0d2a1a; color: #4caf7d; font-size: 11px; padding: 2px 8px; border-radius: 3px; border: 1px solid #4caf7d; }
+  .tag-secondary { display: inline-block; background: #2a1a0d; color: #f0a040; font-size: 11px; padding: 2px 8px; border-radius: 3px; border: 1px solid #f0a040; }
+  .tables-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 24px; }
+</style>
+</head>
+<body>
+<div class="container">
+  <h1>GK-001 — Aircraft Parts &amp; Controls</h1>
+  <p class="subtitle">Transport Canada · TP 12880E · PPL Written Exam</p>
+
+  <div class="section-title">Aircraft Structure — Top-Down &amp; Side Views</div>
+  <div class="diagrams">
+    <!-- Top-down view -->
+    <div class="diagram-box">
+      <div class="diagram-label">TOP-DOWN VIEW</div>
+      <svg viewBox="0 0 340 280" width="100%" height="220">
+        <!-- Fuselage -->
+        <ellipse cx="170" cy="140" rx="22" ry="90" fill="#1e3a50" stroke="#7a9ab5" stroke-width="1.5"/>
+        <!-- Left wing -->
+        <polygon points="148,120 50,155 50,170 148,165" fill="#1e3a50" stroke="#7a9ab5" stroke-width="1.5"/>
+        <!-- Right wing -->
+        <polygon points="192,120 290,155 290,170 192,165" fill="#1e3a50" stroke="#7a9ab5" stroke-width="1.5"/>
+        <!-- Left aileron -->
+        <polygon points="60,156 90,153 90,163 60,168" fill="#f0c040" stroke="#f0c040" stroke-width="1"/>
+        <!-- Right aileron -->
+        <polygon points="250,155 280,156 280,168 250,164" fill="#f0c040" stroke="#f0c040" stroke-width="1"/>
+        <!-- Left flap -->
+        <polygon points="95,153 145,145 145,162 95,163" fill="#4a7a9b" stroke="#7a9ab5" stroke-width="1"/>
+        <!-- Right flap -->
+        <polygon points="195,145 245,153 245,163 195,162" fill="#4a7a9b" stroke="#7a9ab5" stroke-width="1"/>
+        <!-- Horizontal stabilizer left -->
+        <polygon points="148,215 100,230 100,240 148,235" fill="#1e3a50" stroke="#7a9ab5" stroke-width="1.5"/>
+        <!-- Horizontal stabilizer right -->
+        <polygon points="192,215 240,230 240,240 192,235" fill="#1e3a50" stroke="#7a9ab5" stroke-width="1.5"/>
+        <!-- Left elevator -->
+        <polygon points="104,231 128,228 128,238 104,239" fill="#f0c040" stroke="#f0c040" stroke-width="1"/>
+        <!-- Right elevator -->
+        <polygon points="212,228 236,231 236,239 212,238" fill="#f0c040" stroke="#f0c040" stroke-width="1"/>
+        <!-- Vertical fin top view (thin line) -->
+        <rect x="164" y="220" width="12" height="35" fill="#2a4a5a" stroke="#7a9ab5" stroke-width="1"/>
+        <!-- Propeller disc -->
+        <ellipse cx="170" cy="48" rx="38" ry="8" fill="none" stroke="#f0c040" stroke-width="1.5" stroke-dasharray="4,3"/>
+        <!-- Nose -->
+        <ellipse cx="170" cy="48" rx="10" ry="10" fill="#1e3a50" stroke="#7a9ab5" stroke-width="1"/>
+
+        <!-- Labels -->
+        <text x="170" y="135" text-anchor="middle" fill="#e8edf2" font-size="9">FUSELAGE</text>
+        <text x="62" y="143" text-anchor="middle" fill="#e8edf2" font-size="8">WING</text>
+        <text x="278" y="143" text-anchor="middle" fill="#e8edf2" font-size="8">WING</text>
+        <text x="75" y="162" text-anchor="middle" fill="#f0c040" font-size="8">AILERON</text>
+        <text x="265" y="162" text-anchor="middle" fill="#f0c040" font-size="8">AILERON</text>
+        <text x="120" y="155" text-anchor="middle" fill="#7ac0e8" font-size="8">FLAP</text>
+        <text x="220" y="155" text-anchor="middle" fill="#7ac0e8" font-size="8">FLAP</text>
+        <text x="108" y="238" text-anchor="middle" fill="#f0c040" font-size="8">ELEVATOR</text>
+        <text x="232" y="238" text-anchor="middle" fill="#f0c040" font-size="8">ELEVATOR</text>
+        <text x="116" y="226" text-anchor="middle" fill="#e8edf2" font-size="8">H. STAB</text>
+        <text x="224" y="226" text-anchor="middle" fill="#e8edf2" font-size="8">H. STAB</text>
+        <text x="170" y="265" text-anchor="middle" fill="#e8edf2" font-size="8">V. FIN</text>
+        <text x="170" y="38" text-anchor="middle" fill="#f0c040" font-size="8">PROP</text>
+      </svg>
+    </div>
+    <!-- Side view -->
+    <div class="diagram-box">
+      <div class="diagram-label">SIDE VIEW</div>
+      <svg viewBox="0 0 340 280" width="100%" height="220">
+        <!-- Fuselage body -->
+        <path d="M60,145 Q90,120 170,118 Q240,118 285,135 Q300,145 285,158 Q240,165 100,165 Q70,165 60,155 Z" fill="#1e3a50" stroke="#7a9ab5" stroke-width="1.5"/>
+        <!-- Wing (side) -->
+        <polygon points="150,130 200,128 200,138 150,140" fill="#2a4a6a" stroke="#7a9ab5" stroke-width="1"/>
+        <!-- Cockpit canopy -->
+        <path d="M130,118 Q155,98 190,98 Q210,98 215,118" fill="#0d3050" stroke="#7ac0e8" stroke-width="1.5"/>
+        <!-- Nose cowling -->
+        <ellipse cx="65" cy="149" rx="18" ry="14" fill="#1e3a50" stroke="#7a9ab5" stroke-width="1.5"/>
+        <!-- Propeller -->
+        <line x1="47" y1="132" x2="47" y2="168" stroke="#f0c040" stroke-width="4" stroke-linecap="round"/>
+        <!-- Horizontal stabilizer -->
+        <polygon points="265,138 310,132 310,140 265,143" fill="#1e3a50" stroke="#7a9ab5" stroke-width="1.5"/>
+        <!-- Vertical fin -->
+        <polygon points="270,118 290,95 295,95 285,118" fill="#1e3a50" stroke="#7a9ab5" stroke-width="1.5"/>
+        <!-- Elevator -->
+        <polygon points="290,133 310,132 310,138 290,138" fill="#f0c040" stroke="#f0c040" stroke-width="1"/>
+        <!-- Rudder -->
+        <polygon points="286,95 295,95 290,118 284,118" fill="#f0c040" stroke="#f0c040" stroke-width="1"/>
+        <!-- Landing gear -->
+        <line x1="140" y1="165" x2="140" y2="185" stroke="#7a9ab5" stroke-width="2"/>
+        <ellipse cx="140" cy="188" rx="12" ry="6" fill="#1a2d3d" stroke="#7a9ab5" stroke-width="1.5"/>
+        <line x1="230" y1="162" x2="230" y2="182" stroke="#7a9ab5" stroke-width="2"/>
+        <ellipse cx="230" cy="185" rx="12" ry="6" fill="#1a2d3d" stroke="#7a9ab5" stroke-width="1.5"/>
+
+        <!-- Labels -->
+        <text x="170" y="150" text-anchor="middle" fill="#e8edf2" font-size="9">FUSELAGE</text>
+        <text x="175" y="135" text-anchor="middle" fill="#e8edf2" font-size="8">WING</text>
+        <text x="172" y="112" text-anchor="middle" fill="#7ac0e8" font-size="9">COCKPIT</text>
+        <text x="65" y="148" text-anchor="middle" fill="#e8edf2" font-size="8">NOSE</text>
+        <text x="38" y="148" text-anchor="middle" fill="#f0c040" font-size="8">PROP</text>
+        <text x="288" y="110" text-anchor="middle" fill="#e8edf2" font-size="8">V.FIN</text>
+        <text x="292" y="130" text-anchor="middle" fill="#f0c040" font-size="8">RUDDER</text>
+        <text x="290" y="148" text-anchor="middle" fill="#e8edf2" font-size="8">H.STAB</text>
+        <text x="302" y="137" text-anchor="middle" fill="#f0c040" font-size="8">ELEV</text>
+      </svg>
+    </div>
+  </div>
+
+  <div class="tables-grid">
+    <div>
+      <div class="section-title">Primary Flight Controls</div>
+      <table>
+        <thead>
+          <tr><th>Control Surface</th><th>Axis</th><th>Motion</th></tr>
+        </thead>
+        <tbody>
+          <tr><td><strong>Ailerons</strong></td><td>Longitudinal</td><td>Roll (bank left/right)</td></tr>
+          <tr><td><strong>Elevator</strong></td><td>Lateral</td><td>Pitch (nose up/down)</td></tr>
+          <tr><td><strong>Rudder</strong></td><td>Vertical (normal)</td><td>Yaw (nose left/right)</td></tr>
+        </tbody>
+      </table>
+    </div>
+    <div>
+      <div class="section-title">Secondary Flight Controls</div>
+      <table>
+        <thead>
+          <tr><th>Control</th><th>Purpose</th></tr>
+        </thead>
+        <tbody>
+          <tr><td><strong>Flaps</strong></td><td>Increase lift &amp; drag; lower stall speed; steepen approach</td></tr>
+          <tr><td><strong>Trim Tabs</strong></td><td>Relieve control pressure; maintain attitude hands-off</td></tr>
+          <tr><td><strong>Elevator Trim</strong></td><td>Most common — pitch trim for cruise/climb/descent</td></tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+
+  <div class="section-title">Structure Reference</div>
+  <table>
+    <thead>
+      <tr><th>Component</th><th>Location</th><th>Function</th></tr>
+    </thead>
+    <tbody>
+      <tr><td>Fuselage</td><td>Central body</td><td>Houses cockpit, passengers, cargo; connects all components</td></tr>
+      <tr><td>Wings</td><td>Left &amp; right of fuselage</td><td>Generate lift via airfoil shape; house fuel tanks</td></tr>
+      <tr><td>Horizontal Stabilizer</td><td>Tail — horizontal surface</td><td>Provides longitudinal (pitch) stability</td></tr>
+      <tr><td>Vertical Stabilizer / Fin</td><td>Tail — vertical surface</td><td>Provides directional (yaw) stability</td></tr>
+      <tr><td>Propeller</td><td>Front of engine</td><td>Converts engine torque into thrust</td></tr>
+    </tbody>
+  </table>
+</div>
+</body>
+</html>

--- a/web-app/public/visuals/gk002-four-forces.html
+++ b/web-app/public/visuals/gk002-four-forces.html
@@ -1,0 +1,158 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>GK-002: Four Forces of Flight</title>
+<style>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body { background: #0d1b2a; color: #e8edf2; font-family: 'Segoe UI', system-ui, sans-serif; padding: 32px; }
+  h1 { font-size: 22px; color: #f0c040; letter-spacing: 1px; margin-bottom: 6px; }
+  .subtitle { font-size: 13px; color: #7a9ab5; margin-bottom: 32px; letter-spacing: 0.5px; }
+  .container { max-width: 900px; margin: 0 auto; }
+  .section-title { font-size: 14px; color: #f0c040; letter-spacing: 1px; text-transform: uppercase; margin-bottom: 14px; margin-top: 32px; }
+  .layout { display: grid; grid-template-columns: 1fr 1fr; gap: 24px; align-items: start; }
+  .diagram-box { background: #1a2d3d; border: 1px solid #243d52; border-radius: 8px; padding: 16px; }
+  svg text { font-family: 'Segoe UI', system-ui, sans-serif; }
+  table { width: 100%; border-collapse: collapse; margin-bottom: 20px; }
+  th { background: #1a2d3d; color: #f0c040; font-size: 12px; text-align: left; padding: 10px 14px; letter-spacing: 0.5px; }
+  td { font-size: 13px; color: #e8edf2; padding: 9px 14px; border-bottom: 1px solid #1a2d3d; vertical-align: top; }
+  tr:last-child td { border-bottom: none; }
+  .memory-box { background: #1a2d3d; border: 1px solid #f0c040; border-radius: 8px; padding: 20px; margin-top: 24px; }
+  .memory-title { color: #f0c040; font-size: 13px; font-weight: bold; letter-spacing: 0.5px; margin-bottom: 10px; }
+  .memory-item { font-size: 13px; color: #e8edf2; margin-bottom: 6px; padding-left: 12px; }
+  .force-amber { color: #f0c040; font-weight: bold; }
+  .force-blue { color: #5b9bd5; font-weight: bold; }
+  .force-green { color: #4caf7d; font-weight: bold; }
+  .force-red { color: #e05050; font-weight: bold; }
+</style>
+</head>
+<body>
+<div class="container">
+  <h1>GK-002 — Four Forces of Flight</h1>
+  <p class="subtitle">Transport Canada · TP 12880E · PPL Written Exam</p>
+
+  <div class="layout">
+    <div class="diagram-box">
+      <svg viewBox="0 0 320 300" width="100%" height="280">
+        <!-- Background grid hint -->
+        <line x1="160" y1="20" x2="160" y2="280" stroke="#1e3a50" stroke-width="1" stroke-dasharray="4,4"/>
+        <line x1="20" y1="150" x2="300" y2="150" stroke="#1e3a50" stroke-width="1" stroke-dasharray="4,4"/>
+
+        <!-- Aircraft silhouette (side view) -->
+        <!-- Fuselage -->
+        <path d="M100,140 Q120,128 180,126 Q230,126 250,138 Q258,148 250,158 Q200,165 120,165 Q100,165 95,155 Z" fill="#1e3a50" stroke="#7a9ab5" stroke-width="1.5"/>
+        <!-- Wing -->
+        <polygon points="155,130 200,128 200,137 155,140" fill="#243f5a" stroke="#7a9ab5" stroke-width="1"/>
+        <!-- Cockpit -->
+        <path d="M150,126 Q168,110 195,110 Q210,110 215,126" fill="#0d3050" stroke="#7ac0e8" stroke-width="1"/>
+        <!-- Nose -->
+        <ellipse cx="102" cy="150" rx="14" ry="12" fill="#1e3a50" stroke="#7a9ab5" stroke-width="1.5"/>
+        <!-- Propeller -->
+        <line x1="88" y1="135" x2="88" y2="165" stroke="#7a9ab5" stroke-width="3" stroke-linecap="round"/>
+        <!-- H-stab -->
+        <polygon points="238,140 265,135 265,142 238,145" fill="#1e3a50" stroke="#7a9ab5" stroke-width="1"/>
+        <!-- V-fin -->
+        <polygon points="243,126 256,108 260,108 253,126" fill="#1e3a50" stroke="#7a9ab5" stroke-width="1"/>
+
+        <!-- LIFT arrow (up, amber) -->
+        <defs>
+          <marker id="arrowAmber" markerWidth="8" markerHeight="8" refX="4" refY="4" orient="auto">
+            <polygon points="0,0 8,4 0,8" fill="#f0c040"/>
+          </marker>
+          <marker id="arrowBlue" markerWidth="8" markerHeight="8" refX="4" refY="4" orient="auto">
+            <polygon points="0,0 8,4 0,8" fill="#5b9bd5"/>
+          </marker>
+          <marker id="arrowGreen" markerWidth="8" markerHeight="8" refX="4" refY="4" orient="auto">
+            <polygon points="0,0 8,4 0,8" fill="#4caf7d"/>
+          </marker>
+          <marker id="arrowRed" markerWidth="8" markerHeight="8" refX="4" refY="4" orient="auto">
+            <polygon points="0,0 8,4 0,8" fill="#e05050"/>
+          </marker>
+        </defs>
+
+        <!-- LIFT: up -->
+        <line x1="175" y1="125" x2="175" y2="50" stroke="#f0c040" stroke-width="3" marker-end="url(#arrowAmber)"/>
+        <text x="178" y="68" fill="#f0c040" font-size="13" font-weight="bold">LIFT</text>
+        <text x="178" y="80" fill="#f0c040" font-size="9">↑ Upward</text>
+
+        <!-- WEIGHT: down -->
+        <line x1="200" y1="165" x2="200" y2="250" stroke="#5b9bd5" stroke-width="3" marker-end="url(#arrowBlue)"/>
+        <text x="204" y="228" fill="#5b9bd5" font-size="13" font-weight="bold">WEIGHT</text>
+        <text x="204" y="240" fill="#5b9bd5" font-size="9">↓ Gravity</text>
+
+        <!-- THRUST: forward (left) -->
+        <line x1="95" y1="150" x2="28" y2="150" stroke="#4caf7d" stroke-width="3" marker-end="url(#arrowGreen)"/>
+        <text x="14" y="138" fill="#4caf7d" font-size="13" font-weight="bold">THRUST</text>
+        <text x="18" y="148" fill="#4caf7d" font-size="9">← Forward</text>
+
+        <!-- DRAG: rearward (right) -->
+        <line x1="255" y1="150" x2="308" y2="150" stroke="#e05050" stroke-width="3" marker-end="url(#arrowRed)"/>
+        <text x="262" y="138" fill="#e05050" font-size="13" font-weight="bold">DRAG</text>
+        <text x="265" y="148" fill="#e05050" font-size="9">→ Rearward</text>
+
+        <!-- Level flight label -->
+        <text x="160" y="290" text-anchor="middle" fill="#7a9ab5" font-size="10">Level Flight — Forces in Balance</text>
+      </svg>
+    </div>
+
+    <div>
+      <div class="section-title">Force Relationships</div>
+      <table>
+        <thead>
+          <tr><th>Pair</th><th>Imbalance</th><th>Result</th></tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><span class="force-amber">Lift</span> &gt; <span class="force-blue">Weight</span></td>
+            <td>Lift exceeds weight</td>
+            <td>Aircraft climbs</td>
+          </tr>
+          <tr>
+            <td><span class="force-blue">Weight</span> &gt; <span class="force-amber">Lift</span></td>
+            <td>Weight exceeds lift</td>
+            <td>Aircraft descends</td>
+          </tr>
+          <tr>
+            <td><span class="force-green">Thrust</span> &gt; <span class="force-red">Drag</span></td>
+            <td>Thrust exceeds drag</td>
+            <td>Aircraft accelerates</td>
+          </tr>
+          <tr>
+            <td><span class="force-red">Drag</span> &gt; <span class="force-green">Thrust</span></td>
+            <td>Drag exceeds thrust</td>
+            <td>Aircraft decelerates</td>
+          </tr>
+          <tr>
+            <td>All equal</td>
+            <td>Forces balanced</td>
+            <td>Straight and level flight</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <div class="section-title" style="margin-top:16px;">Force Descriptions</div>
+      <table>
+        <thead>
+          <tr><th>Force</th><th>Source</th><th>Direction</th></tr>
+        </thead>
+        <tbody>
+          <tr><td><span class="force-amber">Lift</span></td><td>Wing airfoil (Bernoulli + Newton)</td><td>Perpendicular to relative wind, upward</td></tr>
+          <tr><td><span class="force-blue">Weight</span></td><td>Gravity acting on aircraft mass</td><td>Straight down toward Earth centre</td></tr>
+          <tr><td><span class="force-green">Thrust</span></td><td>Engine + propeller</td><td>Forward, along flight path</td></tr>
+          <tr><td><span class="force-red">Drag</span></td><td>Aerodynamic resistance (parasite + induced)</td><td>Opposite to direction of flight</td></tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+
+  <div class="memory-box">
+    <div class="memory-title">Memory Hook — "LDTW" (Level Down Thrust Weight)</div>
+    <div class="memory-item">Think of two pairs: <strong>Lift/Weight</strong> (vertical axis) and <strong>Thrust/Drag</strong> (horizontal axis).</div>
+    <div class="memory-item">In <strong>level, unaccelerated flight</strong>: Lift = Weight AND Thrust = Drag.</div>
+    <div class="memory-item">Climbing requires <strong>excess lift OR reduced weight</strong> — but in sustained climb, thrust must overcome both drag and the weight component along the flight path.</div>
+    <div class="memory-item">Induced drag <strong>increases</strong> with angle of attack (slow flight). Parasite drag <strong>increases</strong> with airspeed squared.</div>
+  </div>
+</div>
+</body>
+</html>

--- a/web-app/public/visuals/gk003-piston-engines.html
+++ b/web-app/public/visuals/gk003-piston-engines.html
@@ -1,0 +1,167 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>GK-003: Piston Engine Four-Stroke Cycle</title>
+<style>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body { background: #0d1b2a; color: #e8edf2; font-family: 'Segoe UI', system-ui, sans-serif; padding: 32px; }
+  h1 { font-size: 22px; color: #f0c040; letter-spacing: 1px; margin-bottom: 6px; }
+  .subtitle { font-size: 13px; color: #7a9ab5; margin-bottom: 32px; letter-spacing: 0.5px; }
+  .container { max-width: 900px; margin: 0 auto; }
+  .section-title { font-size: 14px; color: #f0c040; letter-spacing: 1px; text-transform: uppercase; margin-bottom: 14px; margin-top: 32px; }
+  .strokes-grid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 16px; margin-bottom: 32px; }
+  .stroke-card { background: #1a2d3d; border: 1px solid #243d52; border-radius: 8px; padding: 14px; text-align: center; }
+  .stroke-number { font-size: 11px; color: #7a9ab5; letter-spacing: 1px; text-transform: uppercase; margin-bottom: 6px; }
+  .stroke-name { font-size: 15px; color: #f0c040; font-weight: bold; margin-bottom: 10px; }
+  .stroke-desc { font-size: 12px; color: #e8edf2; line-height: 1.5; margin-bottom: 10px; min-height: 48px; }
+  .valve-state { font-size: 11px; padding: 4px 8px; border-radius: 4px; margin: 2px 0; }
+  .valve-open { background: #0d2a1a; color: #4caf7d; border: 1px solid #4caf7d; }
+  .valve-closed { background: #2a1a1a; color: #e05050; border: 1px solid #e05050; }
+  svg text { font-family: 'Segoe UI', system-ui, sans-serif; }
+  table { width: 100%; border-collapse: collapse; margin-bottom: 20px; }
+  th { background: #1a2d3d; color: #f0c040; font-size: 12px; text-align: left; padding: 10px 14px; letter-spacing: 0.5px; }
+  td { font-size: 13px; color: #e8edf2; padding: 9px 14px; border-bottom: 1px solid #1a2d3d; vertical-align: top; }
+  tr:last-child td { border-bottom: none; }
+  .note-box { background: #1a2d3d; border-left: 3px solid #f0c040; border-radius: 4px; padding: 14px 18px; margin-top: 20px; font-size: 13px; color: #e8edf2; line-height: 1.6; }
+</style>
+</head>
+<body>
+<div class="container">
+  <h1>GK-003 — Piston Engine: Four-Stroke Cycle</h1>
+  <p class="subtitle">Transport Canada · TP 12880E · PPL Written Exam</p>
+
+  <div class="section-title">The Four Strokes</div>
+  <div class="strokes-grid">
+    <!-- Stroke 1: Intake -->
+    <div class="stroke-card">
+      <div class="stroke-number">Stroke 1</div>
+      <div class="stroke-name">INTAKE</div>
+      <svg viewBox="0 0 80 100" width="100%" height="90">
+        <!-- Cylinder -->
+        <rect x="20" y="10" width="40" height="70" rx="3" fill="#0d1b2a" stroke="#7a9ab5" stroke-width="1.5"/>
+        <!-- Piston (down) -->
+        <rect x="22" y="62" width="36" height="14" rx="2" fill="#2a4a6a" stroke="#7a9ab5" stroke-width="1"/>
+        <!-- Connecting rod -->
+        <line x1="40" y1="76" x2="40" y2="88" stroke="#7a9ab5" stroke-width="2"/>
+        <!-- Intake valve (open — gap at top left) -->
+        <rect x="18" y="8" width="8" height="4" rx="1" fill="#4caf7d" stroke="#4caf7d" stroke-width="1"/>
+        <!-- Exhaust valve (closed — solid at top right) -->
+        <rect x="54" y="6" width="8" height="6" rx="1" fill="#e05050" stroke="#e05050" stroke-width="1"/>
+        <!-- Fuel/air mixture arrows entering -->
+        <line x1="10" y1="22" x2="22" y2="30" stroke="#f0c040" stroke-width="1.5" marker-end="url(#arrowY)"/>
+        <line x1="10" y1="35" x2="22" y2="38" stroke="#f0c040" stroke-width="1.5" marker-end="url(#arrowY)"/>
+        <defs>
+          <marker id="arrowY" markerWidth="6" markerHeight="6" refX="3" refY="3" orient="auto"><polygon points="0,0 6,3 0,6" fill="#f0c040"/></marker>
+        </defs>
+        <!-- Labels -->
+        <text x="40" y="55" text-anchor="middle" fill="#7a9ab5" font-size="8">Piston ↓</text>
+        <text x="22" y="7" text-anchor="middle" fill="#4caf7d" font-size="7">IN</text>
+        <text x="58" y="5" text-anchor="middle" fill="#e05050" font-size="7">EX</text>
+      </svg>
+      <div class="stroke-desc">Piston moves DOWN, intake valve opens. Fuel-air mixture drawn into cylinder.</div>
+      <div class="valve-state valve-open">Intake: OPEN</div>
+      <div class="valve-state valve-closed">Exhaust: CLOSED</div>
+    </div>
+
+    <!-- Stroke 2: Compression -->
+    <div class="stroke-card">
+      <div class="stroke-number">Stroke 2</div>
+      <div class="stroke-name">COMPRESSION</div>
+      <svg viewBox="0 0 80 100" width="100%" height="90">
+        <rect x="20" y="10" width="40" height="70" rx="3" fill="#0d1b2a" stroke="#7a9ab5" stroke-width="1.5"/>
+        <!-- Piston (up) -->
+        <rect x="22" y="24" width="36" height="14" rx="2" fill="#2a4a6a" stroke="#7a9ab5" stroke-width="1"/>
+        <line x1="40" y1="38" x2="40" y2="88" stroke="#7a9ab5" stroke-width="2"/>
+        <!-- Both valves closed -->
+        <rect x="18" y="6" width="8" height="6" rx="1" fill="#e05050" stroke="#e05050" stroke-width="1"/>
+        <rect x="54" y="6" width="8" height="6" rx="1" fill="#e05050" stroke="#e05050" stroke-width="1"/>
+        <!-- Compressed mixture lines -->
+        <line x1="30" y1="16" x2="50" y2="16" stroke="#7ac0e8" stroke-width="1" stroke-dasharray="2,2"/>
+        <line x1="28" y1="19" x2="52" y2="19" stroke="#7ac0e8" stroke-width="1" stroke-dasharray="2,2"/>
+        <line x1="26" y1="22" x2="54" y2="22" stroke="#7ac0e8" stroke-width="1" stroke-dasharray="2,2"/>
+        <text x="40" y="55" text-anchor="middle" fill="#7a9ab5" font-size="8">Piston ↑</text>
+        <text x="22" y="5" text-anchor="middle" fill="#e05050" font-size="7">IN</text>
+        <text x="58" y="5" text-anchor="middle" fill="#e05050" font-size="7">EX</text>
+      </svg>
+      <div class="stroke-desc">Piston moves UP, both valves closed. Mixture compressed to ~1/8 original volume.</div>
+      <div class="valve-state valve-closed">Intake: CLOSED</div>
+      <div class="valve-state valve-closed">Exhaust: CLOSED</div>
+    </div>
+
+    <!-- Stroke 3: Power -->
+    <div class="stroke-card">
+      <div class="stroke-number">Stroke 3</div>
+      <div class="stroke-name">POWER</div>
+      <svg viewBox="0 0 80 100" width="100%" height="90">
+        <rect x="20" y="10" width="40" height="70" rx="3" fill="#0d1b2a" stroke="#7a9ab5" stroke-width="1.5"/>
+        <!-- Piston (down) -->
+        <rect x="22" y="58" width="36" height="14" rx="2" fill="#2a4a6a" stroke="#7a9ab5" stroke-width="1"/>
+        <line x1="40" y1="72" x2="40" y2="88" stroke="#7a9ab5" stroke-width="2"/>
+        <!-- Both valves closed -->
+        <rect x="18" y="6" width="8" height="6" rx="1" fill="#e05050" stroke="#e05050" stroke-width="1"/>
+        <rect x="54" y="6" width="8" height="6" rx="1" fill="#e05050" stroke="#e05050" stroke-width="1"/>
+        <!-- Spark plug -->
+        <circle cx="40" cy="13" r="4" fill="#f0c040" stroke="#f0c040" stroke-width="1"/>
+        <!-- Explosion lines -->
+        <line x1="40" y1="17" x2="35" y2="28" stroke="#f0a040" stroke-width="1.5"/>
+        <line x1="40" y1="17" x2="45" y2="28" stroke="#f0a040" stroke-width="1.5"/>
+        <line x1="40" y1="17" x2="40" y2="30" stroke="#f0a040" stroke-width="1.5"/>
+        <line x1="40" y1="17" x2="30" y2="22" stroke="#f0a040" stroke-width="1.5"/>
+        <line x1="40" y1="17" x2="50" y2="22" stroke="#f0a040" stroke-width="1.5"/>
+        <text x="40" y="50" text-anchor="middle" fill="#7a9ab5" font-size="8">Piston ↓</text>
+        <text x="40" y="10" text-anchor="middle" fill="#f0c040" font-size="7">⚡</text>
+      </svg>
+      <div class="stroke-desc">Spark ignites mixture. Expanding gases force piston DOWN — the only stroke producing power.</div>
+      <div class="valve-state valve-closed">Intake: CLOSED</div>
+      <div class="valve-state valve-closed">Exhaust: CLOSED</div>
+    </div>
+
+    <!-- Stroke 4: Exhaust -->
+    <div class="stroke-card">
+      <div class="stroke-number">Stroke 4</div>
+      <div class="stroke-name">EXHAUST</div>
+      <svg viewBox="0 0 80 100" width="100%" height="90">
+        <rect x="20" y="10" width="40" height="70" rx="3" fill="#0d1b2a" stroke="#7a9ab5" stroke-width="1.5"/>
+        <!-- Piston (up) -->
+        <rect x="22" y="24" width="36" height="14" rx="2" fill="#2a4a6a" stroke="#7a9ab5" stroke-width="1"/>
+        <line x1="40" y1="38" x2="40" y2="88" stroke="#7a9ab5" stroke-width="2"/>
+        <!-- Intake closed, Exhaust open -->
+        <rect x="18" y="6" width="8" height="6" rx="1" fill="#e05050" stroke="#e05050" stroke-width="1"/>
+        <rect x="54" y="8" width="8" height="4" rx="1" fill="#4caf7d" stroke="#4caf7d" stroke-width="1"/>
+        <!-- Exhaust gases exiting right -->
+        <defs><marker id="arrowG" markerWidth="6" markerHeight="6" refX="3" refY="3" orient="auto"><polygon points="0,0 6,3 0,6" fill="#7a9ab5"/></marker></defs>
+        <line x1="60" y1="22" x2="72" y2="16" stroke="#7a9ab5" stroke-width="1.5" marker-end="url(#arrowG)"/>
+        <line x1="60" y1="18" x2="72" y2="12" stroke="#7a9ab5" stroke-width="1.5" marker-end="url(#arrowG)"/>
+        <text x="40" y="55" text-anchor="middle" fill="#7a9ab5" font-size="8">Piston ↑</text>
+        <text x="22" y="5" text-anchor="middle" fill="#e05050" font-size="7">IN</text>
+        <text x="58" y="7" text-anchor="middle" fill="#4caf7d" font-size="7">EX</text>
+      </svg>
+      <div class="stroke-desc">Piston moves UP, exhaust valve opens. Burnt gases expelled from cylinder.</div>
+      <div class="valve-state valve-closed">Intake: CLOSED</div>
+      <div class="valve-state valve-open">Exhaust: OPEN</div>
+    </div>
+  </div>
+
+  <div class="section-title">Engine Components Reference</div>
+  <table>
+    <thead>
+      <tr><th>Component</th><th>Function</th><th>Note</th></tr>
+    </thead>
+    <tbody>
+      <tr><td><strong>Carburetor</strong></td><td>Mixes fuel and air in correct ratio</td><td>Susceptible to icing at 0–21°C with high humidity</td></tr>
+      <tr><td><strong>Magnetos (×2)</strong></td><td>Generate high-voltage spark independently of aircraft electrical system</td><td>Each magneto fires one plug per cylinder; both must work — tested during run-up</td></tr>
+      <tr><td><strong>Spark Plugs (×2 per cyl)</strong></td><td>Ignite fuel-air mixture at correct timing</td><td>Dual plugs provide redundancy and complete combustion</td></tr>
+      <tr><td><strong>Crankshaft</strong></td><td>Converts reciprocating piston motion to rotary motion</td><td>Drives propeller and accessories</td></tr>
+      <tr><td><strong>Camshaft</strong></td><td>Controls opening/closing timing of intake and exhaust valves</td><td>Driven by crankshaft at half speed</td></tr>
+      <tr><td><strong>Oil System</strong></td><td>Lubricates, cools, and cleans engine components</td><td>Check oil level &amp; pressure before and during flight</td></tr>
+    </tbody>
+  </table>
+
+  <div class="note-box">
+    <strong>Exam Tip:</strong> The four strokes in order — <strong>Intake, Compression, Power, Exhaust</strong> — can be remembered as <strong>"I Can't Produce Exhaust"</strong> or <strong>"ICPE"</strong>. Only the Power stroke generates force; the other three are driven by engine momentum (flywheel). A 4-cylinder engine fires one power stroke every 180° of crankshaft rotation.
+  </div>
+</div>
+</body>
+</html>

--- a/web-app/public/visuals/gk004-fuel-system.html
+++ b/web-app/public/visuals/gk004-fuel-system.html
@@ -1,0 +1,148 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>GK-004: Fuel System</title>
+<style>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body { background: #0d1b2a; color: #e8edf2; font-family: 'Segoe UI', system-ui, sans-serif; padding: 32px; }
+  h1 { font-size: 22px; color: #f0c040; letter-spacing: 1px; margin-bottom: 6px; }
+  .subtitle { font-size: 13px; color: #7a9ab5; margin-bottom: 32px; letter-spacing: 0.5px; }
+  .container { max-width: 900px; margin: 0 auto; }
+  .section-title { font-size: 14px; color: #f0c040; letter-spacing: 1px; text-transform: uppercase; margin-bottom: 14px; margin-top: 32px; }
+  .layout { display: grid; grid-template-columns: 1fr 1fr; gap: 24px; align-items: start; }
+  .diagram-box { background: #1a2d3d; border: 1px solid #243d52; border-radius: 8px; padding: 16px; }
+  svg text { font-family: 'Segoe UI', system-ui, sans-serif; }
+  table { width: 100%; border-collapse: collapse; margin-bottom: 20px; }
+  th { background: #1a2d3d; color: #f0c040; font-size: 12px; text-align: left; padding: 10px 14px; letter-spacing: 0.5px; }
+  td { font-size: 13px; color: #e8edf2; padding: 9px 14px; border-bottom: 1px solid #1a2d3d; vertical-align: top; }
+  tr:last-child td { border-bottom: none; }
+  .badge { display: inline-block; font-size: 11px; font-weight: bold; padding: 2px 10px; border-radius: 12px; }
+  .badge-blue { background: #0d1a3a; color: #5b9bd5; border: 1px solid #5b9bd5; }
+  .badge-red { background: #2a0d0d; color: #e05050; border: 1px solid #e05050; }
+  .badge-green { background: #0d2a1a; color: #4caf7d; border: 1px solid #4caf7d; }
+  .warning-box { background: #1a2d3d; border-left: 3px solid #e05050; border-radius: 4px; padding: 14px 18px; margin-top: 20px; font-size: 13px; color: #e8edf2; line-height: 1.6; }
+</style>
+</head>
+<body>
+<div class="container">
+  <h1>GK-004 — Fuel System</h1>
+  <p class="subtitle">Transport Canada · TP 12880E · PPL Written Exam</p>
+
+  <div class="section-title">System Flow Diagram</div>
+  <div class="diagram-box" style="margin-bottom:24px;">
+    <svg viewBox="0 0 760 180" width="100%" height="160">
+      <defs>
+        <marker id="arrowF" markerWidth="7" markerHeight="7" refX="3.5" refY="3.5" orient="auto">
+          <polygon points="0,0 7,3.5 0,7" fill="#f0c040"/>
+        </marker>
+      </defs>
+
+      <!-- Left wing tank -->
+      <rect x="20" y="50" width="90" height="80" rx="6" fill="#1e3a50" stroke="#5b9bd5" stroke-width="2"/>
+      <text x="65" y="82" text-anchor="middle" fill="#5b9bd5" font-size="11" font-weight="bold">LEFT WING</text>
+      <text x="65" y="96" text-anchor="middle" fill="#5b9bd5" font-size="10">FUEL TANK</text>
+      <text x="65" y="118" text-anchor="middle" fill="#7a9ab5" font-size="9">Sump drain ↓</text>
+
+      <!-- Right wing tank -->
+      <rect x="650" y="50" width="90" height="80" rx="6" fill="#1e3a50" stroke="#5b9bd5" stroke-width="2"/>
+      <text x="695" y="82" text-anchor="middle" fill="#5b9bd5" font-size="11" font-weight="bold">RIGHT WING</text>
+      <text x="695" y="96" text-anchor="middle" fill="#5b9bd5" font-size="10">FUEL TANK</text>
+      <text x="695" y="118" text-anchor="middle" fill="#7a9ab5" font-size="9">Sump drain ↓</text>
+
+      <!-- Fuel selector -->
+      <rect x="310" y="55" width="140" height="70" rx="6" fill="#1e3a50" stroke="#f0c040" stroke-width="2"/>
+      <text x="380" y="82" text-anchor="middle" fill="#f0c040" font-size="11" font-weight="bold">FUEL SELECTOR</text>
+      <text x="380" y="96" text-anchor="middle" fill="#e8edf2" font-size="10">LEFT / RIGHT / BOTH / OFF</text>
+      <text x="380" y="112" text-anchor="middle" fill="#7a9ab5" font-size="9">Cockpit control</text>
+
+      <!-- Fuel strainer / gascolator -->
+      <rect x="185" y="120" width="100" height="45" rx="5" fill="#1e3a50" stroke="#4caf7d" stroke-width="1.5"/>
+      <text x="235" y="138" text-anchor="middle" fill="#4caf7d" font-size="10" font-weight="bold">FUEL STRAINER</text>
+      <text x="235" y="152" text-anchor="middle" fill="#e8edf2" font-size="9">Gascolator — sump drain</text>
+
+      <!-- Carburetor/Fuel injector -->
+      <rect x="475" y="120" width="100" height="45" rx="5" fill="#1e3a50" stroke="#4caf7d" stroke-width="1.5"/>
+      <text x="525" y="138" text-anchor="middle" fill="#4caf7d" font-size="10" font-weight="bold">CARBURETOR</text>
+      <text x="525" y="152" text-anchor="middle" fill="#e8edf2" font-size="9">or Fuel Injector</text>
+
+      <!-- Engine -->
+      <rect x="330" y="122" width="100" height="40" rx="5" fill="#243d52" stroke="#7a9ab5" stroke-width="1.5"/>
+      <text x="380" y="143" text-anchor="middle" fill="#e8edf2" font-size="12" font-weight="bold">ENGINE</text>
+
+      <!-- Flow arrows: left tank → selector -->
+      <line x1="110" y1="90" x2="308" y2="90" stroke="#f0c040" stroke-width="2" marker-end="url(#arrowF)"/>
+      <!-- right tank → selector -->
+      <line x1="650" y1="90" x2="452" y2="90" stroke="#f0c040" stroke-width="2" marker-end="url(#arrowF)"/>
+      <!-- selector → strainer -->
+      <line x1="340" y1="126" x2="286" y2="140" stroke="#f0c040" stroke-width="2" marker-end="url(#arrowF)"/>
+      <!-- strainer → carb -->
+      <line x1="285" y1="143" x2="474" y2="143" stroke="#f0c040" stroke-width="2" marker-end="url(#arrowF)"/>
+      <!-- carb → engine -->
+      <line x1="475" y1="142" x2="432" y2="142" stroke="#f0c040" stroke-width="2" marker-end="url(#arrowF)"/>
+    </svg>
+  </div>
+
+  <div class="layout">
+    <div>
+      <div class="section-title">Fuel Grades</div>
+      <table>
+        <thead>
+          <tr><th>Grade</th><th>Colour</th><th>Use</th></tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><strong>AVGAS 100LL</strong></td>
+            <td><span class="badge badge-blue">Blue</span></td>
+            <td>Most common aviation gasoline. Low-lead. Used in piston engines requiring 100 octane.</td>
+          </tr>
+          <tr>
+            <td><strong>AVGAS 80</strong></td>
+            <td><span class="badge badge-red">Red</span></td>
+            <td>Lower octane — only for engines specifically approved for 80 octane.</td>
+          </tr>
+          <tr>
+            <td><strong>Mogas (auto)</strong></td>
+            <td><span class="badge badge-green">Clear/Yellow</span></td>
+            <td>Only if STC (Supplemental Type Certificate) approves it for that aircraft. Not standard.</td>
+          </tr>
+          <tr>
+            <td><strong>Jet-A / Jet B</strong></td>
+            <td><span class="badge" style="background:#2a2a0d;color:#d0c040;border:1px solid #d0c040;">Clear/Straw</span></td>
+            <td>Turbine (jet/turboprop) fuel ONLY. <strong>Fatal if used in piston engine.</strong></td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <div>
+      <div class="section-title">Sump Drains &amp; Pre-flight</div>
+      <table>
+        <thead>
+          <tr><th>Location</th><th>Purpose</th></tr>
+        </thead>
+        <tbody>
+          <tr><td>Each wing tank low point</td><td>Drain sediment and water from each tank</td></tr>
+          <tr><td>Gascolator / fuel strainer</td><td>Main low-point drain — catches water before carb</td></tr>
+          <tr><td>Carburetor bowl</td><td>Drain any accumulated water from carb bowl</td></tr>
+        </tbody>
+      </table>
+      <table>
+        <thead>
+          <tr><th>Contaminant</th><th>Appearance</th><th>Action</th></tr>
+        </thead>
+        <tbody>
+          <tr><td>Water</td><td>Drops settle to bottom; clear/blue separation</td><td>Drain until only pure fuel flows — repeat if necessary</td></tr>
+          <tr><td>Sediment / dirt</td><td>Cloudiness or particles</td><td>Continue draining; inspect fuel source</td></tr>
+          <tr><td>Wrong fuel grade</td><td>Wrong colour</td><td>Do NOT fly — drain and refuel with correct grade</td></tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+
+  <div class="warning-box">
+    <strong>Critical Safety Rule:</strong> Always check for water contamination by draining fuel from ALL sump points before flight. Water is denser than AVGAS and sinks to the bottom — it <strong>will stop the engine</strong>. Never fly immediately after refuelling without re-draining (temperature changes can cause condensation). The fuel selector must be on <strong>BOTH</strong> (or the fuller tank) for takeoff and landing — <em>as specified in the POH</em>.
+  </div>
+</div>
+</body>
+</html>

--- a/web-app/public/visuals/gk005-electrical-system.html
+++ b/web-app/public/visuals/gk005-electrical-system.html
@@ -1,0 +1,170 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>GK-005: Electrical System</title>
+<style>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body { background: #0d1b2a; color: #e8edf2; font-family: 'Segoe UI', system-ui, sans-serif; padding: 32px; }
+  h1 { font-size: 22px; color: #f0c040; letter-spacing: 1px; margin-bottom: 6px; }
+  .subtitle { font-size: 13px; color: #7a9ab5; margin-bottom: 32px; letter-spacing: 0.5px; }
+  .container { max-width: 900px; margin: 0 auto; }
+  .section-title { font-size: 14px; color: #f0c040; letter-spacing: 1px; text-transform: uppercase; margin-bottom: 14px; margin-top: 32px; }
+  .diagram-box { background: #1a2d3d; border: 1px solid #243d52; border-radius: 8px; padding: 16px; margin-bottom: 24px; }
+  svg text { font-family: 'Segoe UI', system-ui, sans-serif; }
+  table { width: 100%; border-collapse: collapse; margin-bottom: 20px; }
+  th { background: #1a2d3d; color: #f0c040; font-size: 12px; text-align: left; padding: 10px 14px; letter-spacing: 0.5px; }
+  td { font-size: 13px; color: #e8edf2; padding: 9px 14px; border-bottom: 1px solid #1a2d3d; vertical-align: top; }
+  tr:last-child td { border-bottom: none; }
+  .layout { display: grid; grid-template-columns: 1fr 1fr; gap: 24px; align-items: start; }
+  .note-box { background: #1a2d3d; border-left: 3px solid #f0c040; border-radius: 4px; padding: 14px 18px; margin-top: 20px; font-size: 13px; color: #e8edf2; line-height: 1.6; }
+</style>
+</head>
+<body>
+<div class="container">
+  <h1>GK-005 — Electrical System</h1>
+  <p class="subtitle">Transport Canada · TP 12880E · PPL Written Exam</p>
+
+  <div class="section-title">System Schematic</div>
+  <div class="diagram-box">
+    <svg viewBox="0 0 780 220" width="100%" height="200">
+      <defs>
+        <marker id="arrowE" markerWidth="7" markerHeight="7" refX="3.5" refY="3.5" orient="auto">
+          <polygon points="0,0 7,3.5 0,7" fill="#f0c040"/>
+        </marker>
+        <marker id="arrowG" markerWidth="7" markerHeight="7" refX="3.5" refY="3.5" orient="auto">
+          <polygon points="0,0 7,3.5 0,7" fill="#4caf7d"/>
+        </marker>
+      </defs>
+
+      <!-- Battery -->
+      <rect x="20" y="70" width="80" height="60" rx="5" fill="#1e3a50" stroke="#5b9bd5" stroke-width="2"/>
+      <text x="60" y="95" text-anchor="middle" fill="#5b9bd5" font-size="10" font-weight="bold">BATTERY</text>
+      <text x="60" y="108" text-anchor="middle" fill="#e8edf2" font-size="9">12V / 24V</text>
+      <text x="60" y="120" text-anchor="middle" fill="#7a9ab5" font-size="8">Lead-acid</text>
+
+      <!-- Alternator -->
+      <rect x="20" y="150" width="80" height="55" rx="5" fill="#1e3a50" stroke="#4caf7d" stroke-width="2"/>
+      <text x="60" y="172" text-anchor="middle" fill="#4caf7d" font-size="10" font-weight="bold">ALTERNATOR</text>
+      <text x="60" y="185" text-anchor="middle" fill="#e8edf2" font-size="9">Engine driven</text>
+      <text x="60" y="197" text-anchor="middle" fill="#7a9ab5" font-size="8">AC → rectified DC</text>
+
+      <!-- Voltage Regulator -->
+      <rect x="150" y="150" width="90" height="55" rx="5" fill="#1e3a50" stroke="#4caf7d" stroke-width="1.5"/>
+      <text x="195" y="172" text-anchor="middle" fill="#4caf7d" font-size="9" font-weight="bold">VOLTAGE</text>
+      <text x="195" y="184" text-anchor="middle" fill="#4caf7d" font-size="9" font-weight="bold">REGULATOR</text>
+      <text x="195" y="196" text-anchor="middle" fill="#7a9ab5" font-size="8">~14V / 28V</text>
+
+      <!-- Master Switch -->
+      <rect x="150" y="70" width="90" height="55" rx="5" fill="#1e3a50" stroke="#f0c040" stroke-width="2"/>
+      <text x="195" y="92" text-anchor="middle" fill="#f0c040" font-size="10" font-weight="bold">MASTER</text>
+      <text x="195" y="104" text-anchor="middle" fill="#f0c040" font-size="10" font-weight="bold">SWITCH</text>
+      <text x="195" y="116" text-anchor="middle" fill="#7a9ab5" font-size="8">BAT + ALT halves</text>
+
+      <!-- Bus Bar -->
+      <rect x="300" y="55" width="110" height="130" rx="5" fill="#243d52" stroke="#7a9ab5" stroke-width="2"/>
+      <text x="355" y="78" text-anchor="middle" fill="#e8edf2" font-size="11" font-weight="bold">BUS BAR</text>
+      <text x="355" y="92" text-anchor="middle" fill="#7a9ab5" font-size="9">Distribution point</text>
+      <!-- CB lines on bus -->
+      <line x1="320" y1="105" x2="395" y2="105" stroke="#7a9ab5" stroke-width="1" stroke-dasharray="3,2"/>
+      <line x1="320" y1="118" x2="395" y2="118" stroke="#7a9ab5" stroke-width="1" stroke-dasharray="3,2"/>
+      <line x1="320" y1="131" x2="395" y2="131" stroke="#7a9ab5" stroke-width="1" stroke-dasharray="3,2"/>
+      <line x1="320" y1="144" x2="395" y2="144" stroke="#7a9ab5" stroke-width="1" stroke-dasharray="3,2"/>
+      <text x="355" y="112" text-anchor="middle" fill="#7a9ab5" font-size="8">CB · CB · CB · CB</text>
+      <text x="355" y="125" text-anchor="middle" fill="#7a9ab5" font-size="8">CB · CB · CB · CB</text>
+
+      <!-- Loads -->
+      <!-- Avionics -->
+      <rect x="470" y="40" width="85" height="38" rx="4" fill="#1e3a50" stroke="#7a9ab5" stroke-width="1"/>
+      <text x="512" y="58" text-anchor="middle" fill="#e8edf2" font-size="9" font-weight="bold">AVIONICS</text>
+      <text x="512" y="70" text-anchor="middle" fill="#7a9ab5" font-size="8">COM / NAV / GPS</text>
+
+      <!-- Lights -->
+      <rect x="470" y="90" width="85" height="38" rx="4" fill="#1e3a50" stroke="#7a9ab5" stroke-width="1"/>
+      <text x="512" y="110" text-anchor="middle" fill="#e8edf2" font-size="9" font-weight="bold">LIGHTS</text>
+      <text x="512" y="122" text-anchor="middle" fill="#7a9ab5" font-size="8">Nav / Landing / Strobe</text>
+
+      <!-- Fuel Pump -->
+      <rect x="470" y="140" width="85" height="38" rx="4" fill="#1e3a50" stroke="#7a9ab5" stroke-width="1"/>
+      <text x="512" y="158" text-anchor="middle" fill="#e8edf2" font-size="9" font-weight="bold">FUEL PUMP</text>
+      <text x="512" y="170" text-anchor="middle" fill="#7a9ab5" font-size="8">Electric aux pump</text>
+
+      <!-- Starter -->
+      <rect x="615" y="90" width="85" height="38" rx="4" fill="#1e3a50" stroke="#7a9ab5" stroke-width="1"/>
+      <text x="657" y="110" text-anchor="middle" fill="#e8edf2" font-size="9" font-weight="bold">STARTER</text>
+      <text x="657" y="122" text-anchor="middle" fill="#7a9ab5" font-size="8">High current draw</text>
+
+      <!-- Ammeter/Loadmeter -->
+      <rect x="615" y="40" width="85" height="38" rx="4" fill="#1e3a50" stroke="#f0c040" stroke-width="1"/>
+      <text x="657" y="58" text-anchor="middle" fill="#f0c040" font-size="9" font-weight="bold">AMMETER /</text>
+      <text x="657" y="70" text-anchor="middle" fill="#f0c040" font-size="9" font-weight="bold">LOADMETER</text>
+
+      <!-- Arrows: Battery → Master -->
+      <line x1="100" y1="100" x2="148" y2="100" stroke="#f0c040" stroke-width="2" marker-end="url(#arrowE)"/>
+      <!-- Master → Bus -->
+      <line x1="240" y1="100" x2="298" y2="100" stroke="#f0c040" stroke-width="2" marker-end="url(#arrowE)"/>
+      <!-- Alternator → Voltage Reg -->
+      <line x1="100" y1="177" x2="148" y2="177" stroke="#4caf7d" stroke-width="2" marker-end="url(#arrowG)"/>
+      <!-- Voltage Reg → Bus -->
+      <line x1="240" y1="177" x2="355" y2="186" stroke="#4caf7d" stroke-width="2" marker-end="url(#arrowG)"/>
+      <!-- Bus → Avionics -->
+      <line x1="410" y1="90" x2="468" y2="60" stroke="#f0c040" stroke-width="1.5" marker-end="url(#arrowE)"/>
+      <!-- Bus → Lights -->
+      <line x1="410" y1="110" x2="468" y2="110" stroke="#f0c040" stroke-width="1.5" marker-end="url(#arrowE)"/>
+      <!-- Bus → Fuel pump -->
+      <line x1="410" y1="130" x2="468" y2="158" stroke="#f0c040" stroke-width="1.5" marker-end="url(#arrowE)"/>
+      <!-- Bus → Starter -->
+      <line x1="410" y1="120" x2="613" y2="110" stroke="#f0c040" stroke-width="1.5" marker-end="url(#arrowE)"/>
+      <!-- Bus → Ammeter -->
+      <line x1="410" y1="80" x2="613" y2="60" stroke="#f0c040" stroke-width="1.5" marker-end="url(#arrowE)"/>
+    </svg>
+  </div>
+
+  <div class="layout">
+    <div>
+      <div class="section-title">Key Components</div>
+      <table>
+        <thead>
+          <tr><th>Component</th><th>Description</th></tr>
+        </thead>
+        <tbody>
+          <tr><td><strong>Battery</strong></td><td>12V (light singles) or 24V. Powers all loads when engine off; enables engine start</td></tr>
+          <tr><td><strong>Alternator</strong></td><td>Engine-driven; primary power source when engine running; charges battery</td></tr>
+          <tr><td><strong>Voltage Regulator</strong></td><td>Maintains constant bus voltage (~14V or ~28V) regardless of engine RPM</td></tr>
+          <tr><td><strong>Master Switch</strong></td><td>Two-part split switch: Battery half + Alternator half (some aircraft)</td></tr>
+          <tr><td><strong>Bus Bar</strong></td><td>Central distribution rail; all loads connect via individual circuit breakers</td></tr>
+          <tr><td><strong>Circuit Breakers</strong></td><td>Protect individual circuits; can be reset once (if trip-free type, cannot be held in)</td></tr>
+        </tbody>
+      </table>
+    </div>
+    <div>
+      <div class="section-title">Ammeter vs. Loadmeter</div>
+      <table>
+        <thead>
+          <tr><th>Type</th><th>Reads</th><th>Normal Indication</th></tr>
+        </thead>
+        <tbody>
+          <tr><td><strong>Ammeter</strong></td><td>Current flow to/from battery</td><td>Slight positive (charging); zero in steady flight</td></tr>
+          <tr><td><strong>Loadmeter</strong></td><td>Total alternator output load</td><td>Some positive reading proportional to electrical load</td></tr>
+        </tbody>
+      </table>
+      <table style="margin-top:12px;">
+        <thead>
+          <tr><th>Indication</th><th>Meaning</th><th>Action</th></tr>
+        </thead>
+        <tbody>
+          <tr><td>Ammeter discharging</td><td>Alternator not charging — battery draining</td><td>Reduce load; land ASAP</td></tr>
+          <tr><td>Ammeter high charge</td><td>Battery deeply discharged; charging hard</td><td>Monitor; normal after start</td></tr>
+          <tr><td>Loadmeter zero</td><td>Alternator failure</td><td>Check ALT switch; reduce load; land soon</td></tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+
+  <div class="note-box">
+    <strong>Key Rule:</strong> The aircraft electrical system is <strong>independent of the ignition magnetos</strong> — magnetos operate entirely on their own and will keep the engine running even if all electrical power is lost. Conversely, the engine does NOT need electrical power to keep running once started (except fuel-injected engines with electric fuel pumps). Always reduce electrical load during an alternator failure to extend battery life.
+  </div>
+</div>
+</body>
+</html>

--- a/web-app/public/visuals/gk006-pitot-static-instruments.html
+++ b/web-app/public/visuals/gk006-pitot-static-instruments.html
@@ -1,0 +1,162 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>GK-006: Pitot-Static System</title>
+<style>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body { background: #0d1b2a; color: #e8edf2; font-family: 'Segoe UI', system-ui, sans-serif; padding: 32px; }
+  h1 { font-size: 22px; color: #f0c040; letter-spacing: 1px; margin-bottom: 6px; }
+  .subtitle { font-size: 13px; color: #7a9ab5; margin-bottom: 32px; letter-spacing: 0.5px; }
+  .container { max-width: 900px; margin: 0 auto; }
+  .section-title { font-size: 14px; color: #f0c040; letter-spacing: 1px; text-transform: uppercase; margin-bottom: 14px; margin-top: 32px; }
+  .diagram-box { background: #1a2d3d; border: 1px solid #243d52; border-radius: 8px; padding: 16px; margin-bottom: 24px; }
+  svg text { font-family: 'Segoe UI', system-ui, sans-serif; }
+  table { width: 100%; border-collapse: collapse; margin-bottom: 20px; }
+  th { background: #1a2d3d; color: #f0c040; font-size: 12px; text-align: left; padding: 10px 14px; letter-spacing: 0.5px; }
+  td { font-size: 13px; color: #e8edf2; padding: 9px 14px; border-bottom: 1px solid #1a2d3d; vertical-align: top; }
+  tr:last-child td { border-bottom: none; }
+  .layout { display: grid; grid-template-columns: 1fr 1fr; gap: 24px; align-items: start; }
+  .arc-row { display: flex; align-items: center; gap: 10px; margin-bottom: 8px; font-size: 13px; }
+  .arc-swatch { width: 32px; height: 14px; border-radius: 3px; flex-shrink: 0; }
+  .note-box { background: #1a2d3d; border-left: 3px solid #e05050; border-radius: 4px; padding: 14px 18px; margin-top: 20px; font-size: 13px; color: #e8edf2; line-height: 1.6; }
+</style>
+</head>
+<body>
+<div class="container">
+  <h1>GK-006 — Pitot-Static System</h1>
+  <p class="subtitle">Transport Canada · TP 12880E · PPL Written Exam</p>
+
+  <div class="section-title">System Diagram</div>
+  <div class="diagram-box">
+    <svg viewBox="0 0 760 200" width="100%" height="185">
+      <defs>
+        <marker id="arrowP" markerWidth="7" markerHeight="7" refX="3.5" refY="3.5" orient="auto">
+          <polygon points="0,0 7,3.5 0,7" fill="#f0c040"/>
+        </marker>
+        <marker id="arrowS" markerWidth="7" markerHeight="7" refX="3.5" refY="3.5" orient="auto">
+          <polygon points="0,0 7,3.5 0,7" fill="#5b9bd5"/>
+        </marker>
+      </defs>
+
+      <!-- Pitot Tube (left side) -->
+      <rect x="20" y="85" width="70" height="30" rx="4" fill="#1e3a50" stroke="#f0c040" stroke-width="2"/>
+      <polygon points="90,85 110,100 90,115" fill="#f0c040"/>
+      <text x="55" y="102" text-anchor="middle" fill="#f0c040" font-size="10" font-weight="bold">PITOT</text>
+      <text x="55" y="78" text-anchor="middle" fill="#7a9ab5" font-size="8">Ram air pressure</text>
+
+      <!-- Static Port (left lower) -->
+      <rect x="20" y="155" width="70" height="30" rx="4" fill="#1e3a50" stroke="#5b9bd5" stroke-width="2"/>
+      <text x="55" y="173" text-anchor="middle" fill="#5b9bd5" font-size="10" font-weight="bold">STATIC</text>
+      <text x="55" y="148" text-anchor="middle" fill="#7a9ab5" font-size="8">Ambient pressure</text>
+      <text x="55" y="192" text-anchor="middle" fill="#7a9ab5" font-size="8">PORT</text>
+
+      <!-- Pitot line (amber) going to ASI -->
+      <line x1="110" y1="100" x2="320" y2="100" stroke="#f0c040" stroke-width="2" stroke-dasharray="5,3" marker-end="url(#arrowP)"/>
+      <text x="215" y="92" text-anchor="middle" fill="#f0c040" font-size="8">Pitot pressure</text>
+
+      <!-- Static lines (blue) - branch to three instruments -->
+      <line x1="90" y1="170" x2="560" y2="170" stroke="#5b9bd5" stroke-width="2" stroke-dasharray="5,3"/>
+      <!-- static → ASI -->
+      <line x1="355" y1="170" x2="355" y2="130" stroke="#5b9bd5" stroke-width="2" stroke-dasharray="4,3" marker-end="url(#arrowS)"/>
+      <!-- static → Altimeter -->
+      <line x1="480" y1="170" x2="480" y2="130" stroke="#5b9bd5" stroke-width="2" stroke-dasharray="4,3" marker-end="url(#arrowS)"/>
+      <!-- static → VSI -->
+      <line x1="595" y1="170" x2="595" y2="130" stroke="#5b9bd5" stroke-width="2" stroke-dasharray="4,3" marker-end="url(#arrowS)"/>
+      <text x="400" y="185" text-anchor="middle" fill="#5b9bd5" font-size="8">Static pressure line</text>
+
+      <!-- ASI Instrument -->
+      <rect x="320" y="50" width="70" height="80" rx="5" fill="#0d1b2a" stroke="#f0c040" stroke-width="2"/>
+      <circle cx="355" cy="80" r="22" fill="#0d2040" stroke="#7a9ab5" stroke-width="1"/>
+      <text x="355" y="85" text-anchor="middle" fill="#f0c040" font-size="8">ASI</text>
+      <text x="355" y="40" text-anchor="middle" fill="#e8edf2" font-size="9" font-weight="bold">AIRSPEED</text>
+      <text x="355" y="145" text-anchor="middle" fill="#7a9ab5" font-size="8">Pitot + Static</text>
+
+      <!-- Altimeter Instrument -->
+      <rect x="445" y="50" width="70" height="80" rx="5" fill="#0d1b2a" stroke="#5b9bd5" stroke-width="2"/>
+      <circle cx="480" cy="80" r="22" fill="#0d2040" stroke="#7a9ab5" stroke-width="1"/>
+      <text x="480" y="85" text-anchor="middle" fill="#5b9bd5" font-size="8">ALT</text>
+      <text x="480" y="40" text-anchor="middle" fill="#e8edf2" font-size="9" font-weight="bold">ALTIMETER</text>
+      <text x="480" y="145" text-anchor="middle" fill="#7a9ab5" font-size="8">Static only</text>
+
+      <!-- VSI Instrument -->
+      <rect x="560" y="50" width="70" height="80" rx="5" fill="#0d1b2a" stroke="#5b9bd5" stroke-width="2"/>
+      <circle cx="595" cy="80" r="22" fill="#0d2040" stroke="#7a9ab5" stroke-width="1"/>
+      <text x="595" y="85" text-anchor="middle" fill="#5b9bd5" font-size="8">VSI</text>
+      <text x="595" y="40" text-anchor="middle" fill="#e8edf2" font-size="9" font-weight="bold">VERT SPEED</text>
+      <text x="595" y="145" text-anchor="middle" fill="#7a9ab5" font-size="8">Static only</text>
+
+      <!-- Pitot heat label -->
+      <rect x="20" y="40" width="70" height="22" rx="3" fill="#2a1a0d" stroke="#f0a040" stroke-width="1"/>
+      <text x="55" y="55" text-anchor="middle" fill="#f0a040" font-size="8">PITOT HEAT SW</text>
+    </svg>
+  </div>
+
+  <div class="layout">
+    <div>
+      <div class="section-title">Instruments at a Glance</div>
+      <table>
+        <thead>
+          <tr><th>Instrument</th><th>Pressure Used</th><th>Measures</th></tr>
+        </thead>
+        <tbody>
+          <tr><td><strong>Airspeed Indicator (ASI)</strong></td><td>Pitot + Static (differential)</td><td>Indicated airspeed (IAS) in knots or MPH</td></tr>
+          <tr><td><strong>Altimeter</strong></td><td>Static only</td><td>Altitude based on atmospheric pressure; requires QNH setting</td></tr>
+          <tr><td><strong>Vertical Speed Indicator (VSI)</strong></td><td>Static only (rate of change)</td><td>Rate of climb/descent in ft/min; ~6–9 second lag</td></tr>
+        </tbody>
+      </table>
+
+      <div class="section-title" style="margin-top:16px;">Failure Effects</div>
+      <table>
+        <thead>
+          <tr><th>Blockage</th><th>Effect on Instruments</th></tr>
+        </thead>
+        <tbody>
+          <tr><td>Pitot blocked (ice/insect)</td><td>ASI reads zero or freezes; ALT and VSI unaffected</td></tr>
+          <tr><td>Static blocked</td><td>ALT and VSI freeze; ASI reads incorrect (over/under reads with altitude change)</td></tr>
+          <tr><td>Both blocked</td><td>All three instruments unreliable</td></tr>
+        </tbody>
+      </table>
+    </div>
+
+    <div>
+      <div class="section-title">ASI Speed Arcs (Colour Code)</div>
+      <div style="background:#1a2d3d; border-radius:8px; padding:16px;">
+        <svg viewBox="0 0 220 200" width="100%" height="180">
+          <!-- ASI dial background -->
+          <circle cx="110" cy="100" r="85" fill="#0d1b2a" stroke="#7a9ab5" stroke-width="2"/>
+          <!-- White arc: Vso to Vfe (flap operating) -->
+          <path d="M 55 145 A 65 65 0 0 1 90 48" fill="none" stroke="white" stroke-width="10" stroke-linecap="round"/>
+          <!-- Green arc: Vs1 to Vno (normal ops) -->
+          <path d="M 80 150 A 65 65 0 0 1 165 48" fill="none" stroke="#4caf7d" stroke-width="10" stroke-linecap="round"/>
+          <!-- Yellow arc: Vno to Vne (caution) -->
+          <path d="M 165 48 A 65 65 0 0 1 185 105" fill="none" stroke="#f0c040" stroke-width="10" stroke-linecap="round"/>
+          <!-- Red line: Vne -->
+          <line x1="185" y1="100" x2="195" y2="92" stroke="#e05050" stroke-width="4" stroke-linecap="round"/>
+          <!-- Labels -->
+          <text x="110" y="105" text-anchor="middle" fill="#e8edf2" font-size="12" font-weight="bold">KIAS</text>
+          <text x="35" y="140" text-anchor="middle" fill="white" font-size="9">Vso</text>
+          <text x="72" y="35" text-anchor="middle" fill="white" font-size="9">Vfe</text>
+          <text x="165" y="35" text-anchor="middle" fill="#4caf7d" font-size="9">Vno</text>
+          <text x="200" y="92" text-anchor="middle" fill="#e05050" font-size="9">Vne</text>
+          <text x="68" y="158" text-anchor="middle" fill="#4caf7d" font-size="9">Vs1</text>
+        </svg>
+        <table style="margin-top:8px; margin-bottom:0;">
+          <tbody>
+            <tr><td style="padding:5px 8px;"><span style="color:white;font-weight:bold;">White arc</span></td><td style="padding:5px 8px; font-size:12px;">Vso to Vfe — flap operating range</td></tr>
+            <tr><td style="padding:5px 8px;"><span style="color:#4caf7d;font-weight:bold;">Green arc</span></td><td style="padding:5px 8px; font-size:12px;">Vs1 to Vno — normal operating range</td></tr>
+            <tr><td style="padding:5px 8px;"><span style="color:#f0c040;font-weight:bold;">Yellow arc</span></td><td style="padding:5px 8px; font-size:12px;">Vno to Vne — caution (smooth air only)</td></tr>
+            <tr><td style="padding:5px 8px;"><span style="color:#e05050;font-weight:bold;">Red line</span></td><td style="padding:5px 8px; font-size:12px;">Vne — never exceed speed</td></tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+
+  <div class="note-box">
+    <strong>Pitot Heat:</strong> Turn on pitot heat before entering visible moisture (clouds, rain, freezing temps) to prevent ice from blocking the pitot tube. A blocked pitot in IMC is extremely dangerous. The alternate static source (if installed) bypasses a blocked static port — opens to cockpit interior pressure, which causes slight ASI over-read and ALT over-read.
+  </div>
+</div>
+</body>
+</html>

--- a/web-app/public/visuals/gk007-gyroscopic-instruments.html
+++ b/web-app/public/visuals/gk007-gyroscopic-instruments.html
@@ -1,0 +1,170 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>GK-007: Gyroscopic Instruments</title>
+<style>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body { background: #0d1b2a; color: #e8edf2; font-family: 'Segoe UI', system-ui, sans-serif; padding: 32px; }
+  h1 { font-size: 22px; color: #f0c040; letter-spacing: 1px; margin-bottom: 6px; }
+  .subtitle { font-size: 13px; color: #7a9ab5; margin-bottom: 32px; letter-spacing: 0.5px; }
+  .container { max-width: 900px; margin: 0 auto; }
+  .section-title { font-size: 14px; color: #f0c040; letter-spacing: 1px; text-transform: uppercase; margin-bottom: 14px; margin-top: 32px; }
+  .instruments-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 20px; margin-bottom: 32px; }
+  .instrument-card { background: #1a2d3d; border: 1px solid #243d52; border-radius: 8px; padding: 16px; text-align: center; }
+  .inst-name { font-size: 14px; color: #f0c040; font-weight: bold; margin-bottom: 4px; }
+  .inst-abbr { font-size: 11px; color: #7a9ab5; margin-bottom: 12px; letter-spacing: 1px; }
+  .inst-desc { font-size: 12px; color: #e8edf2; line-height: 1.5; margin-top: 10px; text-align: left; }
+  svg text { font-family: 'Segoe UI', system-ui, sans-serif; }
+  table { width: 100%; border-collapse: collapse; margin-bottom: 20px; }
+  th { background: #1a2d3d; color: #f0c040; font-size: 12px; text-align: left; padding: 10px 14px; letter-spacing: 0.5px; }
+  td { font-size: 13px; color: #e8edf2; padding: 9px 14px; border-bottom: 1px solid #1a2d3d; vertical-align: top; }
+  tr:last-child td { border-bottom: none; }
+  .note-box { background: #1a2d3d; border-left: 3px solid #f0c040; border-radius: 4px; padding: 14px 18px; margin-top: 20px; font-size: 13px; color: #e8edf2; line-height: 1.6; }
+  .warn { color: #e05050; font-weight: bold; }
+</style>
+</head>
+<body>
+<div class="container">
+  <h1>GK-007 — Gyroscopic Instruments</h1>
+  <p class="subtitle">Transport Canada · TP 12880E · PPL Written Exam</p>
+
+  <div class="section-title">The Three Gyroscopic Instruments</div>
+  <div class="instruments-grid">
+
+    <!-- Attitude Indicator -->
+    <div class="instrument-card">
+      <div class="inst-name">Attitude Indicator</div>
+      <div class="inst-abbr">AI — ARTIFICIAL HORIZON</div>
+      <svg viewBox="0 0 140 140" width="100%" height="130">
+        <!-- Instrument bezel -->
+        <circle cx="70" cy="70" r="62" fill="#0d1b2a" stroke="#7a9ab5" stroke-width="2"/>
+        <circle cx="70" cy="70" r="58" fill="#0d1b2a" stroke="#243d52" stroke-width="1"/>
+        <!-- Sky (blue upper half) -->
+        <path d="M 12 70 A 58 58 0 0 1 128 70 L 128 12 A 58 58 0 0 0 12 12 Z" fill="#1a3060"/>
+        <!-- Ground (brown lower half) -->
+        <path d="M 12 70 A 58 58 0 0 0 128 70 L 128 128 A 58 58 0 0 1 12 128 Z" fill="#3d2010"/>
+        <!-- Horizon line -->
+        <line x1="12" y1="70" x2="128" y2="70" stroke="white" stroke-width="2"/>
+        <!-- Bank scale marks -->
+        <line x1="70" y1="12" x2="70" y2="20" stroke="white" stroke-width="1.5"/>
+        <line x1="42" y1="18" x2="45" y2="26" stroke="white" stroke-width="1.5"/>
+        <line x1="98" y1="18" x2="95" y2="26" stroke="white" stroke-width="1.5"/>
+        <!-- Miniature aircraft symbol -->
+        <line x1="40" y1="70" x2="60" y2="70" stroke="#f0c040" stroke-width="3" stroke-linecap="round"/>
+        <line x1="80" y1="70" x2="100" y2="70" stroke="#f0c040" stroke-width="3" stroke-linecap="round"/>
+        <circle cx="70" cy="70" r="4" fill="#f0c040"/>
+        <!-- Pitch lines -->
+        <line x1="50" y1="58" x2="90" y2="58" stroke="white" stroke-width="1" opacity="0.5"/>
+        <line x1="50" y1="82" x2="90" y2="82" stroke="white" stroke-width="1" opacity="0.5"/>
+        <!-- Labels -->
+        <text x="70" y="135" text-anchor="middle" fill="#7a9ab5" font-size="8">Vacuum or Electric</text>
+      </svg>
+      <div class="inst-desc">Shows aircraft pitch and bank attitude relative to the horizon. Rigidity in space keeps gyro fixed. Allows flight reference in IMC. Vacuum powered (typically) or electric on some aircraft.</div>
+    </div>
+
+    <!-- Heading Indicator -->
+    <div class="instrument-card">
+      <div class="inst-name">Heading Indicator</div>
+      <div class="inst-abbr">HI — DIRECTIONAL GYRO (DI)</div>
+      <svg viewBox="0 0 140 140" width="100%" height="130">
+        <circle cx="70" cy="70" r="62" fill="#0d1b2a" stroke="#7a9ab5" stroke-width="2"/>
+        <circle cx="70" cy="70" r="58" fill="#0d2040" stroke="#243d52" stroke-width="1"/>
+        <!-- Compass rose -->
+        <circle cx="70" cy="70" r="48" fill="none" stroke="#7a9ab5" stroke-width="1"/>
+        <!-- Compass points -->
+        <text x="70" y="26" text-anchor="middle" fill="#f0c040" font-size="11" font-weight="bold">N</text>
+        <text x="114" y="74" text-anchor="middle" fill="#e8edf2" font-size="11">E</text>
+        <text x="70" y="122" text-anchor="middle" fill="#e8edf2" font-size="11">S</text>
+        <text x="26" y="74" text-anchor="middle" fill="#e8edf2" font-size="11">W</text>
+        <!-- Tick marks -->
+        <line x1="70" y1="22" x2="70" y2="30" stroke="#7a9ab5" stroke-width="1.5"/>
+        <line x1="118" y1="70" x2="110" y2="70" stroke="#7a9ab5" stroke-width="1.5"/>
+        <line x1="70" y1="118" x2="70" y2="110" stroke="#7a9ab5" stroke-width="1.5"/>
+        <line x1="22" y1="70" x2="30" y2="70" stroke="#7a9ab5" stroke-width="1.5"/>
+        <!-- Heading bug (index) -->
+        <polygon points="70,35 66,44 74,44" fill="#f0c040"/>
+        <!-- Aircraft index -->
+        <line x1="40" y1="70" x2="58" y2="70" stroke="#f0c040" stroke-width="2.5" stroke-linecap="round"/>
+        <line x1="82" y1="70" x2="100" y2="70" stroke="#f0c040" stroke-width="2.5" stroke-linecap="round"/>
+        <circle cx="70" cy="70" r="5" fill="#f0c040"/>
+        <text x="70" y="135" text-anchor="middle" fill="#7a9ab5" font-size="8">Vacuum powered</text>
+      </svg>
+      <div class="inst-desc">Shows magnetic heading via gyro stability. Does NOT sense magnetic north directly — must be set to match magnetic compass. Precesses ~3°/hr — must reset every 15 minutes. Free of compass turning/acceleration errors.</div>
+    </div>
+
+    <!-- Turn Coordinator -->
+    <div class="instrument-card">
+      <div class="inst-name">Turn Coordinator</div>
+      <div class="inst-abbr">TC — TURN &amp; SLIP INDICATOR</div>
+      <svg viewBox="0 0 140 140" width="100%" height="130">
+        <circle cx="70" cy="70" r="62" fill="#0d1b2a" stroke="#7a9ab5" stroke-width="2"/>
+        <circle cx="70" cy="70" r="58" fill="#0d2040" stroke="#243d52" stroke-width="1"/>
+        <!-- Background turn marks -->
+        <text x="30" y="88" text-anchor="middle" fill="#7a9ab5" font-size="9">L</text>
+        <text x="110" y="88" text-anchor="middle" fill="#7a9ab5" font-size="9">R</text>
+        <!-- Standard rate marks -->
+        <line x1="32" y1="60" x2="40" y2="68" stroke="#f0c040" stroke-width="1.5"/>
+        <line x1="108" y1="60" x2="100" y2="68" stroke="#f0c040" stroke-width="1.5"/>
+        <text x="32" y="55" text-anchor="middle" fill="#f0c040" font-size="7">2 MIN</text>
+        <text x="108" y="55" text-anchor="middle" fill="#f0c040" font-size="7">2 MIN</text>
+        <!-- Miniature aircraft (level) -->
+        <line x1="38" y1="72" x2="58" y2="68" stroke="#f0c040" stroke-width="3" stroke-linecap="round"/>
+        <line x1="82" y1="68" x2="102" y2="72" stroke="#f0c040" stroke-width="3" stroke-linecap="round"/>
+        <rect x="65" y="65" width="10" height="8" rx="2" fill="#f0c040"/>
+        <!-- Inclinometer (ball) tube -->
+        <rect x="30" y="105" width="80" height="16" rx="8" fill="#0d1b2a" stroke="#7a9ab5" stroke-width="1.5"/>
+        <circle cx="70" cy="113" r="7" fill="#e8edf2"/>
+        <text x="70" y="132" text-anchor="middle" fill="#7a9ab5" font-size="8">Inclinometer ball</text>
+        <text x="70" y="20" text-anchor="middle" fill="#7a9ab5" font-size="8">Electric powered</text>
+      </svg>
+      <div class="inst-desc">Shows rate and quality of turn. Miniature aircraft indicates turn rate. Inclinometer ball: centred = coordinated; skid = ball to outside; slip = ball to inside. Standard rate = 3°/sec (360° in 2 min).</div>
+    </div>
+  </div>
+
+  <div class="section-title">Gyroscopic Instruments Summary</div>
+  <table>
+    <thead>
+      <tr><th>Instrument</th><th>Power Source</th><th>Gyro Principle</th><th>Key Error / Limitation</th></tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><strong>Attitude Indicator (AI)</strong></td>
+        <td>Vacuum system (engine-driven pump) or electric</td>
+        <td>Rigidity in space — gyro maintains fixed orientation</td>
+        <td>Topples if bank exceeds ~60–70°; unreliable during prolonged unusual attitudes</td>
+      </tr>
+      <tr>
+        <td><strong>Heading Indicator (HI/DI)</strong></td>
+        <td>Vacuum system (engine-driven pump)</td>
+        <td>Rigidity in space — resists precession short-term</td>
+        <td>Precesses ~3°/hour; <span class="warn">must reset from magnetic compass every 15 minutes</span></td>
+      </tr>
+      <tr>
+        <td><strong>Turn Coordinator (TC)</strong></td>
+        <td>Electric (usually)</td>
+        <td>Precession — gyro tilts in proportion to roll/turn rate</td>
+        <td>Shows turn rate and coordination; does NOT show bank angle directly</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <div class="section-title">Vacuum System Note</div>
+  <table>
+    <thead>
+      <tr><th>Component</th><th>Function</th></tr>
+    </thead>
+    <tbody>
+      <tr><td>Engine-driven vacuum pump</td><td>Creates suction to spin gyros in AI and HI via filtered air flow</td></tr>
+      <tr><td>Suction gauge (in-hg)</td><td>Indicates vacuum system serviceability; typical range 4.5–5.5 in Hg</td></tr>
+      <tr><td>Filter</td><td>Removes contaminants from air before entering gyro instruments</td></tr>
+    </tbody>
+  </table>
+
+  <div class="note-box">
+    <strong>Exam Key Points:</strong> The magnetic compass is the only instrument that directly senses magnetic north — the HI must be aligned to it periodically. In a vacuum failure, both AI and HI become unreliable; only the electric Turn Coordinator and magnetic compass remain. The ball in the inclinometer always falls to the low side of a slip/skid — "step on the ball" to correct.
+  </div>
+</div>
+</body>
+</html>

--- a/web-app/public/visuals/gk008-engine-instruments.html
+++ b/web-app/public/visuals/gk008-engine-instruments.html
@@ -1,0 +1,216 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>GK-008: Engine Instruments</title>
+<style>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body { background: #0d1b2a; color: #e8edf2; font-family: 'Segoe UI', system-ui, sans-serif; padding: 32px; }
+  h1 { font-size: 22px; color: #f0c040; letter-spacing: 1px; margin-bottom: 6px; }
+  .subtitle { font-size: 13px; color: #7a9ab5; margin-bottom: 32px; letter-spacing: 0.5px; }
+  .container { max-width: 900px; margin: 0 auto; }
+  .section-title { font-size: 14px; color: #f0c040; letter-spacing: 1px; text-transform: uppercase; margin-bottom: 14px; margin-top: 32px; }
+  .panel-grid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 14px; margin-bottom: 32px; }
+  .gauge-card { background: #1a2d3d; border: 1px solid #243d52; border-radius: 8px; padding: 12px; text-align: center; }
+  .gauge-name { font-size: 11px; color: #f0c040; font-weight: bold; letter-spacing: 0.5px; margin-bottom: 4px; }
+  .gauge-abbr { font-size: 10px; color: #7a9ab5; margin-bottom: 8px; }
+  svg text { font-family: 'Segoe UI', system-ui, sans-serif; }
+  table { width: 100%; border-collapse: collapse; margin-bottom: 20px; }
+  th { background: #1a2d3d; color: #f0c040; font-size: 12px; text-align: left; padding: 10px 14px; letter-spacing: 0.5px; }
+  td { font-size: 13px; color: #e8edf2; padding: 9px 14px; border-bottom: 1px solid #1a2d3d; vertical-align: top; }
+  tr:last-child td { border-bottom: none; }
+  .arc-green { color: #4caf7d; font-weight: bold; }
+  .arc-yellow { color: #f0c040; font-weight: bold; }
+  .arc-red { color: #e05050; font-weight: bold; }
+  .note-box { background: #1a2d3d; border-left: 3px solid #e05050; border-radius: 4px; padding: 14px 18px; margin-top: 20px; font-size: 13px; color: #e8edf2; line-height: 1.6; }
+</style>
+</head>
+<body>
+<div class="container">
+  <h1>GK-008 — Engine Instruments Panel</h1>
+  <p class="subtitle">Transport Canada · TP 12880E · PPL Written Exam</p>
+
+  <div class="section-title">Instrument Panel — Engine Gauges</div>
+  <div class="panel-grid">
+
+    <!-- Tachometer -->
+    <div class="gauge-card">
+      <div class="gauge-name">TACHOMETER</div>
+      <div class="gauge-abbr">RPM</div>
+      <svg viewBox="0 0 100 100" width="100%" height="90">
+        <circle cx="50" cy="50" r="44" fill="#0d1b2a" stroke="#7a9ab5" stroke-width="2"/>
+        <path d="M 10 70 A 44 44 0 0 1 90 70" fill="none" stroke="#4caf7d" stroke-width="7"/>
+        <path d="M 72 28 A 44 44 0 0 1 90 70" fill="none" stroke="#f0c040" stroke-width="7"/>
+        <line x1="90" y1="70" x2="84" y2="66" stroke="#e05050" stroke-width="4" stroke-linecap="round"/>
+        <!-- Needle -->
+        <line x1="50" y1="50" x2="72" y2="22" stroke="white" stroke-width="2" stroke-linecap="round"/>
+        <circle cx="50" cy="50" r="4" fill="#7a9ab5"/>
+        <text x="50" y="85" text-anchor="middle" fill="#7a9ab5" font-size="8">×100 RPM</text>
+        <text x="50" y="50" text-anchor="middle" fill="#e8edf2" font-size="8" dy="15">RPM</text>
+      </svg>
+    </div>
+
+    <!-- Manifold Pressure -->
+    <div class="gauge-card">
+      <div class="gauge-name">MANIFOLD PRESS.</div>
+      <div class="gauge-abbr">MAP — in. Hg</div>
+      <svg viewBox="0 0 100 100" width="100%" height="90">
+        <circle cx="50" cy="50" r="44" fill="#0d1b2a" stroke="#7a9ab5" stroke-width="2"/>
+        <path d="M 10 70 A 44 44 0 0 1 90 70" fill="none" stroke="#4caf7d" stroke-width="7"/>
+        <path d="M 72 28 A 44 44 0 0 1 90 70" fill="none" stroke="#f0c040" stroke-width="7"/>
+        <!-- Needle -->
+        <line x1="50" y1="50" x2="55" y2="12" stroke="white" stroke-width="2" stroke-linecap="round"/>
+        <circle cx="50" cy="50" r="4" fill="#7a9ab5"/>
+        <text x="50" y="85" text-anchor="middle" fill="#7a9ab5" font-size="8">in. Hg</text>
+        <text x="50" y="50" text-anchor="middle" fill="#e8edf2" font-size="8" dy="15">MAP</text>
+      </svg>
+    </div>
+
+    <!-- Oil Temperature -->
+    <div class="gauge-card">
+      <div class="gauge-name">OIL TEMP</div>
+      <div class="gauge-abbr">°C or °F</div>
+      <svg viewBox="0 0 100 100" width="100%" height="90">
+        <circle cx="50" cy="50" r="44" fill="#0d1b2a" stroke="#7a9ab5" stroke-width="2"/>
+        <path d="M 18 76 A 44 44 0 0 1 50 10" fill="none" stroke="#4caf7d" stroke-width="7"/>
+        <path d="M 50 10 A 44 44 0 0 1 82 76" fill="none" stroke="#f0c040" stroke-width="7"/>
+        <line x1="82" y1="70" x2="87" y2="65" stroke="#e05050" stroke-width="4" stroke-linecap="round"/>
+        <!-- Needle -->
+        <line x1="50" y1="50" x2="65" y2="18" stroke="white" stroke-width="2" stroke-linecap="round"/>
+        <circle cx="50" cy="50" r="4" fill="#7a9ab5"/>
+        <text x="50" y="85" text-anchor="middle" fill="#7a9ab5" font-size="8">°C</text>
+        <text x="50" y="50" text-anchor="middle" fill="#e8edf2" font-size="8" dy="15">OIL T</text>
+      </svg>
+    </div>
+
+    <!-- Oil Pressure -->
+    <div class="gauge-card">
+      <div class="gauge-name">OIL PRESSURE</div>
+      <div class="gauge-abbr">PSI</div>
+      <svg viewBox="0 0 100 100" width="100%" height="90">
+        <circle cx="50" cy="50" r="44" fill="#0d1b2a" stroke="#7a9ab5" stroke-width="2"/>
+        <path d="M 10 70 A 44 44 0 0 1 40 12" fill="none" stroke="#f0c040" stroke-width="7"/>
+        <path d="M 40 12 A 44 44 0 0 1 90 70" fill="none" stroke="#4caf7d" stroke-width="7"/>
+        <line x1="10" y1="70" x2="15" y2="64" stroke="#e05050" stroke-width="4" stroke-linecap="round"/>
+        <!-- Needle -->
+        <line x1="50" y1="50" x2="60" y2="16" stroke="white" stroke-width="2" stroke-linecap="round"/>
+        <circle cx="50" cy="50" r="4" fill="#7a9ab5"/>
+        <text x="50" y="85" text-anchor="middle" fill="#7a9ab5" font-size="8">PSI</text>
+        <text x="50" y="50" text-anchor="middle" fill="#e8edf2" font-size="8" dy="15">OIL P</text>
+      </svg>
+    </div>
+
+    <!-- CHT -->
+    <div class="gauge-card">
+      <div class="gauge-name">CYL. HEAD TEMP</div>
+      <div class="gauge-abbr">CHT — °C or °F</div>
+      <svg viewBox="0 0 100 100" width="100%" height="90">
+        <circle cx="50" cy="50" r="44" fill="#0d1b2a" stroke="#7a9ab5" stroke-width="2"/>
+        <path d="M 18 76 A 44 44 0 0 1 50 10" fill="none" stroke="#4caf7d" stroke-width="7"/>
+        <path d="M 50 10 A 44 44 0 0 1 78 22" fill="none" stroke="#f0c040" stroke-width="7"/>
+        <line x1="78" y1="22" x2="85" y2="26" stroke="#e05050" stroke-width="4" stroke-linecap="round"/>
+        <!-- Needle -->
+        <line x1="50" y1="50" x2="62" y2="20" stroke="white" stroke-width="2" stroke-linecap="round"/>
+        <circle cx="50" cy="50" r="4" fill="#7a9ab5"/>
+        <text x="50" y="85" text-anchor="middle" fill="#7a9ab5" font-size="8">°C</text>
+        <text x="50" y="50" text-anchor="middle" fill="#e8edf2" font-size="8" dy="15">CHT</text>
+      </svg>
+    </div>
+
+    <!-- EGT -->
+    <div class="gauge-card">
+      <div class="gauge-name">EXHAUST GAS TEMP</div>
+      <div class="gauge-abbr">EGT — °C or °F</div>
+      <svg viewBox="0 0 100 100" width="100%" height="90">
+        <circle cx="50" cy="50" r="44" fill="#0d1b2a" stroke="#7a9ab5" stroke-width="2"/>
+        <path d="M 10 70 A 44 44 0 0 1 90 70" fill="none" stroke="#4caf7d" stroke-width="7"/>
+        <!-- Needle -->
+        <line x1="50" y1="50" x2="50" y2="10" stroke="white" stroke-width="2" stroke-linecap="round"/>
+        <circle cx="50" cy="50" r="4" fill="#7a9ab5"/>
+        <text x="50" y="85" text-anchor="middle" fill="#7a9ab5" font-size="8">°C</text>
+        <text x="50" y="50" text-anchor="middle" fill="#e8edf2" font-size="8" dy="15">EGT</text>
+      </svg>
+    </div>
+
+    <!-- Fuel Flow -->
+    <div class="gauge-card">
+      <div class="gauge-name">FUEL FLOW</div>
+      <div class="gauge-abbr">GPH or L/HR</div>
+      <svg viewBox="0 0 100 100" width="100%" height="90">
+        <circle cx="50" cy="50" r="44" fill="#0d1b2a" stroke="#7a9ab5" stroke-width="2"/>
+        <path d="M 10 70 A 44 44 0 0 1 90 70" fill="none" stroke="#4caf7d" stroke-width="7"/>
+        <!-- Needle -->
+        <line x1="50" y1="50" x2="30" y2="18" stroke="white" stroke-width="2" stroke-linecap="round"/>
+        <circle cx="50" cy="50" r="4" fill="#7a9ab5"/>
+        <text x="50" y="85" text-anchor="middle" fill="#7a9ab5" font-size="8">GPH</text>
+        <text x="50" y="50" text-anchor="middle" fill="#e8edf2" font-size="8" dy="15">FUEL</text>
+      </svg>
+    </div>
+
+    <!-- Fuel Qty -->
+    <div class="gauge-card">
+      <div class="gauge-name">FUEL QUANTITY</div>
+      <div class="gauge-abbr">USG or LITRES</div>
+      <svg viewBox="0 0 100 100" width="100%" height="90">
+        <circle cx="50" cy="50" r="44" fill="#0d1b2a" stroke="#7a9ab5" stroke-width="2"/>
+        <path d="M 10 70 A 44 44 0 0 1 50 10" fill="none" stroke="#e05050" stroke-width="7"/>
+        <path d="M 50 10 A 44 44 0 0 1 90 70" fill="none" stroke="#4caf7d" stroke-width="7"/>
+        <!-- E and F labels -->
+        <text x="18" y="78" text-anchor="middle" fill="#e05050" font-size="10" font-weight="bold">E</text>
+        <text x="82" y="78" text-anchor="middle" fill="#4caf7d" font-size="10" font-weight="bold">F</text>
+        <!-- Needle -->
+        <line x1="50" y1="50" x2="72" y2="25" stroke="white" stroke-width="2" stroke-linecap="round"/>
+        <circle cx="50" cy="50" r="4" fill="#7a9ab5"/>
+        <text x="50" y="85" text-anchor="middle" fill="#7a9ab5" font-size="8">USG</text>
+        <text x="50" y="50" text-anchor="middle" fill="#e8edf2" font-size="8" dy="15">FUEL QTY</text>
+      </svg>
+    </div>
+
+  </div>
+
+  <div class="section-title">Colour Arc Reference</div>
+  <table>
+    <thead>
+      <tr><th>Instrument</th><th><span class="arc-green">Green Arc</span></th><th><span class="arc-yellow">Yellow Arc</span></th><th><span class="arc-red">Red Line / Arc</span></th></tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><strong>Tachometer (RPM)</strong></td>
+        <td>Normal operating range (e.g. 1800–2300 RPM)</td>
+        <td>Caution range — avoid continuous operation</td>
+        <td>Maximum RPM — never exceed</td>
+      </tr>
+      <tr>
+        <td><strong>Oil Temperature</strong></td>
+        <td>Normal operating temp (e.g. 75–120°C)</td>
+        <td>High caution range</td>
+        <td>Max oil temperature limit</td>
+      </tr>
+      <tr>
+        <td><strong>Oil Pressure</strong></td>
+        <td>Normal operating pressure (e.g. 25–90 PSI)</td>
+        <td>Low pressure caution</td>
+        <td>Min pressure (red low) / Max pressure (red high)</td>
+      </tr>
+      <tr>
+        <td><strong>Cylinder Head Temp (CHT)</strong></td>
+        <td>Normal ops range</td>
+        <td>High — reduce power / enrichen mixture</td>
+        <td>Never exceed — risk of detonation/engine damage</td>
+      </tr>
+      <tr>
+        <td><strong>Manifold Pressure</strong></td>
+        <td>Normal cruise MAP range</td>
+        <td>High MAP caution</td>
+        <td>Maximum allowable MAP</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <div class="note-box">
+    <strong>Critical Limits to Memorize:</strong> Oil pressure must be in the green within <strong>30 seconds</strong> of starting (cold) or engine must be shut down. Low oil pressure + high oil temperature = likely oil leak or pump failure — <strong>land immediately</strong>. EGT is used to lean the mixture: richest mixture at peak EGT minus ~50°F (rich of peak) or specific lean-of-peak per POH. Always refer to the specific aircraft POH for actual numerical limits.
+  </div>
+</div>
+</body>
+</html>

--- a/web-app/public/visuals/gk009-weight-and-balance.html
+++ b/web-app/public/visuals/gk009-weight-and-balance.html
@@ -1,0 +1,186 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>GK-009: Weight and Balance</title>
+<style>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body { background: #0d1b2a; color: #e8edf2; font-family: 'Segoe UI', system-ui, sans-serif; padding: 32px; }
+  h1 { font-size: 22px; color: #f0c040; letter-spacing: 1px; margin-bottom: 6px; }
+  .subtitle { font-size: 13px; color: #7a9ab5; margin-bottom: 32px; letter-spacing: 0.5px; }
+  .container { max-width: 900px; margin: 0 auto; }
+  .section-title { font-size: 14px; color: #f0c040; letter-spacing: 1px; text-transform: uppercase; margin-bottom: 14px; margin-top: 32px; }
+  .layout { display: grid; grid-template-columns: 1fr 1fr; gap: 24px; align-items: start; }
+  .diagram-box { background: #1a2d3d; border: 1px solid #243d52; border-radius: 8px; padding: 16px; }
+  svg text { font-family: 'Segoe UI', system-ui, sans-serif; }
+  table { width: 100%; border-collapse: collapse; margin-bottom: 20px; }
+  th { background: #1a2d3d; color: #f0c040; font-size: 12px; text-align: left; padding: 10px 14px; letter-spacing: 0.5px; }
+  td { font-size: 13px; color: #e8edf2; padding: 9px 14px; border-bottom: 1px solid #1a2d3d; vertical-align: top; text-align: right; }
+  td:first-child { text-align: left; }
+  tr:last-child td { border-bottom: none; }
+  .formula-box { background: #1a2d3d; border: 1px solid #f0c040; border-radius: 8px; padding: 18px; margin-bottom: 20px; text-align: center; }
+  .formula { font-size: 18px; color: #f0c040; font-weight: bold; letter-spacing: 1px; margin-bottom: 6px; }
+  .formula-sub { font-size: 12px; color: #7a9ab5; }
+  .total-row td { background: #243d52; color: #f0c040; font-weight: bold; }
+  .note-box { background: #1a2d3d; border-left: 3px solid #f0c040; border-radius: 4px; padding: 14px 18px; margin-top: 20px; font-size: 13px; color: #e8edf2; line-height: 1.6; }
+  .warning { color: #e05050; font-weight: bold; }
+</style>
+</head>
+<body>
+<div class="container">
+  <h1>GK-009 — Weight &amp; Balance</h1>
+  <p class="subtitle">Transport Canada · TP 12880E · PPL Written Exam</p>
+
+  <div class="formula-box">
+    <div class="formula">CG = Total Moment ÷ Total Weight</div>
+    <div class="formula-sub">Moment = Weight × Arm &nbsp;|&nbsp; CG must fall within the approved envelope</div>
+  </div>
+
+  <div class="layout">
+    <!-- CG Envelope diagram -->
+    <div class="diagram-box">
+      <svg viewBox="0 0 320 280" width="100%" height="260">
+        <defs>
+          <marker id="arrowWB" markerWidth="7" markerHeight="7" refX="3.5" refY="3.5" orient="auto">
+            <polygon points="0,0 7,3.5 0,7" fill="#7a9ab5"/>
+          </marker>
+        </defs>
+
+        <!-- Axes -->
+        <!-- Y-axis (weight) -->
+        <line x1="60" y1="220" x2="60" y2="30" stroke="#7a9ab5" stroke-width="1.5" marker-end="url(#arrowWB)"/>
+        <!-- X-axis (CG/arm) -->
+        <line x1="60" y1="220" x2="300" y2="220" stroke="#7a9ab5" stroke-width="1.5" marker-end="url(#arrowWB)"/>
+
+        <!-- Axis labels -->
+        <text x="25" y="130" text-anchor="middle" fill="#7a9ab5" font-size="10" transform="rotate(-90, 25, 130)">Gross Weight (lbs)</text>
+        <text x="180" y="242" text-anchor="middle" fill="#7a9ab5" font-size="10">CG Position (inches aft of datum)</text>
+
+        <!-- Envelope polygon -->
+        <polygon points="100,210 100,80 140,60 220,60 250,80 250,210" fill="#0d2a40" stroke="#f0c040" stroke-width="2"/>
+
+        <!-- Max gross weight line -->
+        <line x1="60" y1="80" x2="255" y2="80" stroke="#e05050" stroke-width="1.5" stroke-dasharray="5,3"/>
+        <text x="270" y="83" fill="#e05050" font-size="9">Max GW</text>
+
+        <!-- Forward CG limit -->
+        <line x1="100" y1="220" x2="100" y2="60" stroke="#5b9bd5" stroke-width="1.5" stroke-dasharray="4,3"/>
+        <text x="100" y="232" text-anchor="middle" fill="#5b9bd5" font-size="9">Fwd CG</text>
+
+        <!-- Aft CG limit -->
+        <line x1="250" y1="220" x2="250" y2="60" stroke="#f0a040" stroke-width="1.5" stroke-dasharray="4,3"/>
+        <text x="250" y="232" text-anchor="middle" fill="#f0a040" font-size="9">Aft CG</text>
+
+        <!-- Sample CG point -->
+        <circle cx="185" cy="130" r="7" fill="#4caf7d" stroke="#4caf7d" stroke-width="2"/>
+        <text x="198" y="128" fill="#4caf7d" font-size="9">Sample CG</text>
+        <text x="198" y="139" fill="#4caf7d" font-size="9">(within envelope)</text>
+
+        <!-- Y-axis tick marks and values -->
+        <line x1="55" y1="210" x2="65" y2="210" stroke="#7a9ab5" stroke-width="1"/>
+        <text x="50" y="213" text-anchor="end" fill="#7a9ab5" font-size="8">1500</text>
+        <line x1="55" y1="145" x2="65" y2="145" stroke="#7a9ab5" stroke-width="1"/>
+        <text x="50" y="148" text-anchor="end" fill="#7a9ab5" font-size="8">1800</text>
+        <line x1="55" y1="80" x2="65" y2="80" stroke="#7a9ab5" stroke-width="1"/>
+        <text x="50" y="83" text-anchor="end" fill="#7a9ab5" font-size="8">2150</text>
+
+        <!-- X-axis tick marks -->
+        <line x1="100" y1="215" x2="100" y2="225" stroke="#7a9ab5" stroke-width="1"/>
+        <text x="100" y="237" text-anchor="middle" fill="#7a9ab5" font-size="8">82"</text>
+        <line x1="175" y1="215" x2="175" y2="225" stroke="#7a9ab5" stroke-width="1"/>
+        <text x="175" y="237" text-anchor="middle" fill="#7a9ab5" font-size="8">90"</text>
+        <line x1="250" y1="215" x2="250" y2="225" stroke="#7a9ab5" stroke-width="1"/>
+        <text x="250" y="237" text-anchor="middle" fill="#7a9ab5" font-size="8">98"</text>
+
+        <!-- Region labels -->
+        <text x="175" y="120" text-anchor="middle" fill="#4caf7d" font-size="9">APPROVED</text>
+        <text x="175" y="132" text-anchor="middle" fill="#4caf7d" font-size="9">CG ENVELOPE</text>
+      </svg>
+    </div>
+
+    <!-- Calculation table -->
+    <div>
+      <div class="section-title">Sample W&amp;B Calculation</div>
+      <table>
+        <thead>
+          <tr>
+            <th>Item</th>
+            <th style="text-align:right;">Weight (lbs)</th>
+            <th style="text-align:right;">Arm (in.)</th>
+            <th style="text-align:right;">Moment (lb·in)</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Empty Aircraft</td>
+            <td>1,340</td>
+            <td>87.2</td>
+            <td>116,848</td>
+          </tr>
+          <tr>
+            <td>Pilot (front left)</td>
+            <td>170</td>
+            <td>85.0</td>
+            <td>14,450</td>
+          </tr>
+          <tr>
+            <td>Passenger (front right)</td>
+            <td>150</td>
+            <td>85.0</td>
+            <td>12,750</td>
+          </tr>
+          <tr>
+            <td>Rear Passengers</td>
+            <td>0</td>
+            <td>117.0</td>
+            <td>0</td>
+          </tr>
+          <tr>
+            <td>Baggage</td>
+            <td>30</td>
+            <td>140.0</td>
+            <td>4,200</td>
+          </tr>
+          <tr>
+            <td>Fuel (30 USG × 6 lb/USG)</td>
+            <td>180</td>
+            <td>96.0</td>
+            <td>17,280</td>
+          </tr>
+          <tr class="total-row">
+            <td>TOTALS</td>
+            <td>1,870</td>
+            <td>—</td>
+            <td>165,528</td>
+          </tr>
+        </tbody>
+      </table>
+      <div class="formula-box" style="margin-top:0;">
+        <div class="formula">CG = 165,528 ÷ 1,870 = <span style="color:#4caf7d;">88.5 inches</span></div>
+        <div class="formula-sub">CG is aft of datum by 88.5 inches — check against envelope limits</div>
+      </div>
+    </div>
+  </div>
+
+  <div class="section-title">Key Definitions</div>
+  <table>
+    <thead>
+      <tr><th>Term</th><th>Definition</th></tr>
+    </thead>
+    <tbody>
+      <tr><td><strong>Datum</strong></td><td>Reference point (often nose of aircraft or firewall) from which all arms are measured. Defined in the POH.</td></tr>
+      <tr><td><strong>Arm</strong></td><td>Horizontal distance (inches) from the datum to the item's centre of gravity. Forward = negative (usually); aft = positive.</td></tr>
+      <tr><td><strong>Moment</strong></td><td>Product of weight × arm. Represents the turning force about the datum. Units: lb·in or kg·m.</td></tr>
+      <tr><td><strong>Centre of Gravity (CG)</strong></td><td>Point where aircraft balances. Must stay within forward and aft limits for the given gross weight.</td></tr>
+      <tr><td><strong>Max Gross Weight</strong></td><td>Maximum allowable total weight — certified structural limit.</td></tr>
+      <tr><td><strong>Useful Load</strong></td><td>Max gross weight minus empty weight. Available for crew, passengers, fuel, baggage.</td></tr>
+    </tbody>
+  </table>
+
+  <div class="note-box">
+    <strong>CG Effects:</strong> <span class="warning">Forward CG</span> — more stable, nose-heavy, higher stall speed, requires more back pressure, may lack elevator authority at low speeds (e.g. landing flare). <span class="warning">Aft CG</span> — less stable, harder to recover from stalls/spins, lighter control feel. Both out-of-limits conditions are <strong>illegal and unsafe</strong> — the flight must not be conducted.
+  </div>
+</div>
+</body>
+</html>

--- a/web-app/public/visuals/gk010-performance-charts.html
+++ b/web-app/public/visuals/gk010-performance-charts.html
@@ -1,0 +1,137 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>GK-010: Performance Charts Reference</title>
+<style>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body { background: #0d1b2a; color: #e8edf2; font-family: 'Segoe UI', system-ui, sans-serif; padding: 32px; }
+  h1 { font-size: 22px; color: #f0c040; letter-spacing: 1px; margin-bottom: 6px; }
+  .subtitle { font-size: 13px; color: #7a9ab5; margin-bottom: 32px; letter-spacing: 0.5px; }
+  .container { max-width: 900px; margin: 0 auto; }
+  .section-title { font-size: 14px; color: #f0c040; letter-spacing: 1px; text-transform: uppercase; margin-bottom: 14px; margin-top: 32px; }
+  .grid-2 { display: grid; grid-template-columns: 1fr 1fr; gap: 24px; margin-bottom: 24px; }
+  .grid-4 { display: grid; grid-template-columns: repeat(4, 1fr); gap: 16px; margin-bottom: 24px; }
+  .card { background: #1a2d3d; border: 1px solid #243d52; border-radius: 8px; padding: 16px; }
+  .card-title { font-size: 12px; color: #f0c040; font-weight: bold; letter-spacing: 0.5px; margin-bottom: 10px; text-transform: uppercase; }
+  svg text { font-family: 'Segoe UI', system-ui, sans-serif; }
+  table { width: 100%; border-collapse: collapse; margin-bottom: 0; }
+  th { background: #1a2d3d; color: #f0c040; font-size: 12px; text-align: left; padding: 9px 12px; letter-spacing: 0.5px; }
+  td { font-size: 12px; color: #e8edf2; padding: 8px 12px; border-bottom: 1px solid #1a2d3d; vertical-align: top; }
+  tr:last-child td { border-bottom: none; }
+  .isa-box { background: #0d2040; border: 2px solid #5b9bd5; border-radius: 8px; padding: 18px; text-align: center; margin-bottom: 24px; }
+  .isa-main { font-size: 18px; color: #5b9bd5; font-weight: bold; margin-bottom: 4px; }
+  .isa-sub { font-size: 12px; color: #7a9ab5; line-height: 1.6; }
+  .better { color: #4caf7d; font-weight: bold; }
+  .worse { color: #e05050; font-weight: bold; }
+  .neutral { color: #7a9ab5; }
+  .da-diagram { background: #1a2d3d; border: 1px solid #243d52; border-radius: 8px; padding: 16px; }
+</style>
+</head>
+<body>
+<div class="container">
+  <h1>GK-010 — Performance Charts Reference</h1>
+  <p class="subtitle">Transport Canada · TP 12880E · PPL Written Exam</p>
+
+  <div class="isa-box">
+    <div class="isa-main">ISA — International Standard Atmosphere</div>
+    <div class="isa-sub">Sea Level: 15°C · 1013.25 hPa (29.92 in.Hg) · Density 1.225 kg/m³<br>
+    Lapse Rate: −2°C per 1,000 ft (−1.98°C/1000 ft standard) up to the tropopause (~36,000 ft)<br>
+    Pressure lapse rate: approx. −1 in.Hg per 1,000 ft</div>
+  </div>
+
+  <div class="section-title">1. Density Altitude</div>
+  <div class="grid-2">
+    <div class="da-diagram">
+      <svg viewBox="0 0 320 200" width="100%" height="180">
+        <defs>
+          <marker id="arrowDA" markerWidth="7" markerHeight="7" refX="3.5" refY="3.5" orient="auto">
+            <polygon points="0,0 7,3.5 0,7" fill="#7a9ab5"/>
+          </marker>
+        </defs>
+        <!-- Axes -->
+        <line x1="55" y1="170" x2="55" y2="20" stroke="#7a9ab5" stroke-width="1.5" marker-end="url(#arrowDA)"/>
+        <line x1="55" y1="170" x2="310" y2="170" stroke="#7a9ab5" stroke-width="1.5" marker-end="url(#arrowDA)"/>
+        <text x="22" y="100" text-anchor="middle" fill="#7a9ab5" font-size="9" transform="rotate(-90,22,100)">Density Alt (ft)</text>
+        <text x="182" y="188" text-anchor="middle" fill="#7a9ab5" font-size="9">Outside Air Temperature (°C)</text>
+
+        <!-- ISA line -->
+        <line x1="80" y1="155" x2="290" y2="40" stroke="#5b9bd5" stroke-width="2"/>
+        <text x="295" y="38" fill="#5b9bd5" font-size="8">ISA std</text>
+
+        <!-- Hot day line (higher DA) -->
+        <line x1="80" y1="140" x2="290" y2="25" stroke="#f0c040" stroke-width="2" stroke-dasharray="4,3"/>
+        <text x="295" y="24" fill="#f0c040" font-size="8">Hot day</text>
+
+        <!-- Pressure altitude lines (horizontal dashed) -->
+        <line x1="55" y1="140" x2="300" y2="140" stroke="#4caf7d" stroke-width="0.8" stroke-dasharray="2,3"/>
+        <text x="52" y="143" text-anchor="end" fill="#4caf7d" font-size="8">3000 PA</text>
+        <line x1="55" y1="100" x2="300" y2="100" stroke="#4caf7d" stroke-width="0.8" stroke-dasharray="2,3"/>
+        <text x="52" y="103" text-anchor="end" fill="#4caf7d" font-size="8">5000 PA</text>
+
+        <!-- Temp tick marks -->
+        <line x1="120" y1="165" x2="120" y2="175" stroke="#7a9ab5" stroke-width="1"/>
+        <text x="120" y="183" text-anchor="middle" fill="#7a9ab5" font-size="8">0°</text>
+        <line x1="185" y1="165" x2="185" y2="175" stroke="#7a9ab5" stroke-width="1"/>
+        <text x="185" y="183" text-anchor="middle" fill="#7a9ab5" font-size="8">15°</text>
+        <line x1="250" y1="165" x2="250" y2="175" stroke="#7a9ab5" stroke-width="1"/>
+        <text x="250" y="183" text-anchor="middle" fill="#7a9ab5" font-size="8">30°</text>
+      </svg>
+    </div>
+    <div>
+      <table>
+        <thead>
+          <tr><th>Factor</th><th>Effect on Density Altitude</th><th>Performance Effect</th></tr>
+        </thead>
+        <tbody>
+          <tr><td>Higher temperature</td><td><span class="worse">Increases DA</span></td><td>Longer TO/landing, less climb</td></tr>
+          <tr><td>Lower pressure (high elev or low QNH)</td><td><span class="worse">Increases DA</span></td><td>Longer TO/landing, less climb</td></tr>
+          <tr><td>High humidity</td><td><span class="worse">Increases DA slightly</span></td><td>Marginal but adds up with other factors</td></tr>
+          <tr><td>Cold temperature</td><td><span class="better">Decreases DA</span></td><td>Shorter TO/landing, better climb</td></tr>
+          <tr><td>High pressure (high QNH)</td><td><span class="better">Decreases DA</span></td><td>Better performance</td></tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+
+  <div class="section-title">2. POH Chart Types</div>
+  <div class="grid-4">
+    <div class="card">
+      <div class="card-title">Takeoff Distance</div>
+      <div style="font-size:12px; color:#e8edf2; line-height:1.6;">Ground roll distance + distance to clear 50 ft obstacle. Variables: pressure altitude, temp, weight, wind, runway surface</div>
+    </div>
+    <div class="card">
+      <div class="card-title">Climb Performance</div>
+      <div style="font-size:12px; color:#e8edf2; line-height:1.6;">Best rate (Vy) and best angle (Vx) climb speeds and rates vs. pressure altitude and temperature</div>
+    </div>
+    <div class="card">
+      <div class="card-title">Cruise Performance</div>
+      <div style="font-size:12px; color:#e8edf2; line-height:1.6;">TAS, fuel flow at various power settings, altitudes, temps. Used for flight planning and range/endurance</div>
+    </div>
+    <div class="card">
+      <div class="card-title">Landing Distance</div>
+      <div style="font-size:12px; color:#e8edf2; line-height:1.6;">Ground roll + distance from 50 ft obstacle to stop. Variables: same as takeoff. Generally shorter than TO distances</div>
+    </div>
+  </div>
+
+  <div class="section-title">3. Performance Variables Summary</div>
+  <table>
+    <thead>
+      <tr><th>Variable</th><th>Change</th><th>Takeoff Distance</th><th>Landing Distance</th><th>Climb Rate</th></tr>
+    </thead>
+    <tbody>
+      <tr><td>Altitude / DA</td><td>Higher</td><td><span class="worse">Longer</span></td><td><span class="worse">Longer</span></td><td><span class="worse">Reduced</span></td></tr>
+      <tr><td>Temperature</td><td>Hotter</td><td><span class="worse">Longer</span></td><td><span class="worse">Longer</span></td><td><span class="worse">Reduced</span></td></tr>
+      <tr><td>Aircraft weight</td><td>Heavier</td><td><span class="worse">Longer</span></td><td><span class="worse">Longer</span></td><td><span class="worse">Reduced</span></td></tr>
+      <tr><td>Wind component</td><td>Headwind</td><td><span class="better">Shorter</span></td><td><span class="better">Shorter</span></td><td><span class="neutral">Slight benefit</span></td></tr>
+      <tr><td>Wind component</td><td>Tailwind</td><td><span class="worse">Longer</span></td><td><span class="worse">Longer</span></td><td><span class="neutral">—</span></td></tr>
+      <tr><td>Runway slope</td><td>Upslope</td><td><span class="worse">Longer</span></td><td><span class="better">Shorter</span></td><td><span class="neutral">—</span></td></tr>
+      <tr><td>Runway slope</td><td>Downslope</td><td><span class="better">Shorter</span></td><td><span class="worse">Longer</span></td><td><span class="neutral">—</span></td></tr>
+      <tr><td>Runway surface</td><td>Grass/soft/wet</td><td><span class="worse">Longer (10–25%)</span></td><td><span class="neutral">Can vary</span></td><td><span class="neutral">—</span></td></tr>
+      <tr><td>Flaps (takeoff)</td><td>Partial flap</td><td><span class="better">Shorter ground roll</span></td><td><span class="neutral">—</span></td><td><span class="neutral">Varies</span></td></tr>
+    </tbody>
+  </table>
+</div>
+</body>
+</html>

--- a/web-app/public/visuals/gk011-takeoff-landing-perf.html
+++ b/web-app/public/visuals/gk011-takeoff-landing-perf.html
@@ -1,0 +1,171 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>GK-011: Takeoff and Landing Performance</title>
+<style>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body { background: #0d1b2a; color: #e8edf2; font-family: 'Segoe UI', system-ui, sans-serif; padding: 32px; }
+  h1 { font-size: 22px; color: #f0c040; letter-spacing: 1px; margin-bottom: 6px; }
+  .subtitle { font-size: 13px; color: #7a9ab5; margin-bottom: 32px; letter-spacing: 0.5px; }
+  .container { max-width: 900px; margin: 0 auto; }
+  .section-title { font-size: 14px; color: #f0c040; letter-spacing: 1px; text-transform: uppercase; margin-bottom: 14px; margin-top: 32px; }
+  .layout { display: grid; grid-template-columns: 1fr 1fr; gap: 24px; align-items: start; }
+  .diagram-box { background: #1a2d3d; border: 1px solid #243d52; border-radius: 8px; padding: 16px; margin-bottom: 24px; }
+  svg text { font-family: 'Segoe UI', system-ui, sans-serif; }
+  table { width: 100%; border-collapse: collapse; margin-bottom: 20px; }
+  th { background: #1a2d3d; color: #f0c040; font-size: 12px; text-align: left; padding: 10px 14px; letter-spacing: 0.5px; }
+  td { font-size: 13px; color: #e8edf2; padding: 9px 14px; border-bottom: 1px solid #1a2d3d; vertical-align: top; }
+  tr:last-child td { border-bottom: none; }
+  .speeds-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 14px; margin-bottom: 24px; }
+  .speed-card { background: #1a2d3d; border: 1px solid #243d52; border-radius: 8px; padding: 14px; text-align: center; }
+  .speed-label { font-size: 22px; color: #f0c040; font-weight: bold; margin-bottom: 4px; }
+  .speed-name { font-size: 11px; color: #7a9ab5; margin-bottom: 8px; letter-spacing: 0.5px; }
+  .speed-desc { font-size: 12px; color: #e8edf2; line-height: 1.5; }
+  .note-box { background: #1a2d3d; border-left: 3px solid #f0c040; border-radius: 4px; padding: 14px 18px; margin-top: 20px; font-size: 13px; color: #e8edf2; line-height: 1.6; }
+</style>
+</head>
+<body>
+<div class="container">
+  <h1>GK-011 — Takeoff &amp; Landing Performance</h1>
+  <p class="subtitle">Transport Canada · TP 12880E · PPL Written Exam</p>
+
+  <div class="layout">
+    <!-- Takeoff diagram -->
+    <div class="diagram-box">
+      <svg viewBox="0 0 320 190" width="100%" height="170">
+        <defs>
+          <marker id="arrowT" markerWidth="7" markerHeight="7" refX="3.5" refY="3.5" orient="auto">
+            <polygon points="0,0 7,3.5 0,7" fill="#7a9ab5"/>
+          </marker>
+          <marker id="arrowTA" markerWidth="7" markerHeight="7" refX="3.5" refY="3.5" orient="auto">
+            <polygon points="0,0 7,3.5 0,7" fill="#f0c040"/>
+          </marker>
+        </defs>
+
+        <!-- Runway -->
+        <rect x="20" y="145" width="290" height="14" fill="#243d52" stroke="#7a9ab5" stroke-width="1"/>
+        <line x1="165" y1="145" x2="165" y2="159" stroke="white" stroke-width="1.5" stroke-dasharray="4,6"/>
+
+        <!-- Ground roll distance label -->
+        <line x1="20" y1="138" x2="180" y2="138" stroke="#4caf7d" stroke-width="1"/>
+        <line x1="20" y1="133" x2="20" y2="143" stroke="#4caf7d" stroke-width="1"/>
+        <line x1="180" y1="133" x2="180" y2="143" stroke="#4caf7d" stroke-width="1"/>
+        <text x="100" y="131" text-anchor="middle" fill="#4caf7d" font-size="9">Ground Roll</text>
+
+        <!-- 50 ft obstacle clearance line -->
+        <line x1="20" y1="85" x2="290" y2="85" stroke="#e05050" stroke-width="1" stroke-dasharray="4,3"/>
+        <text x="292" y="88" fill="#e05050" font-size="8">50 ft</text>
+
+        <!-- Takeoff profile (aircraft climbing) -->
+        <path d="M 40 145 Q 100 144 180 138 Q 220 120 280 70" fill="none" stroke="#f0c040" stroke-width="2"/>
+        <!-- Aircraft at rotation point -->
+        <circle cx="185" cy="136" r="5" fill="#f0c040"/>
+        <!-- Vr label -->
+        <text x="188" y="128" fill="#f0c040" font-size="8">Vr</text>
+
+        <!-- Total distance bracket -->
+        <line x1="20" y1="162" x2="280" y2="162" stroke="#5b9bd5" stroke-width="1"/>
+        <line x1="20" y1="157" x2="20" y2="167" stroke="#5b9bd5" stroke-width="1"/>
+        <line x1="280" y1="157" x2="280" y2="167" stroke="#5b9bd5" stroke-width="1"/>
+        <text x="150" y="176" text-anchor="middle" fill="#5b9bd5" font-size="9">Total Distance over 50 ft obstacle</text>
+
+        <!-- Title -->
+        <text x="160" y="20" text-anchor="middle" fill="#e8edf2" font-size="11" font-weight="bold">TAKEOFF PROFILE</text>
+        <text x="160" y="33" text-anchor="middle" fill="#7a9ab5" font-size="9">Normal TO with 10° flap</text>
+      </svg>
+    </div>
+
+    <!-- Landing diagram -->
+    <div class="diagram-box">
+      <svg viewBox="0 0 320 190" width="100%" height="170">
+        <defs>
+          <marker id="arrowL" markerWidth="7" markerHeight="7" refX="3.5" refY="3.5" orient="auto">
+            <polygon points="0,0 7,3.5 0,7" fill="#7a9ab5"/>
+          </marker>
+        </defs>
+
+        <!-- Runway -->
+        <rect x="100" y="145" width="200" height="14" fill="#243d52" stroke="#7a9ab5" stroke-width="1"/>
+
+        <!-- 50 ft threshold clearance -->
+        <line x1="20" y1="85" x2="320" y2="85" stroke="#e05050" stroke-width="1" stroke-dasharray="4,3"/>
+        <text x="292" y="88" fill="#e05050" font-size="8">50 ft</text>
+
+        <!-- Approach/landing profile -->
+        <path d="M 20 60 L 120 145" fill="none" stroke="#5b9bd5" stroke-width="2"/>
+        <!-- Flare and rollout -->
+        <path d="M 120 145 Q 180 144 280 145" fill="none" stroke="#4caf7d" stroke-width="2"/>
+
+        <!-- Threshold marker -->
+        <line x1="120" y1="140" x2="120" y2="165" stroke="white" stroke-width="2" stroke-dasharray="3,3"/>
+        <text x="115" y="178" text-anchor="middle" fill="#e8edf2" font-size="8">Threshold</text>
+
+        <!-- Touchdown point -->
+        <circle cx="150" cy="145" r="5" fill="#f0c040"/>
+        <text x="155" y="140" fill="#f0c040" font-size="8">TD</text>
+
+        <!-- Stop point -->
+        <line x1="280" y1="140" x2="280" y2="165" stroke="#e05050" stroke-width="2"/>
+        <text x="280" y="178" text-anchor="middle" fill="#e05050" font-size="8">Stop</text>
+
+        <!-- Ground roll -->
+        <line x1="150" y1="162" x2="280" y2="162" stroke="#f0c040" stroke-width="1"/>
+        <line x1="150" y1="157" x2="150" y2="167" stroke="#f0c040" stroke-width="1"/>
+        <line x1="280" y1="157" x2="280" y2="167" stroke="#f0c040" stroke-width="1"/>
+        <text x="215" y="176" text-anchor="middle" fill="#f0c040" font-size="9">Landing Roll</text>
+
+        <!-- Approach glide slope angle -->
+        <text x="55" y="55" text-anchor="middle" fill="#5b9bd5" font-size="8">~3° approach</text>
+
+        <!-- Title -->
+        <text x="160" y="20" text-anchor="middle" fill="#e8edf2" font-size="11" font-weight="bold">LANDING PROFILE</text>
+        <text x="160" y="33" text-anchor="middle" fill="#7a9ab5" font-size="9">Normal approach over 50 ft obstacle</text>
+      </svg>
+    </div>
+  </div>
+
+  <div class="section-title">Reference Speeds</div>
+  <div class="speeds-grid">
+    <div class="speed-card">
+      <div class="speed-label">Vr</div>
+      <div class="speed-name">ROTATION SPEED</div>
+      <div class="speed-desc">Speed at which pilot applies back pressure to lift nose off runway. Aircraft becomes airborne shortly after.</div>
+    </div>
+    <div class="speed-card">
+      <div class="speed-label">Vx</div>
+      <div class="speed-name">BEST ANGLE OF CLIMB</div>
+      <div class="speed-desc">Maximum altitude gain per unit of horizontal distance. Used for obstacle clearance after takeoff. Slower than Vy.</div>
+    </div>
+    <div class="speed-card">
+      <div class="speed-label">Vy</div>
+      <div class="speed-name">BEST RATE OF CLIMB</div>
+      <div class="speed-desc">Maximum altitude gain per unit of time (highest ft/min). Normal climb speed after clearing obstacles.</div>
+    </div>
+  </div>
+
+  <div class="section-title">Factors Affecting Performance</div>
+  <table>
+    <thead>
+      <tr><th>Factor</th><th>Takeoff Effect</th><th>Landing Effect</th></tr>
+    </thead>
+    <tbody>
+      <tr><td><strong>Higher weight</strong></td><td>Longer ground roll; higher Vr; reduced climb rate</td><td>Higher approach speed; longer landing roll</td></tr>
+      <tr><td><strong>Higher density altitude</strong></td><td>Significantly longer ground roll; reduced acceleration</td><td>Higher true airspeed at landing; longer roll</td></tr>
+      <tr><td><strong>Headwind</strong></td><td>Shorter ground roll (subtract ~10% ground roll per 10% headwind)</td><td>Shorter approach; shorter landing roll</td></tr>
+      <tr><td><strong>Tailwind</strong></td><td>Significantly longer ground roll (add ~20% per 10% headwind-equivalent)</td><td>Longer approach; much longer landing roll</td></tr>
+      <tr><td><strong>Upslope runway</strong></td><td>Longer takeoff roll (gravity opposing)</td><td>Shorter landing roll (gravity assisting braking)</td></tr>
+      <tr><td><strong>Downslope runway</strong></td><td>Shorter takeoff roll</td><td>Longer landing roll (gravity works against braking)</td></tr>
+      <tr><td><strong>Soft/grass surface</strong></td><td>Longer roll due to increased rolling resistance (+15–25%)</td><td>Shorter roll (surface friction increases stopping)</td></tr>
+      <tr><td><strong>Wet/icy surface</strong></td><td>Similar to soft; may reduce tire traction</td><td>Longer roll — reduced braking friction on wet/ice</td></tr>
+      <tr><td><strong>Flap setting</strong></td><td>Partial flap: shorter roll, lower Vr, better angle; full flap: may reduce performance</td><td>Full flap: steeper approach, shorter landing roll</td></tr>
+    </tbody>
+  </table>
+
+  <div class="note-box">
+    <strong>Rule of Thumb — Tailwind:</strong> A tailwind of 10% of liftoff speed approximately increases takeoff distance by <strong>20%</strong> and landing distance by <strong>10%</strong>. Exam questions often test tailwind penalty. Always use actual POH charts — never rely on rules of thumb for actual flight planning. V1 (decision speed) applies to multi-engine aircraft only; not relevant for single-engine PPL.
+  </div>
+</div>
+</body>
+</html>

--- a/web-app/public/visuals/gk012-stalls-spins.html
+++ b/web-app/public/visuals/gk012-stalls-spins.html
@@ -1,0 +1,183 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>GK-012: Stalls and Spins</title>
+<style>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body { background: #0d1b2a; color: #e8edf2; font-family: 'Segoe UI', system-ui, sans-serif; padding: 32px; }
+  h1 { font-size: 22px; color: #f0c040; letter-spacing: 1px; margin-bottom: 6px; }
+  .subtitle { font-size: 13px; color: #7a9ab5; margin-bottom: 32px; letter-spacing: 0.5px; }
+  .container { max-width: 900px; margin: 0 auto; }
+  .section-title { font-size: 14px; color: #f0c040; letter-spacing: 1px; text-transform: uppercase; margin-bottom: 14px; margin-top: 32px; }
+  .layout { display: grid; grid-template-columns: 1fr 1fr; gap: 24px; align-items: start; }
+  .diagram-box { background: #1a2d3d; border: 1px solid #243d52; border-radius: 8px; padding: 16px; }
+  svg text { font-family: 'Segoe UI', system-ui, sans-serif; }
+  table { width: 100%; border-collapse: collapse; margin-bottom: 20px; }
+  th { background: #1a2d3d; color: #f0c040; font-size: 12px; text-align: left; padding: 10px 14px; letter-spacing: 0.5px; }
+  td { font-size: 13px; color: #e8edf2; padding: 9px 14px; border-bottom: 1px solid #1a2d3d; vertical-align: top; }
+  tr:last-child td { border-bottom: none; }
+  .recovery-steps { background: #1a2d3d; border: 1px solid #243d52; border-radius: 8px; padding: 16px; }
+  .step { display: flex; gap: 12px; margin-bottom: 12px; align-items: flex-start; }
+  .step:last-child { margin-bottom: 0; }
+  .step-num { background: #f0c040; color: #0d1b2a; font-weight: bold; font-size: 12px; width: 24px; height: 24px; border-radius: 50%; display: flex; align-items: center; justify-content: center; flex-shrink: 0; }
+  .step-text { font-size: 13px; color: #e8edf2; line-height: 1.5; }
+  .step-label { color: #f0c040; font-weight: bold; }
+  .pare-box { background: #0d2040; border: 2px solid #f0c040; border-radius: 8px; padding: 16px; margin-top: 16px; }
+  .pare-title { font-size: 13px; color: #f0c040; font-weight: bold; margin-bottom: 10px; letter-spacing: 1px; }
+  .pare-row { display: flex; gap: 10px; align-items: center; margin-bottom: 8px; font-size: 13px; }
+  .pare-letter { font-size: 22px; color: #f0c040; font-weight: bold; width: 28px; flex-shrink: 0; }
+  .note-box { background: #1a2d3d; border-left: 3px solid #e05050; border-radius: 4px; padding: 14px 18px; margin-top: 20px; font-size: 13px; color: #e8edf2; line-height: 1.6; }
+</style>
+</head>
+<body>
+<div class="container">
+  <h1>GK-012 — Stalls &amp; Spins</h1>
+  <p class="subtitle">Transport Canada · TP 12880E · PPL Written Exam</p>
+
+  <div class="layout">
+    <!-- Airfoil stall diagram -->
+    <div class="diagram-box">
+      <svg viewBox="0 0 300 220" width="100%" height="200">
+        <!-- Title -->
+        <text x="150" y="16" text-anchor="middle" fill="#e8edf2" font-size="10" font-weight="bold">AIRFOIL: Normal vs. Stalled Flow</text>
+
+        <!-- === Normal airflow === -->
+        <text x="10" y="36" fill="#4caf7d" font-size="9">NORMAL FLOW (low AoA)</text>
+
+        <!-- Airfoil shape (normal AoA ~4°) -->
+        <path d="M 30 75 Q 80 45 160 50 Q 220 52 240 70 Q 220 80 160 78 Q 80 75 30 75 Z" fill="#1e3a50" stroke="#7a9ab5" stroke-width="1.5"/>
+
+        <!-- Smooth flow lines top -->
+        <path d="M 15 52 Q 100 35 250 55" fill="none" stroke="#4caf7d" stroke-width="1.2"/>
+        <path d="M 15 58 Q 100 40 250 62" fill="none" stroke="#4caf7d" stroke-width="1.2"/>
+        <!-- Bottom flow -->
+        <path d="M 15 80 Q 100 85 250 75" fill="none" stroke="#4caf7d" stroke-width="1.2"/>
+        <path d="M 15 86 Q 100 92 250 82" fill="none" stroke="#4caf7d" stroke-width="1.2"/>
+
+        <!-- Relative wind arrow -->
+        <defs>
+          <marker id="arrowST" markerWidth="7" markerHeight="7" refX="3.5" refY="3.5" orient="auto">
+            <polygon points="0,0 7,3.5 0,7" fill="#7a9ab5"/>
+          </marker>
+          <marker id="arrowRW" markerWidth="7" markerHeight="7" refX="3.5" refY="3.5" orient="auto">
+            <polygon points="0,0 7,3.5 0,7" fill="#5b9bd5"/>
+          </marker>
+        </defs>
+        <line x1="10" y1="68" x2="28" y2="74" stroke="#5b9bd5" stroke-width="2" marker-end="url(#arrowRW)"/>
+        <text x="8" y="62" fill="#5b9bd5" font-size="8">Rel.</text>
+        <text x="8" y="72" fill="#5b9bd5" font-size="8">Wind</text>
+
+        <!-- Lift arrow (normal) -->
+        <line x1="135" y1="48" x2="135" y2="30" stroke="#f0c040" stroke-width="2" marker-end="url(#arrowST)"/>
+        <text x="142" y="30" fill="#f0c040" font-size="8">LIFT</text>
+
+        <!-- === Stalled airflow === -->
+        <text x="10" y="108" fill="#e05050" font-size="9">STALLED FLOW (high AoA ~15-18°)</text>
+
+        <!-- Airfoil at high AoA -->
+        <path d="M 30 165 Q 60 130 130 125 Q 200 122 240 145 Q 200 160 130 158 Q 60 162 30 165 Z" fill="#1e3a50" stroke="#e05050" stroke-width="1.5"/>
+
+        <!-- Separated flow (turbulent) on top surface -->
+        <path d="M 60 125 Q 70 108 80 118 Q 90 105 100 115 Q 115 100 125 112 Q 140 98 155 110 Q 170 98 185 108" fill="none" stroke="#e05050" stroke-width="1.2" stroke-dasharray="3,2"/>
+        <path d="M 55 128 Q 65 112 75 122 Q 88 108 98 120 Q 113 106 128 118 Q 145 104 160 116" fill="none" stroke="#e05050" stroke-width="1.2" stroke-dasharray="3,2"/>
+
+        <!-- Smooth flow below -->
+        <path d="M 20 170 Q 100 178 250 162" fill="none" stroke="#4caf7d" stroke-width="1.2"/>
+
+        <!-- Separation point indicator -->
+        <line x1="65" y1="128" x2="62" y2="138" stroke="#f0c040" stroke-width="1.5"/>
+        <text x="40" y="150" fill="#f0c040" font-size="8">Separation</text>
+        <text x="40" y="160" fill="#f0c040" font-size="8">point</text>
+
+        <!-- Critical AoA label -->
+        <text x="240" y="130" fill="#e05050" font-size="8">Critical</text>
+        <text x="240" y="140" fill="#e05050" font-size="8">AoA ~15°</text>
+
+        <!-- Relative wind arrow for stall -->
+        <line x1="8" y1="156" x2="28" y2="165" stroke="#5b9bd5" stroke-width="2" marker-end="url(#arrowRW)"/>
+
+        <!-- Reduced lift at stall -->
+        <line x1="135" y1="125" x2="135" y2="112" stroke="#e05050" stroke-width="2" marker-end="url(#arrowST)"/>
+        <text x="142" y="114" fill="#e05050" font-size="8">↓ LIFT</text>
+      </svg>
+    </div>
+
+    <div>
+      <!-- Stall recovery -->
+      <div class="section-title" style="margin-top:0;">Stall Recovery Steps</div>
+      <div class="recovery-steps">
+        <div class="step">
+          <div class="step-num">1</div>
+          <div class="step-text"><span class="step-label">Reduce AoA</span> — push forward on the yoke/stick to lower nose and reduce angle of attack. This is the most critical step.</div>
+        </div>
+        <div class="step">
+          <div class="step-num">2</div>
+          <div class="step-text"><span class="step-label">Apply Full Power</span> — advance throttle to maximum to minimize altitude loss and enable recovery.</div>
+        </div>
+        <div class="step">
+          <div class="step-num">3</div>
+          <div class="step-text"><span class="step-label">Level the Wings</span> — use coordinated aileron and rudder to roll wings level. Avoid excessive aileron if still near stall speed.</div>
+        </div>
+        <div class="step">
+          <div class="step-num">4</div>
+          <div class="step-text"><span class="step-label">Recover Altitude</span> — once airspeed builds above Vs, gently raise nose to level/climb attitude. Avoid secondary stall.</div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="section-title">Spin Phases &amp; Recovery (PARE)</div>
+  <div class="layout">
+    <div>
+      <table>
+        <thead>
+          <tr><th>Spin Phase</th><th>Description</th></tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><strong>Incipient</strong></td>
+            <td>First 1–2 turns. Stall combined with yaw. Aircraft enters autorotation. Recovery is easy at this stage.</td>
+          </tr>
+          <tr>
+            <td><strong>Developed</strong></td>
+            <td>Stable autorotation established. Nose pitched steeply down. Requires specific PARE procedure to recover.</td>
+          </tr>
+          <tr>
+            <td><strong>Recovery</strong></td>
+            <td>PARE applied → rotation stops → pull out of dive. Allow full stop of rotation before pulling out.</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <div>
+      <div class="pare-box">
+        <div class="pare-title">PARE — Spin Recovery Procedure</div>
+        <div class="pare-row"><div class="pare-letter">P</div><div><strong>Power</strong> — Throttle to IDLE. Power increases spin rate.</div></div>
+        <div class="pare-row"><div class="pare-letter">A</div><div><strong>Ailerons</strong> — Neutral. Ailerons worsen spin entry.</div></div>
+        <div class="pare-row"><div class="pare-letter">R</div><div><strong>Rudder</strong> — Full OPPOSITE to spin direction (stop rotation).</div></div>
+        <div class="pare-row"><div class="pare-letter">E</div><div><strong>Elevator</strong> — Briskly FORWARD to break stall, then recover from dive.</div></div>
+      </div>
+    </div>
+  </div>
+
+  <div class="section-title">Stall Speed Reference</div>
+  <table>
+    <thead>
+      <tr><th>Speed</th><th>Definition</th><th>Note</th></tr>
+    </thead>
+    <tbody>
+      <tr><td><strong>Vso</strong></td><td>Stall speed in landing configuration (full flaps, gear down)</td><td>Bottom of white arc on ASI</td></tr>
+      <tr><td><strong>Vs1</strong></td><td>Stall speed in clean configuration (flaps up)</td><td>Bottom of green arc on ASI</td></tr>
+      <tr><td><strong>Critical AoA</strong></td><td>~15–18° for most light aircraft — beyond this lift decreases sharply</td><td>Same regardless of airspeed/weight/attitude</td></tr>
+      <tr><td><strong>Load Factor Effect</strong></td><td>Stall speed increases with bank angle and load factor</td><td>At 60° bank: stall speed = Vs × √2 ≈ 1.41 × Vs</td></tr>
+    </tbody>
+  </table>
+
+  <div class="note-box">
+    <strong>Critical Concept:</strong> A stall occurs when the <strong>critical angle of attack is exceeded</strong> — not necessarily at low airspeed. An aircraft can stall at any airspeed, any attitude, any power setting. Stall recognition cues: buffet, mushy controls, stall warning horn (if installed), high deck angle with low airspeed. Never attempt to stop a wing drop in a stall with aileron alone — use rudder to prevent spin entry.
+  </div>
+</div>
+</body>
+</html>

--- a/web-app/public/visuals/gk013-load-factor.html
+++ b/web-app/public/visuals/gk013-load-factor.html
@@ -1,0 +1,183 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>GK-013: Load Factor and Maneuvering Speed</title>
+<style>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body { background: #0d1b2a; color: #e8edf2; font-family: 'Segoe UI', system-ui, sans-serif; padding: 32px; }
+  h1 { font-size: 22px; color: #f0c040; letter-spacing: 1px; margin-bottom: 6px; }
+  .subtitle { font-size: 13px; color: #7a9ab5; margin-bottom: 32px; letter-spacing: 0.5px; }
+  .container { max-width: 900px; margin: 0 auto; }
+  .section-title { font-size: 14px; color: #f0c040; letter-spacing: 1px; text-transform: uppercase; margin-bottom: 14px; margin-top: 32px; }
+  .layout { display: grid; grid-template-columns: 1fr 1fr; gap: 24px; align-items: start; }
+  .diagram-box { background: #1a2d3d; border: 1px solid #243d52; border-radius: 8px; padding: 16px; }
+  svg text { font-family: 'Segoe UI', system-ui, sans-serif; }
+  table { width: 100%; border-collapse: collapse; margin-bottom: 20px; }
+  th { background: #1a2d3d; color: #f0c040; font-size: 12px; text-align: left; padding: 10px 14px; letter-spacing: 0.5px; }
+  td { font-size: 13px; color: #e8edf2; padding: 9px 14px; border-bottom: 1px solid #1a2d3d; vertical-align: top; }
+  tr:last-child td { border-bottom: none; }
+  .bank-grid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 12px; margin-bottom: 24px; }
+  .bank-card { background: #1a2d3d; border: 1px solid #243d52; border-radius: 8px; padding: 14px; text-align: center; }
+  .bank-angle { font-size: 20px; color: #f0c040; font-weight: bold; margin-bottom: 2px; }
+  .bank-bank { font-size: 11px; color: #7a9ab5; margin-bottom: 8px; }
+  .bank-g { font-size: 16px; color: #4caf7d; font-weight: bold; }
+  .bank-g-label { font-size: 10px; color: #7a9ab5; }
+  .note-box { background: #1a2d3d; border-left: 3px solid #f0c040; border-radius: 4px; padding: 14px 18px; margin-top: 20px; font-size: 13px; color: #e8edf2; line-height: 1.6; }
+  .limit-normal { color: #4caf7d; font-weight: bold; }
+  .limit-utility { color: #f0c040; font-weight: bold; }
+  .limit-acro { color: #e05050; font-weight: bold; }
+</style>
+</head>
+<body>
+<div class="container">
+  <h1>GK-013 — Load Factor &amp; Maneuvering Speed</h1>
+  <p class="subtitle">Transport Canada · TP 12880E · PPL Written Exam</p>
+
+  <div class="layout">
+    <!-- V-n diagram -->
+    <div class="diagram-box">
+      <svg viewBox="0 0 310 260" width="100%" height="240">
+        <defs>
+          <marker id="arrowVN" markerWidth="7" markerHeight="7" refX="3.5" refY="3.5" orient="auto">
+            <polygon points="0,0 7,3.5 0,7" fill="#7a9ab5"/>
+          </marker>
+        </defs>
+
+        <!-- Axes -->
+        <line x1="55" y1="200" x2="55" y2="20" stroke="#7a9ab5" stroke-width="1.5" marker-end="url(#arrowVN)"/>
+        <line x1="55" y1="130" x2="295" y2="130" stroke="#7a9ab5" stroke-width="1.5" marker-end="url(#arrowVN)"/>
+
+        <!-- Axis labels -->
+        <text x="20" y="115" text-anchor="middle" fill="#7a9ab5" font-size="9" transform="rotate(-90,20,115)">Load Factor (g)</text>
+        <text x="175" y="250" text-anchor="middle" fill="#7a9ab5" font-size="9">Airspeed (KIAS)</text>
+
+        <!-- Y axis ticks and labels -->
+        <!-- Zero line is at y=130 -->
+        <!-- +1g at y=100, +2g at y=70, +3.8g at y=40, -1.52g at y=160, -2g at y=190 -->
+        <line x1="50" y1="100" x2="60" y2="100" stroke="#7a9ab5" stroke-width="1"/>
+        <text x="46" y="103" text-anchor="end" fill="#7a9ab5" font-size="8">+1g</text>
+        <line x1="50" y1="70" x2="60" y2="70" stroke="#7a9ab5" stroke-width="1"/>
+        <text x="46" y="73" text-anchor="end" fill="#7a9ab5" font-size="8">+2g</text>
+        <line x1="50" y1="40" x2="60" y2="40" stroke="#7a9ab5" stroke-width="1"/>
+        <text x="46" y="43" text-anchor="end" fill="#f0c040" font-size="8">+3.8g</text>
+        <line x1="50" y1="160" x2="60" y2="160" stroke="#7a9ab5" stroke-width="1"/>
+        <text x="46" y="163" text-anchor="end" fill="#7a9ab5" font-size="8">-1g</text>
+        <line x1="50" y1="185" x2="60" y2="185" stroke="#7a9ab5" stroke-width="1"/>
+        <text x="46" y="188" text-anchor="end" fill="#f0c040" font-size="8">-1.52g</text>
+
+        <!-- Zero load line label -->
+        <text x="46" y="133" text-anchor="end" fill="#7a9ab5" font-size="8">0g</text>
+
+        <!-- X axis ticks (Vs=80, Va=108, Vno=160, Vne=180) -->
+        <line x1="85" y1="125" x2="85" y2="135" stroke="#7a9ab5" stroke-width="1"/>
+        <text x="85" y="145" text-anchor="middle" fill="#7a9ab5" font-size="7">Vs</text>
+        <line x1="135" y1="125" x2="135" y2="135" stroke="#7a9ab5" stroke-width="1"/>
+        <text x="135" y="145" text-anchor="middle" fill="#4caf7d" font-size="7">Va</text>
+        <line x1="210" y1="125" x2="210" y2="135" stroke="#7a9ab5" stroke-width="1"/>
+        <text x="210" y="145" text-anchor="middle" fill="#f0c040" font-size="7">Vno</text>
+        <line x1="255" y1="125" x2="255" y2="135" stroke="#7a9ab5" stroke-width="1"/>
+        <text x="255" y="145" text-anchor="middle" fill="#e05050" font-size="7">Vne</text>
+
+        <!-- Positive stall line (curved from Vs at 1g up to Va at 3.8g) -->
+        <path d="M 85 100 Q 100 80 135 40" fill="none" stroke="#4caf7d" stroke-width="2"/>
+
+        <!-- Positive structural limit line (horizontal from Va to Vno at +3.8g) -->
+        <line x1="135" y1="40" x2="210" y2="40" stroke="#4caf7d" stroke-width="2"/>
+
+        <!-- Caution range (Vno to Vne) at +3.8g sloping down to Vne -->
+        <line x1="210" y1="40" x2="255" y2="40" stroke="#f0c040" stroke-width="2" stroke-dasharray="5,3"/>
+
+        <!-- Vne vertical line (red) -->
+        <line x1="255" y1="25" x2="255" y2="195" stroke="#e05050" stroke-width="2"/>
+        <text x="260" y="30" fill="#e05050" font-size="8">Vne</text>
+
+        <!-- Negative stall line -->
+        <path d="M 85 160 Q 100 175 135 185" fill="none" stroke="#5b9bd5" stroke-width="2"/>
+
+        <!-- Negative structural limit line -->
+        <line x1="135" y1="185" x2="255" y2="185" stroke="#5b9bd5" stroke-width="2"/>
+
+        <!-- Maneuvering envelope fill -->
+        <polygon points="85,100 135,40 210,40 255,40 255,185 135,185 85,160" fill="#0d2a40" stroke="none" opacity="0.5"/>
+
+        <!-- Normal ops boundary (Vno vertical) -->
+        <line x1="210" y1="35" x2="210" y2="195" stroke="#f0c040" stroke-width="1.5" stroke-dasharray="4,3"/>
+
+        <!-- Va marking -->
+        <line x1="135" y1="25" x2="135" y2="195" stroke="#4caf7d" stroke-width="1.5" stroke-dasharray="3,3"/>
+
+        <!-- Labels in envelope -->
+        <text x="155" y="90" text-anchor="middle" fill="#4caf7d" font-size="9">NORMAL</text>
+        <text x="155" y="100" text-anchor="middle" fill="#4caf7d" font-size="9">ENVELOPE</text>
+        <text x="232" y="75" text-anchor="middle" fill="#f0c040" font-size="8">CAUTION</text>
+        <text x="232" y="85" text-anchor="middle" fill="#f0c040" font-size="8">smooth air</text>
+        <text x="232" y="95" text-anchor="middle" fill="#f0c040" font-size="8">only</text>
+
+        <!-- Title -->
+        <text x="170" y="15" text-anchor="middle" fill="#e8edf2" font-size="10" font-weight="bold">V-n (Velocity–Load Factor) Diagram</text>
+      </svg>
+    </div>
+
+    <div>
+      <div class="section-title" style="margin-top:0;">Load Factor by Bank Angle</div>
+      <div class="bank-grid">
+        <div class="bank-card">
+          <div class="bank-angle">0°</div>
+          <div class="bank-bank">Level flight</div>
+          <div class="bank-g">1.00g</div>
+          <div class="bank-g-label">Normal</div>
+        </div>
+        <div class="bank-card">
+          <div class="bank-angle">30°</div>
+          <div class="bank-bank">Shallow bank</div>
+          <div class="bank-g">1.15g</div>
+          <div class="bank-g-label">Slight increase</div>
+        </div>
+        <div class="bank-card">
+          <div class="bank-angle">45°</div>
+          <div class="bank-bank">Medium bank</div>
+          <div class="bank-g">1.41g</div>
+          <div class="bank-g-label">√2</div>
+        </div>
+        <div class="bank-card">
+          <div class="bank-angle">60°</div>
+          <div class="bank-bank">Steep bank</div>
+          <div class="bank-g" style="color:#f0c040;">2.00g</div>
+          <div class="bank-g-label">Double weight!</div>
+        </div>
+      </div>
+
+      <div class="section-title">Category Limit Load Factors</div>
+      <table>
+        <thead>
+          <tr><th>Category</th><th>Positive Limit</th><th>Negative Limit</th></tr>
+        </thead>
+        <tbody>
+          <tr><td><span class="limit-normal">Normal (N)</span></td><td>+3.8g</td><td>−1.52g</td></tr>
+          <tr><td><span class="limit-utility">Utility (U)</span></td><td>+4.4g</td><td>−1.76g</td></tr>
+          <tr><td><span class="limit-acro">Aerobatic (A)</span></td><td>+6.0g</td><td>−3.0g</td></tr>
+        </tbody>
+      </table>
+
+      <div class="section-title">Critical Speed Definitions</div>
+      <table>
+        <thead>
+          <tr><th>Speed</th><th>Name</th><th>Significance</th></tr>
+        </thead>
+        <tbody>
+          <tr><td><strong style="color:#4caf7d;">Va</strong></td><td>Design Maneuvering Speed</td><td>At or below Va, full control inputs won't overstress the aircraft — it will stall first</td></tr>
+          <tr><td><strong style="color:#f0c040;">Vno</strong></td><td>Max Structural Cruise Speed</td><td>Top of green arc — do not exceed in rough/turbulent air</td></tr>
+          <tr><td><strong style="color:#e05050;">Vne</strong></td><td>Never Exceed Speed</td><td>Red line on ASI — structural failure risk above this</td></tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+
+  <div class="note-box">
+    <strong>Maneuvering Speed (Va) Rule:</strong> Va decreases as aircraft weight decreases. A lighter aircraft will reach critical load factor at a lower airspeed. In turbulence, <strong>slow to Va or below</strong> and avoid large, abrupt control inputs. The formula for bank load factor: <strong>LF = 1 / cos(bank angle)</strong>. At 60° bank, LF = 1/cos(60°) = 1/0.5 = 2g — and stall speed increases by √2 ≈ 41%.
+  </div>
+</div>
+</body>
+</html>

--- a/web-app/public/visuals/gk014-preflight-inspection.html
+++ b/web-app/public/visuals/gk014-preflight-inspection.html
@@ -1,0 +1,188 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>GK-014: Preflight Inspection</title>
+<style>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body { background: #0d1b2a; color: #e8edf2; font-family: 'Segoe UI', system-ui, sans-serif; padding: 32px; }
+  h1 { font-size: 22px; color: #f0c040; letter-spacing: 1px; margin-bottom: 6px; }
+  .subtitle { font-size: 13px; color: #7a9ab5; margin-bottom: 32px; letter-spacing: 0.5px; }
+  .container { max-width: 900px; margin: 0 auto; }
+  .section-title { font-size: 14px; color: #f0c040; letter-spacing: 1px; text-transform: uppercase; margin-bottom: 14px; margin-top: 32px; }
+  .layout { display: grid; grid-template-columns: 1fr 1fr; gap: 24px; align-items: start; }
+  .diagram-box { background: #1a2d3d; border: 1px solid #243d52; border-radius: 8px; padding: 16px; }
+  svg text { font-family: 'Segoe UI', system-ui, sans-serif; }
+  table { width: 100%; border-collapse: collapse; margin-bottom: 20px; }
+  th { background: #1a2d3d; color: #f0c040; font-size: 12px; text-align: left; padding: 10px 14px; letter-spacing: 0.5px; }
+  td { font-size: 12px; color: #e8edf2; padding: 8px 12px; border-bottom: 1px solid #1a2d3d; vertical-align: top; }
+  tr:last-child td { border-bottom: none; }
+  .zone-num { display: inline-flex; align-items: center; justify-content: center; width: 22px; height: 22px; background: #f0c040; color: #0d1b2a; border-radius: 50%; font-size: 11px; font-weight: bold; margin-right: 6px; flex-shrink: 0; }
+  .zone-title { display: flex; align-items: center; font-size: 13px; color: #f0c040; font-weight: bold; margin-bottom: 6px; }
+  .checklist-item { font-size: 12px; color: #e8edf2; padding: 3px 0 3px 28px; display: flex; align-items: flex-start; gap: 6px; }
+  .check-box { width: 12px; height: 12px; border: 1px solid #7a9ab5; border-radius: 2px; flex-shrink: 0; margin-top: 1px; }
+  .zone-card { background: #1a2d3d; border: 1px solid #243d52; border-radius: 8px; padding: 14px; margin-bottom: 14px; }
+  .arrow-box { background: #0d2040; border: 2px solid #f0c040; border-radius: 8px; padding: 16px; margin-top: 16px; }
+  .arrow-title { font-size: 13px; color: #f0c040; font-weight: bold; letter-spacing: 1px; margin-bottom: 10px; }
+  .arrow-row { display: flex; gap: 10px; align-items: center; margin-bottom: 8px; font-size: 13px; }
+  .arrow-letter { font-size: 22px; color: #f0c040; font-weight: bold; width: 28px; flex-shrink: 0; }
+  .note-box { background: #1a2d3d; border-left: 3px solid #4caf7d; border-radius: 4px; padding: 14px 18px; margin-top: 20px; font-size: 13px; color: #e8edf2; line-height: 1.6; }
+</style>
+</head>
+<body>
+<div class="container">
+  <h1>GK-014 — Preflight Inspection Walkaround</h1>
+  <p class="subtitle">Transport Canada · TP 12880E · PPL Written Exam</p>
+
+  <div class="layout">
+    <!-- Aircraft diagram with numbered stations -->
+    <div class="diagram-box">
+      <svg viewBox="0 0 310 300" width="100%" height="280">
+
+        <!-- Top-down aircraft silhouette -->
+        <!-- Fuselage -->
+        <ellipse cx="155" cy="155" rx="20" ry="88" fill="#1e3a50" stroke="#7a9ab5" stroke-width="1.5"/>
+        <!-- Left wing -->
+        <polygon points="135,130 38,160 38,175 135,172" fill="#1e3a50" stroke="#7a9ab5" stroke-width="1.5"/>
+        <!-- Right wing -->
+        <polygon points="175,130 272,160 272,175 175,172" fill="#1e3a50" stroke="#7a9ab5" stroke-width="1.5"/>
+        <!-- Left aileron -->
+        <polygon points="42,161 70,158 70,169 42,172" fill="#243d52" stroke="#7a9ab5" stroke-width="1"/>
+        <!-- Right aileron -->
+        <polygon points="240,159 268,161 268,172 240,168" fill="#243d52" stroke="#7a9ab5" stroke-width="1"/>
+        <!-- Left HS -->
+        <polygon points="135,222 88,236 88,245 135,240" fill="#1e3a50" stroke="#7a9ab5" stroke-width="1.5"/>
+        <!-- Right HS -->
+        <polygon points="175,222 222,236 222,245 175,240" fill="#1e3a50" stroke="#7a9ab5" stroke-width="1.5"/>
+        <!-- Left elevator -->
+        <polygon points="92,237 116,234 116,243 92,244" fill="#243d52" stroke="#7a9ab5" stroke-width="1"/>
+        <!-- Right elevator -->
+        <polygon points="194,234 218,237 218,244 194,243" fill="#243d52" stroke="#7a9ab5" stroke-width="1"/>
+        <!-- V-fin -->
+        <rect x="149" y="228" width="12" height="30" fill="#243d52" stroke="#7a9ab5" stroke-width="1"/>
+        <!-- Prop disc -->
+        <ellipse cx="155" cy="62" rx="36" ry="8" fill="none" stroke="#7a9ab5" stroke-width="1" stroke-dasharray="3,3"/>
+        <!-- Nose -->
+        <ellipse cx="155" cy="62" rx="10" ry="10" fill="#1e3a50" stroke="#7a9ab5" stroke-width="1.5"/>
+
+        <!-- Walkaround direction arrow (dashed circle) -->
+        <path d="M 155 260 A 120 120 0 1 0 154 260" fill="none" stroke="#f0c040" stroke-width="1" stroke-dasharray="3,4" opacity="0.4"/>
+
+        <!-- Station markers with numbers -->
+        <!-- 1: Cockpit (inside) - center -->
+        <circle cx="155" cy="148" r="12" fill="#0d1b2a" stroke="#f0c040" stroke-width="2"/>
+        <text x="155" y="153" text-anchor="middle" fill="#f0c040" font-size="11" font-weight="bold">1</text>
+        <text x="155" y="120" text-anchor="middle" fill="#f0c040" font-size="8">COCKPIT</text>
+
+        <!-- 2: Left wing tip -->
+        <circle cx="25" cy="168" r="10" fill="#0d1b2a" stroke="#4caf7d" stroke-width="2"/>
+        <text x="25" y="172" text-anchor="middle" fill="#4caf7d" font-size="11" font-weight="bold">2</text>
+
+        <!-- 3: Nose -->
+        <circle cx="155" cy="40" r="10" fill="#0d1b2a" stroke="#5b9bd5" stroke-width="2"/>
+        <text x="155" y="44" text-anchor="middle" fill="#5b9bd5" font-size="11" font-weight="bold">3</text>
+
+        <!-- 4: Right wing tip -->
+        <circle cx="285" cy="168" r="10" fill="#0d1b2a" stroke="#4caf7d" stroke-width="2"/>
+        <text x="285" y="172" text-anchor="middle" fill="#4caf7d" font-size="11" font-weight="bold">4</text>
+
+        <!-- 5: Empennage -->
+        <circle cx="155" cy="278" r="10" fill="#0d1b2a" stroke="#f0a040" stroke-width="2"/>
+        <text x="155" y="282" text-anchor="middle" fill="#f0a040" font-size="11" font-weight="bold">5</text>
+
+        <!-- 6: Left main gear -->
+        <circle cx="90" cy="200" r="8" fill="#0d1b2a" stroke="#7a9ab5" stroke-width="1.5"/>
+        <text x="90" y="204" text-anchor="middle" fill="#7a9ab5" font-size="10" font-weight="bold">6</text>
+
+        <!-- 7: Right main gear -->
+        <circle cx="220" cy="200" r="8" fill="#0d1b2a" stroke="#7a9ab5" stroke-width="1.5"/>
+        <text x="220" y="204" text-anchor="middle" fill="#7a9ab5" font-size="10" font-weight="bold">7</text>
+
+        <!-- Left fuel point -->
+        <circle cx="65" cy="145" r="6" fill="#0d1b2a" stroke="#e8edf2" stroke-width="1"/>
+        <text x="65" y="149" text-anchor="middle" fill="#e8edf2" font-size="8" font-weight="bold">F</text>
+
+        <!-- Right fuel point -->
+        <circle cx="245" cy="145" r="6" fill="#0d1b2a" stroke="#e8edf2" stroke-width="1"/>
+        <text x="245" y="149" text-anchor="middle" fill="#e8edf2" font-size="8" font-weight="bold">F</text>
+
+        <!-- Legend -->
+        <rect x="10" y="8" width="8" height="8" rx="2" fill="#0d1b2a" stroke="#f0c040" stroke-width="1.5"/>
+        <text x="22" y="16" fill="#f0c040" font-size="7">Inspection zone</text>
+        <rect x="10" y="20" width="8" height="8" rx="2" fill="#0d1b2a" stroke="#e8edf2" stroke-width="1"/>
+        <text x="22" y="28" fill="#e8edf2" font-size="7">F = Fuel sump drain</text>
+      </svg>
+    </div>
+
+    <!-- Checklist by zone -->
+    <div>
+      <div class="zone-card">
+        <div class="zone-title"><span class="zone-num">1</span> Cockpit / Pre-Walk</div>
+        <div class="checklist-item"><div class="check-box"></div>Documents check (ARROW — see below)</div>
+        <div class="checklist-item"><div class="check-box"></div>Fuel quantity — check gauges vs. visual</div>
+        <div class="checklist-item"><div class="check-box"></div>Oil quantity — dipstick check (min qty)</div>
+        <div class="checklist-item"><div class="check-box"></div>Flight controls — free and correct</div>
+        <div class="checklist-item"><div class="check-box"></div>Instruments, switches, circuit breakers</div>
+        <div class="checklist-item"><div class="check-box"></div>Brakes — set parking brake</div>
+      </div>
+
+      <div class="zone-card">
+        <div class="zone-title"><span class="zone-num">2</span> Left Wing</div>
+        <div class="checklist-item"><div class="check-box"></div>Fuel cap — secure; correct colour fuel</div>
+        <div class="checklist-item"><div class="check-box"></div>Fuel sump drain — check for water</div>
+        <div class="checklist-item"><div class="check-box"></div>Leading edge — no dents, damage</div>
+        <div class="checklist-item"><div class="check-box"></div>Aileron — hinges, freedom of movement</div>
+        <div class="checklist-item"><div class="check-box"></div>Flap — condition, attachment</div>
+        <div class="checklist-item"><div class="check-box"></div>Navigation light — lens intact</div>
+        <div class="checklist-item"><div class="check-box"></div>Left main gear — tire condition, wear</div>
+      </div>
+
+      <div class="zone-card">
+        <div class="zone-title"><span class="zone-num">3</span> Nose / Engine</div>
+        <div class="checklist-item"><div class="check-box"></div>Propeller — nicks, cracks, security</div>
+        <div class="checklist-item"><div class="check-box"></div>Spinner — secure</div>
+        <div class="checklist-item"><div class="check-box"></div>Oil level — correct grade, no leaks</div>
+        <div class="checklist-item"><div class="check-box"></div>Cowling — latched, no damage</div>
+        <div class="checklist-item"><div class="check-box"></div>Nose gear / nosewheel — tire, strut</div>
+        <div class="checklist-item"><div class="check-box"></div>Air inlets — clear of obstructions</div>
+        <div class="checklist-item"><div class="check-box"></div>Pitot tube — clear of insects/covers</div>
+      </div>
+
+      <div class="zone-card">
+        <div class="zone-title"><span class="zone-num">4</span> Right Wing</div>
+        <div class="checklist-item"><div class="check-box"></div>Mirror of left wing checks</div>
+        <div class="checklist-item"><div class="check-box"></div>Fuel sump drain — check for water</div>
+        <div class="checklist-item"><div class="check-box"></div>Fuel cap — secure</div>
+        <div class="checklist-item"><div class="check-box"></div>Right main gear — tire, brake</div>
+      </div>
+
+      <div class="zone-card">
+        <div class="zone-title"><span class="zone-num">5</span> Empennage (Tail)</div>
+        <div class="checklist-item"><div class="check-box"></div>Horizontal stabilizer — no damage</div>
+        <div class="checklist-item"><div class="check-box"></div>Elevators — free movement, no play</div>
+        <div class="checklist-item"><div class="check-box"></div>Trim tab — condition and attachment</div>
+        <div class="checklist-item"><div class="check-box"></div>Vertical fin — condition</div>
+        <div class="checklist-item"><div class="check-box"></div>Rudder — movement, hinges</div>
+        <div class="checklist-item"><div class="check-box"></div>Antennas — secure, no damage</div>
+        <div class="checklist-item"><div class="check-box"></div>Static wicks — condition</div>
+      </div>
+    </div>
+  </div>
+
+  <div class="section-title">ARROW — Required Aircraft Documents</div>
+  <div class="arrow-box">
+    <div class="arrow-title">ARROW — Must be on board for every flight (CAR 605.03)</div>
+    <div class="arrow-row"><div class="arrow-letter">A</div><div><strong>Airworthiness Certificate</strong> — issued by Transport Canada; valid as long as aircraft maintained per CARs</div></div>
+    <div class="arrow-row"><div class="arrow-letter">R</div><div><strong>Registration Certificate</strong> — aircraft registration (C-FXXX); must match aircraft markings</div></div>
+    <div class="arrow-row"><div class="arrow-letter">R</div><div><strong>Radio Station Licence</strong> — required for any radio equipment on board</div></div>
+    <div class="arrow-row"><div class="arrow-letter">O</div><div><strong>Operating Handbook (POH/AFM)</strong> — Pilot's Operating Handbook or Aircraft Flight Manual approved for that specific aircraft</div></div>
+    <div class="arrow-row"><div class="arrow-letter">W</div><div><strong>Weight &amp; Balance</strong> — current W&amp;B data for the aircraft (may be part of the POH)</div></div>
+  </div>
+
+  <div class="note-box">
+    <strong>Exam Tip:</strong> The preflight walkaround is not just procedural — it is <strong>legally required</strong> under CAR 602.72 (pilot-in-command must ensure airworthiness before flight). If the aircraft has a defect listed in the journey log, it must be assessed against the MEL (Minimum Equipment List) before flight. Always drain fuel sumps <em>after</em> fueling, and after temperature changes that could cause condensation. The ARROW acronym is a frequent exam topic — know all five documents.
+  </div>
+</div>
+</body>
+</html>


### PR DESCRIPTION
## Summary

- Creates 14 standalone dark-aviation HTML visuals (`gk001` through `gk014`) in `web-app/public/visuals/`
- Each file follows the canonical dark-aviation theme (#0d1b2a bg, #f0c040 accent, #7a9ab5 secondary) with SVG diagrams and reference tables
- Updates the `visual:` frontmatter field in all 14 `lessons/general-knowledge/*.md` files to point to the new paths
- `npm run build` in `web-app/` passes ✓

## Visuals created

| File | Diagram type |
|------|-------------|
| gk001-aircraft-parts-controls.html | Aircraft parts SVG + controls table |
| gk002-four-forces.html | Four-forces SVG with arrows + memory hook |
| gk003-piston-engines.html | Four-stroke cycle cards + components table |
| gk004-fuel-system.html | Block-diagram flow schematic + fuel grades table |
| gk005-electrical-system.html | Electrical schematic (battery/alternator/bus) |
| gk006-pitot-static-instruments.html | Pitot-static plumbing + ASI colour arcs |
| gk007-gyroscopic-instruments.html | AI/HI/TC instrument faces + gyro table |
| gk008-engine-instruments.html | 8-gauge panel + colour-arc limits table |
| gk009-weight-and-balance.html | CG envelope SVG + sample calculation table |
| gk010-performance-charts.html | ISA standard + density altitude + variables |
| gk011-takeoff-landing-perf.html | Takeoff/landing profiles + speeds reference |
| gk012-stalls-spins.html | Airfoil cross-section + PARE recovery box |
| gk013-load-factor.html | V-n diagram SVG + bank angle cards |
| gk014-preflight-inspection.html | Walkaround SVG + zone checklist + ARROW box |

## Test plan

- [ ] Open each HTML file directly in browser — verify dark-aviation theme, no external resource errors
- [ ] Verify `visual:` paths in GK lesson frontmatter resolve correctly in the web app
- [ ] `npm run build` passes without new errors

Closes #148

🤖 Generated with [Claude Code](https://claude.com/claude-code)