### PR TITLE
[PPL-157] Add visuals for AL-014–AL-018

### DIFF
--- a/lessons/air-law/014-emergency-procedures-law.md
+++ b/lessons/air-law/014-emergency-procedures-law.md
@@ -7,7 +7,7 @@ title: "Emergency Procedures (Legal) — Distress and Urgency"
 duration_min: 20
 status: complete
 audio: null
-visual: null
+visual: /visuals/al014-emergency-procedures-law.html
 sources:
   - CARs Part VI (601, 602)
   - CARs 602.135 (Distress)

--- a/lessons/air-law/015-transponder-codes.md
+++ b/lessons/air-law/015-transponder-codes.md
@@ -7,7 +7,7 @@ title: "Transponder — Codes, Squawk 7700/7600/7500, Mode C Requirements"
 duration_min: 20
 status: complete
 audio: null
-visual: null
+visual: /visuals/al015-transponder-codes.html
 sources:
   - CARs 601.03
   - CARs 605.35

--- a/lessons/air-law/016-wake-turbulence.md
+++ b/lessons/air-law/016-wake-turbulence.md
@@ -7,7 +7,7 @@ title: "Wake Turbulence — Categories, Avoidance Rules, Timing"
 duration_min: 20
 status: complete
 audio: null
-visual: null
+visual: /visuals/al016-wake-turbulence.html
 sources:
   - CARs 602.19
   - AIM AIR 2.0

--- a/lessons/air-law/017-low-level-flight-rules.md
+++ b/lessons/air-law/017-low-level-flight-rules.md
@@ -7,7 +7,7 @@ title: "Low-Level Flight Rules — 500 ft Rule, Congested Areas, Noise Abatement
 duration_min: 20
 status: complete
 audio: null
-visual: null
+visual: /visuals/al017-low-level-flight-rules.html
 sources:
   - CARs 602.13
   - CARs 602.14

--- a/lessons/air-law/018-special-use-airspace.md
+++ b/lessons/air-law/018-special-use-airspace.md
@@ -7,7 +7,7 @@ title: "Special Use Airspace — Restricted, Class F(R), MOAs, ADIZs"
 duration_min: 20
 status: complete
 audio: null
-visual: null
+visual: /visuals/al018-special-use-airspace.html
 sources:
   - CARs Part VI (601.14 – 601.17)
   - AIM RAC 2.8

--- a/web-app/public/visuals/al014-emergency-procedures-law.html
+++ b/web-app/public/visuals/al014-emergency-procedures-law.html
@@ -1,0 +1,156 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>AL-014: Emergency Procedures — Distress and Urgency</title>
+<style>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body { background: #0d1b2a; color: #e8edf2; font-family: 'Segoe UI', system-ui, sans-serif; padding: 32px; max-width: 900px; margin: 0 auto; }
+  h1 { font-size: 22px; color: #f0c040; letter-spacing: 1px; margin-bottom: 6px; }
+  .subtitle { font-size: 13px; color: #7a9ab5; margin-bottom: 32px; letter-spacing: 0.5px; }
+  .section-label { font-size: 11px; color: #7a9ab5; letter-spacing: 1px; text-transform: uppercase; margin-bottom: 8px; font-weight: 600; }
+
+  .cards { display: grid; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); gap: 16px; margin-bottom: 36px; }
+  .card { background: #1a2d3d; border-radius: 10px; border: 1.5px solid #1a2d3d; padding: 20px; }
+  .card-header { display: flex; align-items: center; gap: 12px; margin-bottom: 12px; }
+  .signal-badge { font-size: 18px; font-weight: 900; padding: 6px 14px; border-radius: 6px; letter-spacing: 2px; }
+  .mayday-badge { background: rgba(255,80,80,0.2); color: #ff7070; border: 1.5px solid rgba(255,80,80,0.4); }
+  .panpan-badge { background: rgba(255,200,0,0.15); color: #f0c040; border: 1.5px solid rgba(255,200,0,0.35); }
+  .card-title { font-size: 15px; font-weight: 700; color: #e8edf2; }
+  .card-sub { font-size: 11px; color: #7a9ab5; margin-top: 2px; }
+  .card p { font-size: 13px; color: #c8d8e8; line-height: 1.6; margin-bottom: 8px; }
+  .card p:last-child { margin-bottom: 0; }
+  .highlight { color: #f0c040; font-weight: 700; }
+
+  table { width: 100%; border-collapse: collapse; font-size: 12px; margin-bottom: 28px; }
+  th { background: #1a2d3d; color: #7a9ab5; padding: 8px 10px; text-align: left; font-size: 11px; text-transform: uppercase; letter-spacing: 0.5px; }
+  td { padding: 9px 10px; border-bottom: 1px solid #1a2d3d; vertical-align: top; }
+  tr:last-child td { border-bottom: none; }
+  .col-signal { color: #f0c040; font-weight: 700; }
+  .col-distress { color: #ff7070; font-weight: 600; }
+  .col-urgency { color: #f0c040; font-weight: 600; }
+
+  .squawk-row { display: flex; gap: 12px; margin-bottom: 28px; flex-wrap: wrap; }
+  .squawk-box { background: #1a2d3d; border-radius: 10px; border: 1.5px solid #1a2d3d; padding: 16px; flex: 1; min-width: 180px; }
+  .squawk-code { font-size: 28px; font-weight: 900; letter-spacing: 4px; margin-bottom: 8px; }
+  .squawk-7700 { color: #ff7070; }
+  .squawk-7600 { color: #f0c040; }
+  .squawk-7500 { color: #ff8080; }
+  .squawk-label { font-size: 12px; font-weight: 700; color: #e8edf2; margin-bottom: 4px; }
+  .squawk-desc { font-size: 12px; color: #7a9ab5; line-height: 1.5; }
+
+  .procedure-box { background: #1a2a1a; border: 1.5px solid #2d5a2d; border-radius: 10px; padding: 18px 22px; margin-bottom: 28px; }
+  .procedure-box h2 { font-size: 12px; color: #80c880; text-transform: uppercase; letter-spacing: 1px; margin-bottom: 12px; }
+  .proc-item { display: flex; gap: 10px; margin-bottom: 8px; align-items: flex-start; }
+  .proc-num { background: #2d5a2d; color: #80c880; font-size: 10px; font-weight: 800; width: 22px; height: 22px; border-radius: 50%; display: flex; align-items: center; justify-content: center; flex-shrink: 0; margin-top: 1px; }
+  .proc-text { font-size: 13px; color: #c8d8c8; line-height: 1.5; }
+  .proc-text strong { color: #f0c040; }
+</style>
+</head>
+<body>
+
+<h1>AL-014 — Emergency Procedures: Distress and Urgency</h1>
+<p class="subtitle">Transport Canada · CARs 602.135 · AIM COM 5.0 · TP 12880E Ch.11 · PPL Written Exam</p>
+
+<!-- Emergency signals -->
+<div class="section-label">Emergency Signal Types</div>
+<div class="cards">
+  <div class="card">
+    <div class="card-header">
+      <span class="signal-badge mayday-badge">MAYDAY</span>
+      <div>
+        <div class="card-title">Distress</div>
+        <div class="card-sub">Life-threatening emergency</div>
+      </div>
+    </div>
+    <p>Declare when the aircraft or persons on board are in <span class="highlight">grave and imminent danger</span> requiring immediate assistance.</p>
+    <p>Spoken <span class="highlight">three times</span>: <em>MAYDAY MAYDAY MAYDAY</em></p>
+    <p>Examples: engine failure over water, fire on board, pilot incapacitation, structural failure.</p>
+  </div>
+  <div class="card">
+    <div class="card-header">
+      <span class="signal-badge panpan-badge">PAN-PAN</span>
+      <div>
+        <div class="card-title">Urgency</div>
+        <div class="card-sub">Serious but not immediately life-threatening</div>
+      </div>
+    </div>
+    <p>Declare when there is a <span class="highlight">serious but not yet life-threatening</span> situation — the safety of the aircraft or persons is at risk but immediate assistance is not required at this instant.</p>
+    <p>Spoken <span class="highlight">three times</span>: <em>PAN-PAN PAN-PAN PAN-PAN</em></p>
+    <p>Examples: lost communications, medical issue on board (non-critical), fuel concern with airport in range.</p>
+  </div>
+</div>
+
+<!-- Comparison table -->
+<div class="section-label">Distress vs Urgency — Key Differences</div>
+<table>
+  <thead>
+    <tr>
+      <th>Factor</th>
+      <th>Distress (MAYDAY)</th>
+      <th>Urgency (PAN-PAN)</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Severity</td>
+      <td class="col-distress">Grave and imminent danger</td>
+      <td class="col-urgency">Serious but not immediate threat</td>
+    </tr>
+    <tr>
+      <td>ATC Priority</td>
+      <td class="col-distress">Highest — all other traffic holds</td>
+      <td class="col-urgency">High — expedited handling</td>
+    </tr>
+    <tr>
+      <td>Squawk code</td>
+      <td class="col-distress">7700</td>
+      <td class="col-urgency">7700 (if declared emergency) or assigned</td>
+    </tr>
+    <tr>
+      <td>Frequency</td>
+      <td colspan="2">121.5 MHz (emergency) or any assigned frequency</td>
+    </tr>
+    <tr>
+      <td>Legal source</td>
+      <td colspan="2">CARs 602.135 — pilot's responsibility to declare</td>
+    </tr>
+  </tbody>
+</table>
+
+<!-- Emergency squawk codes -->
+<div class="section-label">Emergency Transponder Codes</div>
+<div class="squawk-row">
+  <div class="squawk-box">
+    <div class="squawk-code squawk-7700">7700</div>
+    <div class="squawk-label">General Emergency</div>
+    <div class="squawk-desc">Any emergency situation — distress or urgency. Set when declaring MAYDAY or PAN-PAN.</div>
+  </div>
+  <div class="squawk-box">
+    <div class="squawk-code squawk-7600">7600</div>
+    <div class="squawk-label">Radio Failure (NORDO)</div>
+    <div class="squawk-desc">Lost communications with ATC. Proceed to destination per regulations; ATC will look for light signals.</div>
+  </div>
+  <div class="squawk-box">
+    <div class="squawk-code squawk-7500">7500</div>
+    <div class="squawk-label">Hijacking / Unlawful Interference</div>
+    <div class="squawk-desc">Set only if subject to unlawful seizure. ATC will alert authorities immediately.</div>
+  </div>
+</div>
+
+<!-- MAYDAY call procedure -->
+<div class="procedure-box">
+  <h2>Standard MAYDAY Call — What to Say</h2>
+  <div class="proc-item"><span class="proc-num">1</span><span class="proc-text"><strong>MAYDAY MAYDAY MAYDAY</strong> — spoken three times to identify as distress</span></div>
+  <div class="proc-item"><span class="proc-num">2</span><span class="proc-text"><strong>Callsign</strong> — the aircraft's radio callsign (e.g. "Golf-Foxtrot Alpha Bravo Charlie")</span></div>
+  <div class="proc-item"><span class="proc-num">3</span><span class="proc-text"><strong>Nature of emergency</strong> — e.g. "engine failure", "fire on board", "pilot incapacitated"</span></div>
+  <div class="proc-item"><span class="proc-num">4</span><span class="proc-text"><strong>Position</strong> — bearing and distance from a known fix, or latitude/longitude if known</span></div>
+  <div class="proc-item"><span class="proc-num">5</span><span class="proc-text"><strong>Altitude</strong> — current altitude</span></div>
+  <div class="proc-item"><span class="proc-num">6</span><span class="proc-text"><strong>Heading</strong> — current magnetic heading</span></div>
+  <div class="proc-item"><span class="proc-num">7</span><span class="proc-text"><strong>Pilot's intentions</strong> — e.g. "proceeding to CYWG", "forced landing on highway 1"</span></div>
+  <div class="proc-item"><span class="proc-num">8</span><span class="proc-text"><strong>Squawk 7700</strong> — set transponder emergency code and ident if able</span></div>
+</div>
+
+</body>
+</html>

--- a/web-app/public/visuals/al015-transponder-codes.html
+++ b/web-app/public/visuals/al015-transponder-codes.html
@@ -1,0 +1,160 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>AL-015: Transponder Codes and Mode C Requirements</title>
+<style>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body { background: #0d1b2a; color: #e8edf2; font-family: 'Segoe UI', system-ui, sans-serif; padding: 32px; max-width: 900px; margin: 0 auto; }
+  h1 { font-size: 22px; color: #f0c040; letter-spacing: 1px; margin-bottom: 6px; }
+  .subtitle { font-size: 13px; color: #7a9ab5; margin-bottom: 32px; letter-spacing: 0.5px; }
+  .section-label { font-size: 11px; color: #7a9ab5; letter-spacing: 1px; text-transform: uppercase; margin-bottom: 8px; font-weight: 600; }
+
+  table { width: 100%; border-collapse: collapse; font-size: 12px; margin-bottom: 28px; }
+  th { background: #1a2d3d; color: #7a9ab5; padding: 8px 10px; text-align: left; font-size: 11px; text-transform: uppercase; letter-spacing: 0.5px; }
+  td { padding: 9px 10px; border-bottom: 1px solid #1a2d3d; vertical-align: top; }
+  tr:last-child td { border-bottom: none; }
+
+  .modes-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(240px, 1fr)); gap: 16px; margin-bottom: 28px; }
+  .mode-card { background: #1a2d3d; border-radius: 10px; padding: 16px 18px; border: 1.5px solid #1a2d3d; }
+  .mode-label { font-size: 20px; font-weight: 900; color: #f0c040; margin-bottom: 6px; letter-spacing: 1px; }
+  .mode-name { font-size: 13px; font-weight: 700; color: #e8edf2; margin-bottom: 6px; }
+  .mode-desc { font-size: 12px; color: #7a9ab5; line-height: 1.5; }
+  .mode-req { font-size: 11px; color: #80c880; margin-top: 8px; font-weight: 600; }
+
+  .codes-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: 12px; margin-bottom: 28px; }
+  .code-card { background: #1a2d3d; border-radius: 8px; padding: 14px 16px; text-align: center; }
+  .code-num { font-size: 30px; font-weight: 900; letter-spacing: 4px; margin-bottom: 6px; }
+  .code-1200 { color: #80c880; }
+  .code-7700 { color: #ff7070; }
+  .code-7600 { color: #f0c040; }
+  .code-7500 { color: #ff8080; }
+  .code-1000 { color: #7a9ab5; }
+  .code-label { font-size: 12px; font-weight: 700; color: #e8edf2; margin-bottom: 4px; }
+  .code-desc { font-size: 11px; color: #7a9ab5; line-height: 1.4; }
+
+  .hook-box { background: #1a2a1a; border: 1.5px solid #2d5a2d; border-radius: 10px; padding: 18px 22px; margin-bottom: 0; }
+  .hook-box h2 { font-size: 12px; color: #80c880; text-transform: uppercase; letter-spacing: 1px; margin-bottom: 12px; }
+  .hook-row { display: flex; gap: 10px; margin-bottom: 8px; align-items: flex-start; }
+  .hook-badge { background: #2d5a2d; color: #80c880; font-size: 10px; font-weight: 800; padding: 2px 8px; border-radius: 10px; white-space: nowrap; flex-shrink: 0; margin-top: 2px; }
+  .hook-text { font-size: 13px; color: #c8d8c8; line-height: 1.5; }
+  .hook-text strong { color: #f0c040; }
+
+  .yes { color: #80e080; font-weight: 700; }
+  .no  { color: #ff8080; font-weight: 700; }
+  .req { color: #f0c040; font-weight: 600; }
+</style>
+</head>
+<body>
+
+<h1>AL-015 — Transponder Codes, Squawks, Mode C Requirements</h1>
+<p class="subtitle">Transport Canada · CARs 601.03, 605.35 · AIM RAC 1.9 · TP 12880E Ch.7 · PPL Written Exam</p>
+
+<!-- Transponder modes -->
+<div class="section-label">Transponder Modes</div>
+<div class="modes-grid">
+  <div class="mode-card">
+    <div class="mode-label">Mode A</div>
+    <div class="mode-name">4-Digit Identity Code (Squawk)</div>
+    <div class="mode-desc">Transmits the 4-digit octal code set by the pilot (e.g. 1200, 7700). Allows ATC radar to identify the return. No altitude information.</div>
+    <div class="mode-req">Squawk code range: 0000–7777 (octal)</div>
+  </div>
+  <div class="mode-card">
+    <div class="mode-label">Mode C</div>
+    <div class="mode-name">Pressure Altitude Encoding</div>
+    <div class="mode-desc">Transmits pressure altitude from the encoding altimeter. Gives ATC an independent altitude readout alongside the radar return. Required in designated airspace.</div>
+    <div class="mode-req">Pressure altitude — not indicated altitude</div>
+  </div>
+  <div class="mode-card">
+    <div class="mode-label">Mode S</div>
+    <div class="mode-name">Selective Address / ADS-B</div>
+    <div class="mode-desc">Each aircraft has a unique 24-bit address. Supports advanced ATC surveillance and is the basis for ADS-B. Provides identity, altitude, and enhanced data.</div>
+    <div class="mode-req">Required in some controlled airspace</div>
+  </div>
+</div>
+
+<!-- Special codes -->
+<div class="section-label">Special Squawk Codes — Memorize These</div>
+<div class="codes-grid">
+  <div class="code-card">
+    <div class="code-num code-1200">1200</div>
+    <div class="code-label">VFR Default (Canada)</div>
+    <div class="code-desc">Standard VFR code when ATC has not assigned a specific code</div>
+  </div>
+  <div class="code-card">
+    <div class="code-num code-7700">7700</div>
+    <div class="code-label">Emergency</div>
+    <div class="code-desc">Any emergency — distress or urgency. Set immediately when declaring MAYDAY or PAN-PAN</div>
+  </div>
+  <div class="code-card">
+    <div class="code-num code-7600">7600</div>
+    <div class="code-label">Radio Failure (NORDO)</div>
+    <div class="code-desc">Lost communications. ATC will attempt light signals; continue to destination per AIM</div>
+  </div>
+  <div class="code-card">
+    <div class="code-num code-7500">7500</div>
+    <div class="code-label">Hijack / Unlawful Seizure</div>
+    <div class="code-desc">Set only under unlawful interference. ATC alerts authorities immediately</div>
+  </div>
+  <div class="code-card">
+    <div class="code-num code-1000">1000</div>
+    <div class="code-label">IFR (assigned)</div>
+    <div class="code-desc">ATC-assigned code for IFR flights. Only set when instructed</div>
+  </div>
+</div>
+
+<!-- Mode C airspace requirements -->
+<div class="section-label">Mode C Requirement — Where It's Mandatory</div>
+<table>
+  <thead>
+    <tr>
+      <th>Airspace / Condition</th>
+      <th>Mode C Required?</th>
+      <th>Rule</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Class A (18,000 ft+)</td>
+      <td class="yes">Yes</td>
+      <td>CARs 605.35</td>
+    </tr>
+    <tr>
+      <td>Class B airspace</td>
+      <td class="yes">Yes</td>
+      <td>CARs 605.35</td>
+    </tr>
+    <tr>
+      <td>Class C airspace</td>
+      <td class="yes">Yes</td>
+      <td>CARs 605.35</td>
+    </tr>
+    <tr>
+      <td>Class D airspace</td>
+      <td class="yes">Yes</td>
+      <td>CARs 605.35</td>
+    </tr>
+    <tr>
+      <td>Above 12,500 ft ASL in Class E</td>
+      <td class="yes">Yes</td>
+      <td>CARs 605.35</td>
+    </tr>
+    <tr>
+      <td>Class G airspace (uncontrolled)</td>
+      <td class="no">Not required</td>
+      <td>No Mode C mandate below 12,500 ft in Class G</td>
+    </tr>
+  </tbody>
+</table>
+
+<!-- Memory hook -->
+<div class="hook-box">
+  <h2>Memory Hook</h2>
+  <div class="hook-row"><span class="hook-badge">1200</span><span class="hook-text"><strong>VFR default.</strong> "1200 = I'm just cruising VFR." Set when no code assigned.</span></div>
+  <div class="hook-row"><span class="hook-badge">75 / 76 / 77</span><span class="hook-text"><strong>7500 = Hijack · 7600 = No radio · 7700 = Emergency.</strong> Remember: 5-6-7 = hijack, lost comms, emergency.</span></div>
+  <div class="hook-row"><span class="hook-badge">Mode C</span><span class="hook-text">Transmits <strong>pressure altitude</strong> — not indicated altitude. ATC sees the same number as your altimeter at standard setting (29.92 / 1013 hPa).</span></div>
+</div>
+
+</body>
+</html>

--- a/web-app/public/visuals/al016-wake-turbulence.html
+++ b/web-app/public/visuals/al016-wake-turbulence.html
@@ -1,0 +1,188 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>AL-016: Wake Turbulence — Categories, Avoidance, Timing</title>
+<style>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body { background: #0d1b2a; color: #e8edf2; font-family: 'Segoe UI', system-ui, sans-serif; padding: 32px; max-width: 900px; margin: 0 auto; }
+  h1 { font-size: 22px; color: #f0c040; letter-spacing: 1px; margin-bottom: 6px; }
+  .subtitle { font-size: 13px; color: #7a9ab5; margin-bottom: 32px; letter-spacing: 0.5px; }
+  .section-label { font-size: 11px; color: #7a9ab5; letter-spacing: 1px; text-transform: uppercase; margin-bottom: 8px; font-weight: 600; }
+
+  table { width: 100%; border-collapse: collapse; font-size: 12px; margin-bottom: 28px; }
+  th { background: #1a2d3d; color: #7a9ab5; padding: 8px 10px; text-align: left; font-size: 11px; text-transform: uppercase; letter-spacing: 0.5px; }
+  td { padding: 9px 10px; border-bottom: 1px solid #1a2d3d; vertical-align: top; }
+  tr:last-child td { border-bottom: none; }
+  .cat-heavy { color: #ff7070; font-weight: 700; }
+  .cat-medium { color: #f0c040; font-weight: 700; }
+  .cat-light { color: #80e080; font-weight: 700; }
+
+  .vortex-diagram { background: #1a2d3d; border-radius: 10px; padding: 20px; margin-bottom: 28px; }
+  .vortex-diagram h2 { font-size: 12px; color: #7a9ab5; text-transform: uppercase; letter-spacing: 1px; margin-bottom: 16px; font-weight: 600; }
+  .runway-svg { width: 100%; height: auto; display: block; }
+
+  .facts-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 14px; margin-bottom: 28px; }
+  .fact-card { background: #1a2d3d; border-radius: 8px; padding: 14px 16px; border-left: 3px solid #f0c040; }
+  .fact-title { font-size: 12px; color: #f0c040; font-weight: 700; text-transform: uppercase; letter-spacing: 0.5px; margin-bottom: 6px; }
+  .fact-value { font-size: 22px; font-weight: 900; color: #e8edf2; margin-bottom: 4px; }
+  .fact-unit { font-size: 11px; color: #7a9ab5; }
+
+  .avoid-list { background: #1a2d3d; border-radius: 10px; padding: 18px; margin-bottom: 28px; }
+  .avoid-item { display: flex; gap: 10px; padding: 8px 0; border-bottom: 1px solid rgba(255,255,255,0.05); align-items: flex-start; }
+  .avoid-item:last-child { border-bottom: none; }
+  .avoid-icon { font-size: 16px; flex-shrink: 0; }
+  .avoid-text { font-size: 13px; color: #c8d8e8; line-height: 1.5; }
+  .avoid-text strong { color: #f0c040; }
+
+  .hook-box { background: #1a2a1a; border: 1.5px solid #2d5a2d; border-radius: 10px; padding: 18px 22px; }
+  .hook-box h2 { font-size: 12px; color: #80c880; text-transform: uppercase; letter-spacing: 1px; margin-bottom: 12px; }
+  .hook-row { display: flex; gap: 10px; margin-bottom: 8px; align-items: flex-start; }
+  .hook-badge { background: #2d5a2d; color: #80c880; font-size: 10px; font-weight: 800; padding: 2px 8px; border-radius: 10px; white-space: nowrap; flex-shrink: 0; margin-top: 2px; }
+  .hook-text { font-size: 13px; color: #c8d8c8; line-height: 1.5; }
+  .hook-text strong { color: #f0c040; }
+</style>
+</head>
+<body>
+
+<h1>AL-016 — Wake Turbulence: Categories, Avoidance, Timing</h1>
+<p class="subtitle">Transport Canada · CARs 602.19 · AIM AIR 2.0 · TP 12880E Ch.12 · PPL Written Exam</p>
+
+<!-- Vortex behaviour diagram -->
+<div class="vortex-diagram">
+  <h2>How Wake Vortices Behave</h2>
+  <svg class="runway-svg" viewBox="0 0 700 200" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Diagram showing wake vortices sinking and drifting downwind after a large aircraft passes">
+    <!-- Sky/ground -->
+    <rect width="700" height="200" fill="#0d1b2a"/>
+    <!-- Ground line -->
+    <line x1="0" y1="170" x2="700" y2="170" stroke="#1a2d3d" stroke-width="2"/>
+    <text x="10" y="185" fill="#7a9ab5" font-size="11" font-family="sans-serif">Ground</text>
+    <!-- Aircraft body (generic silhouette) -->
+    <g transform="translate(40,70)">
+      <!-- Fuselage -->
+      <ellipse cx="60" cy="20" rx="55" ry="9" fill="#4a6a8a"/>
+      <!-- Wings -->
+      <polygon points="35,20 90,20 110,8 15,8" fill="#3a5a7a"/>
+      <!-- Tail -->
+      <polygon points="100,20 115,20 115,5 108,5" fill="#3a5a7a"/>
+      <text x="0" y="45" fill="#7a9ab5" font-size="10" font-family="sans-serif">Large/Heavy aircraft</text>
+    </g>
+    <!-- Vortex left (port) -->
+    <g>
+      <ellipse cx="220" cy="80" rx="22" ry="22" fill="none" stroke="#ff7070" stroke-width="1.5" stroke-dasharray="4,3" opacity="0.8"/>
+      <text x="198" y="72" fill="#ff7070" font-size="11" font-family="sans-serif">Port vortex</text>
+      <!-- Sinking arrow -->
+      <line x1="220" y1="102" x2="220" y2="148" stroke="#ff7070" stroke-width="1.5" marker-end="url(#arrowRed)"/>
+    </g>
+    <!-- Vortex right (starboard) — drifts downwind -->
+    <g>
+      <ellipse cx="350" cy="80" rx="22" ry="22" fill="none" stroke="#ff7070" stroke-width="1.5" stroke-dasharray="4,3" opacity="0.8"/>
+      <text x="328" y="72" fill="#ff7070" font-size="11" font-family="sans-serif">Stbd vortex</text>
+      <line x1="350" y1="102" x2="350" y2="148" stroke="#ff7070" stroke-width="1.5" marker-end="url(#arrowRed)"/>
+    </g>
+    <!-- Crosswind arrow -->
+    <line x1="450" y1="90" x2="550" y2="90" stroke="#7a9ab5" stroke-width="1.5" marker-end="url(#arrowGrey)"/>
+    <text x="455" y="82" fill="#7a9ab5" font-size="11" font-family="sans-serif">Crosswind →</text>
+    <!-- Drifted vortex position -->
+    <ellipse cx="590" cy="115" rx="22" ry="22" fill="none" stroke="#f0c040" stroke-width="1.5" stroke-dasharray="4,3" opacity="0.7"/>
+    <text x="563" y="150" fill="#f0c040" font-size="10" font-family="sans-serif">Drifted downwind</text>
+    <!-- Labels: sink rate -->
+    <text x="230" y="135" fill="#7a9ab5" font-size="10" font-family="sans-serif">~300–500 ft/min sink</text>
+    <!-- Arrow defs -->
+    <defs>
+      <marker id="arrowRed" markerWidth="8" markerHeight="8" refX="4" refY="4" orient="auto">
+        <path d="M0,0 L8,4 L0,8 Z" fill="#ff7070"/>
+      </marker>
+      <marker id="arrowGrey" markerWidth="8" markerHeight="8" refX="4" refY="4" orient="auto">
+        <path d="M0,0 L8,4 L0,8 Z" fill="#7a9ab5"/>
+      </marker>
+    </defs>
+  </svg>
+</div>
+
+<!-- Weight categories -->
+<div class="section-label">Aircraft Weight Categories — ICAO / Transport Canada</div>
+<table>
+  <thead>
+    <tr>
+      <th>Category</th>
+      <th>Maximum Certificated Take-off Weight</th>
+      <th>Vortex Strength</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td class="cat-heavy">Heavy</td>
+      <td>Greater than 136,000 kg (300,000 lb)</td>
+      <td class="cat-heavy">Strongest — can roll a light aircraft</td>
+    </tr>
+    <tr>
+      <td class="cat-medium">Medium</td>
+      <td>7,000 kg – 136,000 kg</td>
+      <td class="cat-medium">Moderate — dangerous to light aircraft</td>
+    </tr>
+    <tr>
+      <td class="cat-light">Light</td>
+      <td>7,000 kg or less</td>
+      <td class="cat-light">Weakest</td>
+    </tr>
+  </tbody>
+</table>
+
+<!-- Key facts -->
+<div class="section-label">Key Physical Facts</div>
+<div class="facts-grid">
+  <div class="fact-card">
+    <div class="fact-title">Vortex Sink Rate</div>
+    <div class="fact-value">300–500</div>
+    <div class="fact-unit">feet per minute — sink below flight path</div>
+  </div>
+  <div class="fact-card">
+    <div class="fact-title">Recommended Time Sep.</div>
+    <div class="fact-value">2 min</div>
+    <div class="fact-unit">light aircraft behind heavy on same runway</div>
+  </div>
+  <div class="fact-card">
+    <div class="fact-title">Crosswind Hazard</div>
+    <div class="fact-value">Upwind</div>
+    <div class="fact-unit">vortex held near centreline; downwind one drifts away</div>
+  </div>
+  <div class="fact-card">
+    <div class="fact-title">Strongest Vortices</div>
+    <div class="fact-value">Slow, Heavy</div>
+    <div class="fact-unit">heavy aircraft at low speed (clean config, high angle of attack)</div>
+  </div>
+</div>
+
+<!-- Avoidance rules -->
+<div class="section-label">Avoidance Rules</div>
+<div class="avoid-list">
+  <div class="avoid-item">
+    <span class="avoid-icon" aria-hidden="true">▶</span>
+    <span class="avoid-text"><strong>Landing behind heavy:</strong> Stay above the heavy's approach path and land beyond its touchdown point. Wait at least 2 minutes if same runway.</span>
+  </div>
+  <div class="avoid-item">
+    <span class="avoid-icon" aria-hidden="true">▶</span>
+    <span class="avoid-text"><strong>Departing behind heavy:</strong> Rotate before the heavy's rotation point and turn to avoid its flight path. Vortices begin at rotation.</span>
+  </div>
+  <div class="avoid-item">
+    <span class="avoid-icon" aria-hidden="true">▶</span>
+    <span class="avoid-text"><strong>Crossing traffic:</strong> Fly above the flight path of the preceding aircraft, not below it, as vortices sink.</span>
+  </div>
+  <div class="avoid-item">
+    <span class="avoid-icon" aria-hidden="true">▶</span>
+    <span class="avoid-text"><strong>Crosswind caution:</strong> A light crosswind can hold the upwind vortex near the centreline. Allow extra separation in calm or light wind conditions.</span>
+  </div>
+</div>
+
+<!-- Hook -->
+<div class="hook-box">
+  <h2>Memory Hook</h2>
+  <div class="hook-row"><span class="hook-badge">SINK</span><span class="hook-text">Vortices always <strong>sink and drift downwind</strong> — fly above and upwind of a preceding heavy aircraft.</span></div>
+  <div class="hook-row"><span class="hook-badge">2 MIN</span><span class="hook-text">Light behind heavy, same runway = <strong>2 minutes</strong> minimum wait after the heavy departs or lands.</span></div>
+  <div class="hook-row"><span class="hook-badge">ROTATION</span><span class="hook-text">Vortices start at <strong>rotation</strong> on departure, at <strong>touchdown</strong> on landing. The zone in between is clear.</span></div>
+</div>
+
+</body>
+</html>

--- a/web-app/public/visuals/al017-low-level-flight-rules.html
+++ b/web-app/public/visuals/al017-low-level-flight-rules.html
@@ -1,0 +1,187 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>AL-017: Low-Level Flight Rules — 500 ft, Congested Areas, Noise Abatement</title>
+<style>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body { background: #0d1b2a; color: #e8edf2; font-family: 'Segoe UI', system-ui, sans-serif; padding: 32px; max-width: 900px; margin: 0 auto; }
+  h1 { font-size: 22px; color: #f0c040; letter-spacing: 1px; margin-bottom: 6px; }
+  .subtitle { font-size: 13px; color: #7a9ab5; margin-bottom: 32px; letter-spacing: 0.5px; }
+  .section-label { font-size: 11px; color: #7a9ab5; letter-spacing: 1px; text-transform: uppercase; margin-bottom: 8px; font-weight: 600; }
+
+  table { width: 100%; border-collapse: collapse; font-size: 12px; margin-bottom: 28px; }
+  th { background: #1a2d3d; color: #7a9ab5; padding: 8px 10px; text-align: left; font-size: 11px; text-transform: uppercase; letter-spacing: 0.5px; }
+  td { padding: 9px 10px; border-bottom: 1px solid #1a2d3d; vertical-align: top; }
+  tr:last-child td { border-bottom: none; }
+  .rule-ref { color: #7a9ab5; font-size: 11px; }
+  .alt-value { color: #f0c040; font-weight: 700; }
+  .dist-value { color: #80c880; font-weight: 600; }
+
+  .diagram-box { background: #1a2d3d; border-radius: 10px; padding: 20px; margin-bottom: 28px; }
+  .diagram-box h2 { font-size: 12px; color: #7a9ab5; text-transform: uppercase; letter-spacing: 1px; margin-bottom: 16px; font-weight: 600; }
+  .alt-svg { width: 100%; height: auto; display: block; }
+
+  .cards { display: grid; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); gap: 14px; margin-bottom: 28px; }
+  .card { background: #1a2d3d; border-radius: 10px; padding: 16px 18px; }
+  .card-title { font-size: 13px; font-weight: 700; color: #f0c040; margin-bottom: 6px; }
+  .card-rule { font-size: 11px; color: #7a9ab5; margin-bottom: 8px; }
+  .card-body { font-size: 13px; color: #c8d8e8; line-height: 1.6; }
+  .card-body strong { color: #e8edf2; }
+
+  .hook-box { background: #1a2a1a; border: 1.5px solid #2d5a2d; border-radius: 10px; padding: 18px 22px; }
+  .hook-box h2 { font-size: 12px; color: #80c880; text-transform: uppercase; letter-spacing: 1px; margin-bottom: 12px; }
+  .hook-row { display: flex; gap: 10px; margin-bottom: 8px; align-items: flex-start; }
+  .hook-badge { background: #2d5a2d; color: #80c880; font-size: 10px; font-weight: 800; padding: 2px 8px; border-radius: 10px; white-space: nowrap; flex-shrink: 0; margin-top: 2px; }
+  .hook-text { font-size: 13px; color: #c8d8c8; line-height: 1.5; }
+  .hook-text strong { color: #f0c040; }
+</style>
+</head>
+<body>
+
+<h1>AL-017 — Low-Level Flight Rules: 500 ft Rule, Congested Areas, Noise Abatement</h1>
+<p class="subtitle">Transport Canada · CARs 602.13–602.15 · AIM AIR 1.0 · TP 12880E Ch.10 · PPL Written Exam</p>
+
+<!-- Altitude diagram -->
+<div class="diagram-box">
+  <h2>Minimum Altitude Rules — Visual Summary</h2>
+  <svg class="alt-svg" viewBox="0 0 700 260" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Diagram comparing minimum altitude rules over open terrain (500 ft from person/vehicle/structure) versus congested area (1000 ft above highest obstacle within 2000 ft horizontally)">
+    <rect width="700" height="260" fill="#0d1b2a"/>
+    <!-- Ground -->
+    <rect x="0" y="210" width="700" height="50" fill="#0d1b2a"/>
+    <line x1="0" y1="210" x2="700" y2="210" stroke="#1a2d3d" stroke-width="1.5"/>
+    <text x="10" y="228" fill="#7a9ab5" font-size="10" font-family="sans-serif">Ground level</text>
+
+    <!-- === OPEN TERRAIN (left side) === -->
+    <text x="30" y="20" fill="#7a9ab5" font-size="11" font-family="sans-serif" font-weight="600" text-decoration="underline">Open Terrain (CAR 602.13)</text>
+
+    <!-- Person/structure on ground -->
+    <!-- Stick figure -->
+    <circle cx="130" cy="200" r="6" fill="#7a9ab5"/>
+    <line x1="130" y1="206" x2="130" y2="220" stroke="#7a9ab5" stroke-width="2"/>
+    <line x1="120" y1="212" x2="140" y2="212" stroke="#7a9ab5" stroke-width="2"/>
+    <text x="110" y="240" fill="#7a9ab5" font-size="10" font-family="sans-serif">Person/vehicle</text>
+
+    <!-- 500 ft arrow -->
+    <line x1="130" y1="95" x2="130" y2="198" stroke="#f0c040" stroke-width="1.5" stroke-dasharray="5,3" marker-start="url(#arrowUp)" marker-end="url(#arrowDown)"/>
+    <text x="138" y="155" fill="#f0c040" font-size="11" font-family="sans-serif" font-weight="700">500 ft</text>
+    <text x="132" y="167" fill="#7a9ab5" font-size="9" font-family="sans-serif">from person,</text>
+    <text x="132" y="178" fill="#7a9ab5" font-size="9" font-family="sans-serif">vehicle, structure</text>
+
+    <!-- Aircraft left -->
+    <g transform="translate(70,70)">
+      <ellipse cx="35" cy="12" rx="38" ry="7" fill="#4a6a8a"/>
+      <polygon points="20,12 55,12 70,5 5,5" fill="#3a5a7a"/>
+    </g>
+
+    <!-- === CONGESTED AREA (right side) === -->
+    <text x="380" y="20" fill="#7a9ab5" font-size="11" font-family="sans-serif" font-weight="600" text-decoration="underline">Congested Area (CAR 602.14)</text>
+
+    <!-- Buildings -->
+    <rect x="430" y="165" width="25" height="45" fill="#1a2d3d" stroke="#2a3d50" stroke-width="1"/>
+    <rect x="460" y="150" width="30" height="60" fill="#1a2d3d" stroke="#2a3d50" stroke-width="1"/>
+    <rect x="495" y="145" width="28" height="65" fill="#1a2d3d" stroke="#2a3d50" stroke-width="1"/>
+    <text x="430" y="240" fill="#7a9ab5" font-size="10" font-family="sans-serif">Built-up area</text>
+
+    <!-- Highest obstacle indicator -->
+    <line x1="523" y1="130" x2="523" y2="145" stroke="#ff7070" stroke-width="1.5" stroke-dasharray="3,2"/>
+    <text x="528" y="140" fill="#ff7070" font-size="9" font-family="sans-serif">Highest obstacle</text>
+
+    <!-- 1000 ft arrow from highest obstacle -->
+    <line x1="523" y1="50" x2="523" y2="128" stroke="#f0c040" stroke-width="1.5" stroke-dasharray="5,3" marker-start="url(#arrowUp)" marker-end="url(#arrowDown)"/>
+    <text x="530" y="95" fill="#f0c040" font-size="11" font-family="sans-serif" font-weight="700">1000 ft</text>
+    <text x="530" y="107" fill="#7a9ab5" font-size="9" font-family="sans-serif">above highest obstacle</text>
+
+    <!-- 2000 ft horizontal bracket -->
+    <line x1="390" y1="135" x2="620" y2="135" stroke="#7a9ab5" stroke-width="1" stroke-dasharray="4,3"/>
+    <line x1="390" y1="130" x2="390" y2="140" stroke="#7a9ab5" stroke-width="1.5"/>
+    <line x1="620" y1="130" x2="620" y2="140" stroke="#7a9ab5" stroke-width="1.5"/>
+    <text x="465" y="128" fill="#7a9ab5" font-size="10" font-family="sans-serif">← 2,000 ft horizontally →</text>
+
+    <!-- Aircraft right -->
+    <g transform="translate(470,25)">
+      <ellipse cx="35" cy="12" rx="38" ry="7" fill="#4a6a8a"/>
+      <polygon points="20,12 55,12 70,5 5,5" fill="#3a5a7a"/>
+    </g>
+
+    <defs>
+      <marker id="arrowUp" markerWidth="8" markerHeight="8" refX="4" refY="0" orient="auto">
+        <path d="M0,8 L4,0 L8,8 Z" fill="#f0c040"/>
+      </marker>
+      <marker id="arrowDown" markerWidth="8" markerHeight="8" refX="4" refY="8" orient="auto">
+        <path d="M0,0 L4,8 L8,0 Z" fill="#f0c040"/>
+      </marker>
+    </defs>
+  </svg>
+</div>
+
+<!-- Rules table -->
+<div class="section-label">Minimum Altitude Rules — Quick Reference</div>
+<table>
+  <thead>
+    <tr>
+      <th>Area Type</th>
+      <th>Minimum Altitude</th>
+      <th>Measured From</th>
+      <th>Rule</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Open terrain (no people/structures)</td>
+      <td class="alt-value">500 ft AGL</td>
+      <td>Minimum clearance from any person, vessel, vehicle, or structure within <span class="dist-value">500 ft</span> horizontally</td>
+      <td class="rule-ref">CARs 602.13</td>
+    </tr>
+    <tr>
+      <td>Built-up area (city, town, settlement) or open-air assembly</td>
+      <td class="alt-value">1,000 ft AGL</td>
+      <td>Above highest obstacle within <span class="dist-value">2,000 ft</span> horizontally of the aircraft</td>
+      <td class="rule-ref">CARs 602.14</td>
+    </tr>
+    <tr>
+      <td>Over-water (within gliding range of shore)</td>
+      <td class="alt-value">500 ft AGL</td>
+      <td>Same as open terrain rule (persons/vessels/structures)</td>
+      <td class="rule-ref">CARs 602.13</td>
+    </tr>
+    <tr>
+      <td>Emergency forced landing (only exception)</td>
+      <td>N/A</td>
+      <td>Emergency allows deviation — document in journey log</td>
+      <td class="rule-ref">CARs 602.13(2)</td>
+    </tr>
+  </tbody>
+</table>
+
+<!-- Special rules cards -->
+<div class="section-label">Special Low-Level Rules</div>
+<div class="cards">
+  <div class="card">
+    <div class="card-title">Open-Air Assembly — CARs 602.14</div>
+    <div class="card-rule">CARs 602.14</div>
+    <div class="card-body">An open-air assembly of persons (outdoor concert, fair, sports event) is treated the same as a congested area: <strong>1,000 ft above highest obstacle within 2,000 ft</strong>. No fly-overs at low altitude for "fun" or photography.</div>
+  </div>
+  <div class="card">
+    <div class="card-title">Noise Abatement Procedures</div>
+    <div class="card-rule">CARs 602.15 / AIM AIR 1.2</div>
+    <div class="card-body">NOTAM or published procedures at specific aerodromes may require noise abatement routing — higher minimum altitudes, turn restrictions, or preferred runways. Compliance is mandatory where published. Does not replace CARs minimums.</div>
+  </div>
+  <div class="card">
+    <div class="card-title">Aerobatics Altitude Limit</div>
+    <div class="card-rule">CARs 602.27</div>
+    <div class="card-body">Aerobatic manoeuvres require minimum <strong>2,000 ft AGL</strong> over a built-up area, and minimum <strong>1,500 ft AGL</strong> elsewhere, unless an air show waiver is in effect.</div>
+  </div>
+</div>
+
+<!-- Hook -->
+<div class="hook-box">
+  <h2>Memory Hook</h2>
+  <div class="hook-row"><span class="hook-badge">500 / 500</span><span class="hook-text">Open terrain: <strong>500 ft clearance, 500 ft radius</strong> from any person, vehicle, or structure.</span></div>
+  <div class="hook-row"><span class="hook-badge">1000 / 2000</span><span class="hook-text">Congested area: <strong>1,000 ft above highest obstacle within 2,000 ft</strong>. Double both numbers vs open terrain.</span></div>
+  <div class="hook-row"><span class="hook-badge">CITY</span><span class="hook-text">"City = 1k/2k" — the higher population density, the higher your minimum altitude and wider your protected radius.</span></div>
+</div>
+
+</body>
+</html>

--- a/web-app/public/visuals/al018-special-use-airspace.html
+++ b/web-app/public/visuals/al018-special-use-airspace.html
@@ -1,0 +1,151 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>AL-018: Special Use Airspace — Class F(R), MOAs, ADIZs</title>
+<style>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body { background: #0d1b2a; color: #e8edf2; font-family: 'Segoe UI', system-ui, sans-serif; padding: 32px; max-width: 900px; margin: 0 auto; }
+  h1 { font-size: 22px; color: #f0c040; letter-spacing: 1px; margin-bottom: 6px; }
+  .subtitle { font-size: 13px; color: #7a9ab5; margin-bottom: 32px; letter-spacing: 0.5px; }
+  .section-label { font-size: 11px; color: #7a9ab5; letter-spacing: 1px; text-transform: uppercase; margin-bottom: 8px; font-weight: 600; }
+
+  .type-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); gap: 14px; margin-bottom: 28px; }
+  .type-card { border-radius: 10px; padding: 18px; border: 1.5px solid; }
+  .card-fr { background: rgba(255,80,80,0.06); border-color: rgba(255,80,80,0.3); }
+  .card-fa { background: rgba(255,200,0,0.06); border-color: rgba(255,200,0,0.3); }
+  .card-moa { background: rgba(100,160,255,0.06); border-color: rgba(100,160,255,0.3); }
+  .card-adiz { background: rgba(130,100,255,0.06); border-color: rgba(130,100,255,0.3); }
+  .type-label { font-size: 18px; font-weight: 900; margin-bottom: 4px; letter-spacing: 1px; }
+  .label-fr { color: #ff7070; }
+  .label-fa { color: #f0c040; }
+  .label-moa { color: #64a0ff; }
+  .label-adiz { color: #a080ff; }
+  .type-name { font-size: 12px; color: #7a9ab5; margin-bottom: 10px; font-weight: 600; }
+  .type-body { font-size: 13px; color: #c8d8e8; line-height: 1.6; }
+  .type-body strong { color: #e8edf2; }
+  .entry-rule { font-size: 12px; font-weight: 700; margin-top: 8px; padding: 4px 8px; border-radius: 4px; display: inline-block; }
+  .rule-restricted { background: rgba(255,80,80,0.15); color: #ff7070; }
+  .rule-advisory { background: rgba(255,200,0,0.12); color: #f0c040; }
+  .rule-restricted-moa { background: rgba(100,160,255,0.15); color: #64a0ff; }
+  .rule-adiz { background: rgba(130,100,255,0.15); color: #a080ff; }
+
+  table { width: 100%; border-collapse: collapse; font-size: 12px; margin-bottom: 28px; }
+  th { background: #1a2d3d; color: #7a9ab5; padding: 8px 10px; text-align: left; font-size: 11px; text-transform: uppercase; letter-spacing: 0.5px; }
+  td { padding: 9px 10px; border-bottom: 1px solid #1a2d3d; vertical-align: top; }
+  tr:last-child td { border-bottom: none; }
+  .yes { color: #80e080; font-weight: 700; }
+  .no  { color: #ff8080; font-weight: 700; }
+  .cond { color: #f0c040; font-weight: 600; }
+
+  .adiz-box { background: rgba(130,100,255,0.06); border: 1.5px solid rgba(130,100,255,0.25); border-radius: 10px; padding: 18px 20px; margin-bottom: 28px; }
+  .adiz-box h2 { font-size: 12px; color: #a080ff; text-transform: uppercase; letter-spacing: 1px; margin-bottom: 12px; font-weight: 600; }
+  .adiz-step { display: flex; gap: 10px; margin-bottom: 8px; align-items: flex-start; }
+  .adiz-num { background: rgba(130,100,255,0.2); color: #a080ff; font-size: 10px; font-weight: 800; width: 22px; height: 22px; border-radius: 50%; display: flex; align-items: center; justify-content: center; flex-shrink: 0; margin-top: 1px; }
+  .adiz-text { font-size: 13px; color: #c8d8e8; line-height: 1.5; }
+  .adiz-text strong { color: #f0c040; }
+
+  .hook-box { background: #1a2a1a; border: 1.5px solid #2d5a2d; border-radius: 10px; padding: 18px 22px; }
+  .hook-box h2 { font-size: 12px; color: #80c880; text-transform: uppercase; letter-spacing: 1px; margin-bottom: 12px; }
+  .hook-row { display: flex; gap: 10px; margin-bottom: 8px; align-items: flex-start; }
+  .hook-badge { background: #2d5a2d; color: #80c880; font-size: 10px; font-weight: 800; padding: 2px 8px; border-radius: 10px; white-space: nowrap; flex-shrink: 0; margin-top: 2px; }
+  .hook-text { font-size: 13px; color: #c8d8c8; line-height: 1.5; }
+  .hook-text strong { color: #f0c040; }
+</style>
+</head>
+<body>
+
+<h1>AL-018 — Special Use Airspace: Class F(R), MOAs, ADIZs</h1>
+<p class="subtitle">Transport Canada · CARs 601.14–601.17 · AIM RAC 2.8, 9.0 · TP 12880E Ch.7 · PPL Written Exam</p>
+
+<!-- Special use types -->
+<div class="section-label">Types of Special Use Airspace</div>
+<div class="type-grid">
+  <div class="type-card card-fr">
+    <div class="type-label label-fr">Class F(R)</div>
+    <div class="type-name">Restricted Airspace</div>
+    <div class="type-body">Airspace in which flight is <strong>prohibited unless specific authorization</strong> is obtained from the controlling authority (usually DND, TC, or NAV CANADA). Listed in the Canada Flight Supplement (CFS).<br><span class="entry-rule rule-restricted">Entry requires authorization</span></div>
+  </div>
+  <div class="type-card card-fa">
+    <div class="type-label label-fa">Class F(A)</div>
+    <div class="type-name">Advisory Airspace</div>
+    <div class="type-body">Airspace that <strong>warns pilots of a hazard</strong> (training, parachuting, glider ops, etc.) but does not prohibit entry. VFR pilots may enter but should exercise caution and may receive ATC advisories.<br><span class="entry-rule rule-advisory">Entry permitted — caution advised</span></div>
+  </div>
+  <div class="type-card card-moa">
+    <div class="type-label label-moa">MOA</div>
+    <div class="type-name">Military Operations Area</div>
+    <div class="type-body">Designated block of airspace for <strong>military flight training</strong>. When active, civil VFR flight is not prohibited but is strongly discouraged. Check NOTAMs and contact the controlling unit before entering an active MOA.<br><span class="entry-rule rule-restricted-moa">Check NOTAM — avoid when active</span></div>
+  </div>
+  <div class="type-card card-adiz">
+    <div class="type-label label-adiz">ADIZ</div>
+    <div class="type-name">Air Defence Identification Zone</div>
+    <div class="type-body">Airspace boundary around Canada requiring identification of all inbound aircraft. VFR aircraft must file a <strong>DVFR (Defence VFR) flight plan</strong> before entering. Failure to do so can trigger a military intercept.<br><span class="entry-rule rule-adiz">DVFR flight plan required before entry</span></div>
+  </div>
+</div>
+
+<!-- Comparison table -->
+<div class="section-label">Entry Requirements — Comparison</div>
+<table>
+  <thead>
+    <tr>
+      <th>Airspace Type</th>
+      <th>Authorization Required?</th>
+      <th>Flight Plan Required?</th>
+      <th>NOTAM Check?</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Class F(R) — Restricted</td>
+      <td class="no">Yes — must get specific auth</td>
+      <td class="cond">Depends on authorization</td>
+      <td class="yes">Always</td>
+    </tr>
+    <tr>
+      <td>Class F(A) — Advisory</td>
+      <td class="yes">No — entry permitted</td>
+      <td class="yes">No (unless otherwise noted)</td>
+      <td class="yes">Recommended</td>
+    </tr>
+    <tr>
+      <td>MOA (Military Operations Area)</td>
+      <td class="cond">Contact controlling unit</td>
+      <td class="yes">No specific requirement</td>
+      <td class="yes">Always</td>
+    </tr>
+    <tr>
+      <td>ADIZ (VFR entry)</td>
+      <td class="yes">No — but DVFR plan required</td>
+      <td class="no">Yes — DVFR flight plan</td>
+      <td class="yes">Always</td>
+    </tr>
+    <tr>
+      <td>Temporary Flight Restriction (TFR)</td>
+      <td class="no">Yes — per NOTAM terms</td>
+      <td class="cond">Depends on TFR type</td>
+      <td class="yes">Always — issued by NOTAM</td>
+    </tr>
+  </tbody>
+</table>
+
+<!-- ADIZ procedure -->
+<div class="adiz-box">
+  <h2>ADIZ Entry Procedure — VFR Aircraft</h2>
+  <div class="adiz-step"><span class="adiz-num">1</span><span class="adiz-text"><strong>File a DVFR (Defence VFR) flight plan</strong> before departure. Include entry point, estimated time of entry, and transponder code.</span></div>
+  <div class="adiz-step"><span class="adiz-num">2</span><span class="adiz-text"><strong>Squawk assigned code</strong> — ATC assigns a discrete code for ADIZ tracking. Squawk it from departure.</span></div>
+  <div class="adiz-step"><span class="adiz-num">3</span><span class="adiz-text"><strong>Maintain schedule</strong> — cross the ADIZ boundary within ±5 minutes of the filed ETA. Deviations beyond this may trigger an interception.</span></div>
+  <div class="adiz-step"><span class="adiz-num">4</span><span class="adiz-text"><strong>Report to ATC</strong> — position report at the ADIZ boundary if instructed, and maintain continuous monitoring of the assigned frequency.</span></div>
+  <div class="adiz-step"><span class="adiz-num">5</span><span class="adiz-text"><strong>Close flight plan</strong> on landing as required. Failure to close may trigger a search and rescue response.</span></div>
+</div>
+
+<!-- Hook -->
+<div class="hook-box">
+  <h2>Memory Hook</h2>
+  <div class="hook-row"><span class="hook-badge">R = Restricted</span><span class="hook-text">F(R) = <strong>Restricted</strong> = you need permission to enter. F(A) = <strong>Advisory</strong> = you can enter but be careful.</span></div>
+  <div class="hook-row"><span class="hook-badge">ADIZ = DVFR</span><span class="hook-text">Crossing into Canadian ADIZ requires a <strong>DVFR flight plan filed before departure</strong>. No plan = possible intercept by CF-18.</span></div>
+  <div class="hook-row"><span class="hook-badge">NOTAM ALWAYS</span><span class="hook-text">For any special use airspace — F(R), F(A), MOA, TFR — <strong>always check NOTAMs</strong>. Activation and deactivation are notified via NOTAM.</span></div>
+</div>
+
+</body>
+</html>


### PR DESCRIPTION
## Summary

- Adds 5 standalone dark-aviation HTML visual files for Air Law lessons AL-014 through AL-018
- Updates `visual:` frontmatter in each corresponding lesson markdown file
- All visuals follow `docs/visuals-standards.md`: dark theme (`#0d1b2a` bg, `#f0c040` accent), no external dependencies, standalone HTML

## Files Added

| Visual | Lesson |
|--------|--------|
| `al014-emergency-procedures-law.html` | MAYDAY/PAN-PAN comparison, squawk codes, call procedure |
| `al015-transponder-codes.html` | Transponder modes (A/C/S), special squawk codes, Mode C requirements table |
| `al016-wake-turbulence.html` | Weight categories, vortex behavior SVG diagram, avoidance rules |
| `al017-low-level-flight-rules.html` | Altitude diagram (500 ft / 1000 ft rules), minimum altitude table |
| `al018-special-use-airspace.html` | F(R)/F(A)/MOA/ADIZ types, entry requirements table, ADIZ procedure |

## Test plan

- [ ] Open each HTML file in a browser and verify it renders correctly (standalone, no broken resources)
- [ ] Confirm dark background and amber accent colours match the canonical sample (`al001-airspace-classifications.html`)
- [ ] Verify `visual:` field in each lesson frontmatter points to the correct `/visuals/` path
- [ ] Confirm no external `<link>`, `<script src>`, or `<img src="https://...">` tags present

Closes #157

🤖 Generated with [Claude Code](https://claude.com/claude-code)