### PR TITLE
[PPL-160] Add PSTAR Path page

### DIFF
--- a/web-app/src/App.tsx
+++ b/web-app/src/App.tsx
@@ -9,6 +9,7 @@ import LessonQuiz from './pages/LessonQuiz';
 import Exam from './pages/Exam';
 import Plan from './pages/Plan';
 import Playlist from './pages/Playlist';
+import PSTARPath from './pages/PSTARPath';
 
 export default function App() {
   return (
@@ -45,6 +46,7 @@ export default function App() {
             <Route path="/plan" element={<Plan />} />
             <Route path="/playlist" element={<Playlist />} />
             <Route path="/playlist/:topic" element={<Playlist />} />
+            <Route path="/pstar" element={<PSTARPath />} />
           </Routes>
         </Box>
       </BrowserRouter>

--- a/web-app/src/pages/PSTARPath.tsx
+++ b/web-app/src/pages/PSTARPath.tsx
@@ -1,0 +1,142 @@
+import { useMemo } from 'react';
+import { Link as RouterLink } from 'react-router-dom';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Chip from '@mui/material/Chip';
+import Container from '@mui/material/Container';
+import Divider from '@mui/material/Divider';
+import LinearProgress from '@mui/material/LinearProgress';
+import Link from '@mui/material/Link';
+import List from '@mui/material/List';
+import ListItem from '@mui/material/ListItem';
+import Typography from '@mui/material/Typography';
+
+import { CURRICULUM } from '../lib/curriculum';
+import { getAllLessons } from '../lib/lesson-loader';
+import { useProgress } from '../lib/progress';
+
+const TIER_1_LESSON_IDS = new Set([
+  'AL-001', 'AL-002', 'AL-003', 'AL-004',
+  'AL-005', 'AL-006', 'AL-007', 'AL-014',
+]);
+
+const AL_LESSONS = CURRICULUM.filter((s) => s.topic === 'air-law');
+
+export default function PSTARPath() {
+  const { isComplete } = useProgress();
+
+  const authoredIds = useMemo(() => {
+    const lessons = getAllLessons();
+    return new Set(lessons.map((l) => l.id));
+  }, []);
+
+  const completedCount = AL_LESSONS.filter((s) => isComplete(s.id)).length;
+  const overallPercent =
+    AL_LESSONS.length > 0 ? Math.round((completedCount / AL_LESSONS.length) * 100) : 0;
+
+  return (
+    <Container id="main-content" tabIndex={-1} maxWidth="md" sx={{ py: 4 }}>
+      {/* ── Page header ── */}
+      <Box sx={{ mb: 4 }}>
+        <Typography variant="h4" gutterBottom>
+          PSTAR Path
+        </Typography>
+        <Typography variant="body2" color="text.secondary" gutterBottom>
+          Pre-Solo Standard Test of Air Regulations — pass mark: 90%
+        </Typography>
+        <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+          Study resource:{' '}
+          <Link
+            href="https://tc.canada.ca/en/aviation/publications/transport-canada-aeronautical-information-manual-tc-aim/tp-14371"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            TP 13014E — Air Regulations (Transport Canada)
+          </Link>
+        </Typography>
+
+        <Typography variant="body2" color="text.secondary" gutterBottom>
+          {completedCount} / {AL_LESSONS.length} lessons complete · {overallPercent}%
+        </Typography>
+        <LinearProgress
+          variant="determinate"
+          value={overallPercent}
+          sx={{ height: 10, borderRadius: 5, mb: 3 }}
+        />
+      </Box>
+
+      {/* ── Lesson list ── */}
+      <Typography variant="h6" gutterBottom>
+        Air Law Lessons
+      </Typography>
+      <Divider sx={{ mb: 1 }} />
+      <List dense disablePadding sx={{ mb: 4 }}>
+        {AL_LESSONS.map((slot) => {
+          const authored = authoredIds.has(slot.id);
+          const done = isComplete(slot.id);
+          const isTier1 = TIER_1_LESSON_IDS.has(slot.id);
+
+          return (
+            <ListItem
+              key={slot.id}
+              disablePadding
+              sx={{ py: 0.5, display: 'flex', alignItems: 'center', gap: 1 }}
+            >
+              {/* Lesson ID badge */}
+              <Typography
+                component="span"
+                variant="caption"
+                sx={{
+                  minWidth: 68,
+                  fontFamily: 'monospace',
+                  color: authored ? 'primary.main' : 'text.disabled',
+                  fontWeight: 600,
+                }}
+              >
+                {slot.id}
+              </Typography>
+
+              {/* Title */}
+              {authored ? (
+                <Typography
+                  component={RouterLink}
+                  to={`/lessons/${slot.topic}/${slot.slug}`}
+                  variant="body2"
+                  sx={{
+                    textDecoration: 'none',
+                    color: done ? 'text.secondary' : 'text.primary',
+                    '&:hover': { textDecoration: 'underline' },
+                    flex: 1,
+                  }}
+                >
+                  {slot.title}
+                </Typography>
+              ) : (
+                <Typography variant="body2" color="text.disabled" sx={{ flex: 1 }}>
+                  {slot.title}
+                </Typography>
+              )}
+
+              {/* Tier 1 chip */}
+              {isTier1 && (
+                <Chip label="Core" size="small" color="primary" variant="outlined" />
+              )}
+            </ListItem>
+          );
+        })}
+      </List>
+
+      {/* ── CTA ── */}
+      <Box sx={{ textAlign: 'center' }}>
+        <Button
+          component={RouterLink}
+          to="/pstar-exam"
+          variant="contained"
+          size="large"
+        >
+          Take PSTAR Practice Exam
+        </Button>
+      </Box>
+    </Container>
+  );
+}

--- a/web-app/src/pages/PSTARPath.tsx
+++ b/web-app/src/pages/PSTARPath.tsx
@@ -42,12 +42,12 @@ export default function PSTARPath() {
           PSTAR Path
         </Typography>
         <Typography variant="body2" color="text.secondary" gutterBottom>
-          Pre-Solo Standard Test of Air Regulations — pass mark: 90%
+          Pre-Solo Standard Test of Air Regulations — 50 questions · 40 min · pass mark: 90%
         </Typography>
         <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
           Study resource:{' '}
           <Link
-            href="https://tc.canada.ca/en/aviation/publications/transport-canada-aeronautical-information-manual-tc-aim/tp-14371"
+            href="https://tc.canada.ca/en/aviation/publications/study-reference-guide-pre-solo-standard-test-air-regulations-pstar-tp-13014"
             target="_blank"
             rel="noopener noreferrer"
           >


### PR DESCRIPTION
## Summary
- Creates `web-app/src/pages/PSTARPath.tsx` rendering all 18 Air Law lessons
- Tier 1 'Core' chips on AL-001–007 and AL-014
- 90% pass-mark header and TP 13014E reference link
- Overall completion progress bar via `useProgress()`
- CTA button linking to `/pstar-exam`
- Adds `<Route path='/pstar' element={<PSTARPath />} />` to `App.tsx`

## Test plan
- [ ] `tsc --noEmit` passes (verified clean)
- [ ] Navigate to `/pstar` — all 18 Air Law lessons display
- [ ] Tier 1 lessons (AL-001–007, AL-014) show "Core" chip
- [ ] Header shows "pass mark: 90%"
- [ ] TP 13014E link renders and is externally linkable
- [ ] Progress bar reflects completed lessons from localStorage
- [ ] CTA routes to `/pstar-exam`

Closes #160

🤖 Generated with [Claude Code](https://claude.com/claude-code)