### PR TITLE
[PPL-149] Add 14 Meteorology visual HTML files

### DIFF
--- a/lessons/meteorology/001-atmosphere-structure.md
+++ b/lessons/meteorology/001-atmosphere-structure.md
@@ -7,7 +7,7 @@ title: "Atmosphere Structure"
 duration_min: 20
 status: complete
 audio: null
-visual: null
+visual: /visuals/met001-atmosphere-structure.html
 sources:
   - TP 12880E Chapter 8
   - AIM MET 1.0

--- a/lessons/meteorology/002-temp-pressure-humidity.md
+++ b/lessons/meteorology/002-temp-pressure-humidity.md
@@ -7,7 +7,7 @@ title: "Temperature, Pressure, Humidity"
 duration_min: 20
 status: complete
 audio: null
-visual: null
+visual: /visuals/met002-temp-pressure-humidity.html
 sources:
   - TP 12880E Chapter 8
   - AIM MET 1.0

--- a/lessons/meteorology/003-clouds-types.md
+++ b/lessons/meteorology/003-clouds-types.md
@@ -7,7 +7,7 @@ title: "Cloud Types and Formation"
 duration_min: 20
 status: complete
 audio: null
-visual: null
+visual: /visuals/met003-clouds-types.html
 sources:
   - TP 12880E Chapter 8
   - AIM MET 1.2

--- a/lessons/meteorology/004-fog-types.md
+++ b/lessons/meteorology/004-fog-types.md
@@ -7,7 +7,7 @@ title: "Fog Formation and Types"
 duration_min: 20
 status: complete
 audio: null
-visual: null
+visual: /visuals/met004-fog-types.html
 sources:
   - TP 12880E Chapter 8
   - AIM MET 1.7

--- a/lessons/meteorology/005-metar-decoding.md
+++ b/lessons/meteorology/005-metar-decoding.md
@@ -7,7 +7,7 @@ title: "METAR Decoding"
 duration_min: 20
 status: complete
 audio: null
-visual: null
+visual: /visuals/met005-metar-decoding.html
 sources:
   - TP 12880E Chapter 8
   - AIM MET 2.1

--- a/lessons/meteorology/006-taf-decoding.md
+++ b/lessons/meteorology/006-taf-decoding.md
@@ -7,7 +7,7 @@ title: "TAF Decoding"
 duration_min: 20
 status: complete
 audio: null
-visual: null
+visual: /visuals/met006-taf-decoding.html
 sources:
   - TP 12880E Chapter 8
   - AIM MET 2.2

--- a/lessons/meteorology/007-gfa.md
+++ b/lessons/meteorology/007-gfa.md
@@ -7,7 +7,7 @@ title: "GFA — Graphical Forecast for Aviation"
 duration_min: 20
 status: complete
 audio: null
-visual: null
+visual: /visuals/met007-gfa.html
 sources:
   - TP 12880E Chapter 8
   - AIM MET 2.4

--- a/lessons/meteorology/008-pireps.md
+++ b/lessons/meteorology/008-pireps.md
@@ -7,7 +7,7 @@ title: "PIREPs"
 duration_min: 20
 status: complete
 audio: null
-visual: null
+visual: /visuals/met008-pireps.html
 sources:
   - TP 12880E Chapter 8
   - AIM MET 2.5

--- a/lessons/meteorology/009-thunderstorms.md
+++ b/lessons/meteorology/009-thunderstorms.md
@@ -7,7 +7,7 @@ title: "Thunderstorms"
 duration_min: 20
 status: complete
 audio: null
-visual: null
+visual: /visuals/met009-thunderstorms.html
 sources:
   - TP 12880E Chapter 8
   - AIM MET 1.5

--- a/lessons/meteorology/010-icing.md
+++ b/lessons/meteorology/010-icing.md
@@ -7,7 +7,7 @@ title: "Icing"
 duration_min: 20
 status: complete
 audio: null
-visual: null
+visual: /visuals/met010-icing.html
 sources:
   - TP 12880E Chapter 8
   - AIM MET 1.6

--- a/lessons/meteorology/011-turbulence.md
+++ b/lessons/meteorology/011-turbulence.md
@@ -7,7 +7,7 @@ title: "Turbulence"
 duration_min: 20
 status: complete
 audio: null
-visual: null
+visual: /visuals/met011-turbulence.html
 sources:
   - TP 12880E Chapter 8
   - AIM MET 1.9

--- a/lessons/meteorology/012-wind-shear-microburst.md
+++ b/lessons/meteorology/012-wind-shear-microburst.md
@@ -7,7 +7,7 @@ title: "Wind Shear and Microburst"
 duration_min: 20
 status: complete
 audio: null
-visual: null
+visual: /visuals/met012-wind-shear-microburst.html
 sources:
   - TP 12880E Chapter 8
   - AIM MET 1.11

--- a/lessons/meteorology/013-fronts.md
+++ b/lessons/meteorology/013-fronts.md
@@ -7,7 +7,7 @@ title: "Fronts"
 duration_min: 20
 status: complete
 audio: null
-visual: null
+visual: /visuals/met013-fronts.html
 sources:
   - TP 12880E Chapter 8
   - AIM MET 1.4

--- a/lessons/meteorology/014-wx-decision-making.md
+++ b/lessons/meteorology/014-wx-decision-making.md
@@ -7,7 +7,7 @@ title: "Weather Decision-Making"
 duration_min: 20
 status: complete
 audio: null
-visual: null
+visual: /visuals/met014-wx-decision-making.html
 sources:
   - TP 12880E Chapter 8
   - AIM MET 3.0

--- a/web-app/public/visuals/met001-atmosphere-structure.html
+++ b/web-app/public/visuals/met001-atmosphere-structure.html
@@ -1,0 +1,140 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>MET-001: The Atmosphere</title>
+<style>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body { background: #0d1b2a; color: #e8edf2; font-family: 'Segoe UI', system-ui, sans-serif; padding: 32px; }
+  h1 { font-size: 22px; color: #f0c040; letter-spacing: 1px; margin-bottom: 6px; }
+  .subtitle { font-size: 13px; color: #7a9ab5; margin-bottom: 32px; letter-spacing: 0.5px; }
+  .section-label { font-size: 11px; color: #7a9ab5; letter-spacing: 1px; text-transform: uppercase; margin-bottom: 8px; font-weight: 600; }
+  table { width: 100%; border-collapse: collapse; font-size: 12px; margin-bottom: 28px; }
+  th { background: #1a2d3d; color: #7a9ab5; padding: 8px 10px; text-align: left; font-size: 11px; text-transform: uppercase; letter-spacing: 0.5px; }
+  td { padding: 9px 10px; border-bottom: 1px solid #1a2d3d; }
+  .hook-box { background: #1a2a1a; border: 1.5px solid #2d5a2d; border-radius: 10px; padding: 18px 22px; margin-top: 8px; }
+  .hook-box h2 { font-size: 12px; color: #80c880; text-transform: uppercase; letter-spacing: 1px; margin-bottom: 12px; }
+  .hook-row { display: flex; gap: 10px; margin-bottom: 8px; align-items: flex-start; }
+  .hook-badge { background: #2d5a2d; color: #80c880; font-size: 10px; font-weight: 800; padding: 2px 8px; border-radius: 10px; white-space: nowrap; flex-shrink: 0; margin-top: 2px; }
+  .hook-text { font-size: 13px; color: #c8d8c8; line-height: 1.5; }
+  .hook-text strong { color: #f0c040; }
+
+  .atmo-stack { display: flex; flex-direction: column; gap: 0; border-radius: 10px; overflow: hidden; border: 1.5px solid #1a2d3d; margin-bottom: 36px; }
+  .atmo-layer { display: grid; grid-template-columns: 180px 160px 1fr; align-items: center; padding: 14px 16px; gap: 16px; border-bottom: 1px solid rgba(255,255,255,0.05); }
+  .atmo-layer:last-child { border-bottom: none; }
+  .layer-name { font-weight: 700; font-size: 14px; }
+  .layer-alt { font-size: 11px; color: #7a9ab5; margin-top: 3px; }
+  .layer-desc { font-size: 12px; color: #c8d8e8; line-height: 1.5; }
+  .layer-tag { display: inline-block; border-radius: 4px; padding: 2px 8px; font-size: 10px; font-weight: 700; margin-top: 4px; }
+  .wx-tag { background: rgba(80,200,80,0.15); color: #80e080; border: 1px solid rgba(80,200,80,0.3); }
+  .hazard-tag { background: rgba(255,80,80,0.15); color: #ff8080; border: 1px solid rgba(255,80,80,0.3); }
+  .neutral-tag { background: rgba(150,150,150,0.1); color: #aaa; border: 1px solid rgba(150,150,150,0.2); }
+</style>
+</head>
+<body>
+<div style="max-width:900px;margin:auto;">
+
+<h1>MET-001 — The Atmosphere</h1>
+<p class="subtitle">Transport Canada · TP 12880E Chapter 8 · PPL Written Exam</p>
+
+<div class="section-label">Atmospheric Layers — Space to Surface</div>
+<div class="atmo-stack">
+  <div class="atmo-layer" style="background:#0a1020;">
+    <div>
+      <div class="layer-name" style="color:#9b7fd4;">Exosphere</div>
+      <div class="layer-alt">Above 500 km (1,640,000 ft)</div>
+    </div>
+    <div><span class="layer-tag neutral-tag">Outer space transition</span></div>
+    <div class="layer-desc">Molecules escape to space. No defined upper limit. Not relevant to aviation operations.</div>
+  </div>
+  <div class="atmo-layer" style="background:#0a1530;">
+    <div>
+      <div class="layer-name" style="color:#6fa8dc;">Thermosphere</div>
+      <div class="layer-alt">80 – 500 km (260,000 – 1,640,000 ft)</div>
+    </div>
+    <div><span class="layer-tag neutral-tag">Ionosphere / aurora</span></div>
+    <div class="layer-desc">Temperatures rise dramatically with altitude. Contains the ionosphere; supports radio wave propagation.</div>
+  </div>
+  <div class="atmo-layer" style="background:#0a1a35;">
+    <div>
+      <div class="layer-name" style="color:#5ba3b8;">Mesosphere</div>
+      <div class="layer-alt">50 – 80 km (164,000 – 260,000 ft)</div>
+    </div>
+    <div><span class="layer-tag neutral-tag">Coldest layer</span></div>
+    <div class="layer-desc">Temperatures decrease with altitude, reaching -90°C at the mesopause. Meteors burn up here.</div>
+  </div>
+  <div class="atmo-layer" style="background:#0a2040;">
+    <div>
+      <div class="layer-name" style="color:#7ac5cd;">Stratosphere</div>
+      <div class="layer-alt">11 – 50 km (36,000 – 164,000 ft)</div>
+    </div>
+    <div><span class="layer-tag neutral-tag">Stable / ozone layer</span></div>
+    <div class="layer-desc">Very stable. Contains ozone layer (~25 km). Temperature constant then rises with altitude. Jet aircraft cruise here. Tropopause at base caps thunderstorms.</div>
+  </div>
+  <div class="atmo-layer" style="background:#0a2a3a;">
+    <div>
+      <div class="layer-name" style="color:#f0c040;">Troposphere</div>
+      <div class="layer-alt">0 – 11 km (Surface to ~36,000 ft)</div>
+      <div style="font-size:10px;color:#7a9ab5;margin-top:2px;">Varies: ~26,000 ft poles / ~60,000 ft equator</div>
+    </div>
+    <div><span class="layer-tag wx-tag">All weather here</span></div>
+    <div class="layer-desc">Contains 75% of atmospheric mass. Temperature decreases with altitude at ~2°C per 1,000 ft (ISA). All significant weather, clouds, and flight operations occur in this layer.</div>
+  </div>
+</div>
+
+<div class="section-label">ISA — International Standard Atmosphere (Sea Level)</div>
+<table>
+  <thead>
+    <tr>
+      <th>Parameter</th>
+      <th>ISA Value</th>
+      <th>Units (alternate)</th>
+      <th>Aviation Significance</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Sea-Level Temperature</td>
+      <td style="color:#f0c040;font-weight:700;">15°C</td>
+      <td>59°F</td>
+      <td>Baseline for density altitude calculations</td>
+    </tr>
+    <tr>
+      <td>Sea-Level Pressure</td>
+      <td style="color:#f0c040;font-weight:700;">1013.25 hPa</td>
+      <td>29.92 inHg</td>
+      <td>Standard altimeter setting; used for Flight Levels</td>
+    </tr>
+    <tr>
+      <td>Temperature Lapse Rate</td>
+      <td style="color:#f0c040;font-weight:700;">2°C per 1,000 ft</td>
+      <td>6.5°C / 1,000 m</td>
+      <td>Expected temperature at any given altitude in ISA</td>
+    </tr>
+    <tr>
+      <td>Sea-Level Density</td>
+      <td>1.225 kg/m³</td>
+      <td>—</td>
+      <td>Reference for aerodynamic performance calculations</td>
+    </tr>
+    <tr>
+      <td>Tropopause (mid-latitude)</td>
+      <td>~36,000 ft / 11 km</td>
+      <td>—</td>
+      <td>Upper limit of weather; caps convective cloud tops</td>
+    </tr>
+  </tbody>
+</table>
+
+<div class="hook-box">
+  <h2>Memory Hook — Atmosphere Essentials</h2>
+  <div class="hook-row"><span class="hook-badge">TROPOSPHERE</span><span class="hook-text"><strong>Weather layer</strong> — all clouds, turbulence, icing, and VFR/IFR flight happen here. Temperature drops ~2°C per 1,000 ft.</span></div>
+  <div class="hook-row"><span class="hook-badge">TROPOPAUSE</span><span class="hook-text"><strong>Cap on thunderstorm tops</strong> — Cb anvils spread sideways when they hit the stable stratosphere. Signals extreme wx below.</span></div>
+  <div class="hook-row"><span class="hook-badge">ISA</span><span class="hook-text"><strong>15°C / 1013.25 hPa / 2°C per 1,000 ft</strong> — the three numbers you must memorize for altimetry, performance, and exam questions.</span></div>
+  <div class="hook-row"><span class="hook-badge">LAYERS</span><span class="hook-text">From surface up: <strong>Tropo → Strato → Meso → Thermo → Exo</strong>. Mnemonic: <strong>T</strong>ropical <strong>S</strong>torms <strong>M</strong>ake <strong>T</strong>he <strong>E</strong>arth vibrate.</span></div>
+</div>
+
+</div>
+</body>
+</html>

--- a/web-app/public/visuals/met002-temp-pressure-humidity.html
+++ b/web-app/public/visuals/met002-temp-pressure-humidity.html
@@ -1,0 +1,174 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>MET-002: Temperature, Pressure &amp; Humidity</title>
+<style>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body { background: #0d1b2a; color: #e8edf2; font-family: 'Segoe UI', system-ui, sans-serif; padding: 32px; }
+  h1 { font-size: 22px; color: #f0c040; letter-spacing: 1px; margin-bottom: 6px; }
+  .subtitle { font-size: 13px; color: #7a9ab5; margin-bottom: 32px; letter-spacing: 0.5px; }
+  .section-label { font-size: 11px; color: #7a9ab5; letter-spacing: 1px; text-transform: uppercase; margin-bottom: 8px; font-weight: 600; }
+  table { width: 100%; border-collapse: collapse; font-size: 12px; margin-bottom: 28px; }
+  th { background: #1a2d3d; color: #7a9ab5; padding: 8px 10px; text-align: left; font-size: 11px; text-transform: uppercase; letter-spacing: 0.5px; }
+  td { padding: 9px 10px; border-bottom: 1px solid #1a2d3d; vertical-align: top; }
+  .hook-box { background: #1a2a1a; border: 1.5px solid #2d5a2d; border-radius: 10px; padding: 18px 22px; margin-top: 8px; }
+  .hook-box h2 { font-size: 12px; color: #80c880; text-transform: uppercase; letter-spacing: 1px; margin-bottom: 12px; }
+  .hook-row { display: flex; gap: 10px; margin-bottom: 8px; align-items: flex-start; }
+  .hook-badge { background: #2d5a2d; color: #80c880; font-size: 10px; font-weight: 800; padding: 2px 8px; border-radius: 10px; white-space: nowrap; flex-shrink: 0; margin-top: 2px; }
+  .hook-text { font-size: 13px; color: #c8d8c8; line-height: 1.5; }
+  .hook-text strong { color: #f0c040; }
+  .hazard-tag { display: inline-block; background: rgba(255,80,80,0.15); color: #ff8080; border: 1px solid rgba(255,80,80,0.3); border-radius: 4px; padding: 2px 8px; font-size: 10px; font-weight: 700; }
+  .ok-tag { display: inline-block; background: rgba(80,200,80,0.15); color: #80e080; border: 1px solid rgba(80,200,80,0.3); border-radius: 4px; padding: 2px 8px; font-size: 10px; font-weight: 700; }
+  .info-tag { display: inline-block; background: rgba(240,192,64,0.15); color: #f0c040; border: 1px solid rgba(240,192,64,0.3); border-radius: 4px; padding: 2px 8px; font-size: 10px; font-weight: 700; }
+  .concept-panel { background: #1a2d3d; border-radius: 8px; padding: 16px 18px; margin-bottom: 16px; }
+  .concept-title { font-size: 14px; font-weight: 700; color: #f0c040; margin-bottom: 8px; }
+  .concept-grid { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 12px; margin-bottom: 28px; }
+  .concept-card { background: #1a2d3d; border-radius: 8px; padding: 14px 16px; border-top: 3px solid #1a2d3d; }
+  .card-temp { border-top-color: #e05050; }
+  .card-pres { border-top-color: #5080e0; }
+  .card-hum { border-top-color: #50b0e0; }
+  .card-label { font-size: 10px; font-weight: 800; text-transform: uppercase; letter-spacing: 1px; margin-bottom: 6px; }
+  .card-temp .card-label { color: #e08080; }
+  .card-pres .card-label { color: #8090e0; }
+  .card-hum .card-label { color: #70c0e8; }
+  .card-value { font-size: 20px; font-weight: 800; color: #f0c040; margin-bottom: 6px; }
+  .card-desc { font-size: 11px; color: #c8d8e8; line-height: 1.5; }
+</style>
+</head>
+<body>
+<div style="max-width:900px;margin:auto;">
+
+<h1>MET-002 — Temperature, Pressure &amp; Humidity</h1>
+<p class="subtitle">Transport Canada · TP 12880E Chapter 8 · PPL Written Exam</p>
+
+<div class="section-label">Three Key Atmospheric Variables</div>
+<div class="concept-grid">
+  <div class="concept-card card-temp">
+    <div class="card-label">Temperature</div>
+    <div class="card-value">T</div>
+    <div class="card-desc">Measure of air molecule kinetic energy. Affects air density directly — warm air is less dense. ISA standard: <strong>15°C at sea level</strong>.</div>
+  </div>
+  <div class="concept-card card-pres">
+    <div class="card-label">Pressure</div>
+    <div class="card-value">P</div>
+    <div class="card-desc">Weight of atmosphere above a point. Decreases with altitude. ISA standard: <strong>1013.25 hPa (29.92 inHg) at sea level</strong>.</div>
+  </div>
+  <div class="concept-card card-hum">
+    <div class="card-label">Humidity</div>
+    <div class="card-value">RH</div>
+    <div class="card-desc">Amount of water vapour in air. High humidity reduces air density further. Key indicator: <strong>dew point spread</strong>.</div>
+  </div>
+</div>
+
+<div class="section-label">Concept Reference Table</div>
+<table>
+  <thead>
+    <tr>
+      <th>Concept</th>
+      <th>Definition</th>
+      <th>Key Value / Formula</th>
+      <th>Aviation Relevance</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><strong>Density Altitude</strong></td>
+      <td>Pressure altitude corrected for non-standard temperature. Represents air density.</td>
+      <td>DA = PA + (120 × (OAT – ISA temp))</td>
+      <td><span class="hazard-tag">Perf. critical</span> High DA = longer takeoff roll, reduced climb, reduced engine power</td>
+    </tr>
+    <tr>
+      <td><strong>ISA Temperature</strong></td>
+      <td>Standard temperature at any altitude: 15°C – (2°C × altitude in thousands of ft)</td>
+      <td>15°C at SL; -57°C at tropopause</td>
+      <td>Compare OAT to ISA to determine if air is warmer (worse DA) or cooler (better DA) than standard</td>
+    </tr>
+    <tr>
+      <td><strong>QNH</strong></td>
+      <td>Altimeter setting adjusted to sea level; shows MSL altitude on altimeter</td>
+      <td>Obtained from ATIS/METAR (e.g. A2992 = 29.92 inHg)</td>
+      <td><span class="ok-tag">Standard use</span> Set on ground, altimeter reads field elevation when correct</td>
+    </tr>
+    <tr>
+      <td><strong>QFE</strong></td>
+      <td>Altimeter set to field elevation pressure; reads zero on the ground</td>
+      <td>Used in some military/circuit ops</td>
+      <td>Altimeter reads AGL height above that aerodrome</td>
+    </tr>
+    <tr>
+      <td><strong>Standard Pressure</strong></td>
+      <td>29.92 inHg / 1013.25 hPa set on altimeter</td>
+      <td>Required above 18,000 ft ASL (Class A/B)</td>
+      <td>All aircraft use same reference — reads Flight Level (e.g. FL180 = 18,000 ft)</td>
+    </tr>
+    <tr>
+      <td><strong>Dew Point</strong></td>
+      <td>Temperature at which air becomes saturated and condensation begins</td>
+      <td>Dew point spread = OAT minus dew point</td>
+      <td>Spread &le; 2°C: fog or low cloud likely. Spread = 0: saturated / fog present</td>
+    </tr>
+    <tr>
+      <td><strong>Relative Humidity</strong></td>
+      <td>Ratio of actual moisture to maximum possible moisture at that temperature</td>
+      <td>100% = saturated; dew point = OAT</td>
+      <td>High RH lowers air density (water vapour lighter than N2/O2)</td>
+    </tr>
+    <tr>
+      <td><strong>Pressure Altitude</strong></td>
+      <td>Altitude indicated when altimeter is set to 29.92 inHg</td>
+      <td>Used as base for density altitude calculation</td>
+      <td>Basis for performance chart lookups when OAT differs from ISA</td>
+    </tr>
+  </tbody>
+</table>
+
+<div class="section-label">Temperature Effects on Aircraft Performance</div>
+<table>
+  <thead>
+    <tr>
+      <th>Condition</th>
+      <th>Effect on Air Density</th>
+      <th>Density Altitude</th>
+      <th>Performance Impact</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><strong>Hot temperature</strong></td>
+      <td>Air expands, fewer molecules per unit volume</td>
+      <td><span class="hazard-tag">Higher DA</span></td>
+      <td>Longer takeoff roll, reduced climb rate, reduced engine output (normally aspirated)</td>
+    </tr>
+    <tr>
+      <td><strong>High altitude</strong></td>
+      <td>Less atmosphere above, lower pressure, thinner air</td>
+      <td><span class="hazard-tag">Higher DA</span></td>
+      <td>Same as hot — aircraft "thinks" it is higher than indicated</td>
+    </tr>
+    <tr>
+      <td><strong>High humidity</strong></td>
+      <td>Water vapour displaces heavier N2/O2 molecules</td>
+      <td><span class="hazard-tag">Higher DA</span></td>
+      <td>Additional degradation on top of temperature/altitude effects</td>
+    </tr>
+    <tr>
+      <td><strong>Cold temperature</strong></td>
+      <td>Air contracts, denser (more molecules per volume)</td>
+      <td><span class="ok-tag">Lower DA</span></td>
+      <td>Shorter takeoff roll, better climb, more engine power</td>
+    </tr>
+  </tbody>
+</table>
+
+<div class="hook-box">
+  <h2>Memory Hook — Density Altitude Warning</h2>
+  <div class="hook-row"><span class="hook-badge">HOT + HIGH + HUMID</span><span class="hook-text"><strong>Triple H = degraded performance</strong>. Each factor independently raises density altitude. All three together can make performance dangerously poor.</span></div>
+  <div class="hook-row"><span class="hook-badge">DEW POINT</span><span class="hook-text">Spread &le; <strong>2°C</strong> means fog or cloud is imminent. Spread = 0 means you are in cloud or fog right now.</span></div>
+  <div class="hook-row"><span class="hook-badge">ALTIMETER</span><span class="hook-text"><strong>QNH</strong> (local setting) = MSL altitude on indicator. <strong>29.92</strong> (standard) = Flight Level altitude. Never forget to update QNH when transitioning areas.</span></div>
+</div>
+
+</div>
+</body>
+</html>

--- a/web-app/public/visuals/met003-clouds-types.html
+++ b/web-app/public/visuals/met003-clouds-types.html
@@ -1,0 +1,182 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>MET-003: Cloud Types and Formation</title>
+<style>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body { background: #0d1b2a; color: #e8edf2; font-family: 'Segoe UI', system-ui, sans-serif; padding: 32px; }
+  h1 { font-size: 22px; color: #f0c040; letter-spacing: 1px; margin-bottom: 6px; }
+  .subtitle { font-size: 13px; color: #7a9ab5; margin-bottom: 32px; letter-spacing: 0.5px; }
+  .section-label { font-size: 11px; color: #7a9ab5; letter-spacing: 1px; text-transform: uppercase; margin-bottom: 8px; font-weight: 600; }
+  table { width: 100%; border-collapse: collapse; font-size: 12px; margin-bottom: 28px; }
+  th { background: #1a2d3d; color: #7a9ab5; padding: 8px 10px; text-align: left; font-size: 11px; text-transform: uppercase; letter-spacing: 0.5px; }
+  td { padding: 9px 10px; border-bottom: 1px solid #1a2d3d; vertical-align: top; }
+  .hook-box { background: #1a2a1a; border: 1.5px solid #2d5a2d; border-radius: 10px; padding: 18px 22px; margin-top: 8px; }
+  .hook-box h2 { font-size: 12px; color: #80c880; text-transform: uppercase; letter-spacing: 1px; margin-bottom: 12px; }
+  .hook-row { display: flex; gap: 10px; margin-bottom: 8px; align-items: flex-start; }
+  .hook-badge { background: #2d5a2d; color: #80c880; font-size: 10px; font-weight: 800; padding: 2px 8px; border-radius: 10px; white-space: nowrap; flex-shrink: 0; margin-top: 2px; }
+  .hook-text { font-size: 13px; color: #c8d8c8; line-height: 1.5; }
+  .hook-text strong { color: #f0c040; }
+  .hazard-tag { display: inline-block; background: rgba(255,80,80,0.15); color: #ff8080; border: 1px solid rgba(255,80,80,0.3); border-radius: 4px; padding: 2px 8px; font-size: 10px; font-weight: 700; }
+  .ok-tag { display: inline-block; background: rgba(80,200,80,0.15); color: #80e080; border: 1px solid rgba(80,200,80,0.3); border-radius: 4px; padding: 2px 8px; font-size: 10px; font-weight: 700; }
+  .warn-tag { display: inline-block; background: rgba(240,192,64,0.15); color: #f0c040; border: 1px solid rgba(240,192,64,0.3); border-radius: 4px; padding: 2px 8px; font-size: 10px; font-weight: 700; }
+  .abbr-badge { display: inline-block; background: #1a2d3d; color: #f0c040; border: 1px solid #2a3d4d; border-radius: 4px; padding: 2px 8px; font-size: 12px; font-weight: 800; font-family: monospace; }
+  .family-row td:first-child { font-weight: 700; }
+  .family-high { background: rgba(100,80,200,0.08); }
+  .family-mid { background: rgba(80,120,200,0.08); }
+  .family-low { background: rgba(80,140,160,0.08); }
+  .family-vert { background: rgba(200,80,80,0.08); }
+  .family-header { font-size: 13px; font-weight: 800; letter-spacing: 0.5px; }
+</style>
+</head>
+<body>
+<div style="max-width:900px;margin:auto;">
+
+<h1>MET-003 — Cloud Types and Formation</h1>
+<p class="subtitle">Transport Canada · TP 12880E Chapter 8 · PPL Written Exam</p>
+
+<div class="section-label">Cloud Classification by Family and Type</div>
+<table>
+  <thead>
+    <tr>
+      <th>Family</th>
+      <th>Cloud Type</th>
+      <th>Abbr</th>
+      <th>Base Altitude (approx.)</th>
+      <th>Formation</th>
+      <th>Key Hazard</th>
+    </tr>
+  </thead>
+  <tbody>
+    <!-- HIGH -->
+    <tr class="family-high">
+      <td rowspan="3" class="family-header" style="color:#b090e0;vertical-align:middle;">HIGH<br><span style="font-size:10px;font-weight:400;color:#7a9ab5;">&gt; 20,000 ft</span></td>
+      <td>Cirrus</td>
+      <td><span class="abbr-badge">Ci</span></td>
+      <td>Above 20,000 ft</td>
+      <td>Ice crystals in thin wispy streaks; high-level winds</td>
+      <td><span class="ok-tag">Minimal</span> Can indicate approaching warm front</td>
+    </tr>
+    <tr class="family-high">
+      <td>Cirrostratus</td>
+      <td><span class="abbr-badge">Cs</span></td>
+      <td>Above 20,000 ft</td>
+      <td>Thin ice crystal sheet; causes halo around sun/moon</td>
+      <td><span class="warn-tag">Front warning</span> Halo = wx deterioration within 24 hr</td>
+    </tr>
+    <tr class="family-high">
+      <td>Cirrocumulus</td>
+      <td><span class="abbr-badge">Cc</span></td>
+      <td>Above 20,000 ft</td>
+      <td>Small white puffs in rows ("mackerel sky")</td>
+      <td><span class="ok-tag">Minimal</span> Rare; indicates high-level instability</td>
+    </tr>
+    <!-- MIDDLE -->
+    <tr class="family-mid">
+      <td rowspan="2" class="family-header" style="color:#80a0d8;vertical-align:middle;">MIDDLE<br><span style="font-size:10px;font-weight:400;color:#7a9ab5;">6,500 – 20,000 ft</span></td>
+      <td>Altostratus</td>
+      <td><span class="abbr-badge">As</span></td>
+      <td>6,500 – 20,000 ft</td>
+      <td>Grey/blue sheet; sun visible as through frosted glass</td>
+      <td><span class="warn-tag">Icing risk</span> Continuous rain/snow; instrument conditions</td>
+    </tr>
+    <tr class="family-mid">
+      <td>Altocumulus</td>
+      <td><span class="abbr-badge">Ac</span></td>
+      <td>6,500 – 20,000 ft</td>
+      <td>Patchy grey/white rolls; larger than Cc</td>
+      <td><span class="warn-tag">Turbulence</span> Ac castellanus = convective activity developing</td>
+    </tr>
+    <!-- LOW -->
+    <tr class="family-low">
+      <td rowspan="3" class="family-header" style="color:#70b8c8;vertical-align:middle;">LOW<br><span style="font-size:10px;font-weight:400;color:#7a9ab5;">Surface – 6,500 ft</span></td>
+      <td>Stratus</td>
+      <td><span class="abbr-badge">St</span></td>
+      <td>Surface – 2,000 ft</td>
+      <td>Uniform grey layer; like fog that doesn't reach ground</td>
+      <td><span class="hazard-tag">Low ceiling</span> Drizzle; poor visibility; IFR conditions</td>
+    </tr>
+    <tr class="family-low">
+      <td>Stratocumulus</td>
+      <td><span class="abbr-badge">Sc</span></td>
+      <td>Surface – 6,500 ft</td>
+      <td>Lumpy grey/white rolls; most common cloud globally</td>
+      <td><span class="warn-tag">Low ceiling</span> Light precipitation; VFR marginal</td>
+    </tr>
+    <tr class="family-low">
+      <td>Nimbostratus</td>
+      <td><span class="abbr-badge">Ns</span></td>
+      <td>Surface – 10,000 ft (thick)</td>
+      <td>Dark grey rain cloud; obscures sky completely</td>
+      <td><span class="hazard-tag">IFR / icing</span> Continuous moderate rain or snow; low visibility</td>
+    </tr>
+    <!-- VERTICAL -->
+    <tr class="family-vert">
+      <td rowspan="2" class="family-header" style="color:#e08080;vertical-align:middle;">VERTICAL<br><span style="font-size:10px;font-weight:400;color:#7a9ab5;">Surface to tropopause</span></td>
+      <td>Cumulus</td>
+      <td><span class="abbr-badge">Cu</span></td>
+      <td>1,000 – 6,000 ft base</td>
+      <td>Convective heating; cauliflower appearance; fair wx Cu benign</td>
+      <td><span class="warn-tag">Moderate</span> Building Cu indicates instability; can develop to Cb</td>
+    </tr>
+    <tr class="family-vert">
+      <td><strong>Cumulonimbus</strong></td>
+      <td><span class="abbr-badge" style="color:#ff8080;">Cb</span></td>
+      <td>500 – 6,000 ft base; tops to 50,000+ ft</td>
+      <td>Explosive convection; anvil-shaped top at tropopause; requires moisture + instability + lifting</td>
+      <td><span class="hazard-tag">EXTREME HAZARD</span> All icing types, severe turbulence, lightning, hail, microbursts, tornadoes — AVOID</td>
+    </tr>
+  </tbody>
+</table>
+
+<div class="section-label">Cumulonimbus — Hazard Summary</div>
+<table>
+  <thead>
+    <tr>
+      <th>Hazard</th>
+      <th>Description</th>
+      <th>Risk Level</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><strong>Severe Turbulence</strong></td>
+      <td>Updrafts and downdrafts up to 10,000 fpm within the storm; gust fronts outward</td>
+      <td><span class="hazard-tag">Extreme</span></td>
+    </tr>
+    <tr>
+      <td><strong>All Icing Types</strong></td>
+      <td>Clear, rime, and mixed icing; supercooled water droplets throughout</td>
+      <td><span class="hazard-tag">Severe</span></td>
+    </tr>
+    <tr>
+      <td><strong>Lightning</strong></td>
+      <td>Every active Cb produces lightning; can strike well outside visible cloud</td>
+      <td><span class="hazard-tag">Extreme</span></td>
+    </tr>
+    <tr>
+      <td><strong>Hail</strong></td>
+      <td>Can be ejected up to 20 NM ahead of storm anvil at altitude</td>
+      <td><span class="hazard-tag">Severe</span></td>
+    </tr>
+    <tr>
+      <td><strong>Wind Shear / Microburst</strong></td>
+      <td>Severe wind shear at low altitude; microburst downdraft up to 6,000 fpm</td>
+      <td><span class="hazard-tag">Extreme</span></td>
+    </tr>
+  </tbody>
+</table>
+
+<div class="hook-box">
+  <h2>Memory Hook — Cloud Prefixes and Families</h2>
+  <div class="hook-row"><span class="hook-badge">HEIGHT</span><span class="hook-text"><strong>Alto = middle</strong>, <strong>Cirro = high</strong>, no prefix (St, Cu, Ns) = low. Height determines the prefix.</span></div>
+  <div class="hook-row"><span class="hook-badge">SHAPE</span><span class="hook-text"><strong>Cu = heap/puffy</strong> (cumulo = heap), <strong>Ci = hair/wispy</strong> (cirrus = curl of hair), <strong>St = sheet/layer</strong> (stratus = spread), <strong>Ns = rain</strong> (nimbus = rain).</span></div>
+  <div class="hook-row"><span class="hook-badge">Cb RULE</span><span class="hook-text"><strong>Never enter a Cb</strong>. Never fly under one. Clear by at least <strong>20 NM laterally</strong>. The anvil shows downwind extent — go upwind side.</span></div>
+  <div class="hook-row"><span class="hook-badge">FRONT CLUES</span><span class="hook-text">Ci → Cs → As → Ns sequence = <strong>warm front approaching</strong>. Cu → Cb rapid build = <strong>cold front / afternoon convection</strong>.</span></div>
+</div>
+
+</div>
+</body>
+</html>

--- a/web-app/public/visuals/met004-fog-types.html
+++ b/web-app/public/visuals/met004-fog-types.html
@@ -1,0 +1,154 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>MET-004: Fog Types</title>
+<style>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body { background: #0d1b2a; color: #e8edf2; font-family: 'Segoe UI', system-ui, sans-serif; padding: 32px; }
+  h1 { font-size: 22px; color: #f0c040; letter-spacing: 1px; margin-bottom: 6px; }
+  .subtitle { font-size: 13px; color: #7a9ab5; margin-bottom: 32px; letter-spacing: 0.5px; }
+  .section-label { font-size: 11px; color: #7a9ab5; letter-spacing: 1px; text-transform: uppercase; margin-bottom: 8px; font-weight: 600; }
+  table { width: 100%; border-collapse: collapse; font-size: 12px; margin-bottom: 28px; }
+  th { background: #1a2d3d; color: #7a9ab5; padding: 8px 10px; text-align: left; font-size: 11px; text-transform: uppercase; letter-spacing: 0.5px; }
+  td { padding: 9px 10px; border-bottom: 1px solid #1a2d3d; vertical-align: top; }
+  .hook-box { background: #1a2a1a; border: 1.5px solid #2d5a2d; border-radius: 10px; padding: 18px 22px; margin-top: 8px; }
+  .hook-box h2 { font-size: 12px; color: #80c880; text-transform: uppercase; letter-spacing: 1px; margin-bottom: 12px; }
+  .hook-row { display: flex; gap: 10px; margin-bottom: 8px; align-items: flex-start; }
+  .hook-badge { background: #2d5a2d; color: #80c880; font-size: 10px; font-weight: 800; padding: 2px 8px; border-radius: 10px; white-space: nowrap; flex-shrink: 0; margin-top: 2px; }
+  .hook-text { font-size: 13px; color: #c8d8c8; line-height: 1.5; }
+  .hook-text strong { color: #f0c040; }
+  .hazard-tag { display: inline-block; background: rgba(255,80,80,0.15); color: #ff8080; border: 1px solid rgba(255,80,80,0.3); border-radius: 4px; padding: 2px 8px; font-size: 10px; font-weight: 700; }
+  .warn-tag { display: inline-block; background: rgba(240,192,64,0.15); color: #f0c040; border: 1px solid rgba(240,192,64,0.3); border-radius: 4px; padding: 2px 8px; font-size: 10px; font-weight: 700; }
+  .ok-tag { display: inline-block; background: rgba(80,200,80,0.15); color: #80e080; border: 1px solid rgba(80,200,80,0.3); border-radius: 4px; padding: 2px 8px; font-size: 10px; font-weight: 700; }
+  .fog-name { font-weight: 700; font-size: 13px; color: #f0c040; }
+  .compare-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; margin-bottom: 28px; }
+  .compare-card { background: #1a2d3d; border-radius: 8px; padding: 16px 18px; }
+  .compare-title { font-size: 13px; font-weight: 700; margin-bottom: 10px; }
+  .compare-row { font-size: 12px; color: #c8d8e8; margin-bottom: 6px; line-height: 1.5; }
+  .compare-label { color: #7a9ab5; font-size: 11px; text-transform: uppercase; letter-spacing: 0.5px; }
+</style>
+</head>
+<body>
+<div style="max-width:900px;margin:auto;">
+
+<h1>MET-004 — Fog Types</h1>
+<p class="subtitle">Transport Canada · TP 12880E Chapter 8 · PPL Written Exam</p>
+
+<div class="section-label">Fog Type Reference Table</div>
+<table>
+  <thead>
+    <tr>
+      <th>Fog Type</th>
+      <th>Formation Mechanism</th>
+      <th>Typical Conditions</th>
+      <th>Aviation Hazard</th>
+      <th>Dissipation</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><span class="fog-name">Radiation Fog</span></td>
+      <td>Ground radiates heat to sky after sunset, cooling the air above to dew point</td>
+      <td>Clear night, light wind (1–5 kt), moist air, calm conditions. Most common in valleys.</td>
+      <td><span class="hazard-tag">Severe</span> Can reduce visibility to near zero overnight; forms rapidly</td>
+      <td>Burns off after sunrise (1–3 hr) as ground warms. Wind also disperses it.</td>
+    </tr>
+    <tr>
+      <td><span class="fog-name">Advection Fog</span></td>
+      <td>Warm moist air moves (advects) over a cooler surface and is cooled to dew point</td>
+      <td>Warm air over cold ocean, snow-covered ground, or cold lake. Common on Canadian coasts.</td>
+      <td><span class="hazard-tag">Persistent</span> Can cover large areas; not dependent on time of day; does NOT burn off at sunrise</td>
+      <td>Requires change in wind direction to remove the warm moist air source</td>
+    </tr>
+    <tr>
+      <td><span class="fog-name">Upslope Fog</span></td>
+      <td>Moist air forced up terrain cools adiabatically until it reaches dew point</td>
+      <td>Moist air flowing toward elevated terrain; common in foothills (e.g. Alberta Rockies approach)</td>
+      <td><span class="hazard-tag">Terrain</span> Combined low visibility and elevated terrain; disorients VFR pilots</td>
+      <td>Clears when flow changes or air mass dries; can persist for extended periods</td>
+    </tr>
+    <tr>
+      <td><span class="fog-name">Steam Fog</span></td>
+      <td>Cold dry air moves over warm water; water evaporates and immediately re-condenses</td>
+      <td>Arctic air over open water (lakes in autumn, coastal areas). Looks like steam rising.</td>
+      <td><span class="warn-tag">Moderate</span> Low-level wisps; can reduce visibility over water; turbulence possible</td>
+      <td>Dissipates as air mass warms or moves inland; generally shallow</td>
+    </tr>
+    <tr>
+      <td><span class="fog-name">Freezing Fog</span></td>
+      <td>Radiation or advection fog that exists at temperatures below 0°C; supercooled droplets</td>
+      <td>Any fog conditions when OAT at or below 0°C</td>
+      <td><span class="hazard-tag">Extreme</span> Deposits clear ice on aircraft surfaces, windscreens, and runways; aircraft icing hazard</td>
+      <td>Dissipates with temperature rise above 0°C or change in air mass</td>
+    </tr>
+  </tbody>
+</table>
+
+<div class="section-label">Radiation vs. Advection — Key Differences</div>
+<div class="compare-grid">
+  <div class="compare-card" style="border-top: 3px solid #f0c040;">
+    <div class="compare-title" style="color:#f0c040;">Radiation Fog</div>
+    <div class="compare-row"><span class="compare-label">Trigger</span><br>Nighttime ground cooling (radiative)</div>
+    <div class="compare-row"><span class="compare-label">Wind requirement</span><br>Calm to light (1–5 kt). Strong wind mixes it away.</div>
+    <div class="compare-row"><span class="compare-label">Location</span><br>Inland, valleys, low-lying areas</div>
+    <div class="compare-row"><span class="compare-label">Time of occurrence</span><br>Night to early morning; clears after sunrise</div>
+    <div class="compare-row"><span class="compare-label">Prediction</span><br>Predictable — check dew point spread at sunset</div>
+    <div class="compare-row"><span class="compare-label">Area covered</span><br>Local / regional (valley scale)</div>
+  </div>
+  <div class="compare-card" style="border-top: 3px solid #5080e0;">
+    <div class="compare-title" style="color:#8090e0;">Advection Fog</div>
+    <div class="compare-row"><span class="compare-label">Trigger</span><br>Warm moist air moving over cold surface</div>
+    <div class="compare-row"><span class="compare-label">Wind requirement</span><br>Needs wind to advect the moist air — wind does NOT clear it</div>
+    <div class="compare-row"><span class="compare-label">Location</span><br>Coastal, offshore, areas with cold ocean currents</div>
+    <div class="compare-row"><span class="compare-label">Time of occurrence</span><br>Any time of day or night; does NOT clear at sunrise</div>
+    <div class="compare-row"><span class="compare-label">Prediction</span><br>Harder to predict; requires knowledge of air mass trajectory</div>
+    <div class="compare-row"><span class="compare-label">Area covered</span><br>Can cover very large areas (hundreds of km)</div>
+  </div>
+</div>
+
+<div class="section-label">Forecasting Fog — Dew Point Spread Rule</div>
+<table>
+  <thead>
+    <tr>
+      <th>Dew Point Spread (OAT minus Dew Point)</th>
+      <th>Interpretation</th>
+      <th>Action</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><strong>&gt; 5°C</strong></td>
+      <td><span class="ok-tag">Clear skies likely</span> Air far from saturation</td>
+      <td>No immediate fog concern; monitor trend</td>
+    </tr>
+    <tr>
+      <td><strong>3 – 5°C</strong></td>
+      <td><span class="warn-tag">Monitor closely</span> Approaching saturation if cooling continues</td>
+      <td>Check hourly METAR trend, especially at sunset</td>
+    </tr>
+    <tr>
+      <td><strong>&le; 2°C</strong></td>
+      <td><span class="hazard-tag">Fog expected</span> Near or at saturation point</td>
+      <td>Expect fog; plan alternate; consider delay or divert</td>
+    </tr>
+    <tr>
+      <td><strong>0°C (spread = 0)</strong></td>
+      <td><span class="hazard-tag">Fog or cloud present now</span></td>
+      <td>Do not depart VFR; obtain current METAR + ATIS</td>
+    </tr>
+  </tbody>
+</table>
+
+<div class="hook-box">
+  <h2>Memory Hook — Fog Types at a Glance</h2>
+  <div class="hook-row"><span class="hook-badge">RADIATION</span><span class="hook-text"><strong>Clear + calm + cool night + moist air</strong> = radiation fog by morning. Clears after sunrise. Valley airports: brief operations delay.</span></div>
+  <div class="hook-row"><span class="hook-badge">ADVECTION</span><span class="hook-text"><strong>Warm air over cold surface</strong> = advection fog. Coastal hazard. Sunrise does NOT clear it. Needs wind shift to dissipate.</span></div>
+  <div class="hook-row"><span class="hook-badge">FREEZING</span><span class="hook-text">Any fog below <strong>0°C</strong> = freezing fog. Supercooled droplets freeze on contact. Aircraft icing hazard even on the ground.</span></div>
+  <div class="hook-row"><span class="hook-badge">DEW POINT</span><span class="hook-text">Spread <strong>&le; 2°C</strong> = fog likely. Spread = <strong>0</strong> = saturated. Check METAR reported as TEMP/DP (e.g. 12/10 = 2°C spread).</span></div>
+</div>
+
+</div>
+</body>
+</html>

--- a/web-app/public/visuals/met005-metar-decoding.html
+++ b/web-app/public/visuals/met005-metar-decoding.html
@@ -1,0 +1,252 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>MET-005: METAR Decoding</title>
+<style>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body { background: #0d1b2a; color: #e8edf2; font-family: 'Segoe UI', system-ui, sans-serif; padding: 32px; }
+  h1 { font-size: 22px; color: #f0c040; letter-spacing: 1px; margin-bottom: 6px; }
+  .subtitle { font-size: 13px; color: #7a9ab5; margin-bottom: 32px; letter-spacing: 0.5px; }
+  .section-label { font-size: 11px; color: #7a9ab5; letter-spacing: 1px; text-transform: uppercase; margin-bottom: 8px; font-weight: 600; }
+  table { width: 100%; border-collapse: collapse; font-size: 12px; margin-bottom: 28px; }
+  th { background: #1a2d3d; color: #7a9ab5; padding: 8px 10px; text-align: left; font-size: 11px; text-transform: uppercase; letter-spacing: 0.5px; }
+  td { padding: 9px 10px; border-bottom: 1px solid #1a2d3d; vertical-align: top; }
+  .hook-box { background: #1a2a1a; border: 1.5px solid #2d5a2d; border-radius: 10px; padding: 18px 22px; margin-top: 8px; }
+  .hook-box h2 { font-size: 12px; color: #80c880; text-transform: uppercase; letter-spacing: 1px; margin-bottom: 12px; }
+  .hook-row { display: flex; gap: 10px; margin-bottom: 8px; align-items: flex-start; }
+  .hook-badge { background: #2d5a2d; color: #80c880; font-size: 10px; font-weight: 800; padding: 2px 8px; border-radius: 10px; white-space: nowrap; flex-shrink: 0; margin-top: 2px; }
+  .hook-text { font-size: 13px; color: #c8d8c8; line-height: 1.5; }
+  .hook-text strong { color: #f0c040; }
+  .hazard-tag { display: inline-block; background: rgba(255,80,80,0.15); color: #ff8080; border: 1px solid rgba(255,80,80,0.3); border-radius: 4px; padding: 2px 8px; font-size: 10px; font-weight: 700; }
+  .ok-tag { display: inline-block; background: rgba(80,200,80,0.15); color: #80e080; border: 1px solid rgba(80,200,80,0.3); border-radius: 4px; padding: 2px 8px; font-size: 10px; font-weight: 700; }
+  .warn-tag { display: inline-block; background: rgba(240,192,64,0.15); color: #f0c040; border: 1px solid rgba(240,192,64,0.3); border-radius: 4px; padding: 2px 8px; font-size: 10px; font-weight: 700; }
+
+  .metar-banner { background: #0a1520; border: 1.5px solid #2a4060; border-radius: 8px; padding: 18px 20px; margin-bottom: 28px; font-family: 'Courier New', monospace; }
+  .metar-line { font-size: 16px; color: #e8edf2; line-height: 2; letter-spacing: 0.5px; flex-wrap: wrap; display: flex; gap: 8px; align-items: baseline; }
+  .m-type { color: #9b7fd4; font-weight: 800; }
+  .m-station { color: #6fa8dc; font-weight: 800; }
+  .m-time { color: #7ac5cd; font-weight: 800; }
+  .m-wind { color: #f0c040; font-weight: 800; }
+  .m-vis { color: #80e080; font-weight: 800; }
+  .m-cloud { color: #80b8e0; font-weight: 800; }
+  .m-temp { color: #e08080; font-weight: 800; }
+  .m-alt { color: #e0c080; font-weight: 800; }
+  .m-rmk { color: #7a9ab5; }
+  .metar-legend { display: flex; flex-wrap: wrap; gap: 8px; margin-top: 12px; }
+  .leg-item { display: flex; align-items: center; gap: 5px; font-size: 11px; }
+  .leg-dot { width: 10px; height: 10px; border-radius: 50%; flex-shrink: 0; }
+  .code-cell { font-family: 'Courier New', monospace; font-weight: 700; color: #f0c040; }
+</style>
+</head>
+<body>
+<div style="max-width:900px;margin:auto;">
+
+<h1>MET-005 — METAR Decoding</h1>
+<p class="subtitle">Transport Canada · TP 12880E Chapter 8 · PPL Written Exam</p>
+
+<div class="section-label">Sample METAR — Colour-Coded by Field</div>
+<div class="metar-banner">
+  <div class="metar-line">
+    <span class="m-type">METAR</span>
+    <span class="m-station">CYYZ</span>
+    <span class="m-time">151800Z</span>
+    <span class="m-wind">27015KT</span>
+    <span class="m-vis">15SM</span>
+    <span class="m-cloud">FEW030</span>
+    <span class="m-cloud">BKN080</span>
+    <span class="m-cloud">OVC150</span>
+    <span class="m-temp">18/08</span>
+    <span class="m-alt">A2992</span>
+    <span class="m-rmk">RMK SLP214</span>
+  </div>
+  <div class="metar-legend">
+    <div class="leg-item"><div class="leg-dot" style="background:#9b7fd4;"></div><span style="color:#9b7fd4;">Report Type</span></div>
+    <div class="leg-item"><div class="leg-dot" style="background:#6fa8dc;"></div><span style="color:#6fa8dc;">Station ID</span></div>
+    <div class="leg-item"><div class="leg-dot" style="background:#7ac5cd;"></div><span style="color:#7ac5cd;">Date/Time UTC</span></div>
+    <div class="leg-item"><div class="leg-dot" style="background:#f0c040;"></div><span style="color:#f0c040;">Wind</span></div>
+    <div class="leg-item"><div class="leg-dot" style="background:#80e080;"></div><span style="color:#80e080;">Visibility</span></div>
+    <div class="leg-item"><div class="leg-dot" style="background:#80b8e0;"></div><span style="color:#80b8e0;">Cloud</span></div>
+    <div class="leg-item"><div class="leg-dot" style="background:#e08080;"></div><span style="color:#e08080;">Temp/Dew Point</span></div>
+    <div class="leg-item"><div class="leg-dot" style="background:#e0c080;"></div><span style="color:#e0c080;">Altimeter</span></div>
+    <div class="leg-item"><div class="leg-dot" style="background:#7a9ab5;"></div><span style="color:#7a9ab5;">Remarks</span></div>
+  </div>
+</div>
+
+<div class="section-label">Field-by-Field Decode</div>
+<table>
+  <thead>
+    <tr>
+      <th>Field</th>
+      <th>Sample Code</th>
+      <th>Format</th>
+      <th>Meaning</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><strong>Report Type</strong></td>
+      <td class="code-cell">METAR</td>
+      <td>METAR or SPECI</td>
+      <td>METAR = routine hourly. SPECI = special report issued when significant change occurs.</td>
+    </tr>
+    <tr>
+      <td><strong>Station ID</strong></td>
+      <td class="code-cell">CYYZ</td>
+      <td>ICAO 4-letter ID</td>
+      <td>Canadian stations start with CY. CYYZ = Toronto Pearson. Used to match TAF.</td>
+    </tr>
+    <tr>
+      <td><strong>Date/Time (UTC)</strong></td>
+      <td class="code-cell">151800Z</td>
+      <td>DDHHMMz</td>
+      <td>Day 15 of month, 1800 UTC (Z = Zulu/UTC). Always UTC — not local time.</td>
+    </tr>
+    <tr>
+      <td><strong>Wind</strong></td>
+      <td class="code-cell">27015KT</td>
+      <td>DDDSSKT or DDDSSGGKT</td>
+      <td>From 270° (west) at 15 knots. Gusts shown as 27015G25KT. VRB = variable direction. 00000KT = calm.</td>
+    </tr>
+    <tr>
+      <td><strong>Visibility</strong></td>
+      <td class="code-cell">15SM</td>
+      <td>NNSMx or MNNNN (metres)</td>
+      <td>15 statute miles. P6SM = more than 6 SM (prevailing). Canadian METARs may use metres (e.g. 9000).</td>
+    </tr>
+    <tr>
+      <td><strong>Present Weather</strong></td>
+      <td class="code-cell">-RA +SN TSRA</td>
+      <td>Intensity + Descriptor + Phenomenon</td>
+      <td>- = light, + = heavy, no sign = moderate. RA=rain, SN=snow, FG=fog, TS=thunderstorm, BR=mist, DZ=drizzle.</td>
+    </tr>
+    <tr>
+      <td><strong>Cloud Amount</strong></td>
+      <td class="code-cell">FEW030 BKN080</td>
+      <td>AMTHHHx (hundreds of ft)</td>
+      <td>030 = 3,000 ft AGL. See cloud amount codes below. CB or TCU appended for cumulonimbus/towering Cu.</td>
+    </tr>
+    <tr>
+      <td><strong>Temperature / Dew Point</strong></td>
+      <td class="code-cell">18/08</td>
+      <td>TT/TDx in Celsius</td>
+      <td>OAT 18°C, dew point 8°C. Spread = 10°C (no fog concern). Minus temps: M02 = -2°C.</td>
+    </tr>
+    <tr>
+      <td><strong>Altimeter Setting</strong></td>
+      <td class="code-cell">A2992</td>
+      <td>ANNNN (inHg x100)</td>
+      <td>29.92 inHg. Canadian METARs also use Q format: Q1013 = 1013 hPa (QNH). Set on altimeter before flight.</td>
+    </tr>
+    <tr>
+      <td><strong>Remarks</strong></td>
+      <td class="code-cell">RMK SLP214</td>
+      <td>Free text / coded</td>
+      <td>SLP = sea-level pressure (1021.4 hPa if SLP214). May include PRESRR (pressure rising rapidly), peak wind, etc.</td>
+    </tr>
+  </tbody>
+</table>
+
+<div class="section-label">Cloud Amount Codes</div>
+<table>
+  <thead>
+    <tr>
+      <th>Code</th>
+      <th>Full Name</th>
+      <th>Oktas (eighths of sky)</th>
+      <th>VFR Impact</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td class="code-cell">SKC / CLR</td>
+      <td>Sky Clear</td>
+      <td>0/8 — no cloud</td>
+      <td><span class="ok-tag">Unrestricted</span></td>
+    </tr>
+    <tr>
+      <td class="code-cell">FEW</td>
+      <td>Few</td>
+      <td>1–2/8</td>
+      <td><span class="ok-tag">VFR OK</span> Not operationally significant</td>
+    </tr>
+    <tr>
+      <td class="code-cell">SCT</td>
+      <td>Scattered</td>
+      <td>3–4/8</td>
+      <td><span class="ok-tag">VFR OK</span> Check ceiling for legal minimums</td>
+    </tr>
+    <tr>
+      <td class="code-cell">BKN</td>
+      <td>Broken</td>
+      <td>5–7/8</td>
+      <td><span class="warn-tag">Ceiling</span> Counts as ceiling — may restrict VFR</td>
+    </tr>
+    <tr>
+      <td class="code-cell">OVC</td>
+      <td>Overcast</td>
+      <td>8/8</td>
+      <td><span class="hazard-tag">Ceiling</span> Overcast = ceiling. Height determines VFR legality.</td>
+    </tr>
+    <tr>
+      <td class="code-cell">VV</td>
+      <td>Vertical Visibility</td>
+      <td>Sky obscured</td>
+      <td><span class="hazard-tag">IFR likely</span> Fog, smoke, or precipitation obscures sky. VV004 = 400 ft vertical visibility.</td>
+    </tr>
+  </tbody>
+</table>
+
+<div class="section-label">Present Weather Codes — Quick Reference</div>
+<table>
+  <thead>
+    <tr>
+      <th>Code</th>
+      <th>Meaning</th>
+      <th>Code</th>
+      <th>Meaning</th>
+      <th>Code</th>
+      <th>Meaning</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td class="code-cell">RA</td><td>Rain</td>
+      <td class="code-cell">SN</td><td>Snow</td>
+      <td class="code-cell">DZ</td><td>Drizzle</td>
+    </tr>
+    <tr>
+      <td class="code-cell">FG</td><td>Fog (vis &lt; 1 SM)</td>
+      <td class="code-cell">BR</td><td>Mist (vis 5/8 – 6 SM)</td>
+      <td class="code-cell">HZ</td><td>Haze</td>
+    </tr>
+    <tr>
+      <td class="code-cell">TS</td><td>Thunderstorm</td>
+      <td class="code-cell">GR</td><td>Hail (&gt; 5 mm)</td>
+      <td class="code-cell">GS</td><td>Small hail / snow pellets</td>
+    </tr>
+    <tr>
+      <td class="code-cell">FZRA</td><td>Freezing rain</td>
+      <td class="code-cell">FZDZ</td><td>Freezing drizzle</td>
+      <td class="code-cell">FZFG</td><td>Freezing fog</td>
+    </tr>
+    <tr>
+      <td class="code-cell">-</td><td>Light intensity</td>
+      <td class="code-cell">(none)</td><td>Moderate intensity</td>
+      <td class="code-cell">+</td><td>Heavy intensity</td>
+    </tr>
+  </tbody>
+</table>
+
+<div class="hook-box">
+  <h2>Memory Hook — METAR Reading Order</h2>
+  <div class="hook-row"><span class="hook-badge">ORDER</span><span class="hook-text"><strong>Type → Station → Time → Wind → Vis → Wx → Cloud → Temp/DP → Altimeter → Remarks</strong>. Always read in sequence — don't skip fields.</span></div>
+  <div class="hook-row"><span class="hook-badge">CEILING</span><span class="hook-text">Only <strong>BKN or OVC</strong> count as ceiling. FEW and SCT are not ceilings even if low. VFR ceiling limits apply to the lowest BKN/OVC layer.</span></div>
+  <div class="hook-row"><span class="hook-badge">UTC</span><span class="hook-text">All METAR times are <strong>UTC (Zulu)</strong>. In Canada: UTC-3.5 to UTC-8 depending on province and DST. Know your offset for local interpretation.</span></div>
+  <div class="hook-row"><span class="hook-badge">ALTIMETER</span><span class="hook-text"><strong>A2992 = 29.92 inHg = 1013 hPa</strong>. Set on altimeter to read correct MSL altitude. Update when given new ATIS or crossing altimeter zones.</span></div>
+</div>
+
+</div>
+</body>
+</html>

--- a/web-app/public/visuals/met006-taf-decoding.html
+++ b/web-app/public/visuals/met006-taf-decoding.html
@@ -1,0 +1,201 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>MET-006: TAF Decoding</title>
+<style>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body { background: #0d1b2a; color: #e8edf2; font-family: 'Segoe UI', system-ui, sans-serif; padding: 32px; }
+  h1 { font-size: 22px; color: #f0c040; letter-spacing: 1px; margin-bottom: 6px; }
+  .subtitle { font-size: 13px; color: #7a9ab5; margin-bottom: 32px; letter-spacing: 0.5px; }
+  .section-label { font-size: 11px; color: #7a9ab5; letter-spacing: 1px; text-transform: uppercase; margin-bottom: 8px; font-weight: 600; }
+  table { width: 100%; border-collapse: collapse; font-size: 12px; margin-bottom: 28px; }
+  th { background: #1a2d3d; color: #7a9ab5; padding: 8px 10px; text-align: left; font-size: 11px; text-transform: uppercase; letter-spacing: 0.5px; }
+  td { padding: 9px 10px; border-bottom: 1px solid #1a2d3d; vertical-align: top; }
+  .hook-box { background: #1a2a1a; border: 1.5px solid #2d5a2d; border-radius: 10px; padding: 18px 22px; margin-top: 8px; }
+  .hook-box h2 { font-size: 12px; color: #80c880; text-transform: uppercase; letter-spacing: 1px; margin-bottom: 12px; }
+  .hook-row { display: flex; gap: 10px; margin-bottom: 8px; align-items: flex-start; }
+  .hook-badge { background: #2d5a2d; color: #80c880; font-size: 10px; font-weight: 800; padding: 2px 8px; border-radius: 10px; white-space: nowrap; flex-shrink: 0; margin-top: 2px; }
+  .hook-text { font-size: 13px; color: #c8d8c8; line-height: 1.5; }
+  .hook-text strong { color: #f0c040; }
+  .hazard-tag { display: inline-block; background: rgba(255,80,80,0.15); color: #ff8080; border: 1px solid rgba(255,80,80,0.3); border-radius: 4px; padding: 2px 8px; font-size: 10px; font-weight: 700; }
+  .ok-tag { display: inline-block; background: rgba(80,200,80,0.15); color: #80e080; border: 1px solid rgba(80,200,80,0.3); border-radius: 4px; padding: 2px 8px; font-size: 10px; font-weight: 700; }
+  .warn-tag { display: inline-block; background: rgba(240,192,64,0.15); color: #f0c040; border: 1px solid rgba(240,192,64,0.3); border-radius: 4px; padding: 2px 8px; font-size: 10px; font-weight: 700; }
+  .taf-banner { background: #0a1520; border: 1.5px solid #2a4060; border-radius: 8px; padding: 18px 20px; margin-bottom: 28px; font-family: 'Courier New', monospace; }
+  .taf-line { font-size: 14px; color: #e8edf2; line-height: 2.2; letter-spacing: 0.5px; }
+  .m-type { color: #9b7fd4; font-weight: 800; }
+  .m-station { color: #6fa8dc; font-weight: 800; }
+  .m-issue { color: #7ac5cd; font-weight: 800; }
+  .m-valid { color: #f0c040; font-weight: 800; }
+  .m-wind { color: #e0a030; font-weight: 800; }
+  .m-vis { color: #80e080; font-weight: 800; }
+  .m-cloud { color: #80b8e0; font-weight: 800; }
+  .m-change { color: #e08080; font-weight: 800; }
+  .m-prob { color: #d080d0; font-weight: 800; }
+  .code-cell { font-family: 'Courier New', monospace; font-weight: 700; color: #f0c040; }
+  .change-card { background: #1a2d3d; border-radius: 8px; padding: 14px 16px; margin-bottom: 10px; display: grid; grid-template-columns: 120px 1fr 1fr; gap: 12px; align-items: start; }
+  .change-kw { font-family: 'Courier New', monospace; font-size: 15px; font-weight: 800; color: #e08080; }
+  .change-def { font-size: 12px; color: #e8edf2; line-height: 1.5; }
+  .change-note { font-size: 11px; color: #7a9ab5; line-height: 1.5; }
+  .compare-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; margin-bottom: 28px; }
+  .compare-card { background: #1a2d3d; border-radius: 8px; padding: 16px 18px; }
+  .compare-title { font-size: 13px; font-weight: 700; margin-bottom: 10px; }
+  .compare-row { font-size: 12px; color: #c8d8e8; margin-bottom: 6px; line-height: 1.5; }
+  .compare-label { color: #7a9ab5; font-size: 11px; text-transform: uppercase; letter-spacing: 0.5px; }
+</style>
+</head>
+<body>
+<div style="max-width:900px;margin:auto;">
+
+<h1>MET-006 — TAF Decoding</h1>
+<p class="subtitle">Transport Canada · TP 12880E Chapter 8 · PPL Written Exam</p>
+
+<div class="section-label">Sample TAF — Colour-Coded by Field</div>
+<div class="taf-banner">
+  <div class="taf-line">
+    <span class="m-type">TAF</span>
+    <span class="m-station">CYYZ</span>
+    <span class="m-issue">151720Z</span>
+    <span class="m-valid">1518/1618</span>
+    <span class="m-wind">27015KT</span>
+    <span class="m-vis">P6SM</span>
+    <span class="m-cloud">FEW030</span>
+  </div>
+  <div class="taf-line" style="padding-left:20px;">
+    <span class="m-change">TEMPO</span>
+    <span class="m-valid">1600/1606</span>
+    <span class="m-vis">2SM</span>
+    <span class="m-cloud">-RASN</span>
+    <span class="m-cloud">OVC015</span>
+  </div>
+  <div class="taf-line" style="padding-left:20px;">
+    <span class="m-change">FM</span><span class="m-valid">160800</span>
+    <span class="m-wind">30020KT</span>
+    <span class="m-vis">P6SM</span>
+    <span class="m-cloud">SCT040</span>
+  </div>
+  <div class="taf-line" style="padding-left:20px;">
+    <span class="m-prob">PROB30</span>
+    <span class="m-valid">1612/1615</span>
+    <span class="m-cloud">TSRA</span>
+    <span class="m-cloud">BKN020CB</span>
+  </div>
+</div>
+
+<div class="section-label">TAF Field Decode</div>
+<table>
+  <thead>
+    <tr>
+      <th>Field</th>
+      <th>Sample</th>
+      <th>Format</th>
+      <th>Meaning</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><strong>Report Type</strong></td>
+      <td class="code-cell">TAF</td>
+      <td>TAF or TAF AMD</td>
+      <td>TAF = Terminal Aerodrome Forecast. AMD = amended (corrected) TAF issued between routine issuances.</td>
+    </tr>
+    <tr>
+      <td><strong>Station ID</strong></td>
+      <td class="code-cell">CYYZ</td>
+      <td>ICAO 4-letter ID</td>
+      <td>Same station identifier as METAR. TAF issued for specific airports (not all airports have TAF).</td>
+    </tr>
+    <tr>
+      <td><strong>Issue Time</strong></td>
+      <td class="code-cell">151720Z</td>
+      <td>DDHHMMz</td>
+      <td>When the TAF was prepared: day 15, 1720 UTC. Not the valid period start.</td>
+    </tr>
+    <tr>
+      <td><strong>Valid Period</strong></td>
+      <td class="code-cell">1518/1618</td>
+      <td>DDHH/DDHH</td>
+      <td>Forecast valid from day 15, 18 UTC to day 16, 18 UTC. Standard TAF = 24 hr; some airports 30 hr.</td>
+    </tr>
+    <tr>
+      <td><strong>Wind</strong></td>
+      <td class="code-cell">27015KT</td>
+      <td>Same as METAR</td>
+      <td>Prevailing wind forecast. Same format as METAR wind field.</td>
+    </tr>
+    <tr>
+      <td><strong>Visibility</strong></td>
+      <td class="code-cell">P6SM</td>
+      <td>SM or metres</td>
+      <td>P6SM = prevailing more than 6 statute miles. TAFs typically use SM in Canada.</td>
+    </tr>
+    <tr>
+      <td><strong>Weather / Cloud</strong></td>
+      <td class="code-cell">FEW030 OVC015</td>
+      <td>Same as METAR</td>
+      <td>Same codes as METAR. CB appended after cloud amount for cumulonimbus (e.g. BKN020CB).</td>
+    </tr>
+    <tr>
+      <td><strong>Change Groups</strong></td>
+      <td class="code-cell">TEMPO FM BECMG PROB</td>
+      <td>Keyword + period + conditions</td>
+      <td>Describe changes from the base forecast. See table below for details.</td>
+    </tr>
+  </tbody>
+</table>
+
+<div class="section-label">Change Indicator Keywords</div>
+<div class="change-card">
+  <div class="change-kw">FM</div>
+  <div class="change-def"><strong>From (permanent change)</strong><br>New conditions replace ALL previous forecast from the stated time. FM160800 = from day 16 at 0800 UTC onwards.</div>
+  <div class="change-note">Always followed by DDHHmm (no period). Entire forecast resets. Most definitive change type.</div>
+</div>
+<div class="change-card">
+  <div class="change-kw">TEMPO</div>
+  <div class="change-def"><strong>Temporary fluctuations</strong><br>Conditions expected for less than half of the period, each occurrence lasting less than 60 minutes.</div>
+  <div class="change-note">TEMPO does not replace base — base conditions return between episodes. Period shown as DDHH/DDHH.</div>
+</div>
+<div class="change-card">
+  <div class="change-kw">BECMG</div>
+  <div class="change-def"><strong>Becoming (gradual change)</strong><br>Conditions expected to change gradually during the period, reaching the new conditions by the end of the period.</div>
+  <div class="change-note">Change is permanent once complete. Period shown as DDHH/DDHH. Slower transition than FM.</div>
+</div>
+<div class="change-card">
+  <div class="change-kw">PROB30</div>
+  <div class="change-def"><strong>30% probability</strong><br>Conditions have a 30% chance of occurring during the stated period.</div>
+  <div class="change-note">PROB40 = 40% chance. Typically used for thunderstorms. PROB30 alone (no TEMPO) = brief occurrence.</div>
+</div>
+<div style="margin-bottom:28px;"></div>
+
+<div class="section-label">METAR vs. TAF — Key Comparison</div>
+<div class="compare-grid">
+  <div class="compare-card" style="border-top:3px solid #7ac5cd;">
+    <div class="compare-title" style="color:#7ac5cd;">METAR — Observed</div>
+    <div class="compare-row"><span class="compare-label">Type</span><br>Actual current conditions (observation)</div>
+    <div class="compare-row"><span class="compare-label">Frequency</span><br>Hourly (or SPECI for significant changes)</div>
+    <div class="compare-row"><span class="compare-label">Valid period</span><br>Snapshot at time of observation</div>
+    <div class="compare-row"><span class="compare-label">Use for</span><br>Departure planning; current conditions at destination</div>
+    <div class="compare-row"><span class="compare-label">Change groups</span><br>None (it's an observation, not a forecast)</div>
+  </div>
+  <div class="compare-card" style="border-top:3px solid #f0c040;">
+    <div class="compare-title" style="color:#f0c040;">TAF — Forecast</div>
+    <div class="compare-row"><span class="compare-label">Type</span><br>Weather forecast for a specific aerodrome</div>
+    <div class="compare-row"><span class="compare-label">Frequency</span><br>4x/day (0000, 0600, 1200, 1800 UTC)</div>
+    <div class="compare-row"><span class="compare-label">Valid period</span><br>24 hours (some airports 30 hours)</div>
+    <div class="compare-row"><span class="compare-label">Use for</span><br>En route planning; ETA weather; alternate requirements</div>
+    <div class="compare-row"><span class="compare-label">Change groups</span><br>FM, TEMPO, BECMG, PROB30/40</div>
+  </div>
+</div>
+
+<div class="hook-box">
+  <h2>Memory Hook — TAF Decoding</h2>
+  <div class="hook-row"><span class="hook-badge">VALID PERIOD</span><span class="hook-text">Format is <strong>DDHH/DDHH</strong>. First group = start, second = end. Day can roll over (e.g. 1518/1618 spans two calendar days).</span></div>
+  <div class="hook-row"><span class="hook-badge">FM vs TEMPO</span><span class="hook-text"><strong>FM = permanent reset</strong> of all conditions. <strong>TEMPO = temporary spike</strong> less than half the period; base forecast resumes between occurrences.</span></div>
+  <div class="hook-row"><span class="hook-badge">PROB30</span><span class="hook-text">30% probability = plan for it if it would be a <strong>go/no-go condition</strong>. PROB30 thunderstorms = check alternate carefully.</span></div>
+  <div class="hook-row"><span class="hook-badge">METAR vs TAF</span><span class="hook-text"><strong>METAR = what IS</strong>. <strong>TAF = what WILL BE</strong>. Always check the latest METAR closest to your departure time; TAF for en route and destination.</span></div>
+</div>
+
+</div>
+</body>
+</html>

--- a/web-app/public/visuals/met007-gfa.html
+++ b/web-app/public/visuals/met007-gfa.html
@@ -1,0 +1,153 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>MET-007: GFA — Graphical Forecast for Aviation</title>
+<style>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body { background: #0d1b2a; color: #e8edf2; font-family: 'Segoe UI', system-ui, sans-serif; padding: 32px; }
+  h1 { font-size: 22px; color: #f0c040; letter-spacing: 1px; margin-bottom: 6px; }
+  .subtitle { font-size: 13px; color: #7a9ab5; margin-bottom: 32px; letter-spacing: 0.5px; }
+  .section-label { font-size: 11px; color: #7a9ab5; letter-spacing: 1px; text-transform: uppercase; margin-bottom: 8px; font-weight: 600; }
+  table { width: 100%; border-collapse: collapse; font-size: 12px; margin-bottom: 28px; }
+  th { background: #1a2d3d; color: #7a9ab5; padding: 8px 10px; text-align: left; font-size: 11px; text-transform: uppercase; letter-spacing: 0.5px; }
+  td { padding: 9px 10px; border-bottom: 1px solid #1a2d3d; vertical-align: top; }
+  .hook-box { background: #1a2a1a; border: 1.5px solid #2d5a2d; border-radius: 10px; padding: 18px 22px; margin-top: 8px; }
+  .hook-box h2 { font-size: 12px; color: #80c880; text-transform: uppercase; letter-spacing: 1px; margin-bottom: 12px; }
+  .hook-row { display: flex; gap: 10px; margin-bottom: 8px; align-items: flex-start; }
+  .hook-badge { background: #2d5a2d; color: #80c880; font-size: 10px; font-weight: 800; padding: 2px 8px; border-radius: 10px; white-space: nowrap; flex-shrink: 0; margin-top: 2px; }
+  .hook-text { font-size: 13px; color: #c8d8c8; line-height: 1.5; }
+  .hook-text strong { color: #f0c040; }
+  .hazard-tag { display: inline-block; background: rgba(255,80,80,0.15); color: #ff8080; border: 1px solid rgba(255,80,80,0.3); border-radius: 4px; padding: 2px 8px; font-size: 10px; font-weight: 700; }
+  .ok-tag { display: inline-block; background: rgba(80,200,80,0.15); color: #80e080; border: 1px solid rgba(80,200,80,0.3); border-radius: 4px; padding: 2px 8px; font-size: 10px; font-weight: 700; }
+  .warn-tag { display: inline-block; background: rgba(240,192,64,0.15); color: #f0c040; border: 1px solid rgba(240,192,64,0.3); border-radius: 4px; padding: 2px 8px; font-size: 10px; font-weight: 700; }
+  .chart-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; margin-bottom: 28px; }
+  .chart-card { background: #1a2d3d; border-radius: 8px; padding: 16px 18px; }
+  .chart-title { font-size: 13px; font-weight: 700; color: #f0c040; margin-bottom: 8px; }
+  .chart-row { font-size: 12px; color: #c8d8e8; margin-bottom: 5px; line-height: 1.5; }
+  .chart-label { color: #7a9ab5; font-size: 10px; text-transform: uppercase; letter-spacing: 0.5px; }
+  .region-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 10px; margin-bottom: 28px; }
+  .region-card { background: #1a2d3d; border-radius: 8px; padding: 12px 14px; text-align: center; }
+  .region-name { font-size: 13px; font-weight: 700; color: #7ac5cd; margin-bottom: 4px; }
+  .region-desc { font-size: 11px; color: #7a9ab5; }
+  .checklist { list-style: none; padding: 0; margin: 0 0 28px 0; }
+  .checklist li { display: flex; align-items: flex-start; gap: 10px; padding: 8px 12px; border-bottom: 1px solid #1a2d3d; font-size: 12px; color: #c8d8e8; line-height: 1.5; }
+  .checklist li:last-child { border-bottom: none; }
+  .check-num { display: inline-block; background: #1a2d3d; color: #f0c040; font-size: 11px; font-weight: 800; width: 22px; height: 22px; border-radius: 50%; text-align: center; line-height: 22px; flex-shrink: 0; }
+  .check-label { font-weight: 700; color: #e8edf2; }
+</style>
+</head>
+<body>
+<div style="max-width:900px;margin:auto;">
+
+<h1>MET-007 — GFA (Graphical Forecast for Aviation)</h1>
+<p class="subtitle">Transport Canada · NAV CANADA · TP 12880E Chapter 8 · PPL Written Exam</p>
+
+<div class="section-label">What is a GFA?</div>
+<p style="font-size:13px;color:#c8d8e8;line-height:1.6;margin-bottom:24px;">
+The Graphical Forecast for Aviation (GFA) replaced the old written FA (Area Forecast) in Canada. Issued by NAV CANADA's Meteorological Service, GFAs are colour-coded graphical charts covering weather conditions across Canadian regions. Updated 4 times per day, they provide forecasts at multiple valid times up to 24 hours ahead.
+</p>
+
+<div class="section-label">GFA Chart Types — Two Charts Per Region</div>
+<div class="chart-grid">
+  <div class="chart-card" style="border-top:3px solid #5080e0;">
+    <div class="chart-title">Chart 1: Clouds &amp; Weather</div>
+    <div class="chart-row"><span class="chart-label">Shows</span><br>Cloud coverage and types (BKN, OVC, SCT), cloud base and tops, precipitation areas, visibility restrictions, freezing precipitation, thunderstorm areas</div>
+    <div class="chart-row" style="margin-top:8px;"><span class="chart-label">Key use</span><br>Go/no-go decision; VFR ceiling and visibility assessment; identifying IFR conditions</div>
+  </div>
+  <div class="chart-card" style="border-top:3px solid #e08080;">
+    <div class="chart-title">Chart 2: Icing, Freezing Level &amp; Turbulence</div>
+    <div class="chart-row"><span class="chart-label">Shows</span><br>Freezing level altitude (0°C isotherm), icing areas with intensity, turbulence areas with intensity, mountain wave activity</div>
+    <div class="chart-row" style="margin-top:8px;"><span class="chart-label">Key use</span><br>Icing risk assessment; turbulence avoidance altitude selection; identifying safe altitude bands</div>
+  </div>
+</div>
+
+<div class="section-label">GFA Valid Times</div>
+<table>
+  <thead>
+    <tr>
+      <th>Issuance Time (UTC)</th>
+      <th>Valid Times (UTC)</th>
+      <th>Hours of Forecast</th>
+      <th>Coverage</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>0000Z</td>
+      <td>0000, 0600, 1200, 1800, 2400Z</td>
+      <td>0 – 24 hr</td>
+      <td>5 forecast periods</td>
+    </tr>
+    <tr>
+      <td>0600Z</td>
+      <td>0600, 1200, 1800, 0000, 0600Z (+1)</td>
+      <td>0 – 24 hr</td>
+      <td>5 forecast periods</td>
+    </tr>
+    <tr>
+      <td>1200Z</td>
+      <td>1200, 1800, 0000, 0600, 1200Z (+1)</td>
+      <td>0 – 24 hr</td>
+      <td>5 forecast periods</td>
+    </tr>
+    <tr>
+      <td>1800Z</td>
+      <td>1800, 0000, 0600, 1200, 1800Z (+1)</td>
+      <td>0 – 24 hr</td>
+      <td>5 forecast periods</td>
+    </tr>
+  </tbody>
+</table>
+
+<div class="section-label">Canadian GFA Regions</div>
+<div class="region-grid">
+  <div class="region-card">
+    <div class="region-name">British Columbia</div>
+    <div class="region-desc">Pacific coast, coastal mountains, interior plateau</div>
+  </div>
+  <div class="region-card">
+    <div class="region-name">Prairies</div>
+    <div class="region-desc">Alberta, Saskatchewan, Manitoba — open terrain</div>
+  </div>
+  <div class="region-card">
+    <div class="region-name">Ontario &amp; Quebec</div>
+    <div class="region-desc">Great Lakes, St. Lawrence, populated southern corridor</div>
+  </div>
+  <div class="region-card">
+    <div class="region-name">Atlantic</div>
+    <div class="region-desc">NB, NS, PEI, NL — marine influence, coastal fog</div>
+  </div>
+  <div class="region-card">
+    <div class="region-name">Northern Canada</div>
+    <div class="region-desc">YT, NWT, NU — Arctic conditions, sparse reporting</div>
+  </div>
+  <div class="region-card">
+    <div class="region-name">Arctic</div>
+    <div class="region-desc">High Arctic; extreme cold; polar air masses</div>
+  </div>
+</div>
+
+<div class="section-label">GFA Pre-Flight Checklist — What to Look For</div>
+<ul class="checklist">
+  <li><span class="check-num">1</span><div><span class="check-label">Freezing Level</span> — Where is the 0°C isotherm? Are you flying above or below? Icing possible from surface to that level in cloud.</div></li>
+  <li><span class="check-num">2</span><div><span class="check-label">Icing Areas</span> — Look for shaded icing regions on Chart 2. Note intensity (LGT, MOD, SEV) and altitude band.</div></li>
+  <li><span class="check-num">3</span><div><span class="check-label">Turbulence</span> — Check for moderate or severe turbulence areas, especially near mountains or frontal zones. Note altitude affected.</div></li>
+  <li><span class="check-num">4</span><div><span class="check-label">Cloud Bases and Tops</span> — Identify ceiling heights along route. BKN or OVC below 1,000 ft = IFR. Check tops to determine if VFR on top is feasible.</div></li>
+  <li><span class="check-num">5</span><div><span class="check-label">Visibility</span> — Look for areas of precipitation or fog reducing visibility. Match to METAR/TAF for destination.</div></li>
+  <li><span class="check-num">6</span><div><span class="check-label">Thunderstorm Areas</span> — TS marked on Clouds &amp; Weather chart. Plan to avoid by at least 20 NM.</div></li>
+  <li><span class="check-num">7</span><div><span class="check-label">Valid Time Match</span> — Select the GFA valid time closest to your ETA at each waypoint. Don't use 0-hour chart for a flight 5 hours away.</div></li>
+</ul>
+
+<div class="hook-box">
+  <h2>Memory Hook — GFA Essentials</h2>
+  <div class="hook-row"><span class="hook-badge">GFA REPLACED FA</span><span class="hook-text">The old written Area Forecast (FA) is gone in Canada. <strong>GFA is the standard</strong> — graphical, updated 4x/day at 0000/0600/1200/1800 UTC.</span></div>
+  <div class="hook-row"><span class="hook-badge">TWO CHARTS</span><span class="hook-text">Always look at both: <strong>Clouds &amp; Wx</strong> for ceiling/visibility, <strong>Icing/Turbulence</strong> for altitude hazards. Never use just one.</span></div>
+  <div class="hook-row"><span class="hook-badge">FREEZING LEVEL</span><span class="hook-text">The 0°C level is on Chart 2. If you fly in cloud below that altitude, <strong>expect icing</strong>. It shifts with temperature — recheck for long flights.</span></div>
+  <div class="hook-row"><span class="hook-badge">VALID TIME</span><span class="hook-text">GFA covers 0, 6, 12, 18, 24 hrs. Use the chart whose valid time matches your <strong>ETA</strong>, not your departure time.</span></div>
+</div>
+
+</div>
+</body>
+</html>

--- a/web-app/public/visuals/met008-pireps.html
+++ b/web-app/public/visuals/met008-pireps.html
@@ -1,0 +1,174 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>MET-008: PIREPs</title>
+<style>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body { background: #0d1b2a; color: #e8edf2; font-family: 'Segoe UI', system-ui, sans-serif; padding: 32px; }
+  h1 { font-size: 22px; color: #f0c040; letter-spacing: 1px; margin-bottom: 6px; }
+  .subtitle { font-size: 13px; color: #7a9ab5; margin-bottom: 32px; letter-spacing: 0.5px; }
+  .section-label { font-size: 11px; color: #7a9ab5; letter-spacing: 1px; text-transform: uppercase; margin-bottom: 8px; font-weight: 600; }
+  table { width: 100%; border-collapse: collapse; font-size: 12px; margin-bottom: 28px; }
+  th { background: #1a2d3d; color: #7a9ab5; padding: 8px 10px; text-align: left; font-size: 11px; text-transform: uppercase; letter-spacing: 0.5px; }
+  td { padding: 9px 10px; border-bottom: 1px solid #1a2d3d; vertical-align: top; }
+  .hook-box { background: #1a2a1a; border: 1.5px solid #2d5a2d; border-radius: 10px; padding: 18px 22px; margin-top: 8px; }
+  .hook-box h2 { font-size: 12px; color: #80c880; text-transform: uppercase; letter-spacing: 1px; margin-bottom: 12px; }
+  .hook-row { display: flex; gap: 10px; margin-bottom: 8px; align-items: flex-start; }
+  .hook-badge { background: #2d5a2d; color: #80c880; font-size: 10px; font-weight: 800; padding: 2px 8px; border-radius: 10px; white-space: nowrap; flex-shrink: 0; margin-top: 2px; }
+  .hook-text { font-size: 13px; color: #c8d8c8; line-height: 1.5; }
+  .hook-text strong { color: #f0c040; }
+  .hazard-tag { display: inline-block; background: rgba(255,80,80,0.15); color: #ff8080; border: 1px solid rgba(255,80,80,0.3); border-radius: 4px; padding: 2px 8px; font-size: 10px; font-weight: 700; }
+  .ok-tag { display: inline-block; background: rgba(80,200,80,0.15); color: #80e080; border: 1px solid rgba(80,200,80,0.3); border-radius: 4px; padding: 2px 8px; font-size: 10px; font-weight: 700; }
+  .warn-tag { display: inline-block; background: rgba(240,192,64,0.15); color: #f0c040; border: 1px solid rgba(240,192,64,0.3); border-radius: 4px; padding: 2px 8px; font-size: 10px; font-weight: 700; }
+  .pirep-banner { background: #0a1520; border: 1.5px solid #2a4060; border-radius: 8px; padding: 18px 20px; margin-bottom: 24px; font-family: 'Courier New', monospace; font-size: 13px; line-height: 2; }
+  .code-cell { font-family: 'Courier New', monospace; font-weight: 700; color: #f0c040; }
+  .field-code { color: #e08080; font-weight: 800; }
+  .field-val { color: #80e080; }
+  .intensity-grid { display: grid; grid-template-columns: repeat(5, 1fr); gap: 8px; margin-bottom: 28px; }
+  .int-card { background: #1a2d3d; border-radius: 6px; padding: 10px; text-align: center; }
+  .int-code { font-family: 'Courier New', monospace; font-weight: 800; font-size: 14px; margin-bottom: 4px; }
+  .int-label { font-size: 10px; color: #7a9ab5; }
+</style>
+</head>
+<body>
+<div style="max-width:900px;margin:auto;">
+
+<h1>MET-008 — PIREPs (Pilot Reports)</h1>
+<p class="subtitle">Transport Canada · TP 12880E Chapter 8 · PPL Written Exam</p>
+
+<div class="section-label">What is a PIREP?</div>
+<p style="font-size:13px;color:#c8d8e8;line-height:1.6;margin-bottom:24px;">
+A PIREP (Pilot Report) is a real-time weather observation submitted by a pilot in flight. PIREPs provide ground-truth data on turbulence, icing, and cloud conditions that cannot be detected by ground stations or radar. They are especially critical in areas with sparse weather reporting and for conditions like Clear Air Turbulence. Pilots are encouraged — and sometimes required — to submit PIREPs when encountering significant weather.
+</p>
+
+<div class="section-label">PIREP Format Fields</div>
+<table>
+  <thead>
+    <tr>
+      <th>Field Code</th>
+      <th>Field Name</th>
+      <th>Format / Example</th>
+      <th>Notes</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td class="code-cell">UA / UUA</td>
+      <td>Report Type</td>
+      <td>UA = routine; UUA = urgent</td>
+      <td>UUA issued for SEV turbulence, SEV icing, or other hazards requiring immediate relay</td>
+    </tr>
+    <tr>
+      <td class="code-cell">/OV</td>
+      <td>Location</td>
+      <td>/OV YYZ / /OV YYZ-YTZ</td>
+      <td>NAVAID or fix; or between two fixes. Can include bearing/distance (YYZ090025 = 025 NM east of YYZ)</td>
+    </tr>
+    <tr>
+      <td class="code-cell">/TM</td>
+      <td>Time</td>
+      <td>/TM 1755</td>
+      <td>UTC time of observation in HHMM format</td>
+    </tr>
+    <tr>
+      <td class="code-cell">/FL</td>
+      <td>Altitude (Flight Level)</td>
+      <td>/FL085 or /FLDURC</td>
+      <td>In hundreds of feet. FLDURC = during climb. FLDURD = during descent.</td>
+    </tr>
+    <tr>
+      <td class="code-cell">/TP</td>
+      <td>Aircraft Type</td>
+      <td>/TP C172</td>
+      <td>ICAO designator. Important — turbulence severity is relative to aircraft size/weight</td>
+    </tr>
+    <tr>
+      <td class="code-cell">/SK</td>
+      <td>Sky / Cloud</td>
+      <td>/SK BKN045-TOP065</td>
+      <td>Cloud layer base-top in hundreds of ft. OVC = overcast. CLR = clear.</td>
+    </tr>
+    <tr>
+      <td class="code-cell">/WX</td>
+      <td>Weather</td>
+      <td>/WX FV03SM RA</td>
+      <td>Flight visibility and present weather. FV = flight visibility in SM.</td>
+    </tr>
+    <tr>
+      <td class="code-cell">/TA</td>
+      <td>Temperature</td>
+      <td>/TA M08</td>
+      <td>Outside air temperature in Celsius. M prefix = minus (negative). M08 = -8°C.</td>
+    </tr>
+    <tr>
+      <td class="code-cell">/WV</td>
+      <td>Wind</td>
+      <td>/WV 27035KT</td>
+      <td>Wind direction and speed as observed in flight. Direction in degrees true.</td>
+    </tr>
+    <tr>
+      <td class="code-cell">/TB</td>
+      <td>Turbulence</td>
+      <td>/TB MOD 070-090</td>
+      <td>Intensity + altitude band. See intensity table below.</td>
+    </tr>
+    <tr>
+      <td class="code-cell">/IC</td>
+      <td>Icing</td>
+      <td>/IC LGT-MOD RIME 060-080</td>
+      <td>Intensity + type (RIME, CLR, MIXED) + altitude band</td>
+    </tr>
+    <tr>
+      <td class="code-cell">/RM</td>
+      <td>Remarks</td>
+      <td>/RM LLWS ON APCH</td>
+      <td>Free text. Common: LLWS (low-level wind shear), ACFT MSK (aircraft masked), DURC (during climb)</td>
+    </tr>
+  </tbody>
+</table>
+
+<div class="section-label">Sample PIREP — Decoded Line by Line</div>
+<div class="pirep-banner">
+  <div><span class="field-code">UUA</span> <span style="color:#7a9ab5;">→ Urgent PIREP (hazardous conditions)</span></div>
+  <div><span class="field-code">/OV YYZ180030</span> <span style="color:#7a9ab5;">→ Location: 30 NM south of Toronto Pearson (180° bearing)</span></div>
+  <div><span class="field-code">/TM 1432</span> <span style="color:#7a9ab5;">→ Time: 1432 UTC</span></div>
+  <div><span class="field-code">/FL085</span> <span style="color:#7a9ab5;">→ Altitude: 8,500 ft</span></div>
+  <div><span class="field-code">/TP B738</span> <span style="color:#7a9ab5;">→ Aircraft: Boeing 737-800</span></div>
+  <div><span class="field-code">/SK OVC060-TOP110</span> <span style="color:#7a9ab5;">→ Overcast cloud layer base 6,000 ft, tops 11,000 ft</span></div>
+  <div><span class="field-code">/TA M06</span> <span style="color:#7a9ab5;">→ Temperature: -6°C (prime icing range)</span></div>
+  <div><span class="field-code">/TB SEV 080-090</span> <span style="color:#7a9ab5;">→ Severe turbulence between 8,000 and 9,000 ft</span></div>
+  <div><span class="field-code">/IC MOD CLEAR 070-090</span> <span style="color:#7a9ab5;">→ Moderate clear (glaze) icing between 7,000 and 9,000 ft</span></div>
+  <div><span class="field-code">/RM LLWS +20KT ON APCH</span> <span style="color:#7a9ab5;">→ Remarks: +20 kt wind shear on approach</span></div>
+</div>
+
+<div class="section-label">Turbulence Intensity Codes</div>
+<div class="intensity-grid">
+  <div class="int-card"><div class="int-code" style="color:#80e080;">NEG</div><div class="int-label">None</div><div style="font-size:10px;color:#c8d8e8;margin-top:4px;">No turbulence encountered</div></div>
+  <div class="int-card"><div class="int-code" style="color:#80e080;">LGT</div><div class="int-label">Light</div><div style="font-size:10px;color:#c8d8e8;margin-top:4px;">Slight erratic attitude changes; occupants feel slight strain</div></div>
+  <div class="int-card"><div class="int-code" style="color:#f0c040;">MOD</div><div class="int-label">Moderate</div><div style="font-size:10px;color:#c8d8e8;margin-top:4px;">Definite changes; hard to walk; unsecured items displaced</div></div>
+  <div class="int-card"><div class="int-code" style="color:#ff8080;">SEV</div><div class="int-label">Severe</div><div style="font-size:10px;color:#c8d8e8;margin-top:4px;">Large abrupt changes; momentarily out of control; UUA required</div></div>
+  <div class="int-card"><div class="int-code" style="color:#ff8080;">EXTM</div><div class="int-label">Extreme</div><div style="font-size:10px;color:#c8d8e8;margin-top:4px;">Violent; aircraft structural damage possible; extremely rare</div></div>
+</div>
+
+<div class="section-label">Icing Intensity Codes</div>
+<div class="intensity-grid">
+  <div class="int-card"><div class="int-code" style="color:#80e080;">NEG</div><div class="int-label">None</div><div style="font-size:10px;color:#c8d8e8;margin-top:4px;">No icing encountered</div></div>
+  <div class="int-card"><div class="int-code" style="color:#80e080;">TRC</div><div class="int-label">Trace</div><div style="font-size:10px;color:#c8d8e8;margin-top:4px;">Barely perceptible; no de-icing needed unless exposed &gt; 1 hr</div></div>
+  <div class="int-card"><div class="int-code" style="color:#f0c040;">LGT</div><div class="int-label">Light</div><div style="font-size:10px;color:#c8d8e8;margin-top:4px;">Ice accumulates slowly; de-icing adequate to control</div></div>
+  <div class="int-card"><div class="int-code" style="color:#f0c040;">MOD</div><div class="int-label">Moderate</div><div style="font-size:10px;color:#c8d8e8;margin-top:4px;">Rapid accumulation; de-icing may not be adequate</div></div>
+  <div class="int-card"><div class="int-code" style="color:#ff8080;">SEV</div><div class="int-label">Severe</div><div style="font-size:10px;color:#c8d8e8;margin-top:4px;">Rate of accumulation exceeds de-icing capacity; exit immediately</div></div>
+</div>
+
+<div class="hook-box">
+  <h2>Memory Hook — PIREP Key Points</h2>
+  <div class="hook-row"><span class="hook-badge">UUA</span><span class="hook-text"><strong>Urgent PIREP</strong> = SEV or EXTM turbulence, SEV icing, or other critical hazards. ATC relays immediately to other aircraft.</span></div>
+  <div class="hook-row"><span class="hook-badge">AIRCRAFT TYPE</span><span class="hook-text">Always note <strong>/TP</strong>. SEV turbulence in a B747 may be MOD in a C172. Consider the reporting aircraft size when interpreting.</span></div>
+  <div class="hook-row"><span class="hook-badge">TEMP + CLOUD</span><span class="hook-text">If /TA shows <strong>0°C to -20°C</strong> and /SK shows cloud, expect icing. Prime icing range is <strong>-2°C to -10°C</strong>.</span></div>
+  <div class="hook-row"><span class="hook-badge">REPORT DUTY</span><span class="hook-text">When you encounter SEV turbulence or icing, <strong>report it</strong>. PIREPs protect other pilots. Failure to report is a missed safety opportunity.</span></div>
+</div>
+
+</div>
+</body>
+</html>

--- a/web-app/public/visuals/met009-thunderstorms.html
+++ b/web-app/public/visuals/met009-thunderstorms.html
@@ -1,0 +1,184 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>MET-009: Thunderstorms</title>
+<style>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body { background: #0d1b2a; color: #e8edf2; font-family: 'Segoe UI', system-ui, sans-serif; padding: 32px; }
+  h1 { font-size: 22px; color: #f0c040; letter-spacing: 1px; margin-bottom: 6px; }
+  .subtitle { font-size: 13px; color: #7a9ab5; margin-bottom: 32px; letter-spacing: 0.5px; }
+  .section-label { font-size: 11px; color: #7a9ab5; letter-spacing: 1px; text-transform: uppercase; margin-bottom: 8px; font-weight: 600; }
+  table { width: 100%; border-collapse: collapse; font-size: 12px; margin-bottom: 28px; }
+  th { background: #1a2d3d; color: #7a9ab5; padding: 8px 10px; text-align: left; font-size: 11px; text-transform: uppercase; letter-spacing: 0.5px; }
+  td { padding: 9px 10px; border-bottom: 1px solid #1a2d3d; vertical-align: top; }
+  .hook-box { background: #1a2a1a; border: 1.5px solid #2d5a2d; border-radius: 10px; padding: 18px 22px; margin-top: 8px; }
+  .hook-box h2 { font-size: 12px; color: #80c880; text-transform: uppercase; letter-spacing: 1px; margin-bottom: 12px; }
+  .hook-row { display: flex; gap: 10px; margin-bottom: 8px; align-items: flex-start; }
+  .hook-badge { background: #2d5a2d; color: #80c880; font-size: 10px; font-weight: 800; padding: 2px 8px; border-radius: 10px; white-space: nowrap; flex-shrink: 0; margin-top: 2px; }
+  .hook-text { font-size: 13px; color: #c8d8c8; line-height: 1.5; }
+  .hook-text strong { color: #f0c040; }
+  .hazard-tag { display: inline-block; background: rgba(255,80,80,0.15); color: #ff8080; border: 1px solid rgba(255,80,80,0.3); border-radius: 4px; padding: 2px 8px; font-size: 10px; font-weight: 700; }
+  .ok-tag { display: inline-block; background: rgba(80,200,80,0.15); color: #80e080; border: 1px solid rgba(80,200,80,0.3); border-radius: 4px; padding: 2px 8px; font-size: 10px; font-weight: 700; }
+  .warn-tag { display: inline-block; background: rgba(240,192,64,0.15); color: #f0c040; border: 1px solid rgba(240,192,64,0.3); border-radius: 4px; padding: 2px 8px; font-size: 10px; font-weight: 700; }
+  .stage-grid { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 16px; margin-bottom: 28px; }
+  .stage-card { background: #1a2d3d; border-radius: 8px; padding: 16px 18px; }
+  .stage-title { font-size: 13px; font-weight: 700; margin-bottom: 10px; }
+  .stage-row { font-size: 12px; color: #c8d8e8; margin-bottom: 6px; line-height: 1.5; }
+  .stage-label { font-size: 10px; color: #7a9ab5; text-transform: uppercase; letter-spacing: 0.5px; }
+  .avoid-box { background: rgba(255,80,80,0.08); border: 1.5px solid rgba(255,80,80,0.3); border-radius: 10px; padding: 18px 22px; margin-bottom: 28px; }
+  .avoid-box h2 { font-size: 12px; color: #ff8080; text-transform: uppercase; letter-spacing: 1px; margin-bottom: 12px; }
+  .avoid-row { display: flex; gap: 10px; margin-bottom: 8px; align-items: flex-start; }
+  .avoid-badge { background: rgba(255,80,80,0.2); color: #ff8080; font-size: 10px; font-weight: 800; padding: 2px 8px; border-radius: 10px; white-space: nowrap; flex-shrink: 0; margin-top: 2px; }
+  .avoid-text { font-size: 13px; color: #e8d0d0; line-height: 1.5; }
+  .avoid-text strong { color: #ff8080; }
+</style>
+</head>
+<body>
+<div style="max-width:900px;margin:auto;">
+
+<h1>MET-009 — Thunderstorms</h1>
+<p class="subtitle">Transport Canada · TP 12880E Chapter 8 · PPL Written Exam</p>
+
+<div class="section-label">Three Requirements for Thunderstorm Development</div>
+<table>
+  <thead>
+    <tr>
+      <th>Requirement</th>
+      <th>Description</th>
+      <th>Example Source</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><strong>1. Sufficient Moisture</strong></td>
+      <td>Adequate water vapour in the lower troposphere to fuel condensation and latent heat release</td>
+      <td>Moist air from Gulf of Mexico, Great Lakes, ocean surfaces</td>
+    </tr>
+    <tr>
+      <td><strong>2. A Lifting Mechanism</strong></td>
+      <td>Force to lift moist air to its condensation level (LCL) and beyond free convection level</td>
+      <td>Surface heating, cold front, orographic lifting, low pressure</td>
+    </tr>
+    <tr>
+      <td><strong>3. Instability</strong></td>
+      <td>Environmental lapse rate exceeds saturated adiabatic lapse rate — rising air accelerates</td>
+      <td>Cold air aloft over warm surface; steep environmental lapse rate</td>
+    </tr>
+  </tbody>
+</table>
+
+<div class="section-label">Thunderstorm Lifecycle — Three Stages</div>
+<div class="stage-grid">
+  <div class="stage-card" style="border-top:3px solid #80e080;">
+    <div class="stage-title" style="color:#80e080;">Stage 1: Cumulus</div>
+    <div class="stage-row"><span class="stage-label">Duration</span><br>~20 minutes</div>
+    <div class="stage-row"><span class="stage-label">Air motion</span><br>Updrafts only — 3,000 to 8,000 fpm</div>
+    <div class="stage-row"><span class="stage-label">Precipitation</span><br>None reaching surface yet (held aloft by updraft)</div>
+    <div class="stage-row"><span class="stage-label">Cloud appearance</span><br>Building cumulus towering rapidly</div>
+    <div class="stage-row"><span class="stage-label">Hazards</span><br><span class="warn-tag">Moderate turbulence</span></div>
+    <div class="stage-row"><span class="stage-label">Recognizable by</span><br>Rapidly building Cu — can grow 1,000 ft/min</div>
+  </div>
+  <div class="stage-card" style="border-top:3px solid #ff8080;">
+    <div class="stage-title" style="color:#ff8080;">Stage 2: Mature</div>
+    <div class="stage-row"><span class="stage-label">Duration</span><br>~20-40 minutes (most intense phase)</div>
+    <div class="stage-row"><span class="stage-label">Air motion</span><br>BOTH updrafts AND downdrafts simultaneously</div>
+    <div class="stage-row"><span class="stage-label">Precipitation</span><br>Heavy rain, hail reaching surface</div>
+    <div class="stage-row"><span class="stage-label">Cloud appearance</span><br>Full Cb with anvil spreading at tropopause</div>
+    <div class="stage-row"><span class="stage-label">Hazards</span><br><span class="hazard-tag">ALL hazards present</span></div>
+    <div class="stage-row"><span class="stage-label">Recognizable by</span><br>Anvil top, heavy rain, lightning frequency increases</div>
+  </div>
+  <div class="stage-card" style="border-top:3px solid #7a9ab5;">
+    <div class="stage-title" style="color:#7a9ab5;">Stage 3: Dissipating</div>
+    <div class="stage-row"><span class="stage-label">Duration</span><br>~20-30 minutes</div>
+    <div class="stage-row"><span class="stage-label">Air motion</span><br>Downdrafts dominate — cuts off updraft supply</div>
+    <div class="stage-row"><span class="stage-label">Precipitation</span><br>Light rain, drizzle; then ending</div>
+    <div class="stage-row"><span class="stage-label">Cloud appearance</span><br>Anvil persists; cloud base dissolves</div>
+    <div class="stage-row"><span class="stage-label">Hazards</span><br><span class="warn-tag">Still turbulence + icing</span></div>
+    <div class="stage-row"><span class="stage-label">Recognizable by</span><br>Precipitation lightens; lightning decreases; anvil remains</div>
+  </div>
+</div>
+
+<div class="section-label">Thunderstorm Hazard Summary</div>
+<table>
+  <thead>
+    <tr>
+      <th>Hazard</th>
+      <th>Description</th>
+      <th>Stage</th>
+      <th>Severity</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><strong>Turbulence</strong></td>
+      <td>Updrafts up to 8,000 fpm and downdrafts simultaneously; extreme shear between them</td>
+      <td>Mature (worst)</td>
+      <td><span class="hazard-tag">Extreme</span></td>
+    </tr>
+    <tr>
+      <td><strong>Icing</strong></td>
+      <td>All types present: rime, clear, and mixed; supercooled water from base to top</td>
+      <td>All stages</td>
+      <td><span class="hazard-tag">Severe</span></td>
+    </tr>
+    <tr>
+      <td><strong>Lightning</strong></td>
+      <td>Every Cb produces lightning; can strike aircraft several miles from storm; damages avionics</td>
+      <td>Mature (peak)</td>
+      <td><span class="hazard-tag">Extreme</span></td>
+    </tr>
+    <tr>
+      <td><strong>Hail</strong></td>
+      <td>Can be ejected 20+ NM from storm under the anvil; largest hail in mature stage updraft core</td>
+      <td>Mature</td>
+      <td><span class="hazard-tag">Severe</span></td>
+    </tr>
+    <tr>
+      <td><strong>Wind Shear</strong></td>
+      <td>Outflow boundary = sudden wind shift + gust front at surface; approaches at up to 100 kt</td>
+      <td>Mature / Dissipating</td>
+      <td><span class="hazard-tag">Severe</span></td>
+    </tr>
+    <tr>
+      <td><strong>Microbursts</strong></td>
+      <td>Intense downdraft &lt; 4 km diameter; downdraft to 6,000 fpm; outflow to 45 kt</td>
+      <td>Mature</td>
+      <td><span class="hazard-tag">Extreme</span></td>
+    </tr>
+    <tr>
+      <td><strong>Tornadoes</strong></td>
+      <td>Supercell Cb can produce tornadoes; rare in Canada but documented</td>
+      <td>Mature (supercell)</td>
+      <td><span class="hazard-tag">Extreme</span></td>
+    </tr>
+    <tr>
+      <td><strong>Low-Level Wind Shear</strong></td>
+      <td>Rapid airspeed and direction changes on approach/departure; invisible hazard</td>
+      <td>Mature / Dissipating</td>
+      <td><span class="hazard-tag">Extreme on approach</span></td>
+    </tr>
+  </tbody>
+</table>
+
+<div class="avoid-box">
+  <h2>Thunderstorm Avoidance Rules — Non-Negotiable</h2>
+  <div class="avoid-row"><span class="avoid-badge">20 NM RULE</span><span class="avoid-text">Clear all Cb by at least <strong>20 NM laterally</strong>. Hail, turbulence, and lightning can extend well beyond the visible cloud boundary.</span></div>
+  <div class="avoid-row"><span class="avoid-badge">NEVER ENTER</span><span class="avoid-text"><strong>Never intentionally fly into a cumulonimbus</strong>. No aircraft certified for PPL operations is designed to safely penetrate an active Cb.</span></div>
+  <div class="avoid-row"><span class="avoid-badge">NEVER UNDER</span><span class="avoid-text"><strong>Never fly beneath a Cb</strong>. The gust front, downbursts, and heavy precipitation under a mature Cb are lethal hazards at low altitude.</span></div>
+  <div class="avoid-row"><span class="avoid-badge">ANVIL SIDE</span><span class="avoid-text">If you must pass near a storm, go on the <strong>upwind (windward) side</strong>. The anvil and hail extend downwind. The upwind side is still hazardous but less so.</span></div>
+  <div class="avoid-row"><span class="avoid-badge">DIVERT</span><span class="avoid-text">If you cannot safely circumnavigate, <strong>divert and wait</strong>. A storm dissipates in ~1 hour. No schedule justifies penetrating a thunderstorm.</span></div>
+</div>
+
+<div class="hook-box">
+  <h2>Memory Hook — Thunderstorm Stages</h2>
+  <div class="hook-row"><span class="hook-badge">CUMULUS</span><span class="hook-text"><strong>Updrafts only</strong>. Storm is growing — building fast. Avoid. No precipitation at surface yet.</span></div>
+  <div class="hook-row"><span class="hook-badge">MATURE</span><span class="hook-text"><strong>Most dangerous stage</strong> — both updrafts AND downdrafts. All hazards active simultaneously: turbulence, icing, hail, lightning, microbursts.</span></div>
+  <div class="hook-row"><span class="hook-badge">DISSIPATING</span><span class="hook-text"><strong>Downdrafts dominate</strong>. Storm dying, but still dangerous — icing and turbulence persist. Anvil can remain hours after storm ends.</span></div>
+  <div class="hook-row"><span class="hook-badge">THREE NEEDS</span><span class="hook-text"><strong>Moisture + Lift + Instability</strong>. Remove any one and no thunderstorm forms. Forecasters look for all three to predict convective activity.</span></div>
+</div>
+
+</div>
+</body>
+</html>

--- a/web-app/public/visuals/met010-icing.html
+++ b/web-app/public/visuals/met010-icing.html
@@ -1,0 +1,200 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>MET-010: Aircraft Icing</title>
+<style>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body { background: #0d1b2a; color: #e8edf2; font-family: 'Segoe UI', system-ui, sans-serif; padding: 32px; }
+  h1 { font-size: 22px; color: #f0c040; letter-spacing: 1px; margin-bottom: 6px; }
+  .subtitle { font-size: 13px; color: #7a9ab5; margin-bottom: 32px; letter-spacing: 0.5px; }
+  .section-label { font-size: 11px; color: #7a9ab5; letter-spacing: 1px; text-transform: uppercase; margin-bottom: 8px; font-weight: 600; }
+  table { width: 100%; border-collapse: collapse; font-size: 12px; margin-bottom: 28px; }
+  th { background: #1a2d3d; color: #7a9ab5; padding: 8px 10px; text-align: left; font-size: 11px; text-transform: uppercase; letter-spacing: 0.5px; }
+  td { padding: 9px 10px; border-bottom: 1px solid #1a2d3d; vertical-align: top; }
+  .hook-box { background: #1a2a1a; border: 1.5px solid #2d5a2d; border-radius: 10px; padding: 18px 22px; margin-top: 8px; }
+  .hook-box h2 { font-size: 12px; color: #80c880; text-transform: uppercase; letter-spacing: 1px; margin-bottom: 12px; }
+  .hook-row { display: flex; gap: 10px; margin-bottom: 8px; align-items: flex-start; }
+  .hook-badge { background: #2d5a2d; color: #80c880; font-size: 10px; font-weight: 800; padding: 2px 8px; border-radius: 10px; white-space: nowrap; flex-shrink: 0; margin-top: 2px; }
+  .hook-text { font-size: 13px; color: #c8d8c8; line-height: 1.5; }
+  .hook-text strong { color: #f0c040; }
+  .hazard-tag { display: inline-block; background: rgba(255,80,80,0.15); color: #ff8080; border: 1px solid rgba(255,80,80,0.3); border-radius: 4px; padding: 2px 8px; font-size: 10px; font-weight: 700; }
+  .ok-tag { display: inline-block; background: rgba(80,200,80,0.15); color: #80e080; border: 1px solid rgba(80,200,80,0.3); border-radius: 4px; padding: 2px 8px; font-size: 10px; font-weight: 700; }
+  .warn-tag { display: inline-block; background: rgba(240,192,64,0.15); color: #f0c040; border: 1px solid rgba(240,192,64,0.3); border-radius: 4px; padding: 2px 8px; font-size: 10px; font-weight: 700; }
+  .type-grid { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 16px; margin-bottom: 28px; }
+  .type-card { background: #1a2d3d; border-radius: 8px; padding: 16px 18px; }
+  .type-title { font-size: 14px; font-weight: 700; margin-bottom: 10px; }
+  .type-row { font-size: 12px; color: #c8d8e8; margin-bottom: 6px; line-height: 1.5; }
+  .type-label { font-size: 10px; color: #7a9ab5; text-transform: uppercase; letter-spacing: 0.5px; }
+  .location-grid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 10px; margin-bottom: 28px; }
+  .loc-card { background: #1a2d3d; border-radius: 8px; padding: 12px; text-align: center; }
+  .loc-name { font-size: 12px; font-weight: 700; color: #f0c040; margin-bottom: 4px; }
+  .loc-effect { font-size: 10px; color: #c8d8e8; line-height: 1.4; }
+</style>
+</head>
+<body>
+<div style="max-width:900px;margin:auto;">
+
+<h1>MET-010 — Aircraft Icing</h1>
+<p class="subtitle">Transport Canada · TP 12880E Chapter 8 · PPL Written Exam</p>
+
+<div class="section-label">Conditions Required for Structural Icing</div>
+<table>
+  <thead>
+    <tr>
+      <th>Requirement</th>
+      <th>Specific Condition</th>
+      <th>Notes</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><strong>Visible Moisture</strong></td>
+      <td>Cloud, fog, freezing rain, drizzle, wet snow</td>
+      <td>Clear air cannot cause structural icing. Carb icing can occur in clear air (different mechanism).</td>
+    </tr>
+    <tr>
+      <td><strong>Temperature at or below 0°C</strong></td>
+      <td>OAT 0°C down to approximately -40°C</td>
+      <td>Most severe icing: <strong>-2°C to -10°C</strong> (large supercooled droplets). Below -40°C droplets freeze before impact.</td>
+    </tr>
+    <tr>
+      <td><strong>Aircraft surface below 0°C</strong></td>
+      <td>Airframe temperature must be at or below freezing</td>
+      <td>Flying into cloud above freezing: no structural icing even if droplets exist</td>
+    </tr>
+  </tbody>
+</table>
+
+<div class="section-label">Icing Types — Formation and Hazard</div>
+<div class="type-grid">
+  <div class="type-card" style="border-top:3px solid #80b8e0;">
+    <div class="type-title" style="color:#80b8e0;">Clear Ice (Glaze)</div>
+    <div class="type-row"><span class="type-label">Temperature range</span><br>0°C to -10°C</div>
+    <div class="type-row"><span class="type-label">Droplet size</span><br>Large supercooled droplets</div>
+    <div class="type-row"><span class="type-label">Appearance</span><br>Transparent, glossy, smooth surface</div>
+    <div class="type-row"><span class="type-label">Adhesion</span><br>Extremely hard; bonds firmly to surface</div>
+    <div class="type-row"><span class="type-label">Hazard level</span><br><span class="hazard-tag">Most hazardous</span></div>
+    <div class="type-row"><span class="type-label">Removal</span><br>Hardest to remove; can bridge gaps in de-ice boots</div>
+    <div class="type-row"><span class="type-label">Where found</span><br>Freezing rain, base of convective clouds</div>
+  </div>
+  <div class="type-card" style="border-top:3px solid #c8d8e8;">
+    <div class="type-title" style="color:#c8d8e8;">Rime Ice</div>
+    <div class="type-row"><span class="type-label">Temperature range</span><br>-10°C to -20°C</div>
+    <div class="type-row"><span class="type-label">Droplet size</span><br>Small supercooled droplets</div>
+    <div class="type-row"><span class="type-label">Appearance</span><br>White, milky, rough; looks like frost</div>
+    <div class="type-row"><span class="type-label">Adhesion</span><br>Brittle; relatively easier to remove</div>
+    <div class="type-row"><span class="type-label">Hazard level</span><br><span class="warn-tag">Significant</span></div>
+    <div class="type-row"><span class="type-label">Removal</span><br>Brittle — pneumatic boots more effective</div>
+    <div class="type-row"><span class="type-label">Where found</span><br>Stratiform clouds, light freezing drizzle</div>
+  </div>
+  <div class="type-card" style="border-top:3px solid #e08080;">
+    <div class="type-title" style="color:#e08080;">Mixed Ice</div>
+    <div class="type-row"><span class="type-label">Temperature range</span><br>0°C to -15°C (transitional zone)</div>
+    <div class="type-row"><span class="type-label">Droplet size</span><br>Combination of large and small droplets</div>
+    <div class="type-row"><span class="type-label">Appearance</span><br>Combination of clear and white portions; irregular shape</div>
+    <div class="type-row"><span class="type-label">Adhesion</span><br>Irregular shape disrupts airflow severely</div>
+    <div class="type-row"><span class="type-label">Hazard level</span><br><span class="hazard-tag">Most aerodynamically disruptive</span></div>
+    <div class="type-row"><span class="type-label">Removal</span><br>Difficult; irregular shape unpredictable</div>
+    <div class="type-row"><span class="type-label">Where found</span><br>Convective clouds, areas of mixed droplet sizes</div>
+  </div>
+</div>
+
+<div class="section-label">Icing Intensity — PIREP Codes and Operational Impact</div>
+<table>
+  <thead>
+    <tr>
+      <th>Intensity</th>
+      <th>PIREP Code</th>
+      <th>Accumulation Rate</th>
+      <th>Operational Impact</th>
+      <th>Action Required</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>None</td>
+      <td style="font-family:monospace;font-weight:700;color:#80e080;">NEG</td>
+      <td>No accumulation</td>
+      <td><span class="ok-tag">No effect</span></td>
+      <td>Continue normally</td>
+    </tr>
+    <tr>
+      <td>Trace</td>
+      <td style="font-family:monospace;font-weight:700;color:#80e080;">TRC</td>
+      <td>Barely perceptible</td>
+      <td><span class="ok-tag">Minimal</span></td>
+      <td>Monitor; de-icing not required unless exposed &gt; 1 hr</td>
+    </tr>
+    <tr>
+      <td>Light</td>
+      <td style="font-family:monospace;font-weight:700;color:#80e080;">LGT</td>
+      <td>Slow accumulation</td>
+      <td><span class="warn-tag">Manageable</span></td>
+      <td>De-icing adequate; consider altitude change</td>
+    </tr>
+    <tr>
+      <td>Moderate</td>
+      <td style="font-family:monospace;font-weight:700;color:#f0c040;">MOD</td>
+      <td>Rapid accumulation</td>
+      <td><span class="hazard-tag">Performance degraded</span></td>
+      <td>Immediate change of altitude or route; de-icing may not be adequate</td>
+    </tr>
+    <tr>
+      <td>Severe</td>
+      <td style="font-family:monospace;font-weight:700;color:#ff8080;">SEV</td>
+      <td>Rate exceeds de-icing capacity</td>
+      <td><span class="hazard-tag">Aircraft out of control risk</span></td>
+      <td>Exit icing conditions immediately; declare emergency if needed; UUA PIREP required</td>
+    </tr>
+  </tbody>
+</table>
+
+<div class="section-label">Structural Icing Locations on Aircraft</div>
+<div class="location-grid">
+  <div class="loc-card">
+    <div class="loc-name">Wings and Tail</div>
+    <div class="loc-effect">Leading edge ice changes airfoil shape; increases stall speed; reduces lift; may cause asymmetric lift</div>
+  </div>
+  <div class="loc-card">
+    <div class="loc-name">Pitot Tube</div>
+    <div class="loc-effect">Ice blocks pitot orifice; airspeed indication fails (reads zero or stuck); critical for flight instruments</div>
+  </div>
+  <div class="loc-card">
+    <div class="loc-name">Propeller</div>
+    <div class="loc-effect">Ice on prop blades; unbalanced shedding causes severe vibration; efficiency loss; thrust reduction</div>
+  </div>
+  <div class="loc-card">
+    <div class="loc-name">Carburettor</div>
+    <div class="loc-effect">Carburettor icing: can occur at temperatures from -20°C to +38°C in humid conditions — even clear air. Engine roughness first sign.</div>
+  </div>
+  <div class="loc-card">
+    <div class="loc-name">Antennas</div>
+    <div class="loc-effect">Comms and nav antenna iced over; potential radio/GPS failure; adds drag</div>
+  </div>
+  <div class="loc-card">
+    <div class="loc-name">Windscreen</div>
+    <div class="loc-effect">Forward visibility lost; crew unable to see for visual approaches or obstacle avoidance</div>
+  </div>
+  <div class="loc-card">
+    <div class="loc-name">Control Surfaces</div>
+    <div class="loc-effect">Ice in hinge gaps restricts control movement; control forces increase; may jam in extreme cases</div>
+  </div>
+  <div class="loc-card">
+    <div class="loc-name">Static Ports</div>
+    <div class="loc-effect">Ice blocks static source; altimeter, VSI, airspeed errors result. Alternate static source required.</div>
+  </div>
+</div>
+
+<div class="hook-box">
+  <h2>Memory Hook — Aircraft Icing</h2>
+  <div class="hook-row"><span class="hook-badge">TWO REQUIREMENTS</span><span class="hook-text"><strong>Visible moisture + temperature at or below 0°C</strong>. Both must be present. No moisture = no structural icing (carburettor icing is different).</span></div>
+  <div class="hook-row"><span class="hook-badge">WORST RANGE</span><span class="hook-text">Most severe icing at <strong>-2°C to -10°C</strong>. Large supercooled droplets stay liquid and freeze on impact as clear ice.</span></div>
+  <div class="hook-row"><span class="hook-badge">ICE TYPES</span><span class="hook-text"><strong>Clear = hardest to remove</strong> (hard/transparent). <strong>Rime = brittle/white</strong>. <strong>Mixed = worst aerodynamic disruption</strong> (irregular shape).</span></div>
+  <div class="hook-row"><span class="hook-badge">CARB ICING</span><span class="hook-text">Carburettor icing does NOT need visible moisture or freezing OAT. Can occur <strong>+38°C to -20°C</strong> with humidity. Apply carb heat at first engine roughness.</span></div>
+</div>
+
+</div>
+</body>
+</html>

--- a/web-app/public/visuals/met011-turbulence.html
+++ b/web-app/public/visuals/met011-turbulence.html
@@ -1,0 +1,179 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>MET-011: Turbulence</title>
+<style>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body { background: #0d1b2a; color: #e8edf2; font-family: 'Segoe UI', system-ui, sans-serif; padding: 32px; }
+  h1 { font-size: 22px; color: #f0c040; letter-spacing: 1px; margin-bottom: 6px; }
+  .subtitle { font-size: 13px; color: #7a9ab5; margin-bottom: 32px; letter-spacing: 0.5px; }
+  .section-label { font-size: 11px; color: #7a9ab5; letter-spacing: 1px; text-transform: uppercase; margin-bottom: 8px; font-weight: 600; }
+  table { width: 100%; border-collapse: collapse; font-size: 12px; margin-bottom: 28px; }
+  th { background: #1a2d3d; color: #7a9ab5; padding: 8px 10px; text-align: left; font-size: 11px; text-transform: uppercase; letter-spacing: 0.5px; }
+  td { padding: 9px 10px; border-bottom: 1px solid #1a2d3d; vertical-align: top; }
+  .hook-box { background: #1a2a1a; border: 1.5px solid #2d5a2d; border-radius: 10px; padding: 18px 22px; margin-top: 8px; }
+  .hook-box h2 { font-size: 12px; color: #80c880; text-transform: uppercase; letter-spacing: 1px; margin-bottom: 12px; }
+  .hook-row { display: flex; gap: 10px; margin-bottom: 8px; align-items: flex-start; }
+  .hook-badge { background: #2d5a2d; color: #80c880; font-size: 10px; font-weight: 800; padding: 2px 8px; border-radius: 10px; white-space: nowrap; flex-shrink: 0; margin-top: 2px; }
+  .hook-text { font-size: 13px; color: #c8d8c8; line-height: 1.5; }
+  .hook-text strong { color: #f0c040; }
+  .hazard-tag { display: inline-block; background: rgba(255,80,80,0.15); color: #ff8080; border: 1px solid rgba(255,80,80,0.3); border-radius: 4px; padding: 2px 8px; font-size: 10px; font-weight: 700; }
+  .ok-tag { display: inline-block; background: rgba(80,200,80,0.15); color: #80e080; border: 1px solid rgba(80,200,80,0.3); border-radius: 4px; padding: 2px 8px; font-size: 10px; font-weight: 700; }
+  .warn-tag { display: inline-block; background: rgba(240,192,64,0.15); color: #f0c040; border: 1px solid rgba(240,192,64,0.3); border-radius: 4px; padding: 2px 8px; font-size: 10px; font-weight: 700; }
+  .type-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; margin-bottom: 28px; }
+  .type-card { background: #1a2d3d; border-radius: 8px; padding: 14px 16px; }
+  .type-title { font-size: 13px; font-weight: 700; color: #f0c040; margin-bottom: 8px; }
+  .type-row { font-size: 12px; color: #c8d8e8; margin-bottom: 5px; line-height: 1.5; }
+  .type-label { font-size: 10px; color: #7a9ab5; text-transform: uppercase; letter-spacing: 0.5px; }
+</style>
+</head>
+<body>
+<div style="max-width:900px;margin:auto;">
+
+<h1>MET-011 — Turbulence</h1>
+<p class="subtitle">Transport Canada · TP 12880E Chapter 8 · PPL Written Exam</p>
+
+<div class="section-label">Turbulence Intensity — Cockpit Effects and PIREP Reporting</div>
+<table>
+  <thead>
+    <tr>
+      <th>Intensity</th>
+      <th>PIREP Code</th>
+      <th>Cockpit Effects</th>
+      <th>Aircraft Attitude</th>
+      <th>Action Required</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><strong style="color:#80e080;">Light</strong></td>
+      <td style="font-family:monospace;font-weight:700;color:#80e080;">LGT</td>
+      <td>Slight erratic changes in altitude or attitude; occupants feel slight strain against seatbelts; unsecured items show slight movement</td>
+      <td>Slight deviation from wings level; immediate correction possible</td>
+      <td><span class="ok-tag">Monitor</span> Report; slow to turbulence penetration speed if sustained</td>
+    </tr>
+    <tr>
+      <td><strong style="color:#f0c040;">Moderate</strong></td>
+      <td style="font-family:monospace;font-weight:700;color:#f0c040;">MOD</td>
+      <td>Definite strain against seatbelts; difficult to walk; unsecured items displaced; food/beverage service impossible</td>
+      <td>Definite but controllable changes in attitude and altitude</td>
+      <td><span class="warn-tag">Seatbelts</span> Brief ATC; reduce to turbulence penetration speed (Va); consider altitude change</td>
+    </tr>
+    <tr>
+      <td><strong style="color:#ff8080;">Severe</strong></td>
+      <td style="font-family:monospace;font-weight:700;color:#ff8080;">SEV</td>
+      <td>Large abrupt changes; aircraft momentarily out of control; occupants forced violently against seatbelts; loose items thrown about</td>
+      <td>Large deviations in altitude and attitude; possible brief loss of control</td>
+      <td><span class="hazard-tag">Emergency action</span> Slow to Va immediately; issue UUA PIREP; divert if unable to exit</td>
+    </tr>
+    <tr>
+      <td><strong style="color:#ff8080;">Extreme</strong></td>
+      <td style="font-family:monospace;font-weight:700;color:#ff8080;">EXTM</td>
+      <td>Violent; aircraft practically impossible to control; may cause structural damage</td>
+      <td>Violent pitch and roll; uncontrollable momentarily</td>
+      <td><span class="hazard-tag">Structural damage possible</span> UUA PIREP; reduce power; maintain wings level; do not fight</td>
+    </tr>
+  </tbody>
+</table>
+
+<div class="section-label">Turbulence Types</div>
+<div class="type-grid">
+  <div class="type-card">
+    <div class="type-title">CAT — Clear Air Turbulence</div>
+    <div class="type-row"><span class="type-label">Altitude</span><br>Above 15,000 ft; typically near jet stream (30,000–40,000 ft)</div>
+    <div class="type-row"><span class="type-label">Cause</span><br>Wind shear between air masses moving at different speeds; jet stream edges</div>
+    <div class="type-row"><span class="type-label">Warning signs</span><br>NONE — no visual cue, no cloud, no precipitation indicator</div>
+    <div class="type-row"><span class="type-label">Severity</span><br><span class="hazard-tag">MOD to SEV possible</span></div>
+    <div class="type-row"><span class="type-label">Avoidance</span><br>PIREP data; GFA icing/turbulence chart; fly perpendicular to jet stream to exit</div>
+  </div>
+  <div class="type-card">
+    <div class="type-title">Mechanical Turbulence</div>
+    <div class="type-row"><span class="type-label">Altitude</span><br>Low level — surface to 3,000 ft AGL</div>
+    <div class="type-row"><span class="type-label">Cause</span><br>Wind flowing over irregular terrain, buildings, trees; friction layer disruption</div>
+    <div class="type-row"><span class="type-label">Warning signs</span><br>Gusty surface winds; terrain features; smoke patterns</div>
+    <div class="type-row"><span class="type-label">Severity</span><br><span class="warn-tag">LGT to MOD typical</span></div>
+    <div class="type-row"><span class="type-label">Avoidance</span><br>Increase approach speed; extend pattern altitude; avoid low-level flight in strong winds</div>
+  </div>
+  <div class="type-card">
+    <div class="type-title">Orographic / Mountain Wave</div>
+    <div class="type-row"><span class="type-label">Altitude</span><br>Can extend from surface to 100,000+ ft; worst near and downwind of ridgeline</div>
+    <div class="type-row"><span class="type-label">Cause</span><br>Wind perpendicular to ridge at &gt; 25 kt causes oscillating waves downwind</div>
+    <div class="type-row"><span class="type-label">Warning signs</span><br>Lenticular (lens-shaped) clouds; rotor clouds below wave crest; cap cloud on ridge</div>
+    <div class="type-row"><span class="type-label">Severity</span><br><span class="hazard-tag">SEV to EXTM in rotor zone</span></div>
+    <div class="type-row"><span class="type-label">Avoidance</span><br>Stay above wave crest altitude; cross ridgelines at 45 degrees; avoid rotor zone; check PIREPs</div>
+  </div>
+  <div class="type-card">
+    <div class="type-title">Convective Turbulence</div>
+    <div class="type-row"><span class="type-label">Altitude</span><br>Low to mid-level; inside and near cumulus/Cb</div>
+    <div class="type-row"><span class="type-label">Cause</span><br>Thermal convection; strong updrafts and downdrafts inside convective cloud</div>
+    <div class="type-row"><span class="type-label">Warning signs</span><br>Cumulus buildups; afternoon heating; cumulonimbus</div>
+    <div class="type-row"><span class="type-label">Severity</span><br><span class="hazard-tag">MOD to EXTM in Cb</span></div>
+    <div class="type-row"><span class="type-label">Avoidance</span><br>Avoid Cb by 20 NM; fly early morning before thermal development; monitor radar</div>
+  </div>
+  <div class="type-card">
+    <div class="type-title">Wake Turbulence</div>
+    <div class="type-row"><span class="type-label">Altitude</span><br>Below the generating aircraft; sink at ~300–500 fpm; spread laterally</div>
+    <div class="type-row"><span class="type-label">Cause</span><br>Counter-rotating vortices shed from wingtips of heavy aircraft; strongest when heavy, slow, clean config</div>
+    <div class="type-row"><span class="type-label">Warning signs</span><br>Heavy aircraft departure/arrival; no visual cue for the vortices themselves</div>
+    <div class="type-row"><span class="type-label">Severity</span><br><span class="hazard-tag">SEV to EXTM for small aircraft</span></div>
+    <div class="type-row"><span class="type-label">Avoidance</span><br>Maintain separation; stay above heavy aircraft flight path; land beyond touchdown point; takeoff before rotation point</div>
+  </div>
+  <div class="type-card">
+    <div class="type-title">Frontal Turbulence</div>
+    <div class="type-row"><span class="type-label">Altitude</span><br>Near frontal boundaries; most intense near cold front</div>
+    <div class="type-row"><span class="type-label">Cause</span><br>Wind shear at frontal surface; instability in prefrontal air; cold front squall lines</div>
+    <div class="type-row"><span class="type-label">Warning signs</span><br>Cold front passage; squall line; rapid pressure change</div>
+    <div class="type-row"><span class="type-label">Severity</span><br><span class="warn-tag">MOD; SEV in squall line</span></div>
+    <div class="type-row"><span class="type-label">Avoidance</span><br>Cross fronts at right angles and quickly; check SIGMET for squall line positions</div>
+  </div>
+</div>
+
+<div class="section-label">Mountain Wave — Key Details</div>
+<table>
+  <thead>
+    <tr>
+      <th>Feature</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><strong>Formation requirement</strong></td>
+      <td>Wind &gt; 25 kt near perpendicular to ridge; stable air aloft; wind speed increases with altitude</td>
+    </tr>
+    <tr>
+      <td><strong>Horizontal extent</strong></td>
+      <td>Waves can extend 100–300 NM downwind of the ridge; do not assume safety just because you are far from mountains</td>
+    </tr>
+    <tr>
+      <td><strong>Lenticular cloud (ACSL)</strong></td>
+      <td>Altocumulus Standing Lenticular — stationary lens-shaped cloud at wave crest; indicates active wave. Does not move with wind.</td>
+    </tr>
+    <tr>
+      <td><strong>Rotor zone</strong></td>
+      <td>Violent turbulent eddies under the wave crest; can be below ridgeline altitude; most dangerous area; associated with rotor cloud</td>
+    </tr>
+    <tr>
+      <td><strong>Cap cloud</strong></td>
+      <td>Cloud cap on ridge crest; indicates moist air being lifted over the ridge; tops may indicate wave height</td>
+    </tr>
+    <tr>
+      <td><strong>PIREP reporting</strong></td>
+      <td>Report location, altitude, intensity (LGT/MOD/SEV), and aircraft type. Mountain wave PIREPs are critical for following aircraft.</td>
+    </tr>
+  </tbody>
+</table>
+
+<div class="hook-box">
+  <h2>Memory Hook — Turbulence Essentials</h2>
+  <div class="hook-row"><span class="hook-badge">CAT</span><span class="hook-text"><strong>No visual warning</strong> — clear air, no cloud, no radar return. Only indicator: PIREPs and GFA turbulence chart. Happens near jet stream.</span></div>
+  <div class="hook-row"><span class="hook-badge">MOUNTAIN WAVE</span><span class="hook-text">Can extend <strong>hundreds of miles downwind</strong> of ridgeline. Lenticular cloud = wave active. Rotor zone = most violent. Cross ridges at 45 degrees.</span></div>
+  <div class="hook-row"><span class="hook-badge">Va SPEED</span><span class="hook-text">In turbulence, reduce to <strong>maneuvering speed (Va)</strong>. Below Va, aircraft will stall before structural failure. Va decreases with lighter weight.</span></div>
+  <div class="hook-row"><span class="hook-badge">WAKE VORTEX</span><span class="hook-text">Vortices sink and spread laterally. In crosswind, upwind vortex stays on runway. Stay <strong>above and upwind</strong> of heavy aircraft. Most dangerous: calm wind.</span></div>
+</div>
+
+</div>
+</body>
+</html>

--- a/web-app/public/visuals/met012-wind-shear-microburst.html
+++ b/web-app/public/visuals/met012-wind-shear-microburst.html
@@ -1,0 +1,202 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>MET-012: Wind Shear and Microbursts</title>
+<style>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body { background: #0d1b2a; color: #e8edf2; font-family: 'Segoe UI', system-ui, sans-serif; padding: 32px; }
+  h1 { font-size: 22px; color: #f0c040; letter-spacing: 1px; margin-bottom: 6px; }
+  .subtitle { font-size: 13px; color: #7a9ab5; margin-bottom: 32px; letter-spacing: 0.5px; }
+  .section-label { font-size: 11px; color: #7a9ab5; letter-spacing: 1px; text-transform: uppercase; margin-bottom: 8px; font-weight: 600; }
+  table { width: 100%; border-collapse: collapse; font-size: 12px; margin-bottom: 28px; }
+  th { background: #1a2d3d; color: #7a9ab5; padding: 8px 10px; text-align: left; font-size: 11px; text-transform: uppercase; letter-spacing: 0.5px; }
+  td { padding: 9px 10px; border-bottom: 1px solid #1a2d3d; vertical-align: top; }
+  .hook-box { background: #1a2a1a; border: 1.5px solid #2d5a2d; border-radius: 10px; padding: 18px 22px; margin-top: 8px; }
+  .hook-box h2 { font-size: 12px; color: #80c880; text-transform: uppercase; letter-spacing: 1px; margin-bottom: 12px; }
+  .hook-row { display: flex; gap: 10px; margin-bottom: 8px; align-items: flex-start; }
+  .hook-badge { background: #2d5a2d; color: #80c880; font-size: 10px; font-weight: 800; padding: 2px 8px; border-radius: 10px; white-space: nowrap; flex-shrink: 0; margin-top: 2px; }
+  .hook-text { font-size: 13px; color: #c8d8c8; line-height: 1.5; }
+  .hook-text strong { color: #f0c040; }
+  .hazard-tag { display: inline-block; background: rgba(255,80,80,0.15); color: #ff8080; border: 1px solid rgba(255,80,80,0.3); border-radius: 4px; padding: 2px 8px; font-size: 10px; font-weight: 700; }
+  .ok-tag { display: inline-block; background: rgba(80,200,80,0.15); color: #80e080; border: 1px solid rgba(80,200,80,0.3); border-radius: 4px; padding: 2px 8px; font-size: 10px; font-weight: 700; }
+  .warn-tag { display: inline-block; background: rgba(240,192,64,0.15); color: #f0c040; border: 1px solid rgba(240,192,64,0.3); border-radius: 4px; padding: 2px 8px; font-size: 10px; font-weight: 700; }
+  .avoid-box { background: rgba(255,80,80,0.08); border: 1.5px solid rgba(255,80,80,0.3); border-radius: 10px; padding: 18px 22px; margin-bottom: 28px; }
+  .avoid-box h2 { font-size: 12px; color: #ff8080; text-transform: uppercase; letter-spacing: 1px; margin-bottom: 12px; }
+  .avoid-row { display: flex; gap: 10px; margin-bottom: 8px; align-items: flex-start; }
+  .avoid-badge { background: rgba(255,80,80,0.2); color: #ff8080; font-size: 10px; font-weight: 800; padding: 2px 8px; border-radius: 10px; white-space: nowrap; flex-shrink: 0; margin-top: 2px; }
+  .avoid-text { font-size: 13px; color: #e8d0d0; line-height: 1.5; }
+  .avoid-text strong { color: #ff8080; }
+  .approach-diagram { background: #0a1520; border: 1.5px solid #2a4060; border-radius: 10px; padding: 20px; margin-bottom: 28px; }
+  .approach-title { font-size: 12px; color: #7a9ab5; text-transform: uppercase; letter-spacing: 1px; margin-bottom: 16px; font-weight: 600; }
+  .phase-row { display: grid; grid-template-columns: 28px 160px 1fr; gap: 12px; align-items: start; margin-bottom: 12px; padding-bottom: 12px; border-bottom: 1px solid #1a2d3d; }
+  .phase-row:last-child { border-bottom: none; margin-bottom: 0; padding-bottom: 0; }
+  .phase-num { display: flex; align-items: center; justify-content: center; width: 28px; height: 28px; border-radius: 50%; font-size: 12px; font-weight: 800; flex-shrink: 0; }
+  .phase-label { font-size: 12px; font-weight: 700; padding-top: 4px; }
+  .phase-desc { font-size: 12px; color: #c8d8e8; line-height: 1.5; }
+</style>
+</head>
+<body>
+<div style="max-width:900px;margin:auto;">
+
+<h1>MET-012 — Wind Shear and Microbursts</h1>
+<p class="subtitle">Transport Canada · TP 12880E Chapter 8 · PPL Written Exam</p>
+
+<div class="section-label">Wind Shear — Definition and Types</div>
+<table>
+  <thead>
+    <tr>
+      <th>Type</th>
+      <th>Definition</th>
+      <th>Common Sources</th>
+      <th>Aviation Risk</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><strong>Horizontal Wind Shear</strong></td>
+      <td>Change in wind speed or direction across a horizontal distance at the same altitude</td>
+      <td>Frontal boundaries, jet stream edges, gust fronts</td>
+      <td><span class="warn-tag">En route hazard</span> Heading and airspeed deviations; drift from track</td>
+    </tr>
+    <tr>
+      <td><strong>Vertical Wind Shear</strong></td>
+      <td>Change in wind speed or direction with a change in altitude (most critical for approach/departure)</td>
+      <td>Low-level jet, temperature inversion, thunderstorm outflow, microburst</td>
+      <td><span class="hazard-tag">Critical on approach</span> Sudden airspeed loss/gain; altitude excursions; potential controlled flight into terrain</td>
+    </tr>
+    <tr>
+      <td><strong>Low-Level Wind Shear (LLWS)</strong></td>
+      <td>Wind shear below 2,000 ft AGL — most dangerous phase of flight</td>
+      <td>Microburst, gust front, mountain wave rotor, strong temperature inversion</td>
+      <td><span class="hazard-tag">Extreme — takeoff/landing phase</span> Airspeed changes of 20–50 kt in seconds; loss of control close to ground</td>
+    </tr>
+  </tbody>
+</table>
+
+<div class="section-label">Microburst — Characteristics</div>
+<table>
+  <thead>
+    <tr>
+      <th>Parameter</th>
+      <th>Value</th>
+      <th>Notes</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><strong>Diameter</strong></td>
+      <td>Less than 4 km (2 NM)</td>
+      <td>Compact; can be entirely within an airport terminal area; may not trigger all sensors</td>
+    </tr>
+    <tr>
+      <td><strong>Duration</strong></td>
+      <td>Less than 15 minutes peak intensity</td>
+      <td>Typically 5–10 minutes of severe conditions; can develop within 5 minutes</td>
+    </tr>
+    <tr>
+      <td><strong>Downdraft speed</strong></td>
+      <td>Up to 6,000 fpm (100 ft/sec)</td>
+      <td>Exceeds maximum climb rate of most light aircraft; impossible to out-climb</td>
+    </tr>
+    <tr>
+      <td><strong>Outflow speed</strong></td>
+      <td>Up to 45 knots</td>
+      <td>Outflow spreads radially outward from impact point at surface</td>
+    </tr>
+    <tr>
+      <td><strong>Wind shear magnitude</strong></td>
+      <td>Up to 90 kt across the microburst</td>
+      <td>Headwind gain entering, then massive tailwind loss exiting — net effect: severe airspeed loss</td>
+    </tr>
+    <tr>
+      <td><strong>Most dangerous phase</strong></td>
+      <td>Approach and initial takeoff climb</td>
+      <td>Low altitude with no margin for recovery; initial headwind increase masks hazard</td>
+    </tr>
+  </tbody>
+</table>
+
+<div class="section-label">Microburst Encounter on Approach — Phase by Phase</div>
+<div class="approach-diagram">
+  <div class="approach-title">Aircraft on Final Approach Flying Into a Microburst</div>
+  <div class="phase-row">
+    <div class="phase-num" style="background:rgba(80,200,80,0.2);color:#80e080;">1</div>
+    <div class="phase-label" style="color:#80e080;">Headwind Increase</div>
+    <div class="phase-desc">Aircraft enters the outflow. Headwind increases suddenly. Airspeed rises (e.g. +15 kt). Aircraft pitches up, climbs above glideslope. Pilot may reduce power to maintain profile. <span class="warn-tag">Deceiving — seems OK</span></div>
+  </div>
+  <div class="phase-row">
+    <div class="phase-num" style="background:rgba(255,200,0,0.2);color:#f0c040;">2</div>
+    <div class="phase-label" style="color:#f0c040;">Downdraft Core</div>
+    <div class="phase-desc">Aircraft enters the downdraft column. Powerful sink up to 6,000 fpm pushes aircraft toward ground. Full power may not arrest descent. Altitude loss is rapid and uncontrollable. <span class="hazard-tag">Critical phase</span></div>
+  </div>
+  <div class="phase-row">
+    <div class="phase-num" style="background:rgba(255,80,80,0.2);color:#ff8080;">3</div>
+    <div class="phase-label" style="color:#ff8080;">Tailwind — Airspeed Loss</div>
+    <div class="phase-desc">Aircraft exits the far side. Wind shifts to tailwind. Airspeed drops dramatically (e.g. -30 kt). Aircraft below glideslope, low airspeed, near stall, close to ground. Power at full but insufficient. <span class="hazard-tag">Maximum danger — CFIT risk</span></div>
+  </div>
+  <div class="phase-row">
+    <div class="phase-num" style="background:rgba(100,100,100,0.2);color:#aaa;">4</div>
+    <div class="phase-label" style="color:#aaa;">Go-Around / Divert</div>
+    <div class="phase-desc">If go-around is initiated: do NOT fly through the downdraft core. Full power, pitch for best angle, turn away from the microburst. If already in core: maximum power, accept sink rate, maintain control. <span class="warn-tag">Divert if possible before encounter</span></div>
+  </div>
+</div>
+
+<div class="section-label">Recognition Cues — Microburst Warning Signs</div>
+<table>
+  <thead>
+    <tr>
+      <th>Cue</th>
+      <th>Description</th>
+      <th>Reliability</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><strong>Rain Shaft / Curtain</strong></td>
+      <td>Visible column of heavy precipitation descending from Cb base to surface; compact and dark</td>
+      <td><span class="warn-tag">Moderate</span> Dry microbursts may lack visible rain shaft</td>
+    </tr>
+    <tr>
+      <td><strong>Virga</strong></td>
+      <td>Precipitation streaks falling from cloud base that evaporate before reaching surface</td>
+      <td><span class="hazard-tag">High</span> Dry microburst indicator — evaporative cooling drives powerful downdraft; no rain at surface so pilots are surprised</td>
+    </tr>
+    <tr>
+      <td><strong>Sudden Airspeed Change</strong></td>
+      <td>Unexpected airspeed increase of &gt; 15 kt on approach not consistent with power setting</td>
+      <td><span class="hazard-tag">High</span> Immediate action cue: initiate go-around and report LLWS to ATC</td>
+    </tr>
+    <tr>
+      <td><strong>PIREP / ATC Warning</strong></td>
+      <td>Previous aircraft reporting LLWS; ATC LLWS alert system activations</td>
+      <td><span class="ok-tag">Best indicator</span> Take all LLWS PIREPs seriously; conditions change rapidly</td>
+    </tr>
+    <tr>
+      <td><strong>Dust Ring</strong></td>
+      <td>Expanding ring of dust or debris at surface below the outflow point</td>
+      <td><span class="warn-tag">Visual only</span> Visible on clear days; not detectable at night or in rain</td>
+    </tr>
+  </tbody>
+</table>
+
+<div class="avoid-box">
+  <h2>Wind Shear and Microburst — Avoidance Rules</h2>
+  <div class="avoid-row"><span class="avoid-badge">DO NOT</span><span class="avoid-text"><strong>Do not attempt a go-around through the microburst core</strong>. The downdraft exceeds aircraft climb performance. Turn laterally to exit the microburst.</span></div>
+  <div class="avoid-row"><span class="avoid-badge">DIVERT</span><span class="avoid-text">If PIREP or ATC reports LLWS on approach, <strong>divert to alternate or hold</strong> until conditions clear. Microbursts dissipate within 15 minutes typically.</span></div>
+  <div class="avoid-row"><span class="avoid-badge">VIRGA</span><span class="avoid-text">Treat virga as a <strong>dry microburst warning</strong>. The evaporative downdraft can be as powerful as a wet microburst but with no visible rain at the surface to warn you.</span></div>
+  <div class="avoid-row"><span class="avoid-badge">REPORT</span><span class="avoid-text">If you encounter LLWS on approach, <strong>report it immediately to ATC</strong>. This protects following aircraft. Use phraseology: "LLWS, airspeed loss of [X] kt on final."</span></div>
+</div>
+
+<div class="hook-box">
+  <h2>Memory Hook — Wind Shear Essentials</h2>
+  <div class="hook-row"><span class="hook-badge">MICROBURST</span><span class="hook-text"><strong>Diameter &lt; 4 km, duration &lt; 15 min, downdraft up to 6,000 fpm, outflow up to 45 kt</strong>. Small, brief, deadly.</span></div>
+  <div class="hook-row"><span class="hook-badge">APPROACH SEQUENCE</span><span class="hook-text"><strong>Headwind gain (misleading) → downdraft core → tailwind/airspeed loss (deadly)</strong>. The headwind gain masks the danger until it is too late.</span></div>
+  <div class="hook-row"><span class="hook-badge">VIRGA = DANGER</span><span class="hook-text">Virga means precipitation evaporating before the surface. The <strong>evaporative cooling drives a powerful invisible downdraft</strong> — dry microburst. Most insidious type.</span></div>
+  <div class="hook-row"><span class="hook-badge">GO-AROUND</span><span class="hook-text">Initiate go-around <strong>at the first sign</strong> of unexpected airspeed change on final. Turn laterally — do NOT fly through the downdraft core.</span></div>
+</div>
+
+</div>
+</body>
+</html>

--- a/web-app/public/visuals/met013-fronts.html
+++ b/web-app/public/visuals/met013-fronts.html
@@ -1,0 +1,164 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>MET-013: Fronts</title>
+<style>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body { background: #0d1b2a; color: #e8edf2; font-family: 'Segoe UI', system-ui, sans-serif; padding: 32px; }
+  h1 { font-size: 22px; color: #f0c040; letter-spacing: 1px; margin-bottom: 6px; }
+  .subtitle { font-size: 13px; color: #7a9ab5; margin-bottom: 32px; letter-spacing: 0.5px; }
+  .section-label { font-size: 11px; color: #7a9ab5; letter-spacing: 1px; text-transform: uppercase; margin-bottom: 8px; font-weight: 600; }
+  table { width: 100%; border-collapse: collapse; font-size: 12px; margin-bottom: 28px; }
+  th { background: #1a2d3d; color: #7a9ab5; padding: 8px 10px; text-align: left; font-size: 11px; text-transform: uppercase; letter-spacing: 0.5px; }
+  td { padding: 9px 10px; border-bottom: 1px solid #1a2d3d; vertical-align: top; }
+  .hook-box { background: #1a2a1a; border: 1.5px solid #2d5a2d; border-radius: 10px; padding: 18px 22px; margin-top: 8px; }
+  .hook-box h2 { font-size: 12px; color: #80c880; text-transform: uppercase; letter-spacing: 1px; margin-bottom: 12px; }
+  .hook-row { display: flex; gap: 10px; margin-bottom: 8px; align-items: flex-start; }
+  .hook-badge { background: #2d5a2d; color: #80c880; font-size: 10px; font-weight: 800; padding: 2px 8px; border-radius: 10px; white-space: nowrap; flex-shrink: 0; margin-top: 2px; }
+  .hook-text { font-size: 13px; color: #c8d8c8; line-height: 1.5; }
+  .hook-text strong { color: #f0c040; }
+  .hazard-tag { display: inline-block; background: rgba(255,80,80,0.15); color: #ff8080; border: 1px solid rgba(255,80,80,0.3); border-radius: 4px; padding: 2px 8px; font-size: 10px; font-weight: 700; }
+  .ok-tag { display: inline-block; background: rgba(80,200,80,0.15); color: #80e080; border: 1px solid rgba(80,200,80,0.3); border-radius: 4px; padding: 2px 8px; font-size: 10px; font-weight: 700; }
+  .warn-tag { display: inline-block; background: rgba(240,192,64,0.15); color: #f0c040; border: 1px solid rgba(240,192,64,0.3); border-radius: 4px; padding: 2px 8px; font-size: 10px; font-weight: 700; }
+  .front-symbol { display: inline-block; width: 20px; height: 20px; border-radius: 50%; vertical-align: middle; margin-right: 4px; }
+  .cold-sym { background: #4040cc; }
+  .warm-sym { background: #cc4040; }
+  .occ-sym { background: #8040cc; }
+  .stat-sym { background: #606060; }
+  .front-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 20px; margin-bottom: 28px; }
+  .front-card { background: #1a2d3d; border-radius: 8px; padding: 16px 18px; }
+  .front-title { font-size: 14px; font-weight: 700; margin-bottom: 12px; display: flex; align-items: center; gap: 8px; }
+  .front-row { font-size: 12px; color: #c8d8e8; margin-bottom: 6px; line-height: 1.5; }
+  .front-label { font-size: 10px; color: #7a9ab5; text-transform: uppercase; letter-spacing: 0.5px; }
+</style>
+</head>
+<body>
+<div style="max-width:900px;margin:auto;">
+
+<h1>MET-013 — Fronts</h1>
+<p class="subtitle">Transport Canada · TP 12880E Chapter 8 · PPL Written Exam</p>
+
+<div class="section-label">Front Type Overview</div>
+<div class="front-grid">
+  <div class="front-card" style="border-top:3px solid #4060cc;">
+    <div class="front-title"><span style="display:inline-block;width:16px;height:16px;border-radius:50%;background:#4060cc;flex-shrink:0;"></span>Cold Front</div>
+    <div class="front-row"><span class="front-label">Symbol</span><br>Blue line with solid triangles pointing in direction of movement</div>
+    <div class="front-row"><span class="front-label">Movement speed</span><br>Fast: 25–50 kt (can be faster); steeper slope than warm front</div>
+    <div class="front-row"><span class="front-label">What happens</span><br>Cold dense air undercuts and lifts warm moist air rapidly. Forces strong convection.</div>
+    <div class="front-row"><span class="front-label">Cloud sequence (approaching)</span><br>Cu → TCu → Cb; possible squall line ahead of front</div>
+    <div class="front-row"><span class="front-label">Precipitation</span><br>Heavy showers, thunderstorms; narrow band (50–100 NM wide); intense but brief</div>
+    <div class="front-row"><span class="front-label">Visibility (prefrontal)</span><br>Good in clear sector; hazy near front</div>
+    <div class="front-row"><span class="front-label">Turbulence</span><br><span class="hazard-tag">Severe</span> — strong vertical motion; Cb possible</div>
+    <div class="front-row"><span class="front-label">Icing</span><br><span class="hazard-tag">All types</span> — convective cloud; all altitudes in Cb</div>
+    <div class="front-row"><span class="front-label">After passage</span><br>Rapid clearing; wind shifts clockwise (veers) to NW; pressure rises quickly; visibility excellent</div>
+  </div>
+  <div class="front-card" style="border-top:3px solid #cc4040;">
+    <div class="front-title"><span style="display:inline-block;width:16px;height:16px;border-radius:50%;background:#cc4040;flex-shrink:0;"></span>Warm Front</div>
+    <div class="front-row"><span class="front-label">Symbol</span><br>Red line with solid semicircles pointing in direction of movement</div>
+    <div class="front-row"><span class="front-label">Movement speed</span><br>Slow: 10–25 kt; shallow slope (~1:150)</div>
+    <div class="front-row"><span class="front-label">What happens</span><br>Warm air overrides cold; gradual lifting over wide area produces stratiform cloud/rain</div>
+    <div class="front-row"><span class="front-label">Cloud sequence (approaching)</span><br>Ci → Cs → As → Ns (hundreds of miles ahead of surface position)</div>
+    <div class="front-row"><span class="front-label">Precipitation</span><br>Continuous rain or snow; wide band (300–500 NM ahead of surface front)</div>
+    <div class="front-row"><span class="front-label">Visibility (prefrontal)</span><br><span class="hazard-tag">Poor</span> — fog, mist, stratus common ahead of surface front</div>
+    <div class="front-row"><span class="front-label">Turbulence</span><br><span class="warn-tag">Light to moderate</span> — stratiform; occasional moderate in Ns</div>
+    <div class="front-row"><span class="front-label">Icing</span><br><span class="hazard-tag">Severe icing risk</span> — widespread freezing rain possible; large area of icing</div>
+    <div class="front-row"><span class="front-label">After passage</span><br>Gradual improvement; temperature rises; wind shifts (veers); visibility slowly improves; may remain foggy</div>
+  </div>
+  <div class="front-card" style="border-top:3px solid #8040cc;">
+    <div class="front-title"><span style="display:inline-block;width:16px;height:16px;border-radius:50%;background:#8040cc;flex-shrink:0;"></span>Occluded Front</div>
+    <div class="front-row"><span class="front-label">Symbol</span><br>Purple line with alternating triangles and semicircles on same side</div>
+    <div class="front-row"><span class="front-label">Formation</span><br>Cold front catches warm front; warm sector lifted entirely off surface. Most complex wx.</div>
+    <div class="front-row"><span class="front-label">Types</span><br>Cold occlusion (cold-type): cold air behind front colder than cold air ahead. Warm occlusion (warm-type): reverse.</div>
+    <div class="front-row"><span class="front-label">Cloud/Precipitation</span><br>Combined characteristics of both cold and warm fronts; complex weather pattern</div>
+    <div class="front-row"><span class="front-label">Turbulence</span><br><span class="hazard-tag">MOD to SEV</span> — combined hazards</div>
+    <div class="front-row"><span class="front-label">Icing</span><br><span class="hazard-tag">Significant icing</span> — wide area, multiple levels</div>
+    <div class="front-row"><span class="front-label">Visibility</span><br>Generally poor; extensive cloud and precipitation area</div>
+  </div>
+  <div class="front-card" style="border-top:3px solid #606060;">
+    <div class="front-title"><span style="display:inline-block;width:16px;height:16px;border-radius:50%;background:#606060;flex-shrink:0;"></span>Stationary Front</div>
+    <div class="front-row"><span class="front-label">Symbol</span><br>Alternating red semicircles (warm side) and blue triangles (cold side) pointing opposite directions</div>
+    <div class="front-row"><span class="front-label">Movement</span><br>Little or no movement; wind nearly parallel to frontal boundary on both sides</div>
+    <div class="front-row"><span class="front-label">Weather</span><br>Prolonged cloudiness and precipitation; similar to warm front but stationary for days</div>
+    <div class="front-row"><span class="front-label">Duration</span><br>Can persist for days; often leads to flooding rains and persistent IFR conditions</div>
+    <div class="front-row"><span class="front-label">Icing</span><br><span class="warn-tag">Persistent icing</span> — extended exposure due to slow movement</div>
+    <div class="front-row"><span class="front-label">Planning</span><br>Requires long detour or delay; check GFA for extent of affected area</div>
+  </div>
+</div>
+
+<div class="section-label">Front Comparison Table — Quick Reference</div>
+<table>
+  <thead>
+    <tr>
+      <th>Feature</th>
+      <th style="color:#6080cc;">Cold Front</th>
+      <th style="color:#cc6060;">Warm Front</th>
+      <th style="color:#9060cc;">Occluded</th>
+      <th style="color:#888;">Stationary</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><strong>Speed</strong></td>
+      <td>Fast (25–50 kt)</td>
+      <td>Slow (10–25 kt)</td>
+      <td>Moderate</td>
+      <td>Minimal</td>
+    </tr>
+    <tr>
+      <td><strong>Cloud band width</strong></td>
+      <td>Narrow (50–100 NM)</td>
+      <td>Wide (300–500 NM)</td>
+      <td>Wide and complex</td>
+      <td>Wide and persistent</td>
+    </tr>
+    <tr>
+      <td><strong>Precipitation type</strong></td>
+      <td>Showers, Cb, TS</td>
+      <td>Continuous rain/snow</td>
+      <td>Mixed types</td>
+      <td>Steady rain/snow</td>
+    </tr>
+    <tr>
+      <td><strong>Visibility</strong></td>
+      <td>Good except in Cb; excellent after</td>
+      <td><span class="hazard-tag">Poor</span> — widespread fog/mist</td>
+      <td>Poor</td>
+      <td>Poor; persistent</td>
+    </tr>
+    <tr>
+      <td><strong>Turbulence severity</strong></td>
+      <td><span class="hazard-tag">Severe in Cb</span></td>
+      <td><span class="warn-tag">Light to moderate</span></td>
+      <td><span class="hazard-tag">Moderate to severe</span></td>
+      <td><span class="warn-tag">Moderate</span></td>
+    </tr>
+    <tr>
+      <td><strong>Primary icing risk</strong></td>
+      <td>All types in Cb; brief</td>
+      <td>Widespread freezing rain; large area</td>
+      <td>Significant; multi-level</td>
+      <td>Persistent; long exposure</td>
+    </tr>
+    <tr>
+      <td><strong>After passage</strong></td>
+      <td><span class="ok-tag">Rapid clearing</span></td>
+      <td><span class="warn-tag">Slow improvement</span></td>
+      <td>Gradual improvement</td>
+      <td>No change (stationary)</td>
+    </tr>
+  </tbody>
+</table>
+
+<div class="hook-box">
+  <h2>Memory Hook — Fronts at a Glance</h2>
+  <div class="hook-row"><span class="hook-badge">COLD = FAST</span><span class="hook-text"><strong>Cold front: fast, narrow, dramatic</strong>. Violent weather, then rapid clearing. If you can wait 2 hours, it may pass. Cb and squall lines possible.</span></div>
+  <div class="hook-row"><span class="hook-badge">WARM = SLOW</span><span class="hook-text"><strong>Warm front: slow, wide, persistent</strong>. Cloud sequence hundreds of miles ahead: Ci → Cs → As → Ns. Freezing rain hazard. Cannot wait it out easily.</span></div>
+  <div class="hook-row"><span class="hook-badge">CLOUD SEQUENCE</span><span class="hook-text">Ci → Cs (halo!) → As → Ns = <strong>warm front approach</strong>. Halo around sun/moon means Cs = front within 24–36 hours. Classic exam question.</span></div>
+  <div class="hook-row"><span class="hook-badge">WIND AFTER</span><span class="hook-text">Wind <strong>veers</strong> (clockwise: S to W to NW) after both cold and warm front passage in Northern Hemisphere. Pressure rises after cold front.</span></div>
+</div>
+
+</div>
+</body>
+</html>

--- a/web-app/public/visuals/met014-wx-decision-making.html
+++ b/web-app/public/visuals/met014-wx-decision-making.html
@@ -1,0 +1,196 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>MET-014: Weather Decision-Making</title>
+<style>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body { background: #0d1b2a; color: #e8edf2; font-family: 'Segoe UI', system-ui, sans-serif; padding: 32px; }
+  h1 { font-size: 22px; color: #f0c040; letter-spacing: 1px; margin-bottom: 6px; }
+  .subtitle { font-size: 13px; color: #7a9ab5; margin-bottom: 32px; letter-spacing: 0.5px; }
+  .section-label { font-size: 11px; color: #7a9ab5; letter-spacing: 1px; text-transform: uppercase; margin-bottom: 8px; font-weight: 600; }
+  table { width: 100%; border-collapse: collapse; font-size: 12px; margin-bottom: 28px; }
+  th { background: #1a2d3d; color: #7a9ab5; padding: 8px 10px; text-align: left; font-size: 11px; text-transform: uppercase; letter-spacing: 0.5px; }
+  td { padding: 9px 10px; border-bottom: 1px solid #1a2d3d; vertical-align: top; }
+  .hook-box { background: #1a2a1a; border: 1.5px solid #2d5a2d; border-radius: 10px; padding: 18px 22px; margin-top: 8px; }
+  .hook-box h2 { font-size: 12px; color: #80c880; text-transform: uppercase; letter-spacing: 1px; margin-bottom: 12px; }
+  .hook-row { display: flex; gap: 10px; margin-bottom: 8px; align-items: flex-start; }
+  .hook-badge { background: #2d5a2d; color: #80c880; font-size: 10px; font-weight: 800; padding: 2px 8px; border-radius: 10px; white-space: nowrap; flex-shrink: 0; margin-top: 2px; }
+  .hook-text { font-size: 13px; color: #c8d8c8; line-height: 1.5; }
+  .hook-text strong { color: #f0c040; }
+  .hazard-tag { display: inline-block; background: rgba(255,80,80,0.15); color: #ff8080; border: 1px solid rgba(255,80,80,0.3); border-radius: 4px; padding: 2px 8px; font-size: 10px; font-weight: 700; }
+  .ok-tag { display: inline-block; background: rgba(80,200,80,0.15); color: #80e080; border: 1px solid rgba(80,200,80,0.3); border-radius: 4px; padding: 2px 8px; font-size: 10px; font-weight: 700; }
+  .warn-tag { display: inline-block; background: rgba(240,192,64,0.15); color: #f0c040; border: 1px solid rgba(240,192,64,0.3); border-radius: 4px; padding: 2px 8px; font-size: 10px; font-weight: 700; }
+  .danger-box { background: rgba(255,80,80,0.08); border: 1.5px solid rgba(255,80,80,0.3); border-radius: 10px; padding: 18px 22px; margin-bottom: 28px; }
+  .danger-box h2 { font-size: 12px; color: #ff8080; text-transform: uppercase; letter-spacing: 1px; margin-bottom: 12px; }
+  .danger-row { display: flex; gap: 10px; margin-bottom: 8px; align-items: flex-start; }
+  .danger-badge { background: rgba(255,80,80,0.2); color: #ff8080; font-size: 10px; font-weight: 800; padding: 2px 8px; border-radius: 10px; white-space: nowrap; flex-shrink: 0; margin-top: 2px; }
+  .danger-text { font-size: 13px; color: #e8d0d0; line-height: 1.5; }
+  .danger-text strong { color: #ff8080; }
+  .checklist { list-style: none; padding: 0; margin: 0 0 28px 0; }
+  .checklist li { display: flex; align-items: flex-start; gap: 10px; padding: 10px 12px; border-bottom: 1px solid #1a2d3d; font-size: 12px; color: #c8d8e8; line-height: 1.5; }
+  .checklist li:last-child { border-bottom: none; }
+  .check-num { display: inline-block; background: #1a2d3d; color: #f0c040; font-size: 11px; font-weight: 800; width: 24px; height: 24px; border-radius: 50%; text-align: center; line-height: 24px; flex-shrink: 0; }
+  .check-label { font-weight: 700; color: #e8edf2; }
+  .imsafe-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 10px; margin-bottom: 28px; }
+  .imsafe-card { background: #1a2d3d; border-radius: 8px; padding: 12px 14px; }
+  .imsafe-letter { font-size: 28px; font-weight: 800; color: #f0c040; line-height: 1; margin-bottom: 4px; }
+  .imsafe-word { font-size: 12px; font-weight: 700; color: #e8edf2; margin-bottom: 6px; }
+  .imsafe-desc { font-size: 11px; color: #c8d8e8; line-height: 1.4; }
+  .imsafe-question { font-size: 10px; color: #7a9ab5; margin-top: 4px; font-style: italic; }
+  .minimums-note { font-size: 11px; color: #7a9ab5; margin-top: 4px; }
+</style>
+</head>
+<body>
+<div style="max-width:900px;margin:auto;">
+
+<h1>MET-014 — Weather Decision-Making</h1>
+<p class="subtitle">Transport Canada · TP 12880E Chapter 8 · CARs Part VI · PPL Written Exam</p>
+
+<div class="section-label">VFR Weather Minima — Quick Reference (CARs 602.114–602.115)</div>
+<table>
+  <thead>
+    <tr>
+      <th>Airspace Class</th>
+      <th>Flight Visibility</th>
+      <th>Distance from Cloud</th>
+      <th>Notes</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><strong>Class B, C, D, E</strong><br>(Controlled)</td>
+      <td>3 SM (1 SM at aerodromes)</td>
+      <td>500 ft below, 1,000 ft above, 2,000 ft horizontal</td>
+      <td>Standard VFR minimums in controlled airspace. ATC clearance required for Class B/C.</td>
+    </tr>
+    <tr>
+      <td><strong>Class G</strong><br>(Uncontrolled, &gt; 1,000 ft AGL)</td>
+      <td>1 SM</td>
+      <td>Clear of cloud</td>
+      <td>Lower minimums in uncontrolled airspace; pilots still responsible for collision avoidance</td>
+    </tr>
+    <tr>
+      <td><strong>Class G</strong><br>(Uncontrolled, &le; 1,000 ft AGL)</td>
+      <td>2 SM</td>
+      <td>Clear of cloud</td>
+      <td>Applies at low altitude over uncontrolled airspace</td>
+    </tr>
+    <tr>
+      <td><strong>Special VFR (SVFR)</strong></td>
+      <td>1 SM flight visibility</td>
+      <td>Clear of cloud</td>
+      <td>Issued by ATC in Class C/D controlled airspace only; requires specific clearance; not at night without IFR rating</td>
+    </tr>
+    <tr>
+      <td><strong>Night VFR</strong></td>
+      <td>3 SM</td>
+      <td>500 ft below, 1,000 ft above, 2,000 ft horizontal</td>
+      <td>Same as day VFR controlled minimums; additional equipment and lighting requirements</td>
+    </tr>
+  </tbody>
+</table>
+
+<div class="section-label">Go / No-Go Decision Framework</div>
+<ul class="checklist">
+  <li><span class="check-num">1</span><div><span class="check-label">Obtain a complete weather brief</span><br>Call 1-866-WXBRIEF (NAV CANADA) or use NavCAN.ca. Get briefing for departure, en route, and destination. Request PIREPs for your route.</div></li>
+  <li><span class="check-num">2</span><div><span class="check-label">Check METAR at departure and destination</span><br>Current ceiling, visibility, wind, temperature/dew point spread. Is the destination currently VMC? What is the trend?</div></li>
+  <li><span class="check-num">3</span><div><span class="check-label">Check TAF for destination and alternates</span><br>What are forecast conditions at your ETA? Are TEMPO or PROB30/40 items significant for your flight?</div></li>
+  <li><span class="check-num">4</span><div><span class="check-label">Review GFA for the route</span><br>Check Clouds &amp; Weather chart (ceiling/visibility) and Icing/Turbulence chart. Identify freezing level. Mark hazard areas on your chart.</div></li>
+  <li><span class="check-num">5</span><div><span class="check-label">Identify all hazards explicitly</span><br>List: icing risk, turbulence areas, IFR conditions, frontal positions, fog potential. Do not rationalize hazards away.</div></li>
+  <li><span class="check-num">6</span><div><span class="check-label">Identify alternate aerodromes</span><br>Select one or more alternates with better forecast conditions. Confirm fuel is adequate to reach alternate. Know when to divert.</div></li>
+  <li><span class="check-num">7</span><div><span class="check-label">Apply personal minimums — make the GO/NO-GO decision</span><br>Compare conditions to your personal minimums (not just legal minimums). When in doubt, do not go. State your decision out loud.</div></li>
+</ul>
+
+<div class="section-label">IMSAFE Checklist — Personal Airworthiness</div>
+<div class="imsafe-grid">
+  <div class="imsafe-card">
+    <div class="imsafe-letter">I</div>
+    <div class="imsafe-word">Illness</div>
+    <div class="imsafe-desc">Any symptoms of illness — cold, flu, GI, headache? Even minor illness degrades performance and may affect pressurization/altitude tolerance.</div>
+    <div class="imsafe-question">"Am I feeling physically well today?"</div>
+  </div>
+  <div class="imsafe-card">
+    <div class="imsafe-letter">M</div>
+    <div class="imsafe-word">Medication</div>
+    <div class="imsafe-desc">Any prescription or OTC medication? Many common drugs are prohibited for flight or cause drowsiness, impaired judgement, or vestibular effects.</div>
+    <div class="imsafe-question">"Am I on any medication that could affect my flying?"</div>
+  </div>
+  <div class="imsafe-card">
+    <div class="imsafe-letter">S</div>
+    <div class="imsafe-word">Stress</div>
+    <div class="imsafe-desc">Personal, financial, family, or work stress occupies mental bandwidth needed for flying. Stress degrades decision-making and situational awareness.</div>
+    <div class="imsafe-question">"Is anything on my mind that will distract me?"</div>
+  </div>
+  <div class="imsafe-card">
+    <div class="imsafe-letter">A</div>
+    <div class="imsafe-word">Alcohol</div>
+    <div class="imsafe-desc">CARs 602.03: No alcohol within 8 hours of flight. Blood alcohol must not exceed 0.04%. Hangover effects persist well beyond 8 hours. When in doubt, do not fly.</div>
+    <div class="imsafe-question">"Have I had alcohol in the last 8+ hours?"</div>
+  </div>
+  <div class="imsafe-card">
+    <div class="imsafe-letter">F</div>
+    <div class="imsafe-word">Fatigue</div>
+    <div class="imsafe-desc">Fatigue impairs judgement as severely as alcohol. Less than 6 hours of sleep, night shift work, or disrupted sleep patterns all increase risk significantly.</div>
+    <div class="imsafe-question">"Am I rested enough to fly safely for the full flight duration?"</div>
+  </div>
+  <div class="imsafe-card">
+    <div class="imsafe-letter">E</div>
+    <div class="imsafe-word">Emotion</div>
+    <div class="imsafe-desc">Emotional upset (grief, anger, anxiety, excitement) impairs cognitive function. Strong emotions narrow attention and reduce risk perception accuracy.</div>
+    <div class="imsafe-question">"Am I emotionally calm enough to make good decisions under pressure?"</div>
+  </div>
+</div>
+
+<div class="danger-box">
+  <h2>Continuation Bias — The #1 Killer in VFR Weather</h2>
+  <div class="danger-row"><span class="danger-badge">DEFINITION</span><span class="danger-text">Continuation bias is the tendency to <strong>continue a plan of action despite deteriorating conditions</strong> or new information that should trigger a change. The earlier decision to "go" creates pressure to stay committed.</span></div>
+  <div class="danger-row"><span class="danger-badge">HOW IT KILLS</span><span class="danger-text">VFR pilot encounters worsening weather en route. Instead of turning back, <strong>presses on hoping it will improve</strong>. Visibility drops. Enters IMC. Spatial disorientation. Controlled flight into terrain (CFIT).</span></div>
+  <div class="danger-row"><span class="danger-badge">SIGNS</span><span class="danger-text">"It'll clear up soon." / "I've come this far." / "The passengers are counting on me." / "I don't want to look foolish by turning back." / "Just a little further."</span></div>
+  <div class="danger-row"><span class="danger-badge">ANTIDOTE</span><span class="danger-text">Establish a <strong>pre-flight decision trigger</strong>: "If visibility drops below [X] SM or ceiling below [Y] ft, I turn back immediately." Commit to it before you depart. Not negotiable in flight.</span></div>
+</div>
+
+<div class="section-label">Personal Minimums — The Concept</div>
+<table>
+  <thead>
+    <tr>
+      <th>Standard</th>
+      <th>Meaning</th>
+      <th>Example</th>
+      <th>Application</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><strong>Legal Minimum</strong></td>
+      <td>The floor set by CARs — the absolute minimum permitted by regulation</td>
+      <td>3 SM visibility, 500 ft below cloud in controlled airspace</td>
+      <td><span class="hazard-tag">Floor only</span> — designed for proficient, experienced pilots in appropriate aircraft</td>
+    </tr>
+    <tr>
+      <td><strong>Personal Minimum</strong></td>
+      <td>Your self-imposed limit that provides a safety buffer above legal minimums</td>
+      <td>Student pilot: 5 SM vis, 2,000 ft ceiling, wind &lt; 15 kt</td>
+      <td><span class="ok-tag">Your real limit</span> — accounts for your experience, currency, aircraft, and the specific flight</td>
+    </tr>
+    <tr>
+      <td><strong>Currency</strong></td>
+      <td>Recent experience — have you flown this type of operation recently?</td>
+      <td>3 takeoffs/landings in last 90 days for passenger carrying; recent night currency</td>
+      <td>Legal currency is the minimum — raise minimums if not recently current in conditions</td>
+    </tr>
+  </tbody>
+</table>
+
+<div class="hook-box">
+  <h2>Memory Hook — Weather Decision-Making</h2>
+  <div class="hook-row"><span class="hook-badge">IMSAFE</span><span class="hook-text"><strong>Illness, Medication, Stress, Alcohol, Fatigue, Emotion</strong>. Check yourself before every flight. One YES = consider no-go or reduced complexity flight.</span></div>
+  <div class="hook-row"><span class="hook-badge">LEGAL vs PERSONAL</span><span class="hook-text"><strong>Legal minimum = floor</strong>. <strong>Personal minimum = YOUR limit</strong>. Personal minimums must always be higher than legal. They decrease as experience grows.</span></div>
+  <div class="hook-row"><span class="hook-badge">CONTINUATION BIAS</span><span class="hook-text">Set your turn-back triggers <strong>before you depart</strong>. Never negotiate with yourself in flight. "When in doubt, don't" applies to en route weather decisions too.</span></div>
+  <div class="hook-row"><span class="hook-badge">BRIEF ORDER</span><span class="hook-text"><strong>METAR (now) → TAF (forecast) → GFA (big picture) → PIREPs (real reports) → Decision</strong>. Use all four. No single product tells the whole story.</span></div>
+</div>
+
+</div>
+</body>
+</html>


### PR DESCRIPTION
## Summary

- Creates 14 standalone dark-aviation HTML visuals (`met001` – `met014`) in `web-app/public/visuals/`, one per Meteorology lesson
- Wires `visual:` frontmatter field in all 14 `lessons/meteorology/*.md` files (only that field changed, lesson bodies untouched)
- All visuals are self-contained (no external deps), match the canonical `al001-airspace-classifications.html` style (`#0d1b2a` bg, `#f0c040` amber accent, `max-width:900px; margin:auto`)
- `npm run build` passes

Closes #149

## Test plan

- [ ] Open each `met*.html` directly in a browser — should render without network requests
- [ ] Verify `visual:` field in each lesson frontmatter points to the correct path (e.g. `/visuals/met001-atmosphere-structure.html`)
- [ ] Check lesson view in web app shows the embedded visual iframe/frame
- [ ] `npm run build` passes in `web-app/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)