### PR TITLE
[PPL-149] Add visuals for Meteorology lessons MET-001 through MET-014

### DIFF
--- a/lessons/meteorology/001-atmosphere-structure.md
+++ b/lessons/meteorology/001-atmosphere-structure.md
@@ -7,7 +7,7 @@ title: "Atmosphere Structure"
 duration_min: 20
 status: complete
 audio: null
-visual: null
+visual: /visuals/met001-atmosphere-structure.html
 sources:
   - TP 12880E Chapter 8
   - AIM MET 1.0

--- a/lessons/meteorology/002-temp-pressure-humidity.md
+++ b/lessons/meteorology/002-temp-pressure-humidity.md
@@ -7,7 +7,7 @@ title: "Temperature, Pressure, Humidity"
 duration_min: 20
 status: complete
 audio: null
-visual: null
+visual: /visuals/met002-temp-pressure-humidity.html
 sources:
   - TP 12880E Chapter 8
   - AIM MET 1.0

--- a/lessons/meteorology/003-clouds-types.md
+++ b/lessons/meteorology/003-clouds-types.md
@@ -7,7 +7,7 @@ title: "Cloud Types and Formation"
 duration_min: 20
 status: complete
 audio: null
-visual: null
+visual: /visuals/met003-clouds-types.html
 sources:
   - TP 12880E Chapter 8
   - AIM MET 1.2

--- a/lessons/meteorology/004-fog-types.md
+++ b/lessons/meteorology/004-fog-types.md
@@ -7,7 +7,7 @@ title: "Fog Formation and Types"
 duration_min: 20
 status: complete
 audio: null
-visual: null
+visual: /visuals/met004-fog-types.html
 sources:
   - TP 12880E Chapter 8
   - AIM MET 1.7

--- a/lessons/meteorology/005-metar-decoding.md
+++ b/lessons/meteorology/005-metar-decoding.md
@@ -7,7 +7,7 @@ title: "METAR Decoding"
 duration_min: 20
 status: complete
 audio: null
-visual: null
+visual: /visuals/met005-metar-decoding.html
 sources:
   - TP 12880E Chapter 8
   - AIM MET 2.1

--- a/lessons/meteorology/006-taf-decoding.md
+++ b/lessons/meteorology/006-taf-decoding.md
@@ -7,7 +7,7 @@ title: "TAF Decoding"
 duration_min: 20
 status: complete
 audio: null
-visual: null
+visual: /visuals/met006-taf-decoding.html
 sources:
   - TP 12880E Chapter 8
   - AIM MET 2.2

--- a/lessons/meteorology/007-gfa.md
+++ b/lessons/meteorology/007-gfa.md
@@ -7,7 +7,7 @@ title: "GFA — Graphical Forecast for Aviation"
 duration_min: 20
 status: complete
 audio: null
-visual: null
+visual: /visuals/met007-gfa.html
 sources:
   - TP 12880E Chapter 8
   - AIM MET 2.4

--- a/lessons/meteorology/008-pireps.md
+++ b/lessons/meteorology/008-pireps.md
@@ -7,7 +7,7 @@ title: "PIREPs"
 duration_min: 20
 status: complete
 audio: null
-visual: null
+visual: /visuals/met008-pireps.html
 sources:
   - TP 12880E Chapter 8
   - AIM MET 2.5

--- a/lessons/meteorology/009-thunderstorms.md
+++ b/lessons/meteorology/009-thunderstorms.md
@@ -7,7 +7,7 @@ title: "Thunderstorms"
 duration_min: 20
 status: complete
 audio: null
-visual: null
+visual: /visuals/met009-thunderstorms.html
 sources:
   - TP 12880E Chapter 8
   - AIM MET 1.5

--- a/lessons/meteorology/010-icing.md
+++ b/lessons/meteorology/010-icing.md
@@ -7,7 +7,7 @@ title: "Icing"
 duration_min: 20
 status: complete
 audio: null
-visual: null
+visual: /visuals/met010-icing.html
 sources:
   - TP 12880E Chapter 8
   - AIM MET 1.6

--- a/lessons/meteorology/011-turbulence.md
+++ b/lessons/meteorology/011-turbulence.md
@@ -7,7 +7,7 @@ title: "Turbulence"
 duration_min: 20
 status: complete
 audio: null
-visual: null
+visual: /visuals/met011-turbulence.html
 sources:
   - TP 12880E Chapter 8
   - AIM MET 1.9

--- a/lessons/meteorology/012-wind-shear-microburst.md
+++ b/lessons/meteorology/012-wind-shear-microburst.md
@@ -7,7 +7,7 @@ title: "Wind Shear and Microburst"
 duration_min: 20
 status: complete
 audio: null
-visual: null
+visual: /visuals/met012-wind-shear-microburst.html
 sources:
   - TP 12880E Chapter 8
   - AIM MET 1.11

--- a/lessons/meteorology/013-fronts.md
+++ b/lessons/meteorology/013-fronts.md
@@ -7,7 +7,7 @@ title: "Fronts"
 duration_min: 20
 status: complete
 audio: null
-visual: null
+visual: /visuals/met013-fronts.html
 sources:
   - TP 12880E Chapter 8
   - AIM MET 1.4

--- a/lessons/meteorology/014-wx-decision-making.md
+++ b/lessons/meteorology/014-wx-decision-making.md
@@ -7,7 +7,7 @@ title: "Weather Decision-Making"
 duration_min: 20
 status: complete
 audio: null
-visual: null
+visual: /visuals/met014-wx-decision-making.html
 sources:
   - TP 12880E Chapter 8
   - AIM MET 3.0

--- a/web-app/public/visuals/met001-atmosphere-structure.html
+++ b/web-app/public/visuals/met001-atmosphere-structure.html
@@ -1,0 +1,138 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>MET-001: Atmosphere Structure</title>
+<style>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body { background: #0d1b2a; color: #e8edf2; font-family: 'Segoe UI', system-ui, sans-serif; padding: 32px; }
+  h1 { font-size: 22px; color: #f0c040; letter-spacing: 1px; margin-bottom: 6px; }
+  .subtitle { font-size: 13px; color: #7a9ab5; margin-bottom: 32px; letter-spacing: 0.5px; }
+  .container { max-width: 900px; margin: 0 auto; }
+  .section-title { font-size: 14px; color: #f0c040; letter-spacing: 1px; text-transform: uppercase; margin: 32px 0 14px; }
+  .layout { display: grid; grid-template-columns: 1.1fr 1fr; gap: 24px; align-items: start; }
+  .diagram-box { background: #1a2d3d; border: 1px solid #243d52; border-radius: 8px; padding: 16px; }
+  svg text { font-family: 'Segoe UI', system-ui, sans-serif; }
+  table { width: 100%; border-collapse: collapse; margin-bottom: 20px; }
+  th { background: #1a2d3d; color: #f0c040; font-size: 12px; text-align: left; padding: 10px 14px; letter-spacing: 0.5px; }
+  td { font-size: 13px; color: #e8edf2; padding: 9px 14px; border-bottom: 1px solid #1a2d3d; vertical-align: top; }
+  tr:last-child td { border-bottom: none; }
+  .fact-card { background: #1a2d3d; border: 1px solid #243d52; border-radius: 8px; padding: 14px 16px; margin-bottom: 12px; }
+  .fact-label { font-size: 11px; color: #7a9ab5; letter-spacing: 0.5px; text-transform: uppercase; margin-bottom: 4px; }
+  .fact-value { font-size: 18px; color: #f0c040; font-weight: bold; }
+  .fact-note { font-size: 12px; color: #e8edf2; margin-top: 4px; }
+  .memory-hook { background: #1a2a1a; border: 1px solid #2d5a2d; border-radius: 8px; padding: 14px 18px; margin-top: 24px; font-size: 13px; line-height: 1.6; }
+  .memory-hook .badge { display: inline-block; background: #2d5a2d; color: #e8edf2; font-size: 10px; letter-spacing: 1px; padding: 2px 8px; border-radius: 3px; margin-bottom: 6px; }
+  @media (max-width: 640px) {
+    body { padding: 16px; }
+    .layout { grid-template-columns: 1fr; }
+  }
+</style>
+</head>
+<body>
+<div class="container">
+  <h1>MET-001 — Atmosphere Structure</h1>
+  <p class="subtitle">Transport Canada · TP 12880E Ch. 8 · AIM MET 1.0</p>
+
+  <div class="layout">
+    <div class="diagram-box">
+      <svg viewBox="0 0 360 360" width="100%" height="360">
+        <!-- Gradient for layers -->
+        <defs>
+          <linearGradient id="tropo" x1="0" y1="1" x2="0" y2="0">
+            <stop offset="0%" stop-color="#2d4a6a"/>
+            <stop offset="100%" stop-color="#1a2d45"/>
+          </linearGradient>
+          <linearGradient id="strato" x1="0" y1="1" x2="0" y2="0">
+            <stop offset="0%" stop-color="#1a2d45"/>
+            <stop offset="100%" stop-color="#0d1b2a"/>
+          </linearGradient>
+        </defs>
+
+        <!-- Axis -->
+        <line x1="70" y1="340" x2="70" y2="20" stroke="#7a9ab5" stroke-width="1.5"/>
+        <text x="40" y="180" text-anchor="middle" fill="#7a9ab5" font-size="10" transform="rotate(-90,40,180)">Altitude (ft)</text>
+
+        <!-- Y-axis ticks -->
+        <g font-size="10" fill="#7a9ab5">
+          <line x1="65" y1="340" x2="75" y2="340" stroke="#7a9ab5"/>
+          <text x="60" y="343" text-anchor="end">SL</text>
+          <line x1="65" y1="280" x2="75" y2="280" stroke="#7a9ab5"/>
+          <text x="60" y="283" text-anchor="end">10k</text>
+          <line x1="65" y1="220" x2="75" y2="220" stroke="#7a9ab5"/>
+          <text x="60" y="223" text-anchor="end">20k</text>
+          <line x1="65" y1="160" x2="75" y2="160" stroke="#7a9ab5"/>
+          <text x="60" y="163" text-anchor="end">30k</text>
+          <line x1="65" y1="130" x2="75" y2="130" stroke="#7a9ab5"/>
+          <text x="60" y="133" text-anchor="end">36k</text>
+          <line x1="65" y1="70" x2="75" y2="70" stroke="#7a9ab5"/>
+          <text x="60" y="73" text-anchor="end">50k</text>
+        </g>
+
+        <!-- Troposphere -->
+        <rect x="75" y="130" width="260" height="210" fill="url(#tropo)" stroke="#243d52"/>
+        <text x="205" y="240" text-anchor="middle" fill="#f0c040" font-size="14" font-weight="bold">TROPOSPHERE</text>
+        <text x="205" y="258" text-anchor="middle" fill="#e8edf2" font-size="11">Weather lives here</text>
+        <text x="205" y="274" text-anchor="middle" fill="#7a9ab5" font-size="10">Temperature ↓ with altitude</text>
+
+        <!-- Tropopause band -->
+        <rect x="75" y="122" width="260" height="12" fill="#f0c040" opacity="0.35"/>
+        <text x="205" y="131" text-anchor="middle" fill="#f0c040" font-size="10" font-weight="bold">TROPOPAUSE</text>
+
+        <!-- Stratosphere -->
+        <rect x="75" y="20" width="260" height="102" fill="url(#strato)" stroke="#243d52"/>
+        <text x="205" y="75" text-anchor="middle" fill="#e8edf2" font-size="13" font-weight="bold">STRATOSPHERE</text>
+        <text x="205" y="92" text-anchor="middle" fill="#7a9ab5" font-size="10">Temperature ↑ with altitude</text>
+        <text x="205" y="106" text-anchor="middle" fill="#7a9ab5" font-size="10">Ozone layer · smooth air</text>
+
+        <!-- Lapse rate arrow in troposphere -->
+        <line x1="100" y1="330" x2="100" y2="140" stroke="#4caf7d" stroke-width="1.5" stroke-dasharray="4,3"/>
+        <text x="106" y="235" fill="#4caf7d" font-size="9">ISA lapse rate</text>
+        <text x="106" y="247" fill="#4caf7d" font-size="9">≈ 2°C / 1,000 ft</text>
+
+        <!-- Tropopause height range annotation -->
+        <line x1="335" y1="180" x2="335" y2="90" stroke="#f0c040" stroke-width="1"/>
+        <text x="345" y="138" fill="#f0c040" font-size="9" text-anchor="start">varies</text>
+        <text x="345" y="150" fill="#f0c040" font-size="9" text-anchor="start">by lat.</text>
+      </svg>
+    </div>
+
+    <div>
+      <div class="fact-card">
+        <div class="fact-label">ISA Sea-Level Standard</div>
+        <div class="fact-value">15 °C · 29.92 inHg</div>
+        <div class="fact-note">Reference point for all altimetry and performance calculations.</div>
+      </div>
+      <div class="fact-card">
+        <div class="fact-label">Standard Lapse Rate</div>
+        <div class="fact-value">≈ 2 °C / 1,000 ft</div>
+        <div class="fact-note">Temperature decreases predictably through the troposphere.</div>
+      </div>
+      <div class="fact-card">
+        <div class="fact-label">Pressure Drop Rule</div>
+        <div class="fact-value">≈ 1 inHg / 1,000 ft</div>
+        <div class="fact-note">Only valid near the surface; rate decreases with altitude.</div>
+      </div>
+    </div>
+  </div>
+
+  <div class="section-title">Tropopause Height by Latitude</div>
+  <table>
+    <thead>
+      <tr><th>Region</th><th>Typical Height</th><th>Why it matters</th></tr>
+    </thead>
+    <tbody>
+      <tr><td>Equator / Tropics</td><td>≈ 55,000 ft</td><td>Higher — tall thunderstorms possible.</td></tr>
+      <tr><td>Mid-latitudes (Canada)</td><td>≈ 36,000 ft</td><td>Jet stream lives here; CAT zone.</td></tr>
+      <tr><td>Polar regions</td><td>≈ 25,000 ft</td><td>Lower — weather caps at lower altitudes.</td></tr>
+    </tbody>
+  </table>
+
+  <div class="memory-hook">
+    <span class="badge">EXAM HOOK</span><br>
+    <strong>All weather is in the troposphere.</strong> Temperature drops with altitude at ≈ 2 °C per 1,000 ft (ISA), pressure drops ≈ 1 inHg per 1,000 ft near the surface. Above the tropopause (≈ 36,000 ft over Canada), the stratosphere is isothermal then warms — smooth air, no clouds, no weather.
+  </div>
+</div>
+</body>
+</html>

--- a/web-app/public/visuals/met002-temp-pressure-humidity.html
+++ b/web-app/public/visuals/met002-temp-pressure-humidity.html
@@ -1,0 +1,133 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>MET-002: Temperature, Pressure, Humidity</title>
+<style>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body { background: #0d1b2a; color: #e8edf2; font-family: 'Segoe UI', system-ui, sans-serif; padding: 32px; }
+  h1 { font-size: 22px; color: #f0c040; letter-spacing: 1px; margin-bottom: 6px; }
+  .subtitle { font-size: 13px; color: #7a9ab5; margin-bottom: 32px; letter-spacing: 0.5px; }
+  .container { max-width: 900px; margin: 0 auto; }
+  .section-title { font-size: 14px; color: #f0c040; letter-spacing: 1px; text-transform: uppercase; margin: 32px 0 14px; }
+  .layout { display: grid; grid-template-columns: 1fr 1fr; gap: 24px; align-items: start; }
+  .diagram-box { background: #1a2d3d; border: 1px solid #243d52; border-radius: 8px; padding: 16px; }
+  svg text { font-family: 'Segoe UI', system-ui, sans-serif; }
+  table { width: 100%; border-collapse: collapse; margin-bottom: 20px; }
+  th { background: #1a2d3d; color: #f0c040; font-size: 12px; text-align: left; padding: 10px 14px; letter-spacing: 0.5px; }
+  td { font-size: 13px; color: #e8edf2; padding: 9px 14px; border-bottom: 1px solid #1a2d3d; vertical-align: top; }
+  tr:last-child td { border-bottom: none; }
+  .memory-hook { background: #1a2a1a; border: 1px solid #2d5a2d; border-radius: 8px; padding: 14px 18px; margin-top: 24px; font-size: 13px; line-height: 1.6; }
+  .memory-hook .badge { display: inline-block; background: #2d5a2d; color: #e8edf2; font-size: 10px; letter-spacing: 1px; padding: 2px 8px; border-radius: 3px; margin-bottom: 6px; }
+  .caption { font-size: 12px; color: #7a9ab5; text-align: center; margin-top: 8px; }
+  @media (max-width: 640px) {
+    body { padding: 16px; }
+    .layout { grid-template-columns: 1fr; }
+  }
+</style>
+</head>
+<body>
+<div class="container">
+  <h1>MET-002 — Temperature, Pressure, Humidity</h1>
+  <p class="subtitle">Transport Canada · TP 12880E · AIM MET 2.0</p>
+
+  <div class="section-title" style="margin-top: 0;">Pressure Systems — Northern Hemisphere Flow</div>
+  <div class="layout">
+    <div class="diagram-box">
+      <svg viewBox="0 0 320 260" width="100%" height="240">
+        <!-- LOW -->
+        <circle cx="80" cy="130" r="60" fill="none" stroke="#5b9bd5" stroke-width="2"/>
+        <circle cx="80" cy="130" r="36" fill="none" stroke="#5b9bd5" stroke-width="1.2" stroke-dasharray="4,3"/>
+        <text x="80" y="128" text-anchor="middle" fill="#5b9bd5" font-size="28" font-weight="bold">L</text>
+        <text x="80" y="146" text-anchor="middle" fill="#7a9ab5" font-size="10">LOW</text>
+        <!-- CCW arrows around LOW -->
+        <g fill="none" stroke="#5b9bd5" stroke-width="1.5">
+          <path d="M 80 78 A 52 52 0 0 0 28 130" marker-end="url(#arrL)"/>
+          <path d="M 28 130 A 52 52 0 0 0 80 182" marker-end="url(#arrL)"/>
+          <path d="M 80 182 A 52 52 0 0 0 132 130" marker-end="url(#arrL)"/>
+          <path d="M 132 130 A 52 52 0 0 0 80 78" marker-end="url(#arrL)"/>
+        </g>
+
+        <!-- HIGH -->
+        <circle cx="240" cy="130" r="60" fill="none" stroke="#e05050" stroke-width="2"/>
+        <circle cx="240" cy="130" r="36" fill="none" stroke="#e05050" stroke-width="1.2" stroke-dasharray="4,3"/>
+        <text x="240" y="128" text-anchor="middle" fill="#e05050" font-size="28" font-weight="bold">H</text>
+        <text x="240" y="146" text-anchor="middle" fill="#7a9ab5" font-size="10">HIGH</text>
+        <!-- CW arrows around HIGH -->
+        <g fill="none" stroke="#e05050" stroke-width="1.5">
+          <path d="M 240 78 A 52 52 0 0 1 292 130" marker-end="url(#arrH)"/>
+          <path d="M 292 130 A 52 52 0 0 1 240 182" marker-end="url(#arrH)"/>
+          <path d="M 240 182 A 52 52 0 0 1 188 130" marker-end="url(#arrH)"/>
+          <path d="M 188 130 A 52 52 0 0 1 240 78" marker-end="url(#arrH)"/>
+        </g>
+
+        <defs>
+          <marker id="arrL" markerWidth="6" markerHeight="6" refX="3" refY="3" orient="auto">
+            <polygon points="0,0 6,3 0,6" fill="#5b9bd5"/>
+          </marker>
+          <marker id="arrH" markerWidth="6" markerHeight="6" refX="3" refY="3" orient="auto">
+            <polygon points="0,0 6,3 0,6" fill="#e05050"/>
+          </marker>
+        </defs>
+
+        <!-- Labels below -->
+        <text x="80" y="220" text-anchor="middle" fill="#5b9bd5" font-size="11" font-weight="bold">Counter-clockwise</text>
+        <text x="80" y="234" text-anchor="middle" fill="#e8edf2" font-size="10">Converging · Rising air</text>
+        <text x="80" y="247" text-anchor="middle" fill="#7a9ab5" font-size="10">Cloud, precip, bumpy</text>
+
+        <text x="240" y="220" text-anchor="middle" fill="#e05050" font-size="11" font-weight="bold">Clockwise</text>
+        <text x="240" y="234" text-anchor="middle" fill="#e8edf2" font-size="10">Diverging · Sinking air</text>
+        <text x="240" y="247" text-anchor="middle" fill="#7a9ab5" font-size="10">Clear, stable, smooth</text>
+
+        <!-- Title -->
+        <text x="160" y="18" text-anchor="middle" fill="#f0c040" font-size="11" font-weight="bold">Surface Flow — Northern Hemisphere</text>
+      </svg>
+      <div class="caption">Buys Ballot: in the NH, wind at your back → low on your left.</div>
+    </div>
+
+    <div>
+      <table>
+        <thead><tr><th>System</th><th>Pressure Trend</th><th>Typical WX</th></tr></thead>
+        <tbody>
+          <tr><td style="color:#5b9bd5;"><strong>Low</strong></td><td>Falling</td><td>Cloud, precip, poor vis</td></tr>
+          <tr><td style="color:#e05050;"><strong>High</strong></td><td>Rising</td><td>Clear, good vis, stable</td></tr>
+          <tr><td>Trough</td><td>Elongated low</td><td>Line of showers/storms</td></tr>
+          <tr><td>Ridge</td><td>Elongated high</td><td>Fair-weather belt</td></tr>
+          <tr><td>Col</td><td>Neutral between systems</td><td>Light &amp; variable winds</td></tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+
+  <div class="section-title">Humidity &amp; Dew Point Spread</div>
+  <table>
+    <thead>
+      <tr><th>T − Td spread</th><th>Relative Humidity</th><th>Expect</th></tr>
+    </thead>
+    <tbody>
+      <tr><td>&gt; 10 °C</td><td>Low (&lt; 50%)</td><td>Dry air, no fog/cloud risk near surface</td></tr>
+      <tr><td>5 – 10 °C</td><td>Moderate</td><td>Some cumulus possible if lifted</td></tr>
+      <tr><td>2 – 4 °C</td><td>High (&gt; 70%)</td><td>Haze, low cloud bases, early-morning fog watch</td></tr>
+      <tr><td>0 – 1 °C</td><td>Saturated (100%)</td><td>Fog / low stratus forming or imminent</td></tr>
+    </tbody>
+  </table>
+
+  <div class="section-title">Cloud-Base Formula</div>
+  <table>
+    <thead><tr><th>Formula</th><th>Example</th></tr></thead>
+    <tbody>
+      <tr>
+        <td><strong style="color:#f0c040;">Base AGL = (T − Td) × 400 ft</strong></td>
+        <td>T = 18 °C, Td = 12 °C → spread 6 °C → cumulus base ≈ 2,400 ft AGL</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <div class="memory-hook">
+    <span class="badge">EXAM HOOK</span><br>
+    <strong>Lows = Lousy</strong> (CCW inflow, rising, cloudy). <strong>Highs = Happy</strong> (CW outflow, sinking, clear). Temperature–dew-point spread of <strong>2 °C or less</strong> means saturation is close — watch for fog. Multiply the spread by <strong>400 ft</strong> to estimate a convective cloud base.
+  </div>
+</div>
+</body>
+</html>

--- a/web-app/public/visuals/met003-clouds-types.html
+++ b/web-app/public/visuals/met003-clouds-types.html
@@ -1,0 +1,132 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>MET-003: Cloud Types</title>
+<style>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body { background: #0d1b2a; color: #e8edf2; font-family: 'Segoe UI', system-ui, sans-serif; padding: 32px; }
+  h1 { font-size: 22px; color: #f0c040; letter-spacing: 1px; margin-bottom: 6px; }
+  .subtitle { font-size: 13px; color: #7a9ab5; margin-bottom: 32px; letter-spacing: 0.5px; }
+  .container { max-width: 900px; margin: 0 auto; }
+  .section-title { font-size: 14px; color: #f0c040; letter-spacing: 1px; text-transform: uppercase; margin: 32px 0 14px; }
+  .tier { display: grid; grid-template-columns: 160px 1fr; gap: 16px; align-items: stretch; margin-bottom: 10px; }
+  .tier-label { background: #1a2d3d; border: 1px solid #243d52; border-radius: 8px; padding: 14px; }
+  .tier-label .alt { font-size: 11px; color: #7a9ab5; letter-spacing: 0.5px; text-transform: uppercase; }
+  .tier-label .name { font-size: 16px; color: #f0c040; font-weight: bold; margin-top: 4px; }
+  .tier-label .range { font-size: 12px; color: #e8edf2; margin-top: 4px; }
+  .tier-clouds { display: grid; grid-template-columns: repeat(auto-fit, minmax(140px, 1fr)); gap: 10px; }
+  .cloud-card { background: #1a2d3d; border: 1px solid #243d52; border-radius: 8px; padding: 12px; }
+  .cloud-card .cname { font-size: 13px; color: #f0c040; font-weight: bold; margin-bottom: 4px; }
+  .cloud-card .cabbr { font-size: 10px; color: #7a9ab5; letter-spacing: 1px; }
+  .cloud-card .cnote { font-size: 11px; color: #e8edf2; margin-top: 6px; line-height: 1.45; }
+  table { width: 100%; border-collapse: collapse; margin-bottom: 20px; }
+  th { background: #1a2d3d; color: #f0c040; font-size: 12px; text-align: left; padding: 10px 14px; letter-spacing: 0.5px; }
+  td { font-size: 13px; color: #e8edf2; padding: 9px 14px; border-bottom: 1px solid #1a2d3d; vertical-align: top; }
+  tr:last-child td { border-bottom: none; }
+  .stability-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; }
+  .stab-card { background: #1a2d3d; border: 1px solid #243d52; border-radius: 8px; padding: 14px; }
+  .stab-card h3 { font-size: 13px; color: #f0c040; margin-bottom: 8px; letter-spacing: 0.5px; }
+  .stab-card ul { margin-left: 18px; color: #e8edf2; font-size: 12px; line-height: 1.7; }
+  .memory-hook { background: #1a2a1a; border: 1px solid #2d5a2d; border-radius: 8px; padding: 14px 18px; margin-top: 24px; font-size: 13px; line-height: 1.6; }
+  .memory-hook .badge { display: inline-block; background: #2d5a2d; color: #e8edf2; font-size: 10px; letter-spacing: 1px; padding: 2px 8px; border-radius: 3px; margin-bottom: 6px; }
+  @media (max-width: 640px) {
+    body { padding: 16px; }
+    .tier { grid-template-columns: 1fr; }
+    .stability-grid { grid-template-columns: 1fr; }
+  }
+</style>
+</head>
+<body>
+<div class="container">
+  <h1>MET-003 — Cloud Types &amp; Formation</h1>
+  <p class="subtitle">Transport Canada · TP 12880E · AIM MET 2.0</p>
+
+  <div class="section-title" style="margin-top: 0;">Three Height Tiers (Mid-Latitudes)</div>
+
+  <div class="tier">
+    <div class="tier-label">
+      <div class="alt">High</div>
+      <div class="name">Cirro-</div>
+      <div class="range">&gt; 20,000 ft</div>
+      <div class="range" style="color:#7a9ab5;">Ice crystals</div>
+    </div>
+    <div class="tier-clouds">
+      <div class="cloud-card"><div class="cname">Cirrus</div><div class="cabbr">CI</div><div class="cnote">Wispy streaks — fair weather, but may signal approaching warm front 24–48 h out.</div></div>
+      <div class="cloud-card"><div class="cname">Cirrostratus</div><div class="cabbr">CS</div><div class="cnote">Thin sheet — halo around sun/moon. Warm front signal.</div></div>
+      <div class="cloud-card"><div class="cname">Cirrocumulus</div><div class="cabbr">CC</div><div class="cnote">"Mackerel sky" — small ripples high up.</div></div>
+    </div>
+  </div>
+
+  <div class="tier">
+    <div class="tier-label">
+      <div class="alt">Middle</div>
+      <div class="name">Alto-</div>
+      <div class="range">6,500 – 20,000 ft</div>
+      <div class="range" style="color:#7a9ab5;">Water + ice</div>
+    </div>
+    <div class="tier-clouds">
+      <div class="cloud-card"><div class="cname">Altostratus</div><div class="cabbr">AS</div><div class="cnote">Grey/blue sheet — sun appears as through frosted glass. Steady rain/snow approaching.</div></div>
+      <div class="cloud-card"><div class="cname">Altocumulus</div><div class="cabbr">AC</div><div class="cnote">White/grey patches. AC castellanus → afternoon thunderstorm risk.</div></div>
+      <div class="cloud-card"><div class="cname">Nimbostratus</div><div class="cabbr">NS</div><div class="cnote">Dark, ragged, continuous precip. Based mid but often extends low.</div></div>
+    </div>
+  </div>
+
+  <div class="tier">
+    <div class="tier-label">
+      <div class="alt">Low</div>
+      <div class="name">Strato- / Cumulo-</div>
+      <div class="range">Surface – 6,500 ft</div>
+      <div class="range" style="color:#7a9ab5;">Mostly water</div>
+    </div>
+    <div class="tier-clouds">
+      <div class="cloud-card"><div class="cname">Stratus</div><div class="cabbr">ST</div><div class="cnote">Uniform low layer — drizzle/mist, poor VFR.</div></div>
+      <div class="cloud-card"><div class="cname">Stratocumulus</div><div class="cabbr">SC</div><div class="cnote">Lumpy grey layer with breaks — generally VFR ceilings.</div></div>
+      <div class="cloud-card"><div class="cname">Cumulus</div><div class="cabbr">CU</div><div class="cnote">Puffy fair-weather clouds — bumpy below, smooth above base.</div></div>
+      <div class="cloud-card"><div class="cname">Cumulonimbus</div><div class="cabbr">CB</div><div class="cnote">Towering thunderstorm cell — avoid by 20 NM. All known hazards.</div></div>
+    </div>
+  </div>
+
+  <div class="section-title">Stable vs Unstable Air</div>
+  <div class="stability-grid">
+    <div class="stab-card">
+      <h3>Stable Air → Stratiform</h3>
+      <ul>
+        <li>Smooth layered clouds</li>
+        <li>Steady precipitation</li>
+        <li>Poor visibility in precip</li>
+        <li>Smooth flight, but low ceilings</li>
+        <li>Icing risk in cloud &lt; 0 °C</li>
+      </ul>
+    </div>
+    <div class="stab-card">
+      <h3>Unstable Air → Cumuliform</h3>
+      <ul>
+        <li>Puffy, vertical clouds</li>
+        <li>Showery precipitation</li>
+        <li>Good vis between showers</li>
+        <li>Turbulent, gusty winds</li>
+        <li>Thunderstorms &amp; hail possible</li>
+      </ul>
+    </div>
+  </div>
+
+  <div class="section-title">Estimate Convective Cloud Base</div>
+  <table>
+    <thead><tr><th>Formula</th><th>Worked Example</th></tr></thead>
+    <tbody>
+      <tr>
+        <td><strong style="color:#f0c040;">Base AGL ≈ (T − Td) × 400 ft</strong></td>
+        <td>Surface T 22 °C, Td 14 °C → spread 8 °C → base ≈ 3,200 ft AGL</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <div class="memory-hook">
+    <span class="badge">EXAM HOOK</span><br>
+    <strong>Strat-</strong> = layered &amp; stable (smooth ride, low vis). <strong>Cumulo-</strong> = heaped &amp; unstable (bumpy, showers). <strong>Nimbo-/-nimbus</strong> = precipitation. <strong>Alto-</strong> = middle level. <strong>Cirro-</strong> = high &amp; icy. A <strong>CB</strong> contains every hazard known to aviation — avoid by 20 NM.
+  </div>
+</div>
+</body>
+</html>

--- a/web-app/public/visuals/met004-fog-types.html
+++ b/web-app/public/visuals/met004-fog-types.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>MET-004: Fog Types</title>
+<style>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body { background: #0d1b2a; color: #e8edf2; font-family: 'Segoe UI', system-ui, sans-serif; padding: 32px; }
+  h1 { font-size: 22px; color: #f0c040; letter-spacing: 1px; margin-bottom: 6px; }
+  .subtitle { font-size: 13px; color: #7a9ab5; margin-bottom: 32px; letter-spacing: 0.5px; }
+  .container { max-width: 900px; margin: 0 auto; }
+  .section-title { font-size: 14px; color: #f0c040; letter-spacing: 1px; text-transform: uppercase; margin: 32px 0 14px; }
+  .grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); gap: 14px; }
+  .card { background: #1a2d3d; border: 1px solid #243d52; border-radius: 8px; padding: 16px; }
+  .card h3 { font-size: 14px; color: #f0c040; margin-bottom: 6px; letter-spacing: 0.5px; }
+  .card .tag { display: inline-block; font-size: 10px; background: #243d52; color: #e8edf2; padding: 2px 7px; border-radius: 3px; letter-spacing: 0.5px; margin-bottom: 8px; }
+  .card .row { font-size: 12px; color: #e8edf2; margin-bottom: 4px; line-height: 1.5; }
+  .card .row .label { color: #7a9ab5; font-size: 10px; letter-spacing: 0.5px; text-transform: uppercase; display: block; margin-top: 6px; }
+  table { width: 100%; border-collapse: collapse; margin-bottom: 20px; }
+  th { background: #1a2d3d; color: #f0c040; font-size: 12px; text-align: left; padding: 10px 14px; letter-spacing: 0.5px; }
+  td { font-size: 13px; color: #e8edf2; padding: 9px 14px; border-bottom: 1px solid #1a2d3d; vertical-align: top; }
+  tr:last-child td { border-bottom: none; }
+  .memory-hook { background: #1a2a1a; border: 1px solid #2d5a2d; border-radius: 8px; padding: 14px 18px; margin-top: 24px; font-size: 13px; line-height: 1.6; }
+  .memory-hook .badge { display: inline-block; background: #2d5a2d; color: #e8edf2; font-size: 10px; letter-spacing: 1px; padding: 2px 8px; border-radius: 3px; margin-bottom: 6px; }
+  @media (max-width: 640px) { body { padding: 16px; } }
+</style>
+</head>
+<body>
+<div class="container">
+  <h1>MET-004 — Fog Formation &amp; Types</h1>
+  <p class="subtitle">Transport Canada · TP 12880E · AIM MET 2.0 · Fog = visibility &lt; ½ SM (vs mist/BR)</p>
+
+  <div class="section-title" style="margin-top: 0;">The Five Fog Types</div>
+  <div class="grid">
+    <div class="card">
+      <h3>Radiation Fog</h3>
+      <span class="tag">RADIATION</span>
+      <div class="row"><span class="label">Trigger</span>Overnight cooling of ground; clear sky, calm/light wind, moist air.</div>
+      <div class="row"><span class="label">Where</span>Land, low-lying valleys. Not over water.</div>
+      <div class="row"><span class="label">Clears</span>Morning sun heats surface (burns off by mid-morning).</div>
+    </div>
+    <div class="card">
+      <h3>Advection Fog</h3>
+      <span class="tag">ADVECTION</span>
+      <div class="row"><span class="label">Trigger</span>Warm, moist air flows over cooler surface.</div>
+      <div class="row"><span class="label">Where</span>Maritime coasts (e.g., East Coast summer). Can form day or night.</div>
+      <div class="row"><span class="label">Clears</span>Wind shift or air-mass change — may persist for days.</div>
+    </div>
+    <div class="card">
+      <h3>Upslope Fog</h3>
+      <span class="tag">UPSLOPE</span>
+      <div class="row"><span class="label">Trigger</span>Moist air forced up sloping terrain; adiabatic cooling saturates it.</div>
+      <div class="row"><span class="label">Where</span>Prairies east of Rockies, Appalachian slopes.</div>
+      <div class="row"><span class="label">Clears</span>Wind shift away from slope.</div>
+    </div>
+    <div class="card">
+      <h3>Steam Fog</h3>
+      <span class="tag">STEAM / SEA-SMOKE</span>
+      <div class="row"><span class="label">Trigger</span>Cold, dry air flows over much warmer water.</div>
+      <div class="row"><span class="label">Where</span>Great Lakes in autumn, Arctic leads, any warm water in cold air.</div>
+      <div class="row"><span class="label">Clears</span>Stops when water cools or air warms.</div>
+    </div>
+    <div class="card">
+      <h3>Precipitation / Frontal Fog</h3>
+      <span class="tag">PRECIPITATION</span>
+      <div class="row"><span class="label">Trigger</span>Warm rain falling through cool air saturates it; evaporation adds moisture.</div>
+      <div class="row"><span class="label">Where</span>Ahead of warm fronts or stalled fronts.</div>
+      <div class="row"><span class="label">Clears</span>Front passage or precipitation ending.</div>
+    </div>
+    <div class="card">
+      <h3>Ice Fog</h3>
+      <span class="tag">ICE (BONUS)</span>
+      <div class="row"><span class="label">Trigger</span>Extreme cold (&lt; −30 °C) — water vapour sublimates directly to ice crystals.</div>
+      <div class="row"><span class="label">Where</span>Arctic &amp; subarctic Canada in winter, near towns (combustion moisture).</div>
+      <div class="row"><span class="label">Clears</span>Slowly; often requires temperature rise.</div>
+    </div>
+  </div>
+
+  <div class="section-title">Quick Reference</div>
+  <table>
+    <thead><tr><th>Type</th><th>Wind</th><th>Over</th><th>Best Clue</th></tr></thead>
+    <tbody>
+      <tr><td>Radiation</td><td>Calm / light</td><td>Land</td><td>Clear night, high RH, small T–Td spread</td></tr>
+      <tr><td>Advection</td><td>Moderate (&lt; 15 kt)</td><td>Water/cold surface</td><td>Warm moist air over cool surface</td></tr>
+      <tr><td>Upslope</td><td>Any</td><td>Rising terrain</td><td>Wind blowing up slope</td></tr>
+      <tr><td>Steam</td><td>Any</td><td>Open water</td><td>Very cold air, warmer water</td></tr>
+      <tr><td>Precipitation</td><td>Any</td><td>Land/sea</td><td>Warm rain falling into cold air</td></tr>
+    </tbody>
+  </table>
+
+  <div class="memory-hook">
+    <span class="badge">EXAM HOOK</span><br>
+    <strong>Radiation fog</strong> needs three things: <strong>clear sky, calm wind, high humidity</strong>. Remove any one and it doesn't form. <strong>Advection fog</strong> forms when warm moist air moves over a cold surface — it's the only type that tolerates steady wind up to ~15 kt. Any fog reduces vis below ½ SM — above that, it's <strong>mist (BR)</strong> or <strong>haze (HZ)</strong>.
+  </div>
+</div>
+</body>
+</html>

--- a/web-app/public/visuals/met005-metar-decoding.html
+++ b/web-app/public/visuals/met005-metar-decoding.html
@@ -1,0 +1,118 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>MET-005: METAR Decoding</title>
+<style>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body { background: #0d1b2a; color: #e8edf2; font-family: 'Segoe UI', system-ui, sans-serif; padding: 32px; }
+  h1 { font-size: 22px; color: #f0c040; letter-spacing: 1px; margin-bottom: 6px; }
+  .subtitle { font-size: 13px; color: #7a9ab5; margin-bottom: 32px; letter-spacing: 0.5px; }
+  .container { max-width: 900px; margin: 0 auto; }
+  .section-title { font-size: 14px; color: #f0c040; letter-spacing: 1px; text-transform: uppercase; margin: 32px 0 14px; }
+  .metar-sample { background: #1a2d3d; border: 1px solid #243d52; border-radius: 8px; padding: 18px 20px; font-family: 'Consolas', 'Menlo', monospace; font-size: 15px; line-height: 1.9; margin-bottom: 14px; word-break: break-word; }
+  .seg { padding: 2px 6px; border-radius: 3px; margin: 0 2px; display: inline-block; }
+  .s-type { background: #2d3e50; color: #e8edf2; }
+  .s-icao { background: #3d5a80; color: #e8edf2; }
+  .s-time { background: #4c5b8c; color: #e8edf2; }
+  .s-wind { background: #5a7a3a; color: #e8edf2; }
+  .s-vis  { background: #806030; color: #e8edf2; }
+  .s-wx   { background: #903a3a; color: #e8edf2; }
+  .s-sky  { background: #3a7a70; color: #e8edf2; }
+  .s-temp { background: #3a5a7a; color: #e8edf2; }
+  .s-alt  { background: #6a4a7a; color: #e8edf2; }
+  .s-rmk  { background: #3d3d3d; color: #e8edf2; }
+  table { width: 100%; border-collapse: collapse; margin-bottom: 20px; }
+  th { background: #1a2d3d; color: #f0c040; font-size: 12px; text-align: left; padding: 10px 14px; letter-spacing: 0.5px; }
+  td { font-size: 13px; color: #e8edf2; padding: 9px 14px; border-bottom: 1px solid #1a2d3d; vertical-align: top; }
+  tr:last-child td { border-bottom: none; }
+  td code { font-family: 'Consolas', 'Menlo', monospace; background: #0d1b2a; color: #f0c040; padding: 1px 6px; border-radius: 3px; font-size: 12px; }
+  .sky-grid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 10px; }
+  .sky-card { background: #1a2d3d; border: 1px solid #243d52; border-radius: 8px; padding: 12px; text-align: center; }
+  .sky-code { font-size: 18px; color: #f0c040; font-weight: bold; font-family: 'Consolas', monospace; }
+  .sky-name { font-size: 11px; color: #e8edf2; margin-top: 4px; }
+  .sky-oktas { font-size: 10px; color: #7a9ab5; margin-top: 2px; }
+  .memory-hook { background: #1a2a1a; border: 1px solid #2d5a2d; border-radius: 8px; padding: 14px 18px; margin-top: 24px; font-size: 13px; line-height: 1.6; }
+  .memory-hook .badge { display: inline-block; background: #2d5a2d; color: #e8edf2; font-size: 10px; letter-spacing: 1px; padding: 2px 8px; border-radius: 3px; margin-bottom: 6px; }
+  @media (max-width: 640px) { body { padding: 16px; } .sky-grid { grid-template-columns: repeat(2, 1fr); } }
+</style>
+</head>
+<body>
+<div class="container">
+  <h1>MET-005 — METAR Decoding</h1>
+  <p class="subtitle">Transport Canada · TP 12880E · AIM MET 3.0 · Hourly aerodrome observation</p>
+
+  <div class="section-title" style="margin-top: 0;">Annotated METAR — CYYZ</div>
+  <div class="metar-sample">
+    <span class="seg s-type">METAR</span>
+    <span class="seg s-icao">CYYZ</span>
+    <span class="seg s-time">121700Z</span>
+    <span class="seg s-wind">24015G22KT</span>
+    <span class="seg s-vis">6SM</span>
+    <span class="seg s-wx">-SHRA</span>
+    <span class="seg s-sky">BKN025 OVC080</span>
+    <span class="seg s-temp">18/14</span>
+    <span class="seg s-alt">A2987</span>
+    <span class="seg s-rmk">RMK SC6SC2 SLP112</span>
+  </div>
+
+  <table>
+    <thead><tr><th>Segment</th><th>Meaning</th></tr></thead>
+    <tbody>
+      <tr><td><code>METAR</code></td><td>Routine hourly report (vs <code>SPECI</code> = special, off-hour).</td></tr>
+      <tr><td><code>CYYZ</code></td><td>ICAO station identifier (Toronto/Pearson).</td></tr>
+      <tr><td><code>121700Z</code></td><td>Day 12, 1700 UTC ("Z" = Zulu / UTC).</td></tr>
+      <tr><td><code>24015G22KT</code></td><td>Wind from 240° true at 15 kt, gusting 22 kt. Prefix <code>VRB</code> = variable; <code>00000KT</code> = calm.</td></tr>
+      <tr><td><code>6SM</code></td><td>Prevailing visibility 6 statute miles. <code>1/2SM</code>, <code>P6SM</code> (&gt; 6), <code>M1/4SM</code> (&lt; 1/4).</td></tr>
+      <tr><td><code>-SHRA</code></td><td>Light rain showers. Intensity: <code>-</code> light, (blank) moderate, <code>+</code> heavy. Descriptors: <code>SH</code> shower, <code>TS</code> thunderstorm, <code>FZ</code> freezing.</td></tr>
+      <tr><td><code>BKN025 OVC080</code></td><td>Broken layer at 2,500 ft AGL; overcast at 8,000 ft AGL.</td></tr>
+      <tr><td><code>18/14</code></td><td>Temperature 18 °C / dew point 14 °C. Prefix <code>M</code> = minus (e.g., <code>M05/M08</code>).</td></tr>
+      <tr><td><code>A2987</code></td><td>Altimeter 29.87 inHg. Canadian METARs use "A" (inches); European <code>Q</code> format is hPa.</td></tr>
+      <tr><td><code>RMK SC6SC2 SLP112</code></td><td>Remarks: cloud oktas (Canadian supplementary), sea-level pressure 1011.2 hPa.</td></tr>
+    </tbody>
+  </table>
+
+  <div class="section-title">Sky Cover — FEW / SCT / BKN / OVC</div>
+  <div class="sky-grid">
+    <div class="sky-card">
+      <div class="sky-code">FEW</div>
+      <div class="sky-name">Few</div>
+      <div class="sky-oktas">1 – 2 oktas</div>
+    </div>
+    <div class="sky-card">
+      <div class="sky-code">SCT</div>
+      <div class="sky-name">Scattered</div>
+      <div class="sky-oktas">3 – 4 oktas</div>
+    </div>
+    <div class="sky-card">
+      <div class="sky-code" style="color:#ffb040;">BKN</div>
+      <div class="sky-name">Broken</div>
+      <div class="sky-oktas">5 – 7 oktas — <strong>ceiling!</strong></div>
+    </div>
+    <div class="sky-card">
+      <div class="sky-code" style="color:#e05050;">OVC</div>
+      <div class="sky-name">Overcast</div>
+      <div class="sky-oktas">8 oktas — <strong>ceiling!</strong></div>
+    </div>
+  </div>
+
+  <div class="section-title">Common Weather Codes</div>
+  <table>
+    <thead><tr><th>Code</th><th>Phenomenon</th><th>Code</th><th>Phenomenon</th></tr></thead>
+    <tbody>
+      <tr><td><code>RA</code></td><td>Rain</td><td><code>SN</code></td><td>Snow</td></tr>
+      <tr><td><code>DZ</code></td><td>Drizzle</td><td><code>FZRA</code></td><td>Freezing rain</td></tr>
+      <tr><td><code>TSRA</code></td><td>Thunderstorm with rain</td><td><code>GR</code></td><td>Hail (&gt; 5 mm)</td></tr>
+      <tr><td><code>BR</code></td><td>Mist (vis ≥ 5/8 SM)</td><td><code>FG</code></td><td>Fog (vis &lt; 5/8 SM)</td></tr>
+      <tr><td><code>HZ</code></td><td>Haze</td><td><code>BLSN</code></td><td>Blowing snow</td></tr>
+    </tbody>
+  </table>
+
+  <div class="memory-hook">
+    <span class="badge">EXAM HOOK</span><br>
+    A <strong>ceiling</strong> is the lowest <strong>BKN or OVC</strong> layer (FEW/SCT do not count). Wind direction in METARs is <strong>true</strong> (ATIS/tower gives magnetic). Heights in sky groups are <strong>AGL at the reporting aerodrome</strong>, in hundreds of feet. Temperatures use <strong>M</strong> for minus, never a minus sign.
+  </div>
+</div>
+</body>
+</html>

--- a/web-app/public/visuals/met006-taf-decoding.html
+++ b/web-app/public/visuals/met006-taf-decoding.html
@@ -1,0 +1,117 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>MET-006: TAF Decoding</title>
+<style>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body { background: #0d1b2a; color: #e8edf2; font-family: 'Segoe UI', system-ui, sans-serif; padding: 32px; }
+  h1 { font-size: 22px; color: #f0c040; letter-spacing: 1px; margin-bottom: 6px; }
+  .subtitle { font-size: 13px; color: #7a9ab5; margin-bottom: 32px; letter-spacing: 0.5px; }
+  .container { max-width: 900px; margin: 0 auto; }
+  .section-title { font-size: 14px; color: #f0c040; letter-spacing: 1px; text-transform: uppercase; margin: 32px 0 14px; }
+  .taf-sample { background: #1a2d3d; border: 1px solid #243d52; border-radius: 8px; padding: 18px 20px; font-family: 'Consolas', 'Menlo', monospace; font-size: 14px; line-height: 1.9; margin-bottom: 14px; word-break: break-word; }
+  .seg { padding: 2px 6px; border-radius: 3px; margin: 0 2px; display: inline-block; }
+  .s-hdr  { background: #2d3e50; color: #e8edf2; }
+  .s-time { background: #4c5b8c; color: #e8edf2; }
+  .s-base { background: #3a7a70; color: #e8edf2; }
+  .s-bec  { background: #806030; color: #e8edf2; }
+  .s-tmp  { background: #903a3a; color: #e8edf2; }
+  .s-fm   { background: #5a7a3a; color: #e8edf2; }
+  .s-prob { background: #6a4a7a; color: #e8edf2; }
+  table { width: 100%; border-collapse: collapse; margin-bottom: 20px; }
+  th { background: #1a2d3d; color: #f0c040; font-size: 12px; text-align: left; padding: 10px 14px; letter-spacing: 0.5px; }
+  td { font-size: 13px; color: #e8edf2; padding: 9px 14px; border-bottom: 1px solid #1a2d3d; vertical-align: top; }
+  tr:last-child td { border-bottom: none; }
+  td code { font-family: 'Consolas', 'Menlo', monospace; background: #0d1b2a; color: #f0c040; padding: 1px 6px; border-radius: 3px; font-size: 12px; }
+  .timeline { background: #1a2d3d; border: 1px solid #243d52; border-radius: 8px; padding: 14px 16px; margin-bottom: 14px; }
+  .t-bar { display: flex; height: 46px; border-radius: 4px; overflow: hidden; border: 1px solid #243d52; }
+  .t-block { flex: 1; padding: 6px 4px; text-align: center; font-size: 11px; color: #e8edf2; border-right: 1px solid #0d1b2a; line-height: 1.2; }
+  .t-block:last-child { border-right: none; }
+  .t-block .hh { display: block; font-size: 10px; color: #7a9ab5; margin-top: 3px; }
+  .t-block.base { background: #2a4a5a; }
+  .t-block.bec  { background: #806030; }
+  .t-block.tmp  { background: #903a3a; }
+  .t-block.fm   { background: #5a7a3a; }
+  .t-legend { margin-top: 10px; font-size: 11px; color: #7a9ab5; display: flex; gap: 14px; flex-wrap: wrap; }
+  .t-legend .sw { display: inline-block; width: 12px; height: 12px; border-radius: 2px; vertical-align: middle; margin-right: 4px; }
+  .memory-hook { background: #1a2a1a; border: 1px solid #2d5a2d; border-radius: 8px; padding: 14px 18px; margin-top: 24px; font-size: 13px; line-height: 1.6; }
+  .memory-hook .badge { display: inline-block; background: #2d5a2d; color: #e8edf2; font-size: 10px; letter-spacing: 1px; padding: 2px 8px; border-radius: 3px; margin-bottom: 6px; }
+  @media (max-width: 640px) { body { padding: 16px; } }
+</style>
+</head>
+<body>
+<div class="container">
+  <h1>MET-006 — TAF Decoding</h1>
+  <p class="subtitle">Transport Canada · TP 12880E · AIM MET 3.7 · 5 NM / 24 h aerodrome forecast</p>
+
+  <div class="section-title" style="margin-top: 0;">Annotated TAF</div>
+  <div class="taf-sample">
+    <span class="seg s-hdr">TAF</span>
+    <span class="seg s-hdr">CYYZ</span>
+    <span class="seg s-time">121738Z 1218/1318</span>
+    <br>
+    <span class="seg s-base">24012KT P6SM BKN030</span>
+    <br>
+    <span class="seg s-bec">BECMG 1220/1222</span>
+    <span class="seg s-base">27008KT</span>
+    <br>
+    <span class="seg s-tmp">TEMPO 1300/1306 4SM -SHRA BKN015</span>
+    <br>
+    <span class="seg s-fm">FM130900</span>
+    <span class="seg s-base">30010KT P6SM SCT040</span>
+    <br>
+    <span class="seg s-prob">PROB30 1312/1316 TSRA</span>
+  </div>
+
+  <table>
+    <thead><tr><th>Group</th><th>Meaning</th></tr></thead>
+    <tbody>
+      <tr><td><code>121738Z</code></td><td>Issued on day 12 at 1738 UTC.</td></tr>
+      <tr><td><code>1218/1318</code></td><td>Valid from day 12 1800Z to day 13 1800Z (24-hour period).</td></tr>
+      <tr><td><code>BECMG 1220/1222</code></td><td><strong>Becoming</strong> — permanent change happening gradually between 2000Z and 2200Z. After the period, use the new conditions.</td></tr>
+      <tr><td><code>TEMPO 1300/1306</code></td><td><strong>Temporary</strong> — fluctuations expected for &lt; 1 hour at a time within the window (day 13, 0000Z–0600Z). Base conditions resume between bursts.</td></tr>
+      <tr><td><code>FM130900</code></td><td><strong>From</strong> — rapid, permanent change starting at day 13 / 0900Z. Replaces all prior base conditions.</td></tr>
+      <tr><td><code>PROB30 1312/1316</code></td><td><strong>30% probability</strong> of TSRA between 1200Z and 1600Z. Rarely &lt; PROB30 or &gt; PROB40.</td></tr>
+    </tbody>
+  </table>
+
+  <div class="section-title">Change-Group Cheat Sheet</div>
+  <table>
+    <thead><tr><th>Group</th><th>Duration</th><th>Certainty</th><th>Effect on previous line</th></tr></thead>
+    <tbody>
+      <tr><td><strong style="color:#4caf7d;">FM</strong></td><td>Rapid (&lt; 1 hr) &amp; permanent</td><td>Certain</td><td>Replaces it entirely.</td></tr>
+      <tr><td><strong style="color:#ffb040;">BECMG</strong></td><td>Gradual, within window</td><td>Certain</td><td>Replaces after window ends.</td></tr>
+      <tr><td><strong style="color:#e05050;">TEMPO</strong></td><td>&lt; 1 hr at a time, &lt; half window</td><td>Certain fluctuations</td><td>Overlays it temporarily.</td></tr>
+      <tr><td><strong style="color:#b070c0;">PROB30 / PROB40</strong></td><td>Window stated</td><td>Likelihood only</td><td>Overlays as possibility.</td></tr>
+    </tbody>
+  </table>
+
+  <div class="section-title">24-Hour Validity Timeline</div>
+  <div class="timeline">
+    <div class="t-bar">
+      <div class="t-block base">Base<span class="hh">18–20Z</span></div>
+      <div class="t-block bec">BECMG<span class="hh">20–22Z</span></div>
+      <div class="t-block base">Base<span class="hh">22–00Z</span></div>
+      <div class="t-block tmp">TEMPO<span class="hh">00–06Z</span></div>
+      <div class="t-block base">Base<span class="hh">06–09Z</span></div>
+      <div class="t-block fm">FM0900<span class="hh">09–12Z</span></div>
+      <div class="t-block fm">FM0900<br>+ PROB30<span class="hh">12–16Z</span></div>
+      <div class="t-block fm">FM0900<span class="hh">16–18Z</span></div>
+    </div>
+    <div class="t-legend">
+      <span><span class="sw" style="background:#2a4a5a;"></span>Base conditions</span>
+      <span><span class="sw" style="background:#806030;"></span>BECMG window</span>
+      <span><span class="sw" style="background:#903a3a;"></span>TEMPO window</span>
+      <span><span class="sw" style="background:#5a7a3a;"></span>FM replacement</span>
+    </div>
+  </div>
+
+  <div class="memory-hook">
+    <span class="badge">EXAM HOOK</span><br>
+    <strong>FM</strong> = from, rapid &amp; certain, <em>replaces</em> everything prior. <strong>BECMG</strong> = gradual &amp; certain. <strong>TEMPO</strong> = brief fluctuations, base still applies between. <strong>PROB30/40</strong> = chance only, never combined with FM. TAFs cover a 5-NM radius around the aerodrome for 24 hours (30 hrs for major sites) and are issued four times daily.
+  </div>
+</div>
+</body>
+</html>

--- a/web-app/public/visuals/met007-gfa.html
+++ b/web-app/public/visuals/met007-gfa.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>MET-007: GFA</title>
+<style>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body { background: #0d1b2a; color: #e8edf2; font-family: 'Segoe UI', system-ui, sans-serif; padding: 32px; }
+  h1 { font-size: 22px; color: #f0c040; letter-spacing: 1px; margin-bottom: 6px; }
+  .subtitle { font-size: 13px; color: #7a9ab5; margin-bottom: 32px; letter-spacing: 0.5px; }
+  .container { max-width: 900px; margin: 0 auto; }
+  .section-title { font-size: 14px; color: #f0c040; letter-spacing: 1px; text-transform: uppercase; margin: 32px 0 14px; }
+  .chart-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; }
+  .chart-card { background: #1a2d3d; border: 1px solid #243d52; border-radius: 8px; padding: 16px; }
+  .chart-card h3 { font-size: 14px; color: #f0c040; margin-bottom: 4px; letter-spacing: 0.5px; }
+  .chart-card .sub { font-size: 11px; color: #7a9ab5; margin-bottom: 12px; letter-spacing: 0.5px; }
+  .chart-card ul { margin-left: 18px; font-size: 12px; color: #e8edf2; line-height: 1.7; }
+  .timeline { display: grid; grid-template-columns: repeat(4, 1fr); gap: 8px; margin-bottom: 14px; }
+  .t-panel { background: #1a2d3d; border: 1px solid #243d52; border-radius: 8px; padding: 12px; text-align: center; }
+  .t-panel .t-label { font-size: 11px; color: #7a9ab5; letter-spacing: 0.5px; }
+  .t-panel .t-time  { font-size: 18px; color: #f0c040; font-weight: bold; margin: 4px 0 2px; }
+  .t-panel .t-use   { font-size: 11px; color: #e8edf2; }
+  table { width: 100%; border-collapse: collapse; margin-bottom: 20px; }
+  th { background: #1a2d3d; color: #f0c040; font-size: 12px; text-align: left; padding: 10px 14px; letter-spacing: 0.5px; }
+  td { font-size: 13px; color: #e8edf2; padding: 9px 14px; border-bottom: 1px solid #1a2d3d; vertical-align: top; }
+  tr:last-child td { border-bottom: none; }
+  .symbol { display: inline-block; min-width: 28px; text-align: center; font-weight: bold; color: #f0c040; font-family: 'Consolas', monospace; }
+  .memory-hook { background: #1a2a1a; border: 1px solid #2d5a2d; border-radius: 8px; padding: 14px 18px; margin-top: 24px; font-size: 13px; line-height: 1.6; }
+  .memory-hook .badge { display: inline-block; background: #2d5a2d; color: #e8edf2; font-size: 10px; letter-spacing: 1px; padding: 2px 8px; border-radius: 3px; margin-bottom: 6px; }
+  @media (max-width: 640px) { body { padding: 16px; } .chart-grid { grid-template-columns: 1fr; } .timeline { grid-template-columns: repeat(2, 1fr); } }
+</style>
+</head>
+<body>
+<div class="container">
+  <h1>MET-007 — Graphical Forecast for Aviation (GFA)</h1>
+  <p class="subtitle">NAV CANADA · AIM MET 3.5 · Surface to 24,000 ft · 7 GFA regions over Canada</p>
+
+  <div class="section-title" style="margin-top: 0;">Two Charts Per Valid Time</div>
+  <div class="chart-grid">
+    <div class="chart-card">
+      <h3>Clouds &amp; Weather</h3>
+      <div class="sub">CLDWX — what you'll see, where, and when</div>
+      <ul>
+        <li>Cloud areas with coverage, bases, tops (AGL unless MSL noted)</li>
+        <li>Precipitation type &amp; intensity</li>
+        <li>Visibility restrictions (haze, fog, precip)</li>
+        <li>Fronts, troughs, pressure systems</li>
+        <li>Surface winds &gt; 20 kt</li>
+      </ul>
+    </div>
+    <div class="chart-card">
+      <h3>Icing, Turbulence &amp; Freezing Level</h3>
+      <div class="sub">ICG TURBC — what could hurt you</div>
+      <ul>
+        <li>Icing areas, type, intensity, altitude band</li>
+        <li>Turbulence intensity &amp; altitude band</li>
+        <li>Freezing-level contours (at surface, 4k, 8k, etc.)</li>
+        <li>LLWS, CAT, mountain-wave zones</li>
+      </ul>
+    </div>
+  </div>
+
+  <div class="section-title">Valid Time Blocks</div>
+  <div class="timeline">
+    <div class="t-panel"><div class="t-label">T+0</div><div class="t-time">Now</div><div class="t-use">Issue time snapshot</div></div>
+    <div class="t-panel"><div class="t-label">T+6</div><div class="t-time">+6 hr</div><div class="t-use">Mid-flight look-ahead</div></div>
+    <div class="t-panel"><div class="t-label">T+12</div><div class="t-time">+12 hr</div><div class="t-use">End-of-day planning</div></div>
+    <div class="t-panel"><div class="t-label">IFO</div><div class="t-time">+24 hr</div><div class="t-use">Outlook only (text)</div></div>
+  </div>
+  <p style="font-size:12px; color:#7a9ab5; margin-bottom:10px;">Issued four times daily: <strong>0000Z, 0600Z, 1200Z, 1800Z</strong> — new set available within ~30 min of issue time.</p>
+
+  <div class="section-title">Symbol Legend (Essentials)</div>
+  <table>
+    <thead><tr><th>Symbol</th><th>Meaning</th><th>Symbol</th><th>Meaning</th></tr></thead>
+    <tbody>
+      <tr><td><span class="symbol">▲▲▲</span></td><td>Cold front (cold air advancing)</td><td><span class="symbol">●●●</span></td><td>Warm front (warm air advancing)</td></tr>
+      <tr><td><span class="symbol">▲●▲●</span></td><td>Occluded front</td><td><span class="symbol">~~~</span></td><td>Trough (line of low pressure)</td></tr>
+      <tr><td><span class="symbol">H / L</span></td><td>High / Low pressure centre</td><td><span class="symbol">RA</span></td><td>Rain area (use METAR codes)</td></tr>
+      <tr><td><span class="symbol">⟟</span></td><td>Icing area outline</td><td><span class="symbol">∿</span></td><td>Turbulence area outline</td></tr>
+      <tr><td><span class="symbol">FZLVL</span></td><td>Freezing level contour (surface, 040, 080 …)</td><td><span class="symbol">BKN025 / 080</span></td><td>Cloud: coverage, base (AGL ×100 ft) / tops</td></tr>
+    </tbody>
+  </table>
+
+  <div class="section-title">GFA Rules of Thumb</div>
+  <table>
+    <thead><tr><th>Rule</th><th>Detail</th></tr></thead>
+    <tbody>
+      <tr><td>Altitudes AGL unless tagged MSL</td><td>Tops usually MSL, bases usually AGL — read labels carefully.</td></tr>
+      <tr><td>Use two charts together</td><td>CLDWX tells you what you'll <em>fly through</em>; ICG TURBC tells you what will <em>fly back at you</em>.</td></tr>
+      <tr><td>Cross-check with SIGMETs / AIRMETs / PIREPs</td><td>GFA is baseline; SIGMETs flag hazards that developed since issue.</td></tr>
+      <tr><td>IFO is text-only</td><td>+24 hr outlook is general (no chart).</td></tr>
+    </tbody>
+  </table>
+
+  <div class="memory-hook">
+    <span class="badge">EXAM HOOK</span><br>
+    Every GFA issue contains <strong>two charts at three valid times</strong> (now, +6, +12), plus a text <strong>IFO</strong> outlook at +24. Issued <strong>four times daily</strong>. For a complete pre-flight picture you also need current <strong>METAR/TAF, SIGMET/AIRMET, PIREP</strong> — GFA is the map, the others are the updates.
+  </div>
+</div>
+</body>
+</html>

--- a/web-app/public/visuals/met008-pireps.html
+++ b/web-app/public/visuals/met008-pireps.html
@@ -1,0 +1,145 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>MET-008: PIREPs</title>
+<style>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body { background: #0d1b2a; color: #e8edf2; font-family: 'Segoe UI', system-ui, sans-serif; padding: 32px; }
+  h1 { font-size: 22px; color: #f0c040; letter-spacing: 1px; margin-bottom: 6px; }
+  .subtitle { font-size: 13px; color: #7a9ab5; margin-bottom: 32px; letter-spacing: 0.5px; }
+  .container { max-width: 900px; margin: 0 auto; }
+  .section-title { font-size: 14px; color: #f0c040; letter-spacing: 1px; text-transform: uppercase; margin: 32px 0 14px; }
+  .pirep-sample { background: #1a2d3d; border: 1px solid #243d52; border-radius: 8px; padding: 18px 20px; font-family: 'Consolas', 'Menlo', monospace; font-size: 14px; line-height: 1.9; margin-bottom: 14px; word-break: break-word; }
+  .seg { padding: 2px 6px; border-radius: 3px; margin: 0 2px; display: inline-block; }
+  .sh { background: #3d5a80; color: #e8edf2; }
+  table { width: 100%; border-collapse: collapse; margin-bottom: 20px; }
+  th { background: #1a2d3d; color: #f0c040; font-size: 12px; text-align: left; padding: 10px 14px; letter-spacing: 0.5px; }
+  td { font-size: 13px; color: #e8edf2; padding: 9px 14px; border-bottom: 1px solid #1a2d3d; vertical-align: top; }
+  tr:last-child td { border-bottom: none; }
+  td code { font-family: 'Consolas', 'Menlo', monospace; background: #0d1b2a; color: #f0c040; padding: 1px 6px; border-radius: 3px; font-size: 12px; }
+  .intensity-grid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 10px; }
+  .int-card { background: #1a2d3d; border: 1px solid #243d52; border-radius: 8px; padding: 12px; text-align: center; }
+  .int-code { font-size: 15px; color: #f0c040; font-weight: bold; font-family: 'Consolas', monospace; }
+  .int-name { font-size: 11px; color: #e8edf2; margin-top: 4px; font-weight: bold; }
+  .int-eff { font-size: 11px; color: #7a9ab5; margin-top: 4px; line-height: 1.4; }
+  .int-card.lgt { border-left: 3px solid #4caf7d; }
+  .int-card.mod { border-left: 3px solid #f0c040; }
+  .int-card.sev { border-left: 3px solid #e05050; }
+  .int-card.ext { border-left: 3px solid #b030b0; }
+  .advisory-grid { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 12px; }
+  .adv-card { background: #1a2d3d; border: 1px solid #243d52; border-radius: 8px; padding: 14px; }
+  .adv-card h3 { font-size: 13px; color: #f0c040; margin-bottom: 6px; letter-spacing: 0.5px; }
+  .adv-card p { font-size: 11px; color: #e8edf2; line-height: 1.5; }
+  .memory-hook { background: #1a2a1a; border: 1px solid #2d5a2d; border-radius: 8px; padding: 14px 18px; margin-top: 24px; font-size: 13px; line-height: 1.6; }
+  .memory-hook .badge { display: inline-block; background: #2d5a2d; color: #e8edf2; font-size: 10px; letter-spacing: 1px; padding: 2px 8px; border-radius: 3px; margin-bottom: 6px; }
+  @media (max-width: 640px) { body { padding: 16px; } .intensity-grid { grid-template-columns: repeat(2, 1fr); } .advisory-grid { grid-template-columns: 1fr; } }
+</style>
+</head>
+<body>
+<div class="container">
+  <h1>MET-008 — PIREPs &amp; Advisories</h1>
+  <p class="subtitle">Transport Canada · TP 12880E · AIM MET 3.8 · Pilot Reports in the NAV CANADA network</p>
+
+  <div class="section-title" style="margin-top: 0;">Annotated PIREP</div>
+  <div class="pirep-sample">
+    <span class="seg sh">UA</span>
+    <span class="seg sh">/OV YYZ 090025</span>
+    <span class="seg sh">/TM 1745</span>
+    <span class="seg sh">/FL080</span>
+    <span class="seg sh">/TP C172</span>
+    <span class="seg sh">/SK BKN060-TOP080</span>
+    <span class="seg sh">/TA M03</span>
+    <span class="seg sh">/TB LGT</span>
+    <span class="seg sh">/IC LGT RIME</span>
+    <span class="seg sh">/RM SMOOTH ABV</span>
+  </div>
+
+  <table>
+    <thead><tr><th>Field</th><th>Meaning</th></tr></thead>
+    <tbody>
+      <tr><td><code>UA</code> / <code>UUA</code></td><td>UA = routine report; UUA = <strong>urgent</strong> (SEV TURB, SEV ICE, LLWS, volcanic ash, tornadoes).</td></tr>
+      <tr><td><code>/OV YYZ 090025</code></td><td>Over a point: 25 NM on the 090° bearing from YYZ.</td></tr>
+      <tr><td><code>/TM 1745</code></td><td>Time of report — 1745 UTC.</td></tr>
+      <tr><td><code>/FL080</code></td><td>Flight level 080 (8,000 ft). <code>DURC</code> = during climb, <code>DURD</code> = during descent.</td></tr>
+      <tr><td><code>/TP C172</code></td><td>Aircraft type — relevant to turbulence/ice severity interpretation.</td></tr>
+      <tr><td><code>/SK BKN060-TOP080</code></td><td>Sky: broken layer with base 6,000, tops 8,000 ft.</td></tr>
+      <tr><td><code>/TA M03</code></td><td>Outside air temperature −3 °C.</td></tr>
+      <tr><td><code>/TB LGT</code></td><td>Turbulence intensity — light.</td></tr>
+      <tr><td><code>/IC LGT RIME</code></td><td>Icing — light rime.</td></tr>
+      <tr><td><code>/RM</code></td><td>Free-text remarks (in English).</td></tr>
+    </tbody>
+  </table>
+
+  <div class="section-title">Turbulence Intensity</div>
+  <div class="intensity-grid">
+    <div class="int-card lgt">
+      <div class="int-code">LGT</div>
+      <div class="int-name">Light</div>
+      <div class="int-eff">Slight, erratic changes in attitude; occupants feel strain against belts.</div>
+    </div>
+    <div class="int-card mod">
+      <div class="int-code">MOD</div>
+      <div class="int-name">Moderate</div>
+      <div class="int-eff">Aircraft remains in positive control but feels definite strain; unsecured items move.</div>
+    </div>
+    <div class="int-card sev">
+      <div class="int-code">SEV</div>
+      <div class="int-name">Severe</div>
+      <div class="int-eff">Large, abrupt changes in attitude/altitude; momentary loss of control. <strong>UUA</strong>.</div>
+    </div>
+    <div class="int-card ext">
+      <div class="int-code">EXTRM</div>
+      <div class="int-name">Extreme</div>
+      <div class="int-eff">Aircraft violently tossed; practically impossible to control; structural damage possible.</div>
+    </div>
+  </div>
+
+  <div class="section-title" style="margin-top: 24px;">Icing Intensity</div>
+  <div class="intensity-grid">
+    <div class="int-card lgt">
+      <div class="int-code">TRACE</div>
+      <div class="int-name">Trace</div>
+      <div class="int-eff">Ice becomes perceptible. No de-ice needed &lt; 1 hr.</div>
+    </div>
+    <div class="int-card lgt">
+      <div class="int-code">LGT</div>
+      <div class="int-name">Light</div>
+      <div class="int-eff">Accumulation problem only if in-cloud &gt; 1 hr; de-ice handles it.</div>
+    </div>
+    <div class="int-card mod">
+      <div class="int-code">MOD</div>
+      <div class="int-name">Moderate</div>
+      <div class="int-eff">Even short encounters are a potential hazard; diversion needed.</div>
+    </div>
+    <div class="int-card sev">
+      <div class="int-code">SEV</div>
+      <div class="int-name">Severe</div>
+      <div class="int-eff">De-ice fails to control; immediate diversion mandatory. <strong>UUA</strong>.</div>
+    </div>
+  </div>
+
+  <div class="section-title">SIGMET · AIRMET · GFACN — Trigger Summary</div>
+  <div class="advisory-grid">
+    <div class="adv-card">
+      <h3>SIGMET</h3>
+      <p>Hazards affecting all aircraft: severe/extreme turb, severe icing, widespread TS, volcanic ash, heavy squall lines, severe mountain waves. Valid ≤ 4 hr.</p>
+    </div>
+    <div class="adv-card">
+      <h3>AIRMET</h3>
+      <p>Hazards to light aircraft: moderate turb, moderate icing, extensive surface winds ≥ 20 kt, vis &lt; 3 SM over wide areas, mountain obscuration. Valid ≤ 6 hr.</p>
+    </div>
+    <div class="adv-card">
+      <h3>Urgent PIREP (UUA)</h3>
+      <p>Triggered by: tornado / funnel cloud, hail ≥ ¾ in, severe turbulence, severe icing, LLWS, volcanic ash, any condition beyond forecast.</p>
+    </div>
+  </div>
+
+  <div class="memory-hook">
+    <span class="badge">EXAM HOOK</span><br>
+    PIREPs are the <strong>only real-time, in-cloud truth</strong> you have — forecasts lag. File one whenever conditions differ from the forecast. <strong>UUA</strong> triggers: severe turb/ice, LLWS, tornado/funnel, hail ≥ ¾ in, volcanic ash. <strong>SIGMETs</strong> amend the GFA for hazards threatening all aircraft; <strong>AIRMETs</strong> target light aircraft.
+  </div>
+</div>
+</body>
+</html>

--- a/web-app/public/visuals/met009-thunderstorms.html
+++ b/web-app/public/visuals/met009-thunderstorms.html
@@ -1,0 +1,141 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>MET-009: Thunderstorms</title>
+<style>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body { background: #0d1b2a; color: #e8edf2; font-family: 'Segoe UI', system-ui, sans-serif; padding: 32px; }
+  h1 { font-size: 22px; color: #f0c040; letter-spacing: 1px; margin-bottom: 6px; }
+  .subtitle { font-size: 13px; color: #7a9ab5; margin-bottom: 32px; letter-spacing: 0.5px; }
+  .container { max-width: 900px; margin: 0 auto; }
+  .section-title { font-size: 14px; color: #f0c040; letter-spacing: 1px; text-transform: uppercase; margin: 32px 0 14px; }
+  .diagram-box { background: #1a2d3d; border: 1px solid #243d52; border-radius: 8px; padding: 16px; }
+  svg text { font-family: 'Segoe UI', system-ui, sans-serif; }
+  table { width: 100%; border-collapse: collapse; margin-bottom: 20px; }
+  th { background: #1a2d3d; color: #f0c040; font-size: 12px; text-align: left; padding: 10px 14px; letter-spacing: 0.5px; }
+  td { font-size: 13px; color: #e8edf2; padding: 9px 14px; border-bottom: 1px solid #1a2d3d; vertical-align: top; }
+  tr:last-child td { border-bottom: none; }
+  .ingredients { display: grid; grid-template-columns: repeat(3, 1fr); gap: 12px; margin-bottom: 14px; }
+  .ing-card { background: #1a2d3d; border: 1px solid #243d52; border-radius: 8px; padding: 14px; text-align: center; }
+  .ing-card .n { font-size: 20px; color: #f0c040; font-weight: bold; }
+  .ing-card .l { font-size: 12px; color: #e8edf2; margin-top: 6px; line-height: 1.5; }
+  .hazards-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 10px; }
+  .haz-card { background: #1a2d3d; border-left: 3px solid #e05050; padding: 10px 14px; font-size: 12px; color: #e8edf2; line-height: 1.5; }
+  .haz-card strong { color: #e05050; }
+  .memory-hook { background: #1a2a1a; border: 1px solid #2d5a2d; border-radius: 8px; padding: 14px 18px; margin-top: 24px; font-size: 13px; line-height: 1.6; }
+  .memory-hook .badge { display: inline-block; background: #2d5a2d; color: #e8edf2; font-size: 10px; letter-spacing: 1px; padding: 2px 8px; border-radius: 3px; margin-bottom: 6px; }
+  @media (max-width: 640px) { body { padding: 16px; } .ingredients { grid-template-columns: 1fr; } .hazards-grid { grid-template-columns: 1fr; } }
+</style>
+</head>
+<body>
+<div class="container">
+  <h1>MET-009 — Thunderstorms</h1>
+  <p class="subtitle">Transport Canada · TP 12880E · AIM MET 2.8 · Avoid by 20 NM</p>
+
+  <div class="section-title" style="margin-top: 0;">Three Ingredients for Any Thunderstorm</div>
+  <div class="ingredients">
+    <div class="ing-card"><div class="n">1</div><div class="l"><strong>Unstable air</strong><br>Steep temperature lapse rate</div></div>
+    <div class="ing-card"><div class="n">2</div><div class="l"><strong>Moisture</strong><br>High humidity through the column</div></div>
+    <div class="ing-card"><div class="n">3</div><div class="l"><strong>Lifting trigger</strong><br>Surface heating, front, terrain, or convergence</div></div>
+  </div>
+
+  <div class="section-title">Three-Stage Lifecycle</div>
+  <div class="diagram-box">
+    <svg viewBox="0 0 780 300" width="100%" height="280">
+      <!-- Ground -->
+      <line x1="20" y1="270" x2="760" y2="270" stroke="#7a9ab5" stroke-width="1.5"/>
+      <!-- Stage 1: Cumulus / developing -->
+      <path d="M 80 270 Q 80 170 130 140 Q 180 110 200 140 Q 230 170 210 270 Z"
+            fill="#2a4a5a" stroke="#f0c040" stroke-width="1.5"/>
+      <text x="145" y="175" text-anchor="middle" fill="#e8edf2" font-size="11" font-weight="bold">Developing</text>
+      <text x="145" y="191" text-anchor="middle" fill="#7a9ab5" font-size="10">(Cumulus)</text>
+      <text x="145" y="290" text-anchor="middle" fill="#f0c040" font-size="11" font-weight="bold">Stage 1 · ~20 min</text>
+      <!-- Updraft arrows -->
+      <g stroke="#4caf7d" stroke-width="1.8" fill="none">
+        <path d="M 110 260 L 110 160" marker-end="url(#upArr)"/>
+        <path d="M 145 265 L 145 140" marker-end="url(#upArr)"/>
+        <path d="M 180 260 L 180 165" marker-end="url(#upArr)"/>
+      </g>
+
+      <!-- Stage 2: Mature -->
+      <path d="M 290 270 Q 290 140 340 80 Q 390 40 440 60 Q 480 80 470 150 Q 480 210 440 270 Z"
+            fill="#3a3a5a" stroke="#e05050" stroke-width="1.8"/>
+      <!-- Anvil top -->
+      <path d="M 340 75 L 310 60 L 470 60 L 490 75 Z" fill="#3a3a5a" stroke="#e05050" stroke-width="1.5"/>
+      <text x="385" y="160" text-anchor="middle" fill="#e8edf2" font-size="11" font-weight="bold">Mature</text>
+      <text x="385" y="176" text-anchor="middle" fill="#7a9ab5" font-size="10">Up + Down</text>
+      <text x="385" y="192" text-anchor="middle" fill="#7a9ab5" font-size="10">Hail · Lightning</text>
+      <text x="385" y="290" text-anchor="middle" fill="#e05050" font-size="11" font-weight="bold">Stage 2 · ~30 min</text>
+      <!-- Updraft / downdraft -->
+      <g stroke="#4caf7d" stroke-width="1.8" fill="none">
+        <path d="M 340 260 L 340 110" marker-end="url(#upArr)"/>
+      </g>
+      <g stroke="#5b9bd5" stroke-width="1.8" fill="none">
+        <path d="M 420 110 L 420 265" marker-end="url(#dnArr)"/>
+      </g>
+      <!-- Precip -->
+      <g stroke="#5b9bd5" stroke-width="1" opacity="0.7">
+        <line x1="405" y1="220" x2="400" y2="268"/>
+        <line x1="420" y1="225" x2="415" y2="268"/>
+        <line x1="440" y1="222" x2="435" y2="268"/>
+      </g>
+
+      <!-- Stage 3: Dissipating -->
+      <path d="M 570 270 Q 570 120 620 80 Q 680 60 720 80 Q 750 120 730 270 Z"
+            fill="#2a3a45" stroke="#7a9ab5" stroke-width="1.5" stroke-dasharray="5,3"/>
+      <path d="M 620 75 L 590 55 L 750 55 L 765 75 Z" fill="#2a3a45" stroke="#7a9ab5" stroke-width="1.2" stroke-dasharray="4,3"/>
+      <text x="660" y="165" text-anchor="middle" fill="#e8edf2" font-size="11" font-weight="bold">Dissipating</text>
+      <text x="660" y="181" text-anchor="middle" fill="#7a9ab5" font-size="10">(Downdraft only)</text>
+      <text x="660" y="290" text-anchor="middle" fill="#7a9ab5" font-size="11" font-weight="bold">Stage 3 · ~30 min</text>
+      <g stroke="#5b9bd5" stroke-width="1.5" fill="none">
+        <path d="M 620 110 L 620 265" marker-end="url(#dnArr)"/>
+        <path d="M 660 90 L 660 265" marker-end="url(#dnArr)"/>
+        <path d="M 700 110 L 700 265" marker-end="url(#dnArr)"/>
+      </g>
+
+      <defs>
+        <marker id="upArr" markerWidth="7" markerHeight="7" refX="3.5" refY="3.5" orient="auto">
+          <polygon points="0,7 3.5,0 7,7" fill="#4caf7d"/>
+        </marker>
+        <marker id="dnArr" markerWidth="7" markerHeight="7" refX="3.5" refY="3.5" orient="auto">
+          <polygon points="0,0 3.5,7 7,0" fill="#5b9bd5"/>
+        </marker>
+      </defs>
+
+      <!-- Legend -->
+      <text x="25" y="25" fill="#4caf7d" font-size="11">↑ Updraft</text>
+      <text x="105" y="25" fill="#5b9bd5" font-size="11">↓ Downdraft</text>
+    </svg>
+  </div>
+
+  <div class="section-title">Every Hazard in One Cell</div>
+  <div class="hazards-grid">
+    <div class="haz-card"><strong>Severe turbulence</strong> — updraft/downdraft shear inside and around the cell.</div>
+    <div class="haz-card"><strong>Hail</strong> — can be ejected from anvil up to 20 NM downwind.</div>
+    <div class="haz-card"><strong>Lightning</strong> — damage to avionics, blind crew temporarily.</div>
+    <div class="haz-card"><strong>Severe icing</strong> — supercooled water in updraft region.</div>
+    <div class="haz-card"><strong>Wind shear / microburst</strong> — especially on approach/departure.</div>
+    <div class="haz-card"><strong>Tornadoes</strong> — associated with severe supercells.</div>
+    <div class="haz-card"><strong>Heavy rain</strong> — IMC, engine flame-out possible.</div>
+    <div class="haz-card"><strong>Static interference</strong> — P-static on radios near cells.</div>
+  </div>
+
+  <div class="section-title">Two Types — Airmass vs Frontal/Squall</div>
+  <table>
+    <thead><tr><th>Type</th><th>Trigger</th><th>Typical Behaviour</th></tr></thead>
+    <tbody>
+      <tr><td>Airmass (single-cell)</td><td>Afternoon surface heating</td><td>Scattered, short-lived, avoidable by deviating.</td></tr>
+      <tr><td>Frontal / squall line</td><td>Cold front or trough lifting</td><td>Organised line; may be unavoidable — delay or divert. Severe weather common.</td></tr>
+      <tr><td>Supercell / multi-cell</td><td>Strong vertical wind shear</td><td>Long-lived (hours), severe to extreme hazards; tornadoes possible.</td></tr>
+    </tbody>
+  </table>
+
+  <div class="memory-hook">
+    <span class="badge">EXAM HOOK</span><br>
+    Minimum safe distance from any thunderstorm: <strong>20 NM</strong>. Never fly under the anvil — hail and severe turbulence possible 10+ NM from the cell. The <strong>mature</strong> stage is most violent (updraft + downdraft side-by-side). A single airmass cell lasts ~60 min total; squall lines can last hours.
+  </div>
+</div>
+</body>
+</html>

--- a/web-app/public/visuals/met010-icing.html
+++ b/web-app/public/visuals/met010-icing.html
@@ -1,0 +1,143 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>MET-010: Icing</title>
+<style>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body { background: #0d1b2a; color: #e8edf2; font-family: 'Segoe UI', system-ui, sans-serif; padding: 32px; }
+  h1 { font-size: 22px; color: #f0c040; letter-spacing: 1px; margin-bottom: 6px; }
+  .subtitle { font-size: 13px; color: #7a9ab5; margin-bottom: 32px; letter-spacing: 0.5px; }
+  .container { max-width: 900px; margin: 0 auto; }
+  .section-title { font-size: 14px; color: #f0c040; letter-spacing: 1px; text-transform: uppercase; margin: 32px 0 14px; }
+  .diagram-box { background: #1a2d3d; border: 1px solid #243d52; border-radius: 8px; padding: 16px; }
+  svg text { font-family: 'Segoe UI', system-ui, sans-serif; }
+  table { width: 100%; border-collapse: collapse; margin-bottom: 20px; }
+  th { background: #1a2d3d; color: #f0c040; font-size: 12px; text-align: left; padding: 10px 14px; letter-spacing: 0.5px; }
+  td { font-size: 13px; color: #e8edf2; padding: 9px 14px; border-bottom: 1px solid #1a2d3d; vertical-align: top; }
+  tr:last-child td { border-bottom: none; }
+  .ice-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 12px; }
+  .ice-card { background: #1a2d3d; border: 1px solid #243d52; border-radius: 8px; padding: 14px; }
+  .ice-card h3 { font-size: 14px; color: #f0c040; margin-bottom: 4px; letter-spacing: 0.5px; }
+  .ice-card .temp { font-size: 11px; color: #7a9ab5; margin-bottom: 8px; }
+  .ice-card ul { margin-left: 18px; font-size: 11px; color: #e8edf2; line-height: 1.6; }
+  .effects { display: grid; grid-template-columns: 1fr 1fr; gap: 10px; }
+  .eff-card { background: #1a2d3d; border-left: 3px solid #e05050; padding: 10px 14px; font-size: 12px; color: #e8edf2; line-height: 1.5; }
+  .eff-card strong { color: #e05050; }
+  .memory-hook { background: #1a2a1a; border: 1px solid #2d5a2d; border-radius: 8px; padding: 14px 18px; margin-top: 24px; font-size: 13px; line-height: 1.6; }
+  .memory-hook .badge { display: inline-block; background: #2d5a2d; color: #e8edf2; font-size: 10px; letter-spacing: 1px; padding: 2px 8px; border-radius: 3px; margin-bottom: 6px; }
+  @media (max-width: 640px) { body { padding: 16px; } .ice-grid { grid-template-columns: 1fr; } .effects { grid-template-columns: 1fr; } }
+</style>
+</head>
+<body>
+<div class="container">
+  <h1>MET-010 — Structural Icing</h1>
+  <p class="subtitle">Transport Canada · TP 12880E · AIM MET 2.4 · Two conditions required: visible moisture + OAT ≤ 0 °C</p>
+
+  <div class="section-title" style="margin-top: 0;">Icing Temperature Envelope</div>
+  <div class="diagram-box">
+    <svg viewBox="0 0 720 200" width="100%" height="180">
+      <!-- Temperature scale bar -->
+      <rect x="40" y="70" width="640" height="50" fill="#2a4a5a" stroke="#243d52"/>
+
+      <!-- Zones: clear ice (0 to -10), mixed (-10 to -15), rime (-15 to -40) -->
+      <rect x="40" y="70" width="160" height="50" fill="#5b9bd5" opacity="0.55"/>
+      <rect x="200" y="70" width="80" height="50" fill="#c08040" opacity="0.6"/>
+      <rect x="280" y="70" width="400" height="50" fill="#e8edf2" opacity="0.35"/>
+
+      <text x="120" y="98" text-anchor="middle" fill="#e8edf2" font-size="13" font-weight="bold">CLEAR ICE</text>
+      <text x="120" y="113" text-anchor="middle" fill="#e8edf2" font-size="10">Large drops · freezing rain</text>
+
+      <text x="240" y="98" text-anchor="middle" fill="#0d1b2a" font-size="12" font-weight="bold">MIXED</text>
+      <text x="240" y="113" text-anchor="middle" fill="#0d1b2a" font-size="10">Worst shapes</text>
+
+      <text x="480" y="98" text-anchor="middle" fill="#0d1b2a" font-size="13" font-weight="bold">RIME ICE</text>
+      <text x="480" y="113" text-anchor="middle" fill="#0d1b2a" font-size="10">Small drops · stratus · low risk &lt; −20 °C</text>
+
+      <!-- Scale ticks -->
+      <g font-size="10" fill="#7a9ab5">
+        <line x1="40"  y1="120" x2="40"  y2="130" stroke="#7a9ab5"/>
+        <text x="40"  y="145" text-anchor="middle">0 °C</text>
+        <line x1="200" y1="120" x2="200" y2="130" stroke="#7a9ab5"/>
+        <text x="200" y="145" text-anchor="middle">−10 °C</text>
+        <line x1="280" y1="120" x2="280" y2="130" stroke="#7a9ab5"/>
+        <text x="280" y="145" text-anchor="middle">−15 °C</text>
+        <line x1="440" y1="120" x2="440" y2="130" stroke="#7a9ab5"/>
+        <text x="440" y="145" text-anchor="middle">−25 °C</text>
+        <line x1="680" y1="120" x2="680" y2="130" stroke="#7a9ab5"/>
+        <text x="680" y="145" text-anchor="middle">−40 °C</text>
+      </g>
+
+      <!-- Peak risk band -->
+      <rect x="40" y="55" width="240" height="12" fill="#e05050" opacity="0.7"/>
+      <text x="160" y="64" text-anchor="middle" fill="#0d1b2a" font-size="11" font-weight="bold">HIGHEST RISK · 0 to −15 °C</text>
+
+      <!-- Title -->
+      <text x="360" y="30" text-anchor="middle" fill="#f0c040" font-size="12" font-weight="bold">Liquid Water Available for Airframe Icing</text>
+      <text x="360" y="180" text-anchor="middle" fill="#7a9ab5" font-size="11">Below −40 °C water is fully crystallised — almost no icing risk.</text>
+    </svg>
+  </div>
+
+  <div class="section-title">Three Ice Types</div>
+  <div class="ice-grid">
+    <div class="ice-card">
+      <h3>Rime</h3>
+      <div class="temp">−10 °C to −40 °C · small droplets</div>
+      <ul>
+        <li>Milky, opaque, rough</li>
+        <li>Freezes on impact; traps air</li>
+        <li>Mostly in stratus clouds</li>
+        <li>Breaks off cleanly when shed</li>
+      </ul>
+    </div>
+    <div class="ice-card">
+      <h3>Clear / Glaze</h3>
+      <div class="temp">0 °C to −10 °C · large droplets</div>
+      <ul>
+        <li>Smooth, transparent, heavy</li>
+        <li>Spreads over wing before freezing</li>
+        <li>Cumuliform cloud &amp; freezing rain</li>
+        <li><strong>Most dangerous</strong> — hard to shed</li>
+      </ul>
+    </div>
+    <div class="ice-card">
+      <h3>Mixed</h3>
+      <div class="temp">−10 °C to −15 °C · varied droplets</div>
+      <ul>
+        <li>Irregular, brittle, rough surface</li>
+        <li>Worst aerodynamic shape</li>
+        <li>Common in TCU with varied drop sizes</li>
+      </ul>
+    </div>
+  </div>
+
+  <div class="section-title">Effects on the Aircraft</div>
+  <div class="effects">
+    <div class="eff-card"><strong>Weight ↑</strong> — reduces useful load, climb performance.</div>
+    <div class="eff-card"><strong>Lift ↓</strong> — wing contour disrupted, stall speed rises.</div>
+    <div class="eff-card"><strong>Drag ↑</strong> — substantial; cruise speed falls, fuel burn climbs.</div>
+    <div class="eff-card"><strong>Thrust ↓</strong> — blocked carb/inlet, iced prop imbalance.</div>
+    <div class="eff-card"><strong>Control ↓</strong> — frozen hinges, jammed surfaces.</div>
+    <div class="eff-card"><strong>Instruments ↓</strong> — pitot/static block, false readings.</div>
+  </div>
+
+  <div class="section-title">Pilot Actions</div>
+  <table>
+    <thead><tr><th>Condition</th><th>Action</th></tr></thead>
+    <tbody>
+      <tr><td>Freezing rain / drizzle</td><td>Climb to above-freezing air, or descend below cloud immediately; turn back.</td></tr>
+      <tr><td>In-cloud icing starts</td><td>Change altitude to exit cloud or find warmer air (check freezing-level chart).</td></tr>
+      <tr><td>Suspected pitot/static ice</td><td>Pitot heat ON, alt. static source if equipped; cross-check GPS ground speed.</td></tr>
+      <tr><td>Suspected induction / carb ice</td><td>Carb heat full ON; watch for initial RPM drop then recovery.</td></tr>
+      <tr><td>Any severe icing</td><td>Declare &amp; divert; file a <strong>UUA</strong> PIREP.</td></tr>
+    </tbody>
+  </table>
+
+  <div class="memory-hook">
+    <span class="badge">EXAM HOOK</span><br>
+    Two conditions are required for structural icing: <strong>visible moisture</strong> AND <strong>OAT ≤ 0 °C</strong>. Highest risk band is <strong>0 to −15 °C</strong>. <strong>Freezing rain</strong> means warmer air above — <strong>climb</strong> to escape (or turn back). Most non-ice-protected GA aircraft are prohibited from flight into known icing conditions.
+  </div>
+</div>
+</body>
+</html>

--- a/web-app/public/visuals/met011-turbulence.html
+++ b/web-app/public/visuals/met011-turbulence.html
@@ -1,0 +1,128 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>MET-011: Turbulence</title>
+<style>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body { background: #0d1b2a; color: #e8edf2; font-family: 'Segoe UI', system-ui, sans-serif; padding: 32px; }
+  h1 { font-size: 22px; color: #f0c040; letter-spacing: 1px; margin-bottom: 6px; }
+  .subtitle { font-size: 13px; color: #7a9ab5; margin-bottom: 32px; letter-spacing: 0.5px; }
+  .container { max-width: 900px; margin: 0 auto; }
+  .section-title { font-size: 14px; color: #f0c040; letter-spacing: 1px; text-transform: uppercase; margin: 32px 0 14px; }
+  .int-grid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 10px; }
+  .int-card { background: #1a2d3d; border: 1px solid #243d52; border-radius: 8px; padding: 12px; }
+  .int-card .h { font-size: 14px; color: #f0c040; font-weight: bold; letter-spacing: 0.5px; margin-bottom: 6px; }
+  .int-card .body { font-size: 11px; color: #e8edf2; line-height: 1.5; }
+  .int-card.lgt { border-left: 3px solid #4caf7d; }
+  .int-card.mod { border-left: 3px solid #f0c040; }
+  .int-card.sev { border-left: 3px solid #e05050; }
+  .int-card.ext { border-left: 3px solid #b030b0; }
+  .type-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 14px; }
+  .type-card { background: #1a2d3d; border: 1px solid #243d52; border-radius: 8px; padding: 14px; }
+  .type-card h3 { font-size: 14px; color: #f0c040; margin-bottom: 6px; letter-spacing: 0.5px; }
+  .type-card .sub { font-size: 11px; color: #7a9ab5; margin-bottom: 8px; }
+  .type-card ul { margin-left: 18px; font-size: 12px; color: #e8edf2; line-height: 1.6; }
+  table { width: 100%; border-collapse: collapse; margin-bottom: 20px; }
+  th { background: #1a2d3d; color: #f0c040; font-size: 12px; text-align: left; padding: 10px 14px; letter-spacing: 0.5px; }
+  td { font-size: 13px; color: #e8edf2; padding: 9px 14px; border-bottom: 1px solid #1a2d3d; vertical-align: top; }
+  tr:last-child td { border-bottom: none; }
+  .memory-hook { background: #1a2a1a; border: 1px solid #2d5a2d; border-radius: 8px; padding: 14px 18px; margin-top: 24px; font-size: 13px; line-height: 1.6; }
+  .memory-hook .badge { display: inline-block; background: #2d5a2d; color: #e8edf2; font-size: 10px; letter-spacing: 1px; padding: 2px 8px; border-radius: 3px; margin-bottom: 6px; }
+  @media (max-width: 640px) { body { padding: 16px; } .int-grid { grid-template-columns: repeat(2, 1fr); } .type-grid { grid-template-columns: 1fr; } }
+</style>
+</head>
+<body>
+<div class="container">
+  <h1>MET-011 — Turbulence</h1>
+  <p class="subtitle">Transport Canada · TP 12880E · AIM MET 2.6</p>
+
+  <div class="section-title" style="margin-top: 0;">Intensity Scale</div>
+  <div class="int-grid">
+    <div class="int-card lgt">
+      <div class="h">LGT — Light</div>
+      <div class="body">Slight, erratic attitude changes. Occupants feel strain against belts. Walking possible.</div>
+    </div>
+    <div class="int-card mod">
+      <div class="h">MOD — Moderate</div>
+      <div class="body">Positive control maintained. Definite strain against belts. Unsecured items shift. Walking difficult.</div>
+    </div>
+    <div class="int-card sev">
+      <div class="h">SEV — Severe</div>
+      <div class="body">Large abrupt changes in attitude/altitude. Momentary loss of control. Loose objects tossed. <strong>UUA report</strong>.</div>
+    </div>
+    <div class="int-card ext">
+      <div class="h">EXT — Extreme</div>
+      <div class="body">Aircraft violently tossed, practically impossible to control. Structural damage possible. <strong>UUA report</strong>.</div>
+    </div>
+  </div>
+
+  <div class="section-title">Four Causes</div>
+  <div class="type-grid">
+    <div class="type-card">
+      <h3>Mechanical</h3>
+      <div class="sub">Wind over rough terrain or structures</div>
+      <ul>
+        <li>Strongest ≥ 20 kt winds over hills/ridges</li>
+        <li>Leeward-side rotor &amp; standing waves</li>
+        <li>Avoid by: upwind flight, higher altitude</li>
+      </ul>
+    </div>
+    <div class="type-card">
+      <h3>Convective (Thermal)</h3>
+      <div class="sub">Unstable air + surface heating</div>
+      <ul>
+        <li>Summer afternoons over dark surfaces</li>
+        <li>CU fair-weather bumps to CB severity</li>
+        <li>Avoid by: early-morning flight, climb above CU tops</li>
+      </ul>
+    </div>
+    <div class="type-card">
+      <h3>Frontal</h3>
+      <div class="sub">Air-mass interface</div>
+      <ul>
+        <li>Worst at fast cold fronts with strong uplift</li>
+        <li>Can mask embedded TS</li>
+        <li>Avoid by: delay crossing, climb above the lift zone</li>
+      </ul>
+    </div>
+    <div class="type-card">
+      <h3>Wind-Shear / CAT</h3>
+      <div class="sub">Sudden wind velocity/direction change</div>
+      <ul>
+        <li>Near jet streams, inversions, mountain waves</li>
+        <li>Clear Air Turbulence invisible; watch for PIREPs</li>
+        <li>Avoid by: altitude change ±2000 ft</li>
+      </ul>
+    </div>
+  </div>
+
+  <div class="section-title">Mountain Waves — Signature Pattern</div>
+  <table>
+    <thead><tr><th>Sign</th><th>Indicates</th></tr></thead>
+    <tbody>
+      <tr><td><strong>Lenticular</strong> clouds (smooth, lens-shaped)</td><td>Standing wave crest in stable air.</td></tr>
+      <tr><td><strong>Rotor</strong> clouds (ragged, cumulus-like, under the crest)</td><td>Very strong, low-level turbulence — severe to extreme.</td></tr>
+      <tr><td><strong>Cap</strong> cloud over ridge top</td><td>Strong upslope flow; downslope turbulence on lee side.</td></tr>
+      <tr><td>Wind ≥ 25 kt perpendicular to ridge</td><td>Mountain wave likely; add ≥ 50% of ridge height to crossing altitude.</td></tr>
+    </tbody>
+  </table>
+
+  <div class="section-title">Airspeed in Turbulence</div>
+  <table>
+    <thead><tr><th>Speed</th><th>Reason</th></tr></thead>
+    <tbody>
+      <tr><td><strong>Slow to Va (manoeuvring speed) or below</strong></td><td>At Va, the wing stalls before the airframe is overstressed, even at full deflection.</td></tr>
+      <tr><td>Keep attitude level</td><td>Chasing altitude spikes overstresses the aircraft more than riding them out.</td></tr>
+      <tr><td>Belts tight, loose items secured</td><td>Injury prevention in MOD or worse.</td></tr>
+    </tbody>
+  </table>
+
+  <div class="memory-hook">
+    <span class="badge">EXAM HOOK</span><br>
+    Four turbulence causes: <strong>Mechanical · Convective · Frontal · Shear/CAT</strong>. Slow to <strong>Va</strong> (manoeuvring speed) and below when MOD or worse — wing stalls before airframe breaks. <strong>Lenticular + rotor</strong> clouds = mountain wave with severe low-level turbulence. Any <strong>SEV</strong> or <strong>EXT</strong> turbulence = file a <strong>UUA PIREP</strong>.
+  </div>
+</div>
+</body>
+</html>

--- a/web-app/public/visuals/met012-wind-shear-microburst.html
+++ b/web-app/public/visuals/met012-wind-shear-microburst.html
@@ -1,0 +1,131 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>MET-012: Wind Shear & Microburst</title>
+<style>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body { background: #0d1b2a; color: #e8edf2; font-family: 'Segoe UI', system-ui, sans-serif; padding: 32px; }
+  h1 { font-size: 22px; color: #f0c040; letter-spacing: 1px; margin-bottom: 6px; }
+  .subtitle { font-size: 13px; color: #7a9ab5; margin-bottom: 32px; letter-spacing: 0.5px; }
+  .container { max-width: 900px; margin: 0 auto; }
+  .section-title { font-size: 14px; color: #f0c040; letter-spacing: 1px; text-transform: uppercase; margin: 32px 0 14px; }
+  .diagram-box { background: #1a2d3d; border: 1px solid #243d52; border-radius: 8px; padding: 16px; margin-bottom: 16px; }
+  svg text { font-family: 'Segoe UI', system-ui, sans-serif; }
+  table { width: 100%; border-collapse: collapse; margin-bottom: 20px; }
+  th { background: #1a2d3d; color: #f0c040; font-size: 12px; text-align: left; padding: 10px 14px; letter-spacing: 0.5px; }
+  td { font-size: 13px; color: #e8edf2; padding: 9px 14px; border-bottom: 1px solid #1a2d3d; vertical-align: top; }
+  tr:last-child td { border-bottom: none; }
+  .memory-hook { background: #1a2a1a; border: 1px solid #2d5a2d; border-radius: 8px; padding: 14px 18px; margin-top: 24px; font-size: 13px; line-height: 1.6; }
+  .memory-hook .badge { display: inline-block; background: #2d5a2d; color: #e8edf2; font-size: 10px; letter-spacing: 1px; padding: 2px 8px; border-radius: 3px; margin-bottom: 6px; }
+  .caption { font-size: 11px; color: #7a9ab5; text-align: center; margin-top: 8px; }
+  .stages { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 10px; }
+  .stage-card { background: #1a2d3d; border-left: 3px solid #f0c040; padding: 10px 14px; font-size: 12px; color: #e8edf2; line-height: 1.5; }
+  .stage-card .n { color: #f0c040; font-weight: bold; font-size: 13px; }
+  @media (max-width: 640px) { body { padding: 16px; } .stages { grid-template-columns: 1fr; } }
+</style>
+</head>
+<body>
+<div class="container">
+  <h1>MET-012 — Wind Shear &amp; Microburst</h1>
+  <p class="subtitle">Transport Canada · TP 12880E · AIM MET 2.7 · LLWS = within 2,000 ft AGL</p>
+
+  <div class="section-title" style="margin-top: 0;">Microburst Side-View — Approach Profile</div>
+  <div class="diagram-box">
+    <svg viewBox="0 0 720 260" width="100%" height="240">
+      <!-- Runway -->
+      <rect x="20" y="230" width="680" height="12" fill="#2a3a45" stroke="#7a9ab5"/>
+      <line x1="30" y1="236" x2="690" y2="236" stroke="#e8edf2" stroke-width="0.5" stroke-dasharray="6,6"/>
+
+      <!-- Microburst cloud (top) -->
+      <ellipse cx="380" cy="70" rx="110" ry="32" fill="#3a3a5a" stroke="#e05050" stroke-width="1.5"/>
+      <text x="380" y="74" text-anchor="middle" fill="#e8edf2" font-size="11" font-weight="bold">Microburst</text>
+
+      <!-- Downdraft shaft -->
+      <rect x="345" y="100" width="70" height="90" fill="#5b9bd5" opacity="0.25"/>
+      <g stroke="#5b9bd5" stroke-width="2" fill="none">
+        <path d="M 355 105 L 355 195" marker-end="url(#dn)"/>
+        <path d="M 380 100 L 380 200" marker-end="url(#dn)"/>
+        <path d="M 405 105 L 405 195" marker-end="url(#dn)"/>
+      </g>
+      <text x="380" y="140" text-anchor="middle" fill="#5b9bd5" font-size="10" font-weight="bold">DOWNDRAFT</text>
+
+      <!-- Outflow arrows -->
+      <g stroke="#f0c040" stroke-width="2.2" fill="none">
+        <path d="M 340 210 L 120 210" marker-end="url(#lf)"/>
+        <path d="M 420 210 L 640 210" marker-end="url(#rt)"/>
+      </g>
+      <text x="220" y="224" text-anchor="middle" fill="#f0c040" font-size="10">OUTFLOW ←</text>
+      <text x="540" y="224" text-anchor="middle" fill="#f0c040" font-size="10">→ OUTFLOW</text>
+
+      <!-- Aircraft on approach (3 positions) -->
+      <g font-size="9" fill="#e8edf2">
+        <!-- Pos 1: headwind boost -->
+        <polygon points="160,168 180,165 180,171" fill="#e8edf2"/>
+        <text x="170" y="158" text-anchor="middle" fill="#4caf7d" font-weight="bold">HW ↑</text>
+        <text x="170" y="185" text-anchor="middle" fill="#7a9ab5">Lift up → tends to rise</text>
+
+        <!-- Pos 2: downdraft -->
+        <polygon points="370,195 390,192 390,198" fill="#e8edf2"/>
+        <text x="380" y="180" text-anchor="middle" fill="#5b9bd5" font-weight="bold">DOWN ↓</text>
+        <text x="380" y="212" text-anchor="middle" fill="#7a9ab5">Sinks fast</text>
+
+        <!-- Pos 3: tailwind loss -->
+        <polygon points="560,225 580,222 580,228" fill="#e8edf2"/>
+        <text x="570" y="218" text-anchor="middle" fill="#e05050" font-weight="bold">TW ↓</text>
+        <text x="570" y="245" text-anchor="middle" fill="#7a9ab5">Airspeed lost → undershoot</text>
+      </g>
+
+      <defs>
+        <marker id="dn" markerWidth="7" markerHeight="7" refX="3.5" refY="3.5" orient="auto">
+          <polygon points="0,0 3.5,7 7,0" fill="#5b9bd5"/>
+        </marker>
+        <marker id="lf" markerWidth="7" markerHeight="7" refX="3.5" refY="3.5" orient="auto">
+          <polygon points="7,0 0,3.5 7,7" fill="#f0c040"/>
+        </marker>
+        <marker id="rt" markerWidth="7" markerHeight="7" refX="3.5" refY="3.5" orient="auto">
+          <polygon points="0,0 7,3.5 0,7" fill="#f0c040"/>
+        </marker>
+      </defs>
+
+      <text x="360" y="30" text-anchor="middle" fill="#f0c040" font-size="12" font-weight="bold">Approach sequence: Headwind gain → Downdraft → Tailwind loss</text>
+    </svg>
+    <div class="caption">Classic microburst "trap": the initial performance boost is followed by a dramatic loss — power may be insufficient to recover close to the ground.</div>
+  </div>
+
+  <div class="section-title">Three Stages a Pilot Experiences</div>
+  <div class="stages">
+    <div class="stage-card"><span class="n">1.</span> <strong>Headwind gain</strong> — airspeed and lift increase; pilot reduces power, trims nose-down to hold glidepath.</div>
+    <div class="stage-card"><span class="n">2.</span> <strong>Downdraft / calm</strong> — sudden sink rate; aircraft drops below path.</div>
+    <div class="stage-card"><span class="n">3.</span> <strong>Tailwind loss</strong> — airspeed and lift collapse; stall or ground contact imminent.</div>
+  </div>
+
+  <div class="section-title">Wet vs Dry Microburst</div>
+  <table>
+    <thead><tr><th>Type</th><th>Clue</th><th>Source</th></tr></thead>
+    <tbody>
+      <tr><td>Wet</td><td>Heavy rain shaft to the surface</td><td>Mature thunderstorm with high liquid water.</td></tr>
+      <tr><td>Dry</td><td>Rain evaporates before ground; visible virga only. Dust ring on surface.</td><td>High-based convection in dry air — prairie summers.</td></tr>
+    </tbody>
+  </table>
+
+  <div class="section-title">LLWS Clues &amp; Actions</div>
+  <table>
+    <thead><tr><th>Clue</th><th>Action</th></tr></thead>
+    <tbody>
+      <tr><td>Convective cloud / TS within 10 NM of aerodrome</td><td>Delay departure/approach until cell clears.</td></tr>
+      <tr><td>Gust front, temperature drop, wind shift on surface</td><td>Hold; allow outflow to pass.</td></tr>
+      <tr><td>PIREP of ±15 kt IAS or ±500 fpm near surface</td><td>Go-around; re-plan.</td></tr>
+      <tr><td>Virga below convective cloud</td><td>Dry microburst risk — avoid overflying.</td></tr>
+      <tr><td>Encounter in flight</td><td>Max power, pitch for best-climb attitude, accept altitude loss; announce &amp; escape.</td></tr>
+    </tbody>
+  </table>
+
+  <div class="memory-hook">
+    <span class="badge">EXAM HOOK</span><br>
+    <strong>LLWS = low-level wind shear</strong>, below <strong>2,000 ft AGL</strong> — most dangerous where no altitude exists to trade for airspeed. A microburst cycle on approach goes <strong>headwind → downdraft → tailwind</strong>. The initial headwind boost can fool you into cutting power — don't. Any <strong>virga</strong> below a convective cloud in dry air means a possible <strong>dry microburst</strong>.
+  </div>
+</div>
+</body>
+</html>

--- a/web-app/public/visuals/met013-fronts.html
+++ b/web-app/public/visuals/met013-fronts.html
@@ -1,0 +1,126 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>MET-013: Fronts</title>
+<style>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body { background: #0d1b2a; color: #e8edf2; font-family: 'Segoe UI', system-ui, sans-serif; padding: 32px; }
+  h1 { font-size: 22px; color: #f0c040; letter-spacing: 1px; margin-bottom: 6px; }
+  .subtitle { font-size: 13px; color: #7a9ab5; margin-bottom: 32px; letter-spacing: 0.5px; }
+  .container { max-width: 900px; margin: 0 auto; }
+  .section-title { font-size: 14px; color: #f0c040; letter-spacing: 1px; text-transform: uppercase; margin: 32px 0 14px; }
+  .diagram-box { background: #1a2d3d; border: 1px solid #243d52; border-radius: 8px; padding: 16px; margin-bottom: 14px; }
+  svg text { font-family: 'Segoe UI', system-ui, sans-serif; }
+  table { width: 100%; border-collapse: collapse; margin-bottom: 20px; }
+  th { background: #1a2d3d; color: #f0c040; font-size: 12px; text-align: left; padding: 10px 14px; letter-spacing: 0.5px; }
+  td { font-size: 13px; color: #e8edf2; padding: 9px 14px; border-bottom: 1px solid #1a2d3d; vertical-align: top; }
+  tr:last-child td { border-bottom: none; }
+  .mass-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 10px; margin-bottom: 14px; }
+  .mass-card { background: #1a2d3d; border: 1px solid #243d52; border-radius: 8px; padding: 12px; text-align: center; }
+  .mass-card .code { font-size: 18px; color: #f0c040; font-weight: bold; font-family: 'Consolas', monospace; }
+  .mass-card .name { font-size: 11px; color: #e8edf2; margin-top: 4px; }
+  .mass-card .note { font-size: 10px; color: #7a9ab5; margin-top: 4px; }
+  .memory-hook { background: #1a2a1a; border: 1px solid #2d5a2d; border-radius: 8px; padding: 14px 18px; margin-top: 24px; font-size: 13px; line-height: 1.6; }
+  .memory-hook .badge { display: inline-block; background: #2d5a2d; color: #e8edf2; font-size: 10px; letter-spacing: 1px; padding: 2px 8px; border-radius: 3px; margin-bottom: 6px; }
+  .caption { font-size: 11px; color: #7a9ab5; text-align: center; margin-top: 8px; }
+  @media (max-width: 640px) { body { padding: 16px; } }
+</style>
+</head>
+<body>
+<div class="container">
+  <h1>MET-013 — Fronts</h1>
+  <p class="subtitle">Transport Canada · TP 12880E · AIM MET 2.3 · Boundary between two air masses</p>
+
+  <div class="section-title" style="margin-top: 0;">Cold Front — Steep Slope</div>
+  <div class="diagram-box">
+    <svg viewBox="0 0 700 220" width="100%" height="220">
+      <line x1="30" y1="190" x2="670" y2="190" stroke="#7a9ab5" stroke-width="1.5"/>
+      <!-- Cold air wedge -->
+      <polygon points="30,190 30,40 260,190" fill="#5b9bd5" opacity="0.35" stroke="#5b9bd5" stroke-width="1.5"/>
+      <text x="95" y="120" fill="#5b9bd5" font-size="12" font-weight="bold">COLD AIR</text>
+      <text x="95" y="136" fill="#7a9ab5" font-size="10">(advancing →)</text>
+      <!-- Warm air pushed up -->
+      <text x="440" y="110" fill="#e05050" font-size="12" font-weight="bold">WARM AIR</text>
+      <text x="440" y="126" fill="#7a9ab5" font-size="10">(lifted rapidly)</text>
+      <!-- CB cell -->
+      <path d="M 230 190 Q 220 100 270 70 Q 320 50 340 85 Q 360 130 340 190 Z"
+            fill="#3a3a5a" stroke="#e05050" stroke-width="1.5"/>
+      <path d="M 270 65 L 240 50 L 350 50 L 360 65 Z" fill="#3a3a5a" stroke="#e05050"/>
+      <text x="295" y="130" text-anchor="middle" fill="#e8edf2" font-size="11" font-weight="bold">CB</text>
+      <!-- Direction -->
+      <path d="M 20 200 L 260 200" stroke="#5b9bd5" stroke-width="1.8" fill="none" marker-end="url(#mov)"/>
+      <text x="140" y="215" text-anchor="middle" fill="#5b9bd5" font-size="10">Front motion · 20–30 kt</text>
+      <defs>
+        <marker id="mov" markerWidth="7" markerHeight="7" refX="3.5" refY="3.5" orient="auto">
+          <polygon points="0,0 7,3.5 0,7" fill="#5b9bd5"/>
+        </marker>
+      </defs>
+      <text x="350" y="22" text-anchor="middle" fill="#f0c040" font-size="12" font-weight="bold">Slope ≈ 1:50 — narrow band (~50–100 NM), short-lived showers/TS</text>
+    </svg>
+  </div>
+
+  <div class="section-title">Warm Front — Shallow Slope</div>
+  <div class="diagram-box">
+    <svg viewBox="0 0 700 220" width="100%" height="220">
+      <line x1="30" y1="190" x2="670" y2="190" stroke="#7a9ab5" stroke-width="1.5"/>
+      <!-- Cold air retreating (left) -->
+      <polygon points="30,190 30,110 550,190" fill="#5b9bd5" opacity="0.3" stroke="#5b9bd5" stroke-width="1.2"/>
+      <text x="100" y="155" fill="#5b9bd5" font-size="12" font-weight="bold">COLD AIR</text>
+      <text x="100" y="171" fill="#7a9ab5" font-size="10">(retreating)</text>
+      <!-- Warm air sliding up -->
+      <text x="520" y="100" fill="#e05050" font-size="12" font-weight="bold">WARM AIR</text>
+      <text x="520" y="116" fill="#7a9ab5" font-size="10">(slides up slowly)</text>
+
+      <!-- Cloud sequence -->
+      <ellipse cx="120" cy="80" rx="40" ry="10" fill="#2a4a5a" stroke="#7a9ab5"/>
+      <text x="120" y="83" text-anchor="middle" fill="#e8edf2" font-size="9">CI / CS</text>
+      <ellipse cx="250" cy="110" rx="55" ry="14" fill="#2a4a5a" stroke="#7a9ab5"/>
+      <text x="250" y="114" text-anchor="middle" fill="#e8edf2" font-size="9">AS / AC</text>
+      <rect x="350" y="140" width="180" height="40" rx="6" fill="#2a4a5a" stroke="#7a9ab5"/>
+      <text x="440" y="162" text-anchor="middle" fill="#e8edf2" font-size="10" font-weight="bold">NS · steady rain</text>
+
+      <path d="M 660 200 L 420 200" stroke="#e05050" stroke-width="1.8" fill="none" marker-end="url(#movW)"/>
+      <text x="540" y="215" text-anchor="middle" fill="#e05050" font-size="10">Front motion · 10–15 kt</text>
+      <defs>
+        <marker id="movW" markerWidth="7" markerHeight="7" refX="3.5" refY="3.5" orient="auto">
+          <polygon points="7,0 0,3.5 7,7" fill="#e05050"/>
+        </marker>
+      </defs>
+      <text x="350" y="22" text-anchor="middle" fill="#f0c040" font-size="12" font-weight="bold">Slope ≈ 1:200 — broad band (~300+ NM), long steady precipitation</text>
+    </svg>
+  </div>
+
+  <div class="section-title">Quick Comparison</div>
+  <table>
+    <thead><tr><th>Feature</th><th>Cold Front</th><th>Warm Front</th><th>Occluded</th></tr></thead>
+    <tbody>
+      <tr><td>Slope</td><td>Steep (~1:50)</td><td>Shallow (~1:200)</td><td>Mixed</td></tr>
+      <tr><td>Speed</td><td>20–30 kt</td><td>10–15 kt</td><td>Slow — "stalled"</td></tr>
+      <tr><td>Clouds</td><td>CU → CB</td><td>CI → CS → AS → NS</td><td>Both types</td></tr>
+      <tr><td>Precipitation</td><td>Showery, brief, heavy</td><td>Continuous, steady, light-moderate</td><td>Widespread, prolonged</td></tr>
+      <tr><td>Visibility after passage</td><td>Good — gusty, cool, dry</td><td>Poor at first; improves slowly</td><td>Variable</td></tr>
+      <tr><td>Pressure trend</td><td>Sharp rise after passage</td><td>Steady fall ahead, slow rise after</td><td>Levels after passage</td></tr>
+      <tr><td>Wind shift</td><td>Abrupt, clockwise (e.g., S → W)</td><td>Gradual, clockwise (e.g., SE → SW)</td><td>Variable</td></tr>
+      <tr><td>Turbulence</td><td>Often severe (TS possible)</td><td>Usually light (smooth lift)</td><td>Both kinds possible</td></tr>
+      <tr><td>Icing</td><td>Clear ice in CBs</td><td>Rime/mixed in stratiform layers</td><td>Worst of both</td></tr>
+    </tbody>
+  </table>
+
+  <div class="section-title">Air-Mass Codes</div>
+  <div class="mass-grid">
+    <div class="mass-card"><div class="code">cP</div><div class="name">Continental Polar</div><div class="note">Cold &amp; dry (winter air over Canada)</div></div>
+    <div class="mass-card"><div class="code">cA</div><div class="name">Continental Arctic</div><div class="note">Very cold &amp; dry</div></div>
+    <div class="mass-card"><div class="code">mP</div><div class="name">Maritime Polar</div><div class="note">Cool &amp; moist (Pacific / N. Atlantic)</div></div>
+    <div class="mass-card"><div class="code">mT</div><div class="name">Maritime Tropical</div><div class="note">Warm &amp; humid (Gulf, Atlantic)</div></div>
+    <div class="mass-card"><div class="code">cT</div><div class="name">Continental Tropical</div><div class="note">Hot &amp; dry (summer SW US)</div></div>
+  </div>
+
+  <div class="memory-hook">
+    <span class="badge">EXAM HOOK</span><br>
+    <strong>Cold front</strong>: steep, fast, short &amp; violent — think <strong>CBs, gust fronts, sharp wind shift clockwise, pressure rise</strong>. <strong>Warm front</strong>: shallow, slow, long &amp; steady — think <strong>CI → CS → AS → NS sequence, low ceilings, rime icing</strong>. At any front, expect <strong>wind shift and pressure change</strong> at passage. Occluded = cold front overtaking warm — hazards of both.
+  </div>
+</div>
+</body>
+</html>

--- a/web-app/public/visuals/met014-wx-decision-making.html
+++ b/web-app/public/visuals/met014-wx-decision-making.html
@@ -1,0 +1,133 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>MET-014: Weather Decision-Making</title>
+<style>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body { background: #0d1b2a; color: #e8edf2; font-family: 'Segoe UI', system-ui, sans-serif; padding: 32px; }
+  h1 { font-size: 22px; color: #f0c040; letter-spacing: 1px; margin-bottom: 6px; }
+  .subtitle { font-size: 13px; color: #7a9ab5; margin-bottom: 32px; letter-spacing: 0.5px; }
+  .container { max-width: 900px; margin: 0 auto; }
+  .section-title { font-size: 14px; color: #f0c040; letter-spacing: 1px; text-transform: uppercase; margin: 32px 0 14px; }
+  .flow { display: flex; flex-direction: column; gap: 10px; }
+  .flow-row { background: #1a2d3d; border-left: 4px solid #f0c040; border-radius: 6px; padding: 14px 18px; }
+  .flow-row h3 { font-size: 13px; color: #f0c040; margin-bottom: 6px; letter-spacing: 0.5px; }
+  .flow-row p { font-size: 12px; color: #e8edf2; line-height: 1.55; }
+  .flow-row.ok { border-left-color: #4caf7d; }
+  .flow-row.warn { border-left-color: #f0c040; }
+  .flow-row.stop { border-left-color: #e05050; }
+  table { width: 100%; border-collapse: collapse; margin-bottom: 20px; }
+  th { background: #1a2d3d; color: #f0c040; font-size: 12px; text-align: left; padding: 10px 14px; letter-spacing: 0.5px; }
+  td { font-size: 13px; color: #e8edf2; padding: 9px 14px; border-bottom: 1px solid #1a2d3d; vertical-align: top; }
+  tr:last-child td { border-bottom: none; }
+  .imsafe { display: grid; grid-template-columns: repeat(auto-fit, minmax(130px, 1fr)); gap: 10px; }
+  .im-card { background: #1a2d3d; border: 1px solid #243d52; border-radius: 8px; padding: 12px; text-align: center; }
+  .im-letter { font-size: 20px; color: #f0c040; font-weight: bold; font-family: 'Consolas', monospace; }
+  .im-word { font-size: 12px; color: #e8edf2; margin-top: 4px; font-weight: bold; }
+  .im-sub { font-size: 10px; color: #7a9ab5; margin-top: 3px; line-height: 1.4; }
+  .risk-matrix { display: grid; grid-template-columns: 120px repeat(3, 1fr); gap: 1px; background: #243d52; border: 1px solid #243d52; border-radius: 8px; overflow: hidden; }
+  .r-cell { background: #1a2d3d; padding: 10px 12px; font-size: 12px; text-align: center; color: #e8edf2; }
+  .r-cell.hdr { background: #243d52; color: #f0c040; font-weight: bold; letter-spacing: 0.5px; font-size: 11px; }
+  .r-cell.low { background: #1e3a28; }
+  .r-cell.med { background: #4a3a1a; }
+  .r-cell.high { background: #4a1a1a; }
+  .memory-hook { background: #1a2a1a; border: 1px solid #2d5a2d; border-radius: 8px; padding: 14px 18px; margin-top: 24px; font-size: 13px; line-height: 1.6; }
+  .memory-hook .badge { display: inline-block; background: #2d5a2d; color: #e8edf2; font-size: 10px; letter-spacing: 1px; padding: 2px 8px; border-radius: 3px; margin-bottom: 6px; }
+  @media (max-width: 640px) { body { padding: 16px; } .risk-matrix { grid-template-columns: 80px repeat(3, 1fr); } }
+</style>
+</head>
+<body>
+<div class="container">
+  <h1>MET-014 — Weather Decision-Making</h1>
+  <p class="subtitle">Transport Canada · TP 12880E · CARs 602.71 · Pre-flight &amp; in-flight decision framework</p>
+
+  <div class="section-title" style="margin-top: 0;">Decision Flow</div>
+  <div class="flow">
+    <div class="flow-row">
+      <h3>1 · Gather</h3>
+      <p>METAR, TAF, GFA (Clouds &amp; Weather + Icing/Turb), SIGMETs, AIRMETs, PIREPs. Cover whole route plus alternates.</p>
+    </div>
+    <div class="flow-row">
+      <h3>2 · Check CARs 602.71 — Pre-flight Information</h3>
+      <p>Legal requirement: the PIC must be familiar with all available weather information relevant to the flight before take-off.</p>
+    </div>
+    <div class="flow-row ok">
+      <h3>3 · Test against regulatory minima</h3>
+      <p>VFR minima by airspace (CAR 602.114/602.115), destination/alternate (for flight plan), fuel reserve. If fail → <strong>no-go</strong>.</p>
+    </div>
+    <div class="flow-row warn">
+      <h3>4 · Test against personal minima</h3>
+      <p>Your own limits on ceiling, vis, wind, crosswind, turbulence, night, terrain. These are tighter than legal minima — if any fails → <strong>no-go</strong>.</p>
+    </div>
+    <div class="flow-row warn">
+      <h3>5 · Run IMSAFE self-check</h3>
+      <p>If you fail any letter, you are unfit to fly regardless of the weather.</p>
+    </div>
+    <div class="flow-row ok">
+      <h3>6 · Identify outs</h3>
+      <p>Alternates, reversals, VFR-on-top option, fuel reserve to reach next suitable aerodrome. If no out → <strong>no-go</strong>.</p>
+    </div>
+    <div class="flow-row stop">
+      <h3>7 · In flight: re-evaluate every 30 min</h3>
+      <p>Update METAR/TAF via FSS/NAV CANADA, watch for trend vs forecast. A divergence is a trigger to divert — <strong>don't press on</strong>.</p>
+    </div>
+  </div>
+
+  <div class="section-title">IMSAFE Self-Check</div>
+  <div class="imsafe">
+    <div class="im-card"><div class="im-letter">I</div><div class="im-word">Illness</div><div class="im-sub">Symptoms even mild</div></div>
+    <div class="im-card"><div class="im-letter">M</div><div class="im-word">Medication</div><div class="im-sub">OTC or Rx; read labels</div></div>
+    <div class="im-card"><div class="im-letter">S</div><div class="im-word">Stress</div><div class="im-sub">Work, life, news</div></div>
+    <div class="im-card"><div class="im-letter">A</div><div class="im-word">Alcohol</div><div class="im-sub">≥ 8 hr "bottle to throttle"; zero residual</div></div>
+    <div class="im-card"><div class="im-letter">F</div><div class="im-word">Fatigue</div><div class="im-sub">Rest, not caffeine</div></div>
+    <div class="im-card"><div class="im-letter">E</div><div class="im-word">Emotion / Eating</div><div class="im-sub">Stable mood, fuelled body</div></div>
+  </div>
+
+  <div class="section-title">Risk Matrix</div>
+  <div class="risk-matrix">
+    <div class="r-cell hdr">Likelihood →<br>Severity ↓</div>
+    <div class="r-cell hdr">Unlikely</div>
+    <div class="r-cell hdr">Possible</div>
+    <div class="r-cell hdr">Likely</div>
+
+    <div class="r-cell hdr">Minor</div>
+    <div class="r-cell low">Low</div>
+    <div class="r-cell low">Low</div>
+    <div class="r-cell med">Medium</div>
+
+    <div class="r-cell hdr">Moderate</div>
+    <div class="r-cell low">Low</div>
+    <div class="r-cell med">Medium</div>
+    <div class="r-cell high">High</div>
+
+    <div class="r-cell hdr">Severe / Catastrophic</div>
+    <div class="r-cell med">Medium</div>
+    <div class="r-cell high">High</div>
+    <div class="r-cell high">High</div>
+  </div>
+  <p style="font-size: 12px; color: #7a9ab5; margin-top: 10px;">
+    Any cell shaded <strong style="color:#e8a060;">medium</strong> needs a mitigation (alternate, delay, extra fuel, second pilot). Any <strong style="color:#e05050;">high</strong> cell = no-go until mitigated.
+  </p>
+
+  <div class="section-title">Hazardous Attitudes — Antidotes</div>
+  <table>
+    <thead><tr><th>Attitude</th><th>Sample Thought</th><th>Antidote</th></tr></thead>
+    <tbody>
+      <tr><td>Anti-authority</td><td>"Regs don't apply to me today."</td><td>Follow the rules. They're usually right.</td></tr>
+      <tr><td>Impulsivity</td><td>"Quick — just go."</td><td>Not so fast. Think first.</td></tr>
+      <tr><td>Invulnerability</td><td>"It won't happen to me."</td><td>It could happen to me.</td></tr>
+      <tr><td>Macho</td><td>"I can do it."</td><td>Taking chances is foolish.</td></tr>
+      <tr><td>Resignation</td><td>"What's the use?"</td><td>I'm not helpless; I can make a difference.</td></tr>
+      <tr><td>Press-on-itis</td><td>"We're so close to destination."</td><td>Divert and live. Nothing at destination is worth a crash.</td></tr>
+    </tbody>
+  </table>
+
+  <div class="memory-hook">
+    <span class="badge">EXAM HOOK</span><br>
+    The <strong>PIC</strong> is legally required by <strong>CARs 602.71</strong> to have all available weather information before departure. Apply two tests: <strong>regulatory minima</strong> (hard floor) AND <strong>personal minima</strong> (your floor). Add <strong>IMSAFE</strong> for the pilot. Always have an <strong>out</strong>. The most dangerous attitude is <strong>press-on-itis</strong> — when "just a few more miles" kills experienced pilots.
+  </div>
+</div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- 14 standalone dark-aviation HTML visuals in \`web-app/public/visuals/\` covering every MET lesson (atmosphere → decision-making).
- Each lesson's \`visual:\` frontmatter updated from \`null\` to \`/visuals/met{NNN}-{slug}.html\`.
- All visuals conform to \`docs/visuals-standards.md\` (palette, standalone, no external resources, responsive down to 375 px).

Closes #149. Unblocks the remaining AC on #87.

## Test plan
- [x] \`ls web-app/public/visuals/ | grep ^met | wc -l\` = 14
- [x] \`grep -c "^visual: /visuals/met" lessons/meteorology/*.md\` = 14
- [x] \`npm run build\` in \`web-app/\` passes
- [ ] QA spot-check MET-001 (atmosphere SVG), MET-005 (METAR decoder info density), MET-013 (fronts cross-sections) at desktop and mobile widths

🤖 Generated with [Claude Code](https://claude.com/claude-code)