### PR TITLE
[PPL-168] Nav redesign — desktop side-rail + mobile bottom-nav

### DIFF
--- a/web-app/src/App.tsx
+++ b/web-app/src/App.tsx
@@ -1,3 +1,4 @@
+import { useState, useEffect } from 'react';
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import { ThemeProvider, CssBaseline, Box } from '@mui/material';
 import theme from './theme';
@@ -12,44 +13,94 @@ import Plan from './pages/Plan';
 import Playlist from './pages/Playlist';
 import PSTARPath from './pages/PSTARPath';
 
+const RAIL_EXPANDED = 240;
+const RAIL_COLLAPSED = 64;
+const LS_KEY = 'ppl-nav-collapsed';
+
 export default function App() {
+  const [collapsed, setCollapsed] = useState<boolean>(() => {
+    try {
+      return localStorage.getItem(LS_KEY) === 'true';
+    } catch {
+      return false;
+    }
+  });
+
+  useEffect(() => {
+    const onStorage = (e: StorageEvent) => {
+      if (e.key === LS_KEY) {
+        setCollapsed(e.newValue === 'true');
+      }
+    };
+    window.addEventListener('storage', onStorage);
+    // Poll localStorage so same-tab Nav toggle updates App layout
+    const id = setInterval(() => {
+      try {
+        setCollapsed(localStorage.getItem(LS_KEY) === 'true');
+      } catch {
+        // ignore
+      }
+    }, 100);
+    return () => {
+      window.removeEventListener('storage', onStorage);
+      clearInterval(id);
+    };
+  }, []);
+
+  const railWidth = collapsed ? RAIL_COLLAPSED : RAIL_EXPANDED;
+
   return (
     <ThemeProvider theme={theme}>
       <CssBaseline />
       <BrowserRouter>
-        <Box
-          component="a"
-          href="#main-content"
-          sx={{
-            position: 'absolute',
-            top: -9999,
-            left: -9999,
-            zIndex: 9999,
-            p: 1,
-            bgcolor: 'background.paper',
-            color: 'text.primary',
-            '&:focus': {
-              top: 8,
-              left: 8,
-            },
-          }}
-        >
-          Skip to main content
-        </Box>
-        <Nav />
-        <Box sx={{ pb: { xs: 7, sm: 7, md: 0 } }}>
-          <Routes>
-            <Route path="/" element={<Home />} />
-            <Route path="/lessons" element={<LessonsIndex />} />
-            <Route path="/lessons/:topic/:slug" element={<LessonDetail />} />
-            <Route path="/lessons/:topic/:slug/quiz" element={<LessonQuiz />} />
-            <Route path="/exam" element={<Exam />} />
-            <Route path="/pstar-exam" element={<PSTARExam />} />
-            <Route path="/plan" element={<Plan />} />
-            <Route path="/playlist" element={<Playlist />} />
-            <Route path="/playlist/:topic" element={<Playlist />} />
-            <Route path="/pstar" element={<PSTARPath />} />
-          </Routes>
+        <Box sx={{ display: 'flex', minHeight: '100vh' }}>
+          <Box
+            component="a"
+            href="#main-content"
+            sx={{
+              position: 'absolute',
+              top: -9999,
+              left: -9999,
+              zIndex: 9999,
+              p: 1,
+              bgcolor: 'background.paper',
+              color: 'text.primary',
+              '&:focus': {
+                top: 8,
+                left: 8,
+              },
+            }}
+          >
+            Skip to main content
+          </Box>
+          <Nav />
+          <Box
+            id="main-content"
+            component="main"
+            sx={{
+              flex: 1,
+              minWidth: 0,
+              pb: { xs: 7, sm: 7, md: 0 },
+              ml: { xs: 0, md: `${railWidth}px` },
+              transition: theme.transitions.create('margin-left', {
+                easing: theme.transitions.easing.sharp,
+                duration: theme.transitions.duration.standard,
+              }),
+            }}
+          >
+            <Routes>
+              <Route path="/" element={<Home />} />
+              <Route path="/lessons" element={<LessonsIndex />} />
+              <Route path="/lessons/:topic/:slug" element={<LessonDetail />} />
+              <Route path="/lessons/:topic/:slug/quiz" element={<LessonQuiz />} />
+              <Route path="/exam" element={<Exam />} />
+              <Route path="/pstar-exam" element={<PSTARExam />} />
+              <Route path="/plan" element={<Plan />} />
+              <Route path="/playlist" element={<Playlist />} />
+              <Route path="/playlist/:topic" element={<Playlist />} />
+              <Route path="/pstar" element={<PSTARPath />} />
+            </Routes>
+          </Box>
         </Box>
       </BrowserRouter>
     </ThemeProvider>

--- a/web-app/src/App.tsx
+++ b/web-app/src/App.tsx
@@ -75,7 +75,6 @@ export default function App() {
           </Box>
           <Nav />
           <Box
-            id="main-content"
             component="main"
             sx={{
               flex: 1,

--- a/web-app/src/components/Nav.tsx
+++ b/web-app/src/components/Nav.tsx
@@ -1,17 +1,22 @@
+import { useState, useEffect } from 'react';
 import BottomNavigation from '@mui/material/BottomNavigation';
 import BottomNavigationAction from '@mui/material/BottomNavigationAction';
-import AppBar from '@mui/material/AppBar';
+import Box from '@mui/material/Box';
+import Drawer from '@mui/material/Drawer';
+import IconButton from '@mui/material/IconButton';
 import Paper from '@mui/material/Paper';
-import Toolbar from '@mui/material/Toolbar';
+import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
-import Button from '@mui/material/Button';
 import useMediaQuery from '@mui/material/useMediaQuery';
 import { useTheme } from '@mui/material/styles';
 import HomeIcon from '@mui/icons-material/Home';
 import MenuBookIcon from '@mui/icons-material/MenuBook';
 import QuizIcon from '@mui/icons-material/Quiz';
 import ChecklistIcon from '@mui/icons-material/Checklist';
+import ChevronLeftIcon from '@mui/icons-material/ChevronLeft';
+import ChevronRightIcon from '@mui/icons-material/ChevronRight';
 import { Link as RouterLink, useLocation, useNavigate } from 'react-router-dom';
+import { colorTokens } from '../tokens';
 
 const NAV_LINKS = [
   { label: 'Home', shortLabel: 'Home', to: '/', icon: <HomeIcon /> },
@@ -20,73 +25,228 @@ const NAV_LINKS = [
   { label: 'Study Plan', shortLabel: 'Plan', to: '/plan', icon: <ChecklistIcon /> },
 ];
 
+const RAIL_EXPANDED = 240;
+const RAIL_COLLAPSED = 64;
+const LS_KEY = 'ppl-nav-collapsed';
+
 function isActiveRoute(pathname: string, to: string): boolean {
   return to === '/' ? pathname === '/' : pathname === to || pathname.startsWith(to + '/');
 }
 
 export default function Nav() {
   const theme = useTheme();
-  const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
+  const isDesktop = useMediaQuery(theme.breakpoints.up('md'));
   const location = useLocation();
   const navigate = useNavigate();
 
-  const activeIndex = NAV_LINKS.findIndex(({ to }) => isActiveRoute(location.pathname, to));
+  const [collapsed, setCollapsed] = useState<boolean>(() => {
+    try {
+      return localStorage.getItem(LS_KEY) === 'true';
+    } catch {
+      return false;
+    }
+  });
 
-  return (
-    <>
-      <AppBar position="sticky" sx={{ backgroundColor: 'rgba(10,22,40,0.85)', backdropFilter: 'blur(12px)', borderBottom: '1px solid rgba(255,255,255,0.06)' }}>
-        <Toolbar>
-          <Typography variant="h6" sx={{ flexGrow: 1, color: 'primary.main', fontWeight: 700 }}>
-            <span aria-hidden="true">✈ </span>PPL Study
-          </Typography>
-          {!isMobile &&
-            NAV_LINKS.map(({ label, to }) => {
-              const active = isActiveRoute(location.pathname, to);
-              return (
-                <Button
-                  key={to}
-                  component={RouterLink}
-                  to={to}
-                  color="inherit"
-                  sx={
-                    active
-                      ? {
-                          color: 'primary.main',
-                          borderBottom: '2px solid',
-                          borderColor: 'primary.main',
-                          borderRadius: 0,
-                        }
-                      : undefined
-                  }
-                >
-                  {label}
-                </Button>
-              );
-            })}
-        </Toolbar>
-      </AppBar>
-      {isMobile && (
-        <Paper
-          elevation={3}
+  useEffect(() => {
+    try {
+      localStorage.setItem(LS_KEY, String(collapsed));
+    } catch {
+      // ignore storage errors
+    }
+  }, [collapsed]);
+
+  const activeIndex = NAV_LINKS.findIndex(({ to }) => isActiveRoute(location.pathname, to));
+  const railWidth = collapsed ? RAIL_COLLAPSED : RAIL_EXPANDED;
+
+  if (isDesktop) {
+    return (
+      <Drawer
+        variant="permanent"
+        sx={{
+          width: railWidth,
+          flexShrink: 0,
+          '& .MuiDrawer-paper': {
+            width: railWidth,
+            boxSizing: 'border-box',
+            backgroundColor: colorTokens.background.paper,
+            borderRight: `1px solid ${colorTokens.divider}`,
+            overflowX: 'hidden',
+            transition: theme.transitions.create('width', {
+              easing: theme.transitions.easing.sharp,
+              duration: theme.transitions.duration.standard,
+            }),
+            display: 'flex',
+            flexDirection: 'column',
+          },
+        }}
+      >
+        {/* Branding */}
+        <Box
           sx={{
-            position: 'fixed',
-            bottom: 0,
-            left: 0,
-            right: 0,
-            zIndex: theme.zIndex.appBar,
-            pb: 'env(safe-area-inset-bottom)',
+            display: 'flex',
+            alignItems: 'center',
+            px: 2,
+            py: 2,
+            minHeight: 56,
+            borderBottom: `1px solid ${colorTokens.divider}`,
+            overflow: 'hidden',
+            whiteSpace: 'nowrap',
           }}
         >
-          <BottomNavigation
-            value={activeIndex}
-            onChange={(_, newValue: number) => navigate(NAV_LINKS[newValue].to)}
+          <Typography
+            component="span"
+            sx={{
+              color: colorTokens.primary.main,
+              fontWeight: 700,
+              fontSize: '1.1rem',
+              letterSpacing: '0.01em',
+              flexShrink: 0,
+            }}
           >
-            {NAV_LINKS.map(({ shortLabel, to, icon }) => (
-              <BottomNavigationAction key={to} label={shortLabel} icon={icon} />
-            ))}
-          </BottomNavigation>
-        </Paper>
-      )}
-    </>
+            <span aria-hidden="true">✈ </span>
+            {!collapsed && 'PPL Study'}
+          </Typography>
+        </Box>
+
+        {/* Nav links */}
+        <Box component="nav" aria-label="Primary navigation" sx={{ flex: 1, py: 1 }}>
+          {NAV_LINKS.map(({ label, to, icon }) => {
+            const active = isActiveRoute(location.pathname, to);
+            return (
+              <Tooltip
+                key={to}
+                title={collapsed ? label : ''}
+                placement="right"
+                disableHoverListener={!collapsed}
+              >
+                <Box
+                  component={RouterLink}
+                  to={to}
+                  aria-current={active ? 'page' : undefined}
+                  sx={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: 1.5,
+                    px: collapsed ? 0 : 2,
+                    py: 1.25,
+                    mx: 1,
+                    borderRadius: '4px',
+                    textDecoration: 'none',
+                    overflow: 'hidden',
+                    whiteSpace: 'nowrap',
+                    borderLeft: active
+                      ? `3px solid ${colorTokens.primary.main}`
+                      : '3px solid transparent',
+                    color: active
+                      ? colorTokens.primary.main
+                      : colorTokens.text.secondary,
+                    backgroundColor: active ? colorTokens.primary.muted : 'transparent',
+                    transition: 'color 0.15s, background-color 0.15s',
+                    justifyContent: collapsed ? 'center' : 'flex-start',
+                    '&:hover': {
+                      color: colorTokens.primary.main,
+                      backgroundColor: colorTokens.primary.muted,
+                    },
+                    '& svg': {
+                      flexShrink: 0,
+                      fontSize: '1.25rem',
+                    },
+                  }}
+                >
+                  {icon}
+                  {!collapsed && (
+                    <Typography
+                      component="span"
+                      sx={{
+                        fontSize: '0.8125rem',
+                        fontWeight: 500,
+                        textTransform: 'uppercase',
+                        letterSpacing: '0.06em',
+                        color: 'inherit',
+                      }}
+                    >
+                      {label}
+                    </Typography>
+                  )}
+                </Box>
+              </Tooltip>
+            );
+          })}
+        </Box>
+
+        {/* Collapse toggle */}
+        <Box
+          sx={{
+            borderTop: `1px solid ${colorTokens.divider}`,
+            display: 'flex',
+            justifyContent: collapsed ? 'center' : 'flex-end',
+            px: collapsed ? 0 : 1,
+            py: 1,
+          }}
+        >
+          <IconButton
+            onClick={() => setCollapsed((c) => !c)}
+            aria-label={collapsed ? 'Expand navigation' : 'Collapse navigation'}
+            size="small"
+            sx={{ color: colorTokens.text.secondary }}
+          >
+            {collapsed ? <ChevronRightIcon /> : <ChevronLeftIcon />}
+          </IconButton>
+        </Box>
+      </Drawer>
+    );
+  }
+
+  // Mobile: bottom nav
+  return (
+    <Paper
+      elevation={3}
+      sx={{
+        position: 'fixed',
+        bottom: 0,
+        left: 0,
+        right: 0,
+        zIndex: theme.zIndex.appBar,
+        pb: 'env(safe-area-inset-bottom)',
+        backgroundColor: colorTokens.background.paper,
+        borderTop: `1px solid ${colorTokens.divider}`,
+      }}
+    >
+      <BottomNavigation
+        value={activeIndex}
+        onChange={(_, newValue: number) => navigate(NAV_LINKS[newValue].to)}
+        sx={{
+          backgroundColor: colorTokens.background.paper,
+          '& .MuiBottomNavigationAction-root': {
+            color: colorTokens.text.secondary,
+            minWidth: 0,
+          },
+          '& .MuiBottomNavigationAction-root.Mui-selected': {
+            color: colorTokens.primary.main,
+          },
+          '& .MuiBottomNavigationAction-label': {
+            fontSize: '0.7rem',
+            fontWeight: 500,
+            textTransform: 'uppercase',
+            letterSpacing: '0.04em',
+          },
+        }}
+      >
+        {NAV_LINKS.map(({ shortLabel, to, icon }, idx) => {
+          const active = isActiveRoute(location.pathname, to);
+          return (
+            <BottomNavigationAction
+              key={to}
+              label={shortLabel}
+              icon={icon}
+              aria-current={active ? 'page' : undefined}
+              component={RouterLink}
+              to={to}
+              value={idx}
+            />
+          );
+        })}
+      </BottomNavigation>
+    </Paper>
   );
 }


### PR DESCRIPTION
Closes #168

## Changes
<details>

- **Nav.tsx**: Replaced AppBar+horizontal buttons with a permanent MUI Drawer side-rail on desktop (≥md). Rail is 240px expanded / 64px collapsed, persisted in localStorage. Active route shows a 3px amber left border (`colorTokens.primary.main`) + amber text — no MUI blue. Added collapse toggle button at bottom of rail with chevron icon. Mobile (<md) keeps BottomNavigation restyled with amber selected state and uppercase labels. All 4 links preserved with original icons. `isActiveRoute` logic preserved verbatim. `aria-current="page"` added on active links.
- **App.tsx**: Main content wrapper uses `ml: { xs: 0, md: railWidth }` to offset from side-rail at ≥md, no offset at <md. Reads same localStorage key to stay in sync with Nav collapse state via 100ms interval poll + storage event listener. Wrapped content in flex container to support Drawer layout.

</details>

## Test Plan
<details>

- [ ] At ≥md (desktop): side-rail appears at 240px, active route has 3px amber left border
- [ ] Collapse toggle shrinks rail to 64px (icons only), state persists on page reload
- [ ] At <md (mobile): bottom nav appears, no side-rail
- [ ] No horizontal scroll between 360px–1440px
- [ ] All 4 nav links work correctly
- [ ] `npm run build` passes with zero TS errors

</details>