### PR TITLE
[PPL-170] Add prev/next lesson navigation

### DIFF
--- a/web-app/src/lib/lesson-loader.ts
+++ b/web-app/src/lib/lesson-loader.ts
@@ -76,3 +76,16 @@ export function getLessonBySlug(topic: string, slug: string): Lesson | undefined
 export function getLessonsByTopic(topic: string): Lesson[] {
   return getAllLessons().filter((l) => l.topic === topic);
 }
+
+export function getAdjacentLessons(
+  topic: string,
+  slug: string,
+): { prev: Lesson | null; next: Lesson | null } {
+  const lessons = getLessonsByTopic(topic);
+  const idx = lessons.findIndex((l) => l.slug === slug);
+  if (idx === -1) return { prev: null, next: null };
+  return {
+    prev: idx > 0 ? lessons[idx - 1] : null,
+    next: idx < lessons.length - 1 ? lessons[idx + 1] : null,
+  };
+}

--- a/web-app/src/pages/LessonDetail.tsx
+++ b/web-app/src/pages/LessonDetail.tsx
@@ -7,10 +7,12 @@ import Chip from '@mui/material/Chip';
 import Container from '@mui/material/Container';
 import Divider from '@mui/material/Divider';
 import Typography from '@mui/material/Typography';
-import { useState, type ReactNode } from 'react';
+import ArrowBackIcon from '@mui/icons-material/ArrowBack';
+import ArrowForwardIcon from '@mui/icons-material/ArrowForward';
+import { useState, useEffect, type ReactNode } from 'react';
 import AudioPlayer from '../components/AudioPlayer';
 import SourceList from '../components/SourceList';
-import { getLessonBySlug } from '../lib/lesson-loader';
+import { getLessonBySlug, getAdjacentLessons } from '../lib/lesson-loader';
 import { useProgress } from '../lib/progress';
 
 function MarkdownTable({ children }: { children?: ReactNode }) {
@@ -81,6 +83,23 @@ export default function LessonDetail() {
   const [showSuccess, setShowSuccess] = useState(false);
 
   const lesson = topic && slug ? getLessonBySlug(topic, slug) : undefined;
+  const { prev, next } = topic && slug && lesson
+    ? getAdjacentLessons(topic, slug)
+    : { prev: null, next: null };
+
+  useEffect(() => {
+    function handleKeyDown(e: KeyboardEvent) {
+      const tag = (e.target as HTMLElement).tagName;
+      if (['INPUT', 'TEXTAREA', 'SELECT'].includes(tag)) return;
+      if (e.key === 'ArrowLeft' && prev) {
+        navigate(`/lessons/${prev.topic}/${prev.slug}`);
+      } else if (e.key === 'ArrowRight' && next) {
+        navigate(`/lessons/${next.topic}/${next.slug}`);
+      }
+    }
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [prev, next, navigate]);
 
   if (!lesson) {
     return (
@@ -171,6 +190,77 @@ export default function LessonDetail() {
       >
         {completed ? 'Completed' : 'Mark Complete'}
       </Button>
+
+      <Divider sx={{ mt: 3, mb: 2 }} />
+
+      <Box
+        sx={{
+          display: 'flex',
+          gap: 1,
+          justifyContent: 'space-between',
+          alignItems: 'stretch',
+        }}
+      >
+        {prev ? (
+          <Button
+            variant="outlined"
+            startIcon={<ArrowBackIcon />}
+            onClick={() => navigate(`/lessons/${prev.topic}/${prev.slug}`)}
+            title={prev.title}
+            aria-label={`Previous lesson: ${prev.title}`}
+            sx={{
+              minHeight: 48,
+              flex: '1 1 0',
+              minWidth: 0,
+              justifyContent: 'flex-start',
+              overflow: 'hidden',
+              '& .MuiButton-startIcon': { flexShrink: 0 },
+            }}
+          >
+            <Box
+              sx={{
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+                whiteSpace: 'nowrap',
+              }}
+            >
+              {prev.title}
+            </Box>
+          </Button>
+        ) : (
+          <Box sx={{ flex: '1 1 0' }} />
+        )}
+
+        {next ? (
+          <Button
+            variant="outlined"
+            endIcon={<ArrowForwardIcon />}
+            onClick={() => navigate(`/lessons/${next.topic}/${next.slug}`)}
+            title={next.title}
+            aria-label={`Next lesson: ${next.title}`}
+            sx={{
+              minHeight: 48,
+              flex: '1 1 0',
+              minWidth: 0,
+              justifyContent: 'flex-end',
+              overflow: 'hidden',
+              '& .MuiButton-endIcon': { flexShrink: 0 },
+            }}
+          >
+            <Box
+              sx={{
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+                whiteSpace: 'nowrap',
+              }}
+            >
+              {next.title}
+            </Box>
+          </Button>
+        ) : (
+          <Box sx={{ flex: '1 1 0' }} />
+        )}
+      </Box>
     </Container>
   );
 }


### PR DESCRIPTION
## Summary
- Adds `getAdjacentLessons` helper to `lesson-loader.ts` that returns the previous and next lesson within the same topic
- Renders Prev/Next buttons at the bottom of `LessonDetail` with lesson titles (truncated via ellipsis overflow on narrow viewports)
- 48px minimum touch targets, buttons hidden at topic boundaries (first/last lesson)
- ArrowLeft/ArrowRight keyboard shortcuts active when lesson page is focused (ignores input/textarea focus)
- Preserves all existing CTAs: View Visual, Take Practice Quiz, Mark Complete

Closes #170

## Test plan
- [ ] Open any mid-topic lesson; verify Prev and Next buttons appear with adjacent lesson titles
- [ ] Open the first lesson in a topic; verify no Prev button
- [ ] Open the last lesson in a topic; verify no Next button
- [ ] Verify titles truncate with ellipsis at 360px viewport width, no horizontal scroll
- [ ] Verify titles display fully at 1440px
- [ ] Press ArrowLeft/ArrowRight to navigate between lessons
- [ ] Verify existing CTAs (View Visual, Take Practice Quiz, Mark Complete) still work
- [ ] `npm run build` passes with no TS errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)