### PR TITLE
[PPL-172] Quiz coverage audit + LessonQuiz UX improvements

### DIFF
--- a/scripts/audit-lesson-questions.sh
+++ b/scripts/audit-lesson-questions.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# Audits every lessons/**/*.md for well-formed quiz questions.
+# Each lesson must have >=3 questions, each with id/prompt/options(>=3)/answer/explanation.
+# Exits non-zero if any lesson fails.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LESSONS_DIR="$SCRIPT_DIR/../lessons"
+
+if [ ! -d "$LESSONS_DIR" ]; then
+  echo "ERROR: lessons directory not found at $LESSONS_DIR" >&2
+  exit 1
+fi
+
+TMPPY=$(mktemp /tmp/audit-lesson-questions-XXXXXX.py)
+trap 'rm -f "$TMPPY"' EXIT
+
+cat > "$TMPPY" << 'PYEOF'
+#!/usr/bin/env python3
+"""Audit lesson files for quiz question coverage."""
+import sys
+import re
+import glob
+import os
+
+try:
+    import yaml
+except ImportError:
+    # Minimal YAML subset parser fallback — not needed if PyYAML present
+    print("ERROR: PyYAML not installed. Run: pip install pyyaml", file=sys.stderr)
+    sys.exit(2)
+
+MIN_QUESTIONS = 3
+MIN_OPTIONS = 3
+
+def parse_frontmatter(path):
+    with open(path) as f:
+        content = f.read()
+    m = re.match(r'^---\n(.*?)\n---', content, re.DOTALL)
+    if not m:
+        return None, content
+    try:
+        fm = yaml.safe_load(m.group(1)) or {}
+    except yaml.YAMLError as e:
+        print(f"  YAML parse error: {e}", file=sys.stderr)
+        return None, content
+    return fm, content[m.end():]
+
+def validate_question(q):
+    if not isinstance(q, dict):
+        return False, "not a mapping"
+    if 'id' not in q:
+        return False, "missing 'id'"
+    if not q.get('prompt'):
+        return False, "missing or empty 'prompt'"
+    choices = q.get('choices', {})
+    if not isinstance(choices, dict) or len(choices) < MIN_OPTIONS:
+        return False, f"'choices' must have >={MIN_OPTIONS} entries (got {len(choices) if isinstance(choices, dict) else 0})"
+    if 'answer' not in q:
+        return False, "missing 'answer'"
+    if not q.get('explanation'):
+        return False, "missing or empty 'explanation'"
+    return True, ""
+
+lessons_dir = sys.argv[1]
+files = sorted(glob.glob(os.path.join(lessons_dir, '**', '*.md'), recursive=True))
+
+if not files:
+    print("ERROR: no lesson files found", file=sys.stderr)
+    sys.exit(2)
+
+failures = []
+
+for path in files:
+    rel = os.path.relpath(path, lessons_dir)
+    fm, _ = parse_frontmatter(path)
+    if fm is None:
+        failures.append((rel, "could not parse frontmatter"))
+        continue
+
+    questions = fm.get('questions', [])
+    if not isinstance(questions, list):
+        failures.append((rel, "'questions' is not a list"))
+        continue
+
+    valid_count = 0
+    for idx, q in enumerate(questions):
+        ok, reason = validate_question(q)
+        if ok:
+            valid_count += 1
+        else:
+            print(f"  [{rel}] question[{idx}] invalid: {reason}")
+
+    if valid_count < MIN_QUESTIONS:
+        failures.append((rel, f"only {valid_count} valid question(s); need {MIN_QUESTIONS}"))
+
+if failures:
+    print(f"\nAUDIT FAILED — {len(failures)} lesson(s) below the bar:\n")
+    for rel, reason in failures:
+        print(f"  FAIL  {rel}: {reason}")
+    sys.exit(1)
+else:
+    print(f"AUDIT PASSED — {len(files)} lessons, all have >={MIN_QUESTIONS} valid questions.")
+    sys.exit(0)
+PYEOF
+
+python3 "$TMPPY" "$LESSONS_DIR"

--- a/web-app/src/pages/LessonQuiz.tsx
+++ b/web-app/src/pages/LessonQuiz.tsx
@@ -1,18 +1,22 @@
 import { useState } from 'react';
-import { useParams, useNavigate } from 'react-router-dom';
+import { useParams, useNavigate, Link } from 'react-router-dom';
 import Alert from '@mui/material/Alert';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
+import Card from '@mui/material/Card';
+import CardContent from '@mui/material/CardContent';
 import CircularProgress from '@mui/material/CircularProgress';
 import Container from '@mui/material/Container';
 import Divider from '@mui/material/Divider';
 import Typography from '@mui/material/Typography';
-import { getLessonBySlug } from '../lib/lesson-loader';
+import { getLessonBySlug, getAllLessons } from '../lib/lesson-loader';
 import { scoreQuiz } from '../lib/quiz';
 import type { QuizResult } from '../lib/quiz';
 import QuizRunner from '../components/QuizRunner';
 
 type Phase = 'intro' | 'quiz' | 'results';
+
+const TOUCH_TARGET = { minHeight: 48, minWidth: 48 };
 
 export default function LessonQuiz() {
   const { topic, slug } = useParams<{ topic: string; slug: string }>();
@@ -29,25 +33,40 @@ export default function LessonQuiz() {
         <Alert severity="error" sx={{ mb: 2 }}>
           Lesson not found: {topic}/{slug}.
         </Alert>
-        <Button variant="outlined" onClick={() => navigate('/lessons')}>
+        <Button variant="outlined" onClick={() => navigate('/lessons')} sx={TOUCH_TARGET}>
           Back to Lessons
         </Button>
       </Container>
     );
   }
 
-  const backToLesson = () => navigate(`/lessons/${lesson.topic}/${lesson.slug}`);
+  const lessonPath = `/lessons/${lesson.topic}/${lesson.slug}`;
+  const backToLesson = () => navigate(lessonPath);
+
+  const allLessons = getAllLessons();
+  const currentIdx = allLessons.findIndex((l) => l.topic === lesson.topic && l.slug === lesson.slug);
+  const nextLesson = currentIdx >= 0 && currentIdx < allLessons.length - 1
+    ? allLessons[currentIdx + 1]
+    : null;
 
   if (lesson.questions.length === 0) {
     return (
       <Container maxWidth="md" sx={{ py: 4 }}>
+        <Button
+          component={Link}
+          to={lessonPath}
+          variant="text"
+          sx={{ mb: 2, pl: 0, ...TOUCH_TARGET }}
+        >
+          ← Back to lesson
+        </Button>
         <Typography variant="h5" sx={{ mb: 2 }}>
           {lesson.title} — Quiz
         </Typography>
         <Alert severity="info" sx={{ mb: 2 }}>
           No quiz questions available for this lesson.
         </Alert>
-        <Button variant="outlined" onClick={backToLesson}>
+        <Button variant="outlined" onClick={backToLesson} sx={TOUCH_TARGET}>
           Back to Lesson
         </Button>
       </Container>
@@ -72,8 +91,13 @@ export default function LessonQuiz() {
 
   return (
     <Container maxWidth="md" sx={{ py: 4 }}>
-      <Button variant="text" onClick={backToLesson} sx={{ mb: 2, pl: 0 }}>
-        ← Back to Lesson
+      <Button
+        component={Link}
+        to={lessonPath}
+        variant="text"
+        sx={{ mb: 2, pl: 0, ...TOUCH_TARGET }}
+      >
+        ← Back to lesson
       </Button>
 
       <Typography variant="h5" sx={{ mb: 3 }}>
@@ -86,7 +110,7 @@ export default function LessonQuiz() {
             {lesson.questions.length} question
             {lesson.questions.length !== 1 ? 's' : ''} · {lesson.title}
           </Typography>
-          <Button variant="contained" onClick={handleStartQuiz}>
+          <Button variant="contained" onClick={handleStartQuiz} sx={TOUCH_TARGET}>
             Start Quiz
           </Button>
         </Box>
@@ -98,46 +122,83 @@ export default function LessonQuiz() {
 
       {phase === 'results' && quizResult && (
         <Box>
-          <Box sx={{ display: 'flex', alignItems: 'center', gap: 3, mb: 3 }}>
-            <Box sx={{ position: 'relative', display: 'inline-flex' }}>
-              <CircularProgress
-                variant="determinate"
-                value={quizResult.percent}
-                size={80}
-                thickness={5}
-              />
-              <Box
-                sx={{
-                  position: 'absolute',
-                  inset: 0,
-                  display: 'flex',
-                  alignItems: 'center',
-                  justifyContent: 'center',
-                }}
-              >
-                <Typography variant="caption" component="div" color="text.secondary">
-                  {quizResult.percent}%
-                </Typography>
+          <Card variant="outlined" sx={{ mb: 3 }}>
+            <CardContent>
+              <Box sx={{ display: 'flex', alignItems: 'center', gap: 3, mb: 3 }}>
+                <Box sx={{ position: 'relative', display: 'inline-flex' }}>
+                  <CircularProgress
+                    variant="determinate"
+                    value={quizResult.percent}
+                    size={80}
+                    thickness={5}
+                  />
+                  <Box
+                    sx={{
+                      position: 'absolute',
+                      inset: 0,
+                      display: 'flex',
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                    }}
+                  >
+                    <Typography variant="caption" component="div" color="text.secondary">
+                      {quizResult.percent}%
+                    </Typography>
+                  </Box>
+                </Box>
+                <Box>
+                  <Typography variant="h5">
+                    {quizResult.correct}/{quizResult.total} correct
+                  </Typography>
+                  <Typography variant="body1" color="text.secondary">
+                    Score: {quizResult.percent}%
+                  </Typography>
+                  <Typography variant="body2" color="text.secondary">
+                    {lesson.title}
+                  </Typography>
+                </Box>
               </Box>
-            </Box>
-            <Box>
-              <Typography variant="h5">
-                {quizResult.correct}/{quizResult.total} · {quizResult.percent}%
-              </Typography>
-              <Typography variant="body2" color="text.secondary">
-                {lesson.title}
-              </Typography>
-            </Box>
-          </Box>
 
-          <Box sx={{ display: 'flex', gap: 2, mb: 3 }}>
-            <Button variant="outlined" onClick={handleRetake}>
-              Retake
-            </Button>
-            <Button variant="text" onClick={backToLesson}>
-              Back to Lesson
-            </Button>
-          </Box>
+              <Box sx={{ display: 'flex', gap: 2, flexWrap: 'wrap' }}>
+                <Button
+                  variant="outlined"
+                  onClick={handleRetake}
+                  sx={TOUCH_TARGET}
+                >
+                  Retake
+                </Button>
+                <Button
+                  component={Link}
+                  to={lessonPath}
+                  variant="contained"
+                  sx={TOUCH_TARGET}
+                >
+                  Review lesson
+                </Button>
+                {nextLesson ? (
+                  <Button
+                    component={Link}
+                    to={`/lessons/${nextLesson.topic}/${nextLesson.slug}`}
+                    variant="outlined"
+                    color="secondary"
+                    sx={TOUCH_TARGET}
+                  >
+                    Next lesson →
+                  </Button>
+                ) : (
+                  <Button
+                    component={Link}
+                    to="/lessons"
+                    variant="outlined"
+                    color="secondary"
+                    sx={TOUCH_TARGET}
+                  >
+                    All lessons
+                  </Button>
+                )}
+              </Box>
+            </CardContent>
+          </Card>
 
           <Divider sx={{ mb: 3 }} />
 

--- a/web-app/src/pages/LessonQuiz.tsx
+++ b/web-app/src/pages/LessonQuiz.tsx
@@ -9,7 +9,7 @@ import CircularProgress from '@mui/material/CircularProgress';
 import Container from '@mui/material/Container';
 import Divider from '@mui/material/Divider';
 import Typography from '@mui/material/Typography';
-import { getLessonBySlug, getAllLessons } from '../lib/lesson-loader';
+import { getLessonBySlug, getAdjacentLessons } from '../lib/lesson-loader';
 import { scoreQuiz } from '../lib/quiz';
 import type { QuizResult } from '../lib/quiz';
 import QuizRunner from '../components/QuizRunner';
@@ -43,11 +43,7 @@ export default function LessonQuiz() {
   const lessonPath = `/lessons/${lesson.topic}/${lesson.slug}`;
   const backToLesson = () => navigate(lessonPath);
 
-  const allLessons = getAllLessons();
-  const currentIdx = allLessons.findIndex((l) => l.topic === lesson.topic && l.slug === lesson.slug);
-  const nextLesson = currentIdx >= 0 && currentIdx < allLessons.length - 1
-    ? allLessons[currentIdx + 1]
-    : null;
+  const { next: nextLesson } = getAdjacentLessons(lesson.topic, lesson.slug);
 
   if (lesson.questions.length === 0) {
     return (


### PR DESCRIPTION
Closes #172

## Changes

- **`scripts/audit-lesson-questions.sh`** — New CI-ready script that scans all `lessons/**/*.md` frontmatter `questions:` arrays and exits non-zero if any lesson has fewer than 3 well-formed questions. Each question must have `id`, `prompt`, `choices` (≥3 options), `answer`, and `explanation`. All 60 existing lessons pass.

- **`web-app/src/pages/LessonQuiz.tsx`**
  - Added a persistent `← Back to lesson` link at the top of all phases (intro, quiz, results), implemented as a React Router `Link` pointing to `/lessons/:topic/:slug`
  - Replaced inline score display with a `Card`-based results section showing **score/total** and **percent** prominently
  - Added **Review lesson** button (navigates back to the lesson page)
  - Added **Next lesson →** button using `getAllLessons()` sort order; falls back to an **All lessons** button on the final lesson
  - All action buttons have `minHeight: 48` / `minWidth: 48` for WCAG-compliant touch targets

## Test Plan

- [x] `scripts/audit-lesson-questions.sh` exits 0 for all 60 lessons
- [x] `npm run build` passes with no TypeScript errors
- [ ] Visit a lesson quiz, complete it — verify results card shows score/total, Review lesson and Next lesson buttons appear
- [ ] Verify `← Back to lesson` link is visible at top during intro, quiz, and results phases
- [ ] Verify Next lesson button is absent on the last lesson (shows All lessons instead)
- [ ] Test on mobile viewport — all buttons should have adequate tap target size