### PR TITLE
[PPL-174] Exam.tsx retrofit to study standards + QuizOption component

### DIFF
--- a/web-app/src/components/QuizOption.tsx
+++ b/web-app/src/components/QuizOption.tsx
@@ -1,0 +1,103 @@
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import { alpha } from '@mui/material/styles';
+import { colorTokens, typographyTokens, radiusTokens } from '../tokens';
+
+export type QuizOptionState = 'default' | 'selected' | 'correct' | 'wrong';
+
+export interface QuizOptionProps {
+  optionKey: string;
+  label: string;
+  state: QuizOptionState;
+  disabled?: boolean;
+  onClick?: () => void;
+}
+
+function accentColor(state: QuizOptionState): string {
+  switch (state) {
+    case 'correct': return colorTokens.success.main;
+    case 'wrong': return colorTokens.error.main;
+    case 'selected': return colorTokens.primary.main;
+    default: return colorTokens.divider;
+  }
+}
+
+function bgColor(state: QuizOptionState): string {
+  switch (state) {
+    case 'correct': return alpha(colorTokens.success.main, 0.1);
+    case 'wrong': return alpha(colorTokens.error.main, 0.1);
+    case 'selected': return alpha(colorTokens.primary.main, 0.08);
+    default: return colorTokens.background.paper;
+  }
+}
+
+export default function QuizOption({ optionKey, label, state, disabled, onClick }: QuizOptionProps) {
+  const accent = accentColor(state);
+  const bg = bgColor(state);
+  const isInteractive = !disabled && state === 'default' || state === 'selected';
+
+  return (
+    <Box
+      role="button"
+      tabIndex={disabled ? -1 : 0}
+      aria-pressed={state === 'selected' || state === 'correct' || state === 'wrong'}
+      aria-disabled={disabled}
+      onClick={disabled ? undefined : onClick}
+      onKeyDown={(e) => {
+        if (!disabled && (e.key === 'Enter' || e.key === ' ')) {
+          e.preventDefault();
+          onClick?.();
+        }
+      }}
+      sx={{
+        display: 'flex',
+        alignItems: 'center',
+        minHeight: 48,
+        width: '100%',
+        px: 2,
+        py: 1.25,
+        gap: 1.5,
+        backgroundColor: bg,
+        border: `1px solid ${colorTokens.divider}`,
+        borderLeft: `4px solid ${accent}`,
+        borderRadius: `0 ${radiusTokens.sm}px ${radiusTokens.sm}px 0`,
+        cursor: disabled ? 'default' : 'pointer',
+        transition: 'transform 150ms ease-out, background-color 150ms ease-out, border-left-color 150ms ease-out',
+        userSelect: 'none',
+        outline: 'none',
+        '&:hover': isInteractive
+          ? { transform: 'translateY(-1px)' }
+          : {},
+        '&:focus-visible': {
+          outline: `2px solid ${colorTokens.primary.main}`,
+          outlineOffset: 2,
+        },
+      }}
+    >
+      <Typography
+        component="span"
+        sx={{
+          fontFamily: typographyTokens.fontFamily.mono,
+          fontSize: '0.8125rem',
+          fontWeight: 600,
+          color: accent === colorTokens.divider ? colorTokens.text.secondary : accent,
+          minWidth: 20,
+          flexShrink: 0,
+        }}
+      >
+        {optionKey}.
+      </Typography>
+      <Typography
+        component="span"
+        sx={{
+          fontFamily: typographyTokens.fontFamily.sans,
+          fontSize: '1rem',
+          lineHeight: 1.5,
+          color: colorTokens.text.primary,
+        }}
+      >
+        {label}
+      </Typography>
+    </Box>
+  );
+}

--- a/web-app/src/components/QuizRunner.tsx
+++ b/web-app/src/components/QuizRunner.tsx
@@ -10,12 +10,23 @@ import RadioGroup from '@mui/material/RadioGroup';
 import Typography from '@mui/material/Typography';
 import type { Question } from '../lib/types';
 
+export interface QuizOptionRenderProps {
+  optionKey: string;
+  label: string;
+  isSelected: boolean;
+  isSubmitted: boolean;
+  isCorrectAnswer: boolean;
+  disabled: boolean;
+  onSelect: () => void;
+}
+
 interface QuizRunnerProps {
   questions: Question[];
   onComplete: (answers: Record<string, string>) => void;
+  renderOption?: (props: QuizOptionRenderProps) => React.ReactNode;
 }
 
-export default function QuizRunner({ questions, onComplete }: QuizRunnerProps) {
+export default function QuizRunner({ questions, onComplete, renderOption }: QuizRunnerProps) {
   const [currentIndex, setCurrentIndex] = useState(0);
   const [selectedAnswer, setSelectedAnswer] = useState('');
   const [submitted, setSubmitted] = useState(false);
@@ -54,23 +65,39 @@ export default function QuizRunner({ questions, onComplete }: QuizRunnerProps) {
         {question.prompt}
       </Typography>
 
-      <FormControl component="fieldset" sx={{ width: '100%' }}>
-        <RadioGroup
-          value={selectedAnswer}
-          onChange={(e) => {
-            if (!submitted) setSelectedAnswer(e.target.value);
-          }}
-        >
-          {Object.entries(question.choices).map(([key, value]) => (
-            <FormControlLabel
-              key={key}
-              value={key}
-              control={<Radio disabled={submitted} />}
-              label={`${key}. ${value}`}
-            />
-          ))}
-        </RadioGroup>
-      </FormControl>
+      {renderOption ? (
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+          {Object.entries(question.choices).map(([key, value]) =>
+            renderOption({
+              optionKey: key,
+              label: value,
+              isSelected: selectedAnswer === key,
+              isSubmitted: submitted,
+              isCorrectAnswer: key === question.answer,
+              disabled: submitted,
+              onSelect: () => { if (!submitted) setSelectedAnswer(key); },
+            }),
+          )}
+        </Box>
+      ) : (
+        <FormControl component="fieldset" sx={{ width: '100%' }}>
+          <RadioGroup
+            value={selectedAnswer}
+            onChange={(e) => {
+              if (!submitted) setSelectedAnswer(e.target.value);
+            }}
+          >
+            {Object.entries(question.choices).map(([key, value]) => (
+              <FormControlLabel
+                key={key}
+                value={key}
+                control={<Radio disabled={submitted} />}
+                label={`${key}. ${value}`}
+              />
+            ))}
+          </RadioGroup>
+        </FormControl>
+      )}
 
       {submitted && (
         <>

--- a/web-app/src/pages/Exam.tsx
+++ b/web-app/src/pages/Exam.tsx
@@ -1,35 +1,50 @@
 import { useState } from 'react';
-import { useSearchParams } from 'react-router-dom';
-import Alert from '@mui/material/Alert';
+import { Link as RouterLink, useSearchParams } from 'react-router-dom';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
+import Chip from '@mui/material/Chip';
 import CircularProgress from '@mui/material/CircularProgress';
 import Container from '@mui/material/Container';
-import Dialog from '@mui/material/Dialog';
-import DialogActions from '@mui/material/DialogActions';
-import DialogContent from '@mui/material/DialogContent';
-import DialogContentText from '@mui/material/DialogContentText';
-import DialogTitle from '@mui/material/DialogTitle';
 import Divider from '@mui/material/Divider';
 import Typography from '@mui/material/Typography';
+import { alpha } from '@mui/material/styles';
 import { getAllLessons } from '../lib/lesson-loader';
 import { useProgress } from '../lib/progress';
 import { scoreQuiz } from '../lib/quiz';
 import type { QuizResult } from '../lib/quiz';
+import type { QuizAttempt } from '../lib/types';
+import { TOPIC_LABELS, TOPICS } from '../lib/curriculum';
 import QuizRunner from '../components/QuizRunner';
+import QuizOption from '../components/QuizOption';
+import type { QuizOptionState } from '../components/QuizOption';
+import { colorTokens, typographyTokens, radiusTokens } from '../tokens';
 
 type Phase = 'select' | 'quiz' | 'results';
+type TopicFilter = 'all' | typeof TOPICS[number];
 
-function formatLessonLabel(id: string, title: string): string {
-  return `${id.toUpperCase()} · ${title}`;
+const FILTER_OPTIONS: { key: TopicFilter; label: string }[] = [
+  { key: 'all', label: 'All' },
+  ...TOPICS.map((t) => ({ key: t as TopicFilter, label: TOPIC_LABELS[t] })),
+];
+
+function deriveOptionState(
+  isSelected: boolean,
+  isSubmitted: boolean,
+  isCorrectAnswer: boolean,
+): QuizOptionState {
+  if (!isSubmitted) return isSelected ? 'selected' : 'default';
+  if (isCorrectAnswer) return 'correct';
+  if (isSelected) return 'wrong';
+  return 'default';
 }
 
 export default function Exam() {
   const [searchParams] = useSearchParams();
-  const { store } = useProgress();
+  const { progress, store } = useProgress();
 
   const lessons = getAllLessons().filter((l) => l.questions.length > 0);
 
+  const [topicFilter, setTopicFilter] = useState<TopicFilter>('all');
   const [selectedLessonId, setSelectedLessonId] = useState<string>(() => {
     const fromUrl = searchParams.get('lesson');
     if (fromUrl && lessons.some((l) => l.id === fromUrl)) return fromUrl;
@@ -39,9 +54,16 @@ export default function Exam() {
   const [quizResult, setQuizResult] = useState<QuizResult | null>(null);
   const [pendingLessonId, setPendingLessonId] = useState<string | null>(null);
 
+  const filteredLessons =
+    topicFilter === 'all' ? lessons : lessons.filter((l) => l.topic === topicFilter);
+
   const selectedLesson = lessons.find((l) => l.id === selectedLessonId);
 
-  function handleLessonChange(newId: string) {
+  function getLastAttempt(lessonId: string): QuizAttempt | undefined {
+    return [...progress.quizHistory].reverse().find((a) => a.lessonId === lessonId);
+  }
+
+  function handleLessonSelect(newId: string) {
     if (phase === 'quiz') {
       setPendingLessonId(newId);
     } else {
@@ -72,7 +94,14 @@ export default function Exam() {
   function handleQuizComplete(answers: Record<string, string>) {
     if (!selectedLesson) return;
     const result = scoreQuiz(answers, selectedLesson.questions);
-    store.setLastExamScore(selectedLesson.id, result.percent);
+    store.recordQuizAttempt({
+      lessonId: selectedLesson.id,
+      timestamp: new Date().toISOString(),
+      score: result.correct,
+      total: result.total,
+      percent: result.percent,
+      answers,
+    });
     setQuizResult(result);
     setPhase('results');
   }
@@ -88,7 +117,18 @@ export default function Exam() {
         <Typography variant="h4" sx={{ mb: 3 }}>
           Practice Quiz
         </Typography>
-        <Alert severity="info">No lessons with quiz questions found.</Alert>
+        <Box
+          sx={{
+            p: 2,
+            borderRadius: `${radiusTokens.sm}px`,
+            border: `1px solid ${colorTokens.info.main}`,
+            backgroundColor: alpha(colorTokens.info.main, 0.1),
+          }}
+        >
+          <Typography variant="body1" color="info.main">
+            No lessons with quiz questions found.
+          </Typography>
+        </Box>
       </Container>
     );
   }
@@ -99,44 +139,176 @@ export default function Exam() {
         Practice Quiz
       </Typography>
 
-      <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1, mb: 3 }}>
-        {lessons.map((l) => (
-          <Button
-            key={l.id}
-            variant={selectedLessonId === l.id ? 'contained' : 'outlined'}
-            size="small"
-            onClick={() => handleLessonChange(l.id)}
+      {/* Inline confirm — replaces MUI Dialog */}
+      {pendingLessonId !== null && (
+        <Box
+          role="alertdialog"
+          aria-label="Switch lesson confirmation"
+          sx={{
+            mb: 3,
+            p: 2,
+            backgroundColor: colorTokens.background.surfaceRaised,
+            border: `1px solid ${colorTokens.divider}`,
+            borderLeft: `4px solid ${colorTokens.primary.main}`,
+            borderRadius: `0 ${radiusTokens.sm}px ${radiusTokens.sm}px 0`,
+          }}
+        >
+          <Typography
+            variant="body2"
+            sx={{
+              mb: 2,
+              fontFamily: typographyTokens.fontFamily.sans,
+              color: colorTokens.text.primary,
+            }}
           >
-            {formatLessonLabel(l.id, l.title)}
-          </Button>
-        ))}
-      </Box>
-
-      {phase === 'select' && selectedLesson && (
-        <Box>
-          <Typography variant="body1" sx={{ mb: 2 }}>
-            {selectedLesson.questions.length} question
-            {selectedLesson.questions.length !== 1 ? 's' : ''} · {selectedLesson.title}
+            Your current quiz progress will be lost. Switch to the new lesson?
           </Typography>
-          <Button variant="contained" onClick={handleStartQuiz}>
-            Start Quiz
-          </Button>
+          <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap' }}>
+            <Button variant="contained" size="small" onClick={handleConfirmSwitch}>
+              Switch
+            </Button>
+            <Button variant="outlined" size="small" onClick={handleCancelSwitch}>
+              Cancel
+            </Button>
+          </Box>
         </Box>
       )}
 
-      {phase === 'quiz' && selectedLesson && (
-        <QuizRunner questions={selectedLesson.questions} onComplete={handleQuizComplete} />
+      {/* Topic filter chips */}
+      <Box
+        sx={{
+          display: 'flex',
+          flexWrap: 'wrap',
+          gap: 1,
+          mb: 3,
+        }}
+      >
+        {FILTER_OPTIONS.map((fo) => (
+          <Chip
+            key={fo.key}
+            label={fo.label}
+            onClick={() => setTopicFilter(fo.key)}
+            variant={topicFilter === fo.key ? 'filled' : 'outlined'}
+            color={topicFilter === fo.key ? 'primary' : 'default'}
+          />
+        ))}
+      </Box>
+
+      {/* Select phase */}
+      {phase === 'select' && (
+        <Box>
+          {filteredLessons.length === 0 && (
+            <Typography variant="body2" color="text.secondary">
+              No lessons with quiz questions in this topic.
+            </Typography>
+          )}
+          {filteredLessons.map((lesson) => {
+            const isSelected = lesson.id === selectedLessonId;
+            const lastAttempt = getLastAttempt(lesson.id);
+            return (
+              <Box
+                key={lesson.id}
+                role="button"
+                tabIndex={0}
+                aria-pressed={isSelected}
+                onClick={() => handleLessonSelect(lesson.id)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault();
+                    handleLessonSelect(lesson.id);
+                  }
+                }}
+                sx={{
+                  mb: 1,
+                  p: 2,
+                  minHeight: 64,
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'space-between',
+                  backgroundColor: isSelected
+                    ? alpha(colorTokens.primary.main, 0.1)
+                    : colorTokens.background.paper,
+                  border: `1px solid ${colorTokens.divider}`,
+                  borderLeft: `4px solid ${isSelected ? colorTokens.primary.main : colorTokens.divider}`,
+                  borderRadius: `0 ${radiusTokens.sm}px ${radiusTokens.sm}px 0`,
+                  cursor: 'pointer',
+                  transition: 'transform 150ms ease-out',
+                  '&:hover': { transform: 'translateY(-1px)' },
+                  '&:focus-visible': {
+                    outline: `2px solid ${colorTokens.primary.main}`,
+                    outlineOffset: 2,
+                  },
+                }}
+              >
+                <Box sx={{ minWidth: 0, flex: 1 }}>
+                  <Typography
+                    variant="overline"
+                    sx={{ display: 'block', mb: 0.25, lineHeight: 1.4 }}
+                  >
+                    {lesson.id.toUpperCase()}
+                  </Typography>
+                  <Typography
+                    variant="body2"
+                    sx={{ lineHeight: 1.4, fontFamily: typographyTokens.fontFamily.sans }}
+                  >
+                    {lesson.title}
+                  </Typography>
+                  <Typography variant="caption" color="text.secondary">
+                    {lesson.questions.length} question{lesson.questions.length !== 1 ? 's' : ''}
+                    {lastAttempt
+                      ? ` · Last score: ${lastAttempt.score}/${lastAttempt.total}`
+                      : ''}
+                  </Typography>
+                </Box>
+                {isSelected && (
+                  <Button
+                    variant="contained"
+                    size="small"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      handleStartQuiz();
+                    }}
+                    sx={{ ml: 2, flexShrink: 0 }}
+                  >
+                    Start
+                  </Button>
+                )}
+              </Box>
+            );
+          })}
+        </Box>
       )}
 
+      {/* Quiz phase */}
+      {phase === 'quiz' && selectedLesson && (
+        <QuizRunner
+          questions={selectedLesson.questions}
+          onComplete={handleQuizComplete}
+          renderOption={(props) => (
+            <QuizOption
+              key={props.optionKey}
+              optionKey={props.optionKey}
+              label={props.label}
+              state={deriveOptionState(props.isSelected, props.isSubmitted, props.isCorrectAnswer)}
+              disabled={props.disabled}
+              onClick={props.onSelect}
+            />
+          )}
+        />
+      )}
+
+      {/* Results phase */}
       {phase === 'results' && quizResult && selectedLesson && (
         <Box>
+          {/* Score summary */}
           <Box sx={{ display: 'flex', alignItems: 'center', gap: 3, mb: 3 }}>
-            <Box sx={{ position: 'relative', display: 'inline-flex' }}>
+            <Box sx={{ position: 'relative', display: 'inline-flex', flexShrink: 0 }}>
               <CircularProgress
                 variant="determinate"
                 value={quizResult.percent}
                 size={80}
                 thickness={5}
+                color={quizResult.percent >= 60 ? 'success' : 'error'}
               />
               <Box
                 sx={{
@@ -152,7 +324,7 @@ export default function Exam() {
                 </Typography>
               </Box>
             </Box>
-            <Box>
+            <Box sx={{ minWidth: 0 }}>
               <Typography variant="h5">
                 {quizResult.correct}/{quizResult.total} · {quizResult.percent}%
               </Typography>
@@ -162,58 +334,86 @@ export default function Exam() {
             </Box>
           </Box>
 
-          <Button variant="outlined" onClick={handleRetake} sx={{ mb: 3 }}>
-            Retake
-          </Button>
+          {/* Actions */}
+          <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 2, mb: 3 }}>
+            <Button variant="outlined" onClick={handleRetake}>
+              Try Again
+            </Button>
+            <Button
+              variant="text"
+              component={RouterLink}
+              to={`/lessons/${selectedLesson.topic}/${selectedLesson.slug}`}
+            >
+              Open this Lesson
+            </Button>
+            <Button variant="text" onClick={handleRetake}>
+              Try Another
+            </Button>
+          </Box>
 
-          <Divider sx={{ mb: 3 }} />
-
-          {quizResult.perQuestion.map((pq, idx) => {
-            const q = selectedLesson.questions.find((sq) => sq.id === pq.questionId);
-            return (
-              <Box key={pq.questionId} sx={{ mb: 3 }}>
-                <Typography variant="subtitle2" color="text.secondary" sx={{ mb: 0.5 }}>
-                  Question {idx + 1}
-                </Typography>
-                <Typography variant="body1" sx={{ mb: 1 }}>
-                  {pq.prompt}
-                </Typography>
-                <Alert severity={pq.isCorrect ? 'success' : 'error'} sx={{ mb: 1 }}>
-                  <Typography variant="body2">
-                    Your answer: {pq.userAnswer}
-                    {q ? `. ${q.choices[pq.userAnswer]}` : ''}
-                  </Typography>
-                  {!pq.isCorrect && (
-                    <Typography variant="body2">
-                      Correct answer: {pq.correctAnswer}
-                      {q ? `. ${q.choices[pq.correctAnswer]}` : ''}
-                    </Typography>
-                  )}
-                </Alert>
-                <Typography variant="body2" sx={{ fontStyle: 'italic' }}>
-                  {pq.explanation}
-                </Typography>
-                {idx < quizResult.perQuestion.length - 1 && <Divider sx={{ mt: 2 }} />}
-              </Box>
-            );
-          })}
+          {/* Missed questions */}
+          {quizResult.perQuestion.some((pq) => !pq.isCorrect) && (
+            <>
+              <Divider sx={{ mb: 3 }} />
+              <Typography variant="h6" sx={{ mb: 2 }}>
+                Missed Questions
+              </Typography>
+              {quizResult.perQuestion
+                .filter((pq) => !pq.isCorrect)
+                .map((pq, idx, arr) => {
+                  const q = selectedLesson.questions.find((sq) => sq.id === pq.questionId);
+                  const lessonUrl = `/lessons/${selectedLesson.topic}/${selectedLesson.slug}`;
+                  return (
+                    <Box key={pq.questionId} sx={{ mb: 3 }}>
+                      <Typography variant="subtitle2" color="text.secondary" sx={{ mb: 0.5 }}>
+                        Missed {idx + 1}
+                      </Typography>
+                      <Typography variant="body1" sx={{ mb: 1.5 }}>
+                        {pq.prompt}
+                      </Typography>
+                      <Box
+                        sx={{
+                          p: 1.5,
+                          mb: 1,
+                          border: `1px solid ${colorTokens.divider}`,
+                          borderLeft: `4px solid ${colorTokens.error.main}`,
+                          backgroundColor: alpha(colorTokens.error.main, 0.08),
+                          borderRadius: `0 ${radiusTokens.sm}px ${radiusTokens.sm}px 0`,
+                        }}
+                      >
+                        <Typography variant="body2" sx={{ mb: 0.5 }}>
+                          Your answer:{' '}
+                          {pq.userAnswer
+                            ? `${pq.userAnswer}. ${q?.choices[pq.userAnswer] ?? ''}`
+                            : 'No answer given'}
+                        </Typography>
+                        <Typography
+                          variant="body2"
+                          sx={{ color: colorTokens.success.main }}
+                        >
+                          Correct: {pq.correctAnswer}. {q?.choices[pq.correctAnswer] ?? ''}
+                        </Typography>
+                      </Box>
+                      <Typography variant="body2" sx={{ fontStyle: 'italic', mb: 1 }}>
+                        {pq.explanation}
+                      </Typography>
+                      <Button
+                        component={RouterLink}
+                        to={lessonUrl}
+                        variant="text"
+                        size="small"
+                        sx={{ pl: 0 }}
+                      >
+                        Back to Lesson
+                      </Button>
+                      {idx < arr.length - 1 && <Divider sx={{ mt: 2 }} />}
+                    </Box>
+                  );
+                })}
+            </>
+          )}
         </Box>
       )}
-
-      <Dialog open={pendingLessonId !== null} onClose={handleCancelSwitch}>
-        <DialogTitle>Switch Lesson?</DialogTitle>
-        <DialogContent>
-          <DialogContentText>
-            Your current quiz progress will be lost. Switch to the new lesson?
-          </DialogContentText>
-        </DialogContent>
-        <DialogActions>
-          <Button onClick={handleCancelSwitch}>Cancel</Button>
-          <Button onClick={handleConfirmSwitch} variant="contained">
-            Switch
-          </Button>
-        </DialogActions>
-      </Dialog>
     </Container>
   );
 }

--- a/web-app/src/theme.ts
+++ b/web-app/src/theme.ts
@@ -36,6 +36,9 @@ const theme = createTheme({
     success: {
       main: colorTokens.success.main,
     },
+    error: {
+      main: colorTokens.error.main,
+    },
     text: {
       primary: colorTokens.text.primary,
       secondary: colorTokens.text.secondary,

--- a/web-app/src/tokens.ts
+++ b/web-app/src/tokens.ts
@@ -20,6 +20,9 @@ export const colorTokens = {
   success: {
     main: '#4caf50',
   },
+  error: {
+    main: '#ef4444',
+  },
   text: {
     primary: '#ffffff',
     secondary: 'rgba(255,255,255,0.65)',


### PR DESCRIPTION
Closes #174

## Changes

- **`web-app/src/components/QuizOption.tsx`** (new): Full-width answer card component with 4px left-border accent, `translateY(-1px)` hover lift, state-based coloring (`default` / `selected` / `correct` / `wrong`) and ≥48px tap target. All colors sourced from `colorTokens`/`typographyTokens` — no hex literals.
- **`web-app/src/components/QuizRunner.tsx`**: Added optional `renderOption` prop (`QuizOptionRenderProps`) for pluggable option rendering; backward-compatible (LessonQuiz.tsx unaffected, defaults to existing MUI Radio when prop is omitted).
- **`web-app/src/pages/Exam.tsx`**: Full retrofit —
  - Topic filter chips (All · Air Law · Navigation · Meteorology · General Knowledge) narrow the lesson selector
  - Lesson selector is now a card list with lesson ID (monospace overline), title, question count, and "Last score: X/Y" drawn from `quizHistory` in localStorage
  - Inline confirm panel replaces MUI Dialog for in-quiz lesson switch
  - Quiz phase renders answers via `QuizOption` (amber selected → green/red on submit)
  - Results screen shows score gauge, "Try Again" / "Open this Lesson" / "Try Another" actions, and missed-question details with explanation + "Back to Lesson" link per question
  - `handleQuizComplete` now calls `store.recordQuizAttempt()` (stores correct+total for X/Y display) instead of only `setLastExamScore`
- **`web-app/src/tokens.ts`** + **`web-app/src/theme.ts`**: Added `error` color token (`#ef4444` per design brief) and wired into MUI palette.

## Test Plan

- [ ] `npm run build` in `web-app/` passes with no TypeScript errors ✓ (verified locally)
- [ ] Topic filter chips narrow lesson list; selecting "Air Law" shows only AL-* lessons
- [ ] Clicking a lesson card highlights it (amber left border) and reveals "Start" button
- [ ] Last score shows "Last score: X/Y" on subsequent attempts
- [ ] During quiz, answer options render as QuizOption cards (not radio buttons); selecting turns amber, submitting turns green/red
- [ ] Switching lesson during quiz shows inline confirm (not MUI Dialog)
- [ ] Results screen shows score gauge, action buttons, and missed-questions section with "Back to Lesson" links
- [ ] LessonQuiz.tsx unaffected — still uses default MUI Radio rendering via QuizRunner
- [ ] No horizontal scroll at 360px viewport width