### PR TITLE
[PPL-171] add back-to-lesson button to visual pages

### DIFF
--- a/docs/visuals-standards.md
+++ b/docs/visuals-standards.md
@@ -138,6 +138,62 @@ produce and meaningfully aids recall.
 
 Set `visual: null` in frontmatter if a lesson has no visual.
 
+## Back-link required
+
+Every visual HTML file **must** include a fixed "← Back to lesson" button injected
+immediately after `<body>`. This allows the user to return to the lesson view when
+the visual is opened in a new tab or iframe.
+
+### Canonical snippet
+
+```html
+<button
+  data-backlink="true"
+  onclick="if(window.history.length<=1){window.close();}else{window.history.back();}"
+  style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:#f0c040;border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);"
+  aria-label="Back to lesson"
+>&#8592; Back to lesson</button>
+<style>.container{padding-top:56px!important;}@media(max-width:480px){.container{padding-top:60px!important;}}</style>
+```
+
+### Styling rules
+
+| Property | Value | Reason |
+|---|---|---|
+| Background | `rgba(13,27,42,0.9)` | Dark-aviation palette with slight transparency |
+| Text colour | `#f0c040` | Amber accent — matches palette |
+| Font size | `14px` minimum | Legible at arm's length |
+| Touch target | `min-width:44px; min-height:44px` | WCAG 2.5.5 minimum |
+| Position | `fixed; top:12px; left:12px; z-index:9999` | Always visible, top-left corner |
+| `backdrop-filter` | `blur(4px)` | Keeps button readable over any content |
+
+### Detection / idempotency
+
+The `data-backlink="true"` attribute is the canonical marker. Use this to detect
+whether the button has already been injected before adding it — the script
+`scripts/add-visual-backlink.sh` handles this automatically.
+
+### Padding for `.container` elements
+
+The injected `<style>` block forces `padding-top: 56px` (60 px on narrow viewports)
+on any `.container` element so the fixed button does not overlap page content.
+Files that use `body` padding directly (no `.container` class) are unaffected
+and need no additional adjustment.
+
+### Adding the back-link to new visuals
+
+Run the script against any new file before committing:
+
+```bash
+bash scripts/add-visual-backlink.sh web-app/public/visuals/your-new-file.html
+```
+
+Or to process all files at once:
+
+```bash
+bash scripts/add-visual-backlink.sh
+```
+
 ## Hard NOs
 
 - **No identifiable people.** No photographs, illustrations, or avatars depicting

--- a/scripts/add-visual-backlink.sh
+++ b/scripts/add-visual-backlink.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Idempotently injects a back-to-lesson button into visual HTML files.
+# Usage: ./scripts/add-visual-backlink.sh [file1.html file2.html ...]
+# If no arguments given, processes all files in web-app/public/visuals/*.html
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+VISUALS_DIR="$REPO_ROOT/web-app/public/visuals"
+
+MARKER='data-backlink="true"'
+
+BACKLINK_BUTTON='  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:#f0c040;border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>'
+BACKLINK_STYLE='  <style>.container{padding-top:56px!important;}@media(max-width:480px){.container{padding-top:60px!important;}}</style>'
+
+FILES=("$@")
+if [ ${#FILES[@]} -eq 0 ]; then
+  while IFS= read -r f; do FILES+=("$f"); done < <(find "$VISUALS_DIR" -maxdepth 1 -name "*.html" | sort)
+fi
+
+INJECTED=0
+SKIPPED=0
+
+for file in "${FILES[@]}"; do
+  if ! [ -f "$file" ]; then
+    echo "WARN: not found: $file" >&2
+    continue
+  fi
+
+  if grep -qF "$MARKER" "$file"; then
+    SKIPPED=$((SKIPPED + 1))
+    continue
+  fi
+
+  # Inject after <body> using Python to avoid Perl variable interpolation issues
+  python3 - "$file" "$BACKLINK_BUTTON" "$BACKLINK_STYLE" <<'PYEOF'
+import sys, re
+path, button, style = sys.argv[1], sys.argv[2], sys.argv[3]
+with open(path, 'r', encoding='utf-8') as f:
+    content = f.read()
+injection = '\n' + button + '\n' + style
+new_content = re.sub(r'(<body[^>]*>)', r'\1' + injection, content, count=1)
+with open(path, 'w', encoding='utf-8') as f:
+    f.write(new_content)
+PYEOF
+
+  INJECTED=$((INJECTED + 1))
+  echo "injected: $file"
+done
+
+echo ""
+echo "Done — injected: $INJECTED, already present (skipped): $SKIPPED"

--- a/web-app/public/visuals/al001-airspace-classifications.html
+++ b/web-app/public/visuals/al001-airspace-classifications.html
@@ -47,6 +47,8 @@
 </style>
 </head>
 <body>
+  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:#f0c040;border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
+  <style>.container{padding-top:56px!important;}@media(max-width:480px){.container{padding-top:60px!important;}}</style>
 
 <h1>AL-001 — Canadian Airspace Classifications</h1>
 <p class="subtitle">Transport Canada · CARs Part VI, TP 12880E Ch.7 · PPL Written Exam</p>

--- a/web-app/public/visuals/al002-controlled-vs-uncontrolled.html
+++ b/web-app/public/visuals/al002-controlled-vs-uncontrolled.html
@@ -45,6 +45,8 @@
 </style>
 </head>
 <body>
+  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:#f0c040;border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
+  <style>.container{padding-top:56px!important;}@media(max-width:480px){.container{padding-top:60px!important;}}</style>
 
 <h1>AL-002 — Controlled vs Uncontrolled Airspace</h1>
 <p class="subtitle">Transport Canada · CARs Part VI, TP 12880E Ch.7 · PPL Written Exam</p>

--- a/web-app/public/visuals/al003-vfr-weather-minimums.html
+++ b/web-app/public/visuals/al003-vfr-weather-minimums.html
@@ -105,6 +105,8 @@
 </style>
 </head>
 <body>
+  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:#f0c040;border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
+  <style>.container{padding-top:56px!important;}@media(max-width:480px){.container{padding-top:60px!important;}}</style>
 
 <h1>AL-003 — VFR Weather Minimums</h1>
 <p class="subtitle">Transport Canada · CARs 602.114–602.117 · PPL Written Exam</p>

--- a/web-app/public/visuals/al004-altimeter-settings.html
+++ b/web-app/public/visuals/al004-altimeter-settings.html
@@ -39,6 +39,8 @@
 </style>
 </head>
 <body>
+  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:#f0c040;border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
+  <style>.container{padding-top:56px!important;}@media(max-width:480px){.container{padding-top:60px!important;}}</style>
 
 <h1>AL-004 — Altimeter Settings</h1>
 <p class="subtitle">Transport Canada · CARs 602.35, TP 12880E Ch.8, AIM RAC 9.11 · PPL Written Exam</p>

--- a/web-app/public/visuals/al005-right-of-way-rules.html
+++ b/web-app/public/visuals/al005-right-of-way-rules.html
@@ -44,6 +44,8 @@
 </style>
 </head>
 <body>
+  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:#f0c040;border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
+  <style>.container{padding-top:56px!important;}@media(max-width:480px){.container{padding-top:60px!important;}}</style>
 
 <h1>AL-005 — Right-of-Way Rules</h1>
 <p class="subtitle">Transport Canada · CARs 602.19–602.21, TP 12880E · PPL Written Exam</p>

--- a/web-app/public/visuals/al006-aerodrome-traffic-circuit.html
+++ b/web-app/public/visuals/al006-aerodrome-traffic-circuit.html
@@ -73,6 +73,8 @@
 </style>
 </head>
 <body>
+  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:#f0c040;border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
+  <style>.container{padding-top:56px!important;}@media(max-width:480px){.container{padding-top:60px!important;}}</style>
 
 <h1>AL-006 — Aerodrome Traffic Circuit</h1>
 <p class="subtitle">Transport Canada · CARs 602.96, 602.105, TP 12880E, AIM RAC 4.5 · PPL Written Exam</p>

--- a/web-app/public/visuals/al007-radio-communications.html
+++ b/web-app/public/visuals/al007-radio-communications.html
@@ -44,6 +44,8 @@
 </style>
 </head>
 <body>
+  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:#f0c040;border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
+  <style>.container{padding-top:56px!important;}@media(max-width:480px){.container{padding-top:60px!important;}}</style>
 
 <h1>AL-007 — Radio Communications</h1>
 <p class="subtitle">Transport Canada · CARs 602.136, 602.138, TP 12880E, AIM COM 5.0 · PPL Written Exam</p>

--- a/web-app/public/visuals/al008-atc-services-clearances.html
+++ b/web-app/public/visuals/al008-atc-services-clearances.html
@@ -64,6 +64,8 @@
 </style>
 </head>
 <body>
+  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:#f0c040;border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
+  <style>.container{padding-top:56px!important;}@media(max-width:480px){.container{padding-top:60px!important;}}</style>
 
 <h1>AL-008 — ATC Services and Clearances</h1>
 <p class="subtitle">Transport Canada · CARs 602.31, 602.32, 602.136, TP 12880E, AIM RAC 1.0 · PPL Written Exam</p>

--- a/web-app/public/visuals/al014-emergency-procedures-law.html
+++ b/web-app/public/visuals/al014-emergency-procedures-law.html
@@ -49,6 +49,8 @@
 </style>
 </head>
 <body>
+  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:#f0c040;border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
+  <style>.container{padding-top:56px!important;}@media(max-width:480px){.container{padding-top:60px!important;}}</style>
 
 <h1>AL-014 — Emergency Procedures: Distress and Urgency</h1>
 <p class="subtitle">Transport Canada · CARs 602.135 · AIM COM 5.0 · TP 12880E Ch.11 · PPL Written Exam</p>

--- a/web-app/public/visuals/al015-transponder-codes.html
+++ b/web-app/public/visuals/al015-transponder-codes.html
@@ -47,6 +47,8 @@
 </style>
 </head>
 <body>
+  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:#f0c040;border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
+  <style>.container{padding-top:56px!important;}@media(max-width:480px){.container{padding-top:60px!important;}}</style>
 
 <h1>AL-015 — Transponder Codes, Squawks, Mode C Requirements</h1>
 <p class="subtitle">Transport Canada · CARs 601.03, 605.35 · AIM RAC 1.9 · TP 12880E Ch.7 · PPL Written Exam</p>

--- a/web-app/public/visuals/al016-wake-turbulence.html
+++ b/web-app/public/visuals/al016-wake-turbulence.html
@@ -45,6 +45,8 @@
 </style>
 </head>
 <body>
+  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:#f0c040;border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
+  <style>.container{padding-top:56px!important;}@media(max-width:480px){.container{padding-top:60px!important;}}</style>
 
 <h1>AL-016 — Wake Turbulence: Categories, Avoidance, Timing</h1>
 <p class="subtitle">Transport Canada · CARs 602.19 · AIM AIR 2.0 · TP 12880E Ch.12 · PPL Written Exam</p>

--- a/web-app/public/visuals/al017-low-level-flight-rules.html
+++ b/web-app/public/visuals/al017-low-level-flight-rules.html
@@ -39,6 +39,8 @@
 </style>
 </head>
 <body>
+  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:#f0c040;border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
+  <style>.container{padding-top:56px!important;}@media(max-width:480px){.container{padding-top:60px!important;}}</style>
 
 <h1>AL-017 — Low-Level Flight Rules: 500 ft Rule, Congested Areas, Noise Abatement</h1>
 <p class="subtitle">Transport Canada · CARs 602.13–602.15 · AIM AIR 1.0 · TP 12880E Ch.10 · PPL Written Exam</p>

--- a/web-app/public/visuals/al018-special-use-airspace.html
+++ b/web-app/public/visuals/al018-special-use-airspace.html
@@ -55,6 +55,8 @@
 </style>
 </head>
 <body>
+  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:#f0c040;border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
+  <style>.container{padding-top:56px!important;}@media(max-width:480px){.container{padding-top:60px!important;}}</style>
 
 <h1>AL-018 — Special Use Airspace: Class F(R), MOAs, ADIZs</h1>
 <p class="subtitle">Transport Canada · CARs 601.14–601.17 · AIM RAC 2.8, 9.0 · TP 12880E Ch.7 · PPL Written Exam</p>

--- a/web-app/public/visuals/gk001-aircraft-parts-controls.html
+++ b/web-app/public/visuals/gk001-aircraft-parts-controls.html
@@ -25,6 +25,8 @@
 </style>
 </head>
 <body>
+  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:#f0c040;border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
+  <style>.container{padding-top:56px!important;}@media(max-width:480px){.container{padding-top:60px!important;}}</style>
 <div class="container">
   <h1>GK-001 — Aircraft Parts &amp; Controls</h1>
   <p class="subtitle">Transport Canada · TP 12880E · PPL Written Exam</p>

--- a/web-app/public/visuals/gk002-four-forces.html
+++ b/web-app/public/visuals/gk002-four-forces.html
@@ -28,6 +28,8 @@
 </style>
 </head>
 <body>
+  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:#f0c040;border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
+  <style>.container{padding-top:56px!important;}@media(max-width:480px){.container{padding-top:60px!important;}}</style>
 <div class="container">
   <h1>GK-002 — Four Forces of Flight</h1>
   <p class="subtitle">Transport Canada · TP 12880E · PPL Written Exam</p>

--- a/web-app/public/visuals/gk003-piston-engines.html
+++ b/web-app/public/visuals/gk003-piston-engines.html
@@ -28,6 +28,8 @@
 </style>
 </head>
 <body>
+  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:#f0c040;border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
+  <style>.container{padding-top:56px!important;}@media(max-width:480px){.container{padding-top:60px!important;}}</style>
 <div class="container">
   <h1>GK-003 — Piston Engine: Four-Stroke Cycle</h1>
   <p class="subtitle">Transport Canada · TP 12880E · PPL Written Exam</p>

--- a/web-app/public/visuals/gk004-fuel-system.html
+++ b/web-app/public/visuals/gk004-fuel-system.html
@@ -26,6 +26,8 @@
 </style>
 </head>
 <body>
+  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:#f0c040;border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
+  <style>.container{padding-top:56px!important;}@media(max-width:480px){.container{padding-top:60px!important;}}</style>
 <div class="container">
   <h1>GK-004 — Fuel System</h1>
   <p class="subtitle">Transport Canada · TP 12880E · PPL Written Exam</p>

--- a/web-app/public/visuals/gk005-electrical-system.html
+++ b/web-app/public/visuals/gk005-electrical-system.html
@@ -22,6 +22,8 @@
 </style>
 </head>
 <body>
+  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:#f0c040;border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
+  <style>.container{padding-top:56px!important;}@media(max-width:480px){.container{padding-top:60px!important;}}</style>
 <div class="container">
   <h1>GK-005 — Electrical System</h1>
   <p class="subtitle">Transport Canada · TP 12880E · PPL Written Exam</p>

--- a/web-app/public/visuals/gk006-pitot-static-instruments.html
+++ b/web-app/public/visuals/gk006-pitot-static-instruments.html
@@ -24,6 +24,8 @@
 </style>
 </head>
 <body>
+  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:#f0c040;border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
+  <style>.container{padding-top:56px!important;}@media(max-width:480px){.container{padding-top:60px!important;}}</style>
 <div class="container">
   <h1>GK-006 — Pitot-Static System</h1>
   <p class="subtitle">Transport Canada · TP 12880E · PPL Written Exam</p>

--- a/web-app/public/visuals/gk007-gyroscopic-instruments.html
+++ b/web-app/public/visuals/gk007-gyroscopic-instruments.html
@@ -26,6 +26,8 @@
 </style>
 </head>
 <body>
+  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:#f0c040;border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
+  <style>.container{padding-top:56px!important;}@media(max-width:480px){.container{padding-top:60px!important;}}</style>
 <div class="container">
   <h1>GK-007 — Gyroscopic Instruments</h1>
   <p class="subtitle">Transport Canada · TP 12880E · PPL Written Exam</p>

--- a/web-app/public/visuals/gk008-engine-instruments.html
+++ b/web-app/public/visuals/gk008-engine-instruments.html
@@ -27,6 +27,8 @@
 </style>
 </head>
 <body>
+  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:#f0c040;border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
+  <style>.container{padding-top:56px!important;}@media(max-width:480px){.container{padding-top:60px!important;}}</style>
 <div class="container">
   <h1>GK-008 — Engine Instruments Panel</h1>
   <p class="subtitle">Transport Canada · TP 12880E · PPL Written Exam</p>

--- a/web-app/public/visuals/gk009-weight-and-balance.html
+++ b/web-app/public/visuals/gk009-weight-and-balance.html
@@ -28,6 +28,8 @@
 </style>
 </head>
 <body>
+  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:#f0c040;border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
+  <style>.container{padding-top:56px!important;}@media(max-width:480px){.container{padding-top:60px!important;}}</style>
 <div class="container">
   <h1>GK-009 — Weight &amp; Balance</h1>
   <p class="subtitle">Transport Canada · TP 12880E · PPL Written Exam</p>

--- a/web-app/public/visuals/gk010-performance-charts.html
+++ b/web-app/public/visuals/gk010-performance-charts.html
@@ -30,6 +30,8 @@
 </style>
 </head>
 <body>
+  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:#f0c040;border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
+  <style>.container{padding-top:56px!important;}@media(max-width:480px){.container{padding-top:60px!important;}}</style>
 <div class="container">
   <h1>GK-010 — Performance Charts Reference</h1>
   <p class="subtitle">Transport Canada · TP 12880E · PPL Written Exam</p>

--- a/web-app/public/visuals/gk011-takeoff-landing-perf.html
+++ b/web-app/public/visuals/gk011-takeoff-landing-perf.html
@@ -27,6 +27,8 @@
 </style>
 </head>
 <body>
+  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:#f0c040;border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
+  <style>.container{padding-top:56px!important;}@media(max-width:480px){.container{padding-top:60px!important;}}</style>
 <div class="container">
   <h1>GK-011 — Takeoff &amp; Landing Performance</h1>
   <p class="subtitle">Transport Canada · TP 12880E · PPL Written Exam</p>

--- a/web-app/public/visuals/gk012-stalls-spins.html
+++ b/web-app/public/visuals/gk012-stalls-spins.html
@@ -32,6 +32,8 @@
 </style>
 </head>
 <body>
+  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:#f0c040;border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
+  <style>.container{padding-top:56px!important;}@media(max-width:480px){.container{padding-top:60px!important;}}</style>
 <div class="container">
   <h1>GK-012 — Stalls &amp; Spins</h1>
   <p class="subtitle">Transport Canada · TP 12880E · PPL Written Exam</p>

--- a/web-app/public/visuals/gk013-load-factor.html
+++ b/web-app/public/visuals/gk013-load-factor.html
@@ -31,6 +31,8 @@
 </style>
 </head>
 <body>
+  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:#f0c040;border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
+  <style>.container{padding-top:56px!important;}@media(max-width:480px){.container{padding-top:60px!important;}}</style>
 <div class="container">
   <h1>GK-013 — Load Factor &amp; Maneuvering Speed</h1>
   <p class="subtitle">Transport Canada · TP 12880E · PPL Written Exam</p>

--- a/web-app/public/visuals/gk014-preflight-inspection.html
+++ b/web-app/public/visuals/gk014-preflight-inspection.html
@@ -31,6 +31,8 @@
 </style>
 </head>
 <body>
+  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:#f0c040;border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
+  <style>.container{padding-top:56px!important;}@media(max-width:480px){.container{padding-top:60px!important;}}</style>
 <div class="container">
   <h1>GK-014 — Preflight Inspection Walkaround</h1>
   <p class="subtitle">Transport Canada · TP 12880E · PPL Written Exam</p>

--- a/web-app/public/visuals/met001-atmosphere-structure.html
+++ b/web-app/public/visuals/met001-atmosphere-structure.html
@@ -31,6 +31,8 @@
 </style>
 </head>
 <body>
+  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:#f0c040;border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
+  <style>.container{padding-top:56px!important;}@media(max-width:480px){.container{padding-top:60px!important;}}</style>
 <div class="container">
   <h1>MET-001 — Atmosphere Structure</h1>
   <p class="subtitle">Transport Canada · TP 12880E Ch. 8 · AIM MET 1.0</p>

--- a/web-app/public/visuals/met002-temp-pressure-humidity.html
+++ b/web-app/public/visuals/met002-temp-pressure-humidity.html
@@ -28,6 +28,8 @@
 </style>
 </head>
 <body>
+  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:#f0c040;border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
+  <style>.container{padding-top:56px!important;}@media(max-width:480px){.container{padding-top:60px!important;}}</style>
 <div class="container">
   <h1>MET-002 — Temperature, Pressure, Humidity</h1>
   <p class="subtitle">Transport Canada · TP 12880E · AIM MET 2.0</p>

--- a/web-app/public/visuals/met003-clouds-types.html
+++ b/web-app/public/visuals/met003-clouds-types.html
@@ -39,6 +39,8 @@
 </style>
 </head>
 <body>
+  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:#f0c040;border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
+  <style>.container{padding-top:56px!important;}@media(max-width:480px){.container{padding-top:60px!important;}}</style>
 <div class="container">
   <h1>MET-003 — Cloud Types &amp; Formation</h1>
   <p class="subtitle">Transport Canada · TP 12880E · AIM MET 2.0</p>

--- a/web-app/public/visuals/met004-fog-types.html
+++ b/web-app/public/visuals/met004-fog-types.html
@@ -27,6 +27,8 @@
 </style>
 </head>
 <body>
+  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:#f0c040;border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
+  <style>.container{padding-top:56px!important;}@media(max-width:480px){.container{padding-top:60px!important;}}</style>
 <div class="container">
   <h1>MET-004 — Fog Formation &amp; Types</h1>
   <p class="subtitle">Transport Canada · TP 12880E · AIM MET 2.0 · Fog = visibility &lt; ½ SM (vs mist/BR)</p>

--- a/web-app/public/visuals/met005-metar-decoding.html
+++ b/web-app/public/visuals/met005-metar-decoding.html
@@ -39,6 +39,8 @@
 </style>
 </head>
 <body>
+  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:#f0c040;border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
+  <style>.container{padding-top:56px!important;}@media(max-width:480px){.container{padding-top:60px!important;}}</style>
 <div class="container">
   <h1>MET-005 — METAR Decoding</h1>
   <p class="subtitle">Transport Canada · TP 12880E · AIM MET 3.0 · Hourly aerodrome observation</p>

--- a/web-app/public/visuals/met006-taf-decoding.html
+++ b/web-app/public/visuals/met006-taf-decoding.html
@@ -42,6 +42,8 @@
 </style>
 </head>
 <body>
+  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:#f0c040;border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
+  <style>.container{padding-top:56px!important;}@media(max-width:480px){.container{padding-top:60px!important;}}</style>
 <div class="container">
   <h1>MET-006 — TAF Decoding</h1>
   <p class="subtitle">Transport Canada · TP 12880E · AIM MET 3.7 · 5 NM / 24 h aerodrome forecast</p>

--- a/web-app/public/visuals/met007-gfa.html
+++ b/web-app/public/visuals/met007-gfa.html
@@ -32,6 +32,8 @@
 </style>
 </head>
 <body>
+  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:#f0c040;border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
+  <style>.container{padding-top:56px!important;}@media(max-width:480px){.container{padding-top:60px!important;}}</style>
 <div class="container">
   <h1>MET-007 — Graphical Forecast for Aviation (GFA)</h1>
   <p class="subtitle">NAV CANADA · AIM MET 3.5 · Surface to 24,000 ft · 7 GFA regions over Canada</p>

--- a/web-app/public/visuals/met008-pireps.html
+++ b/web-app/public/visuals/met008-pireps.html
@@ -38,6 +38,8 @@
 </style>
 </head>
 <body>
+  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:#f0c040;border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
+  <style>.container{padding-top:56px!important;}@media(max-width:480px){.container{padding-top:60px!important;}}</style>
 <div class="container">
   <h1>MET-008 — PIREPs &amp; Advisories</h1>
   <p class="subtitle">Transport Canada · TP 12880E · AIM MET 3.8 · Pilot Reports in the NAV CANADA network</p>

--- a/web-app/public/visuals/met009-thunderstorms.html
+++ b/web-app/public/visuals/met009-thunderstorms.html
@@ -30,6 +30,8 @@
 </style>
 </head>
 <body>
+  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:#f0c040;border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
+  <style>.container{padding-top:56px!important;}@media(max-width:480px){.container{padding-top:60px!important;}}</style>
 <div class="container">
   <h1>MET-009 — Thunderstorms</h1>
   <p class="subtitle">Transport Canada · TP 12880E · AIM MET 2.8 · Avoid by 20 NM</p>

--- a/web-app/public/visuals/met010-icing.html
+++ b/web-app/public/visuals/met010-icing.html
@@ -31,6 +31,8 @@
 </style>
 </head>
 <body>
+  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:#f0c040;border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
+  <style>.container{padding-top:56px!important;}@media(max-width:480px){.container{padding-top:60px!important;}}</style>
 <div class="container">
   <h1>MET-010 — Structural Icing</h1>
   <p class="subtitle">Transport Canada · TP 12880E · AIM MET 2.4 · Two conditions required: visible moisture + OAT ≤ 0 °C</p>

--- a/web-app/public/visuals/met011-turbulence.html
+++ b/web-app/public/visuals/met011-turbulence.html
@@ -34,6 +34,8 @@
 </style>
 </head>
 <body>
+  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:#f0c040;border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
+  <style>.container{padding-top:56px!important;}@media(max-width:480px){.container{padding-top:60px!important;}}</style>
 <div class="container">
   <h1>MET-011 — Turbulence</h1>
   <p class="subtitle">Transport Canada · TP 12880E · AIM MET 2.6</p>

--- a/web-app/public/visuals/met012-wind-shear-microburst.html
+++ b/web-app/public/visuals/met012-wind-shear-microburst.html
@@ -27,6 +27,8 @@
 </style>
 </head>
 <body>
+  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:#f0c040;border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
+  <style>.container{padding-top:56px!important;}@media(max-width:480px){.container{padding-top:60px!important;}}</style>
 <div class="container">
   <h1>MET-012 — Wind Shear &amp; Microburst</h1>
   <p class="subtitle">Transport Canada · TP 12880E · AIM MET 2.7 · LLWS = within 2,000 ft AGL</p>

--- a/web-app/public/visuals/met013-fronts.html
+++ b/web-app/public/visuals/met013-fronts.html
@@ -29,6 +29,8 @@
 </style>
 </head>
 <body>
+  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:#f0c040;border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
+  <style>.container{padding-top:56px!important;}@media(max-width:480px){.container{padding-top:60px!important;}}</style>
 <div class="container">
   <h1>MET-013 — Fronts</h1>
   <p class="subtitle">Transport Canada · TP 12880E · AIM MET 2.3 · Boundary between two air masses</p>

--- a/web-app/public/visuals/met014-wx-decision-making.html
+++ b/web-app/public/visuals/met014-wx-decision-making.html
@@ -39,6 +39,8 @@
 </style>
 </head>
 <body>
+  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:#f0c040;border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
+  <style>.container{padding-top:56px!important;}@media(max-width:480px){.container{padding-top:60px!important;}}</style>
 <div class="container">
   <h1>MET-014 — Weather Decision-Making</h1>
   <p class="subtitle">Transport Canada · TP 12880E · CARs 602.71 · Pre-flight &amp; in-flight decision framework</p>

--- a/web-app/public/visuals/nav001-vfr-charts.html
+++ b/web-app/public/visuals/nav001-vfr-charts.html
@@ -89,6 +89,8 @@
 </style>
 </head>
 <body>
+  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:#f0c040;border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
+  <style>.container{padding-top:56px!important;}@media(max-width:480px){.container{padding-top:60px!important;}}</style>
 
 <h1>NAV-001 — VFR Aeronautical Charts: Reading the Map</h1>
 <p class="subtitle">Transport Canada · TP 12880E Ch.9, TP 9994 VFR Chart User's Guide · PPL Written Exam</p>

--- a/web-app/public/visuals/nav002-lat-lon-map-reading.html
+++ b/web-app/public/visuals/nav002-lat-lon-map-reading.html
@@ -46,6 +46,8 @@
 </style>
 </head>
 <body>
+  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:#f0c040;border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
+  <style>.container{padding-top:56px!important;}@media(max-width:480px){.container{padding-top:60px!important;}}</style>
 
 <h1>NAV-002 — Latitude, Longitude, and Map Reading</h1>
 <p class="subtitle">Transport Canada · TP 12880E Ch.9, TP 9994 VFR Chart User's Guide · PPL Written Exam</p>

--- a/web-app/public/visuals/nav003-true-magnetic-compass.html
+++ b/web-app/public/visuals/nav003-true-magnetic-compass.html
@@ -30,6 +30,8 @@
 </style>
 </head>
 <body>
+  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:#f0c040;border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
+  <style>.container{padding-top:56px!important;}@media(max-width:480px){.container{padding-top:60px!important;}}</style>
 <h1>NAV-003 — True vs Magnetic vs Compass Heading</h1>
 <p class="subtitle">Transport Canada · TP 12880E Ch.9 · AIM GEN 1.1 · PPL Written Exam</p>
 

--- a/web-app/public/visuals/nav004-dead-reckoning-basics.html
+++ b/web-app/public/visuals/nav004-dead-reckoning-basics.html
@@ -36,6 +36,8 @@
 </style>
 </head>
 <body>
+  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:#f0c040;border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
+  <style>.container{padding-top:56px!important;}@media(max-width:480px){.container{padding-top:60px!important;}}</style>
 
 <h1>NAV-004 — Dead Reckoning Basics</h1>
 <p class="subtitle">Transport Canada · TP 12880E Ch.9 · PPL Written Exam</p>

--- a/web-app/public/visuals/nav005-wind-correction-angle.html
+++ b/web-app/public/visuals/nav005-wind-correction-angle.html
@@ -36,6 +36,8 @@
 </style>
 </head>
 <body>
+  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:#f0c040;border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
+  <style>.container{padding-top:56px!important;}@media(max-width:480px){.container{padding-top:60px!important;}}</style>
 
 <h1>NAV-005 — Wind Correction Angle and Ground Speed</h1>
 <p class="subtitle">Transport Canada · TP 12880E Ch.9 · PPL Written Exam</p>

--- a/web-app/public/visuals/nav006-time-speed-distance.html
+++ b/web-app/public/visuals/nav006-time-speed-distance.html
@@ -37,6 +37,8 @@
 </style>
 </head>
 <body>
+  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:#f0c040;border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
+  <style>.container{padding-top:56px!important;}@media(max-width:480px){.container{padding-top:60px!important;}}</style>
 
 <h1>NAV-006 — Time-Speed-Distance Calculations</h1>
 <p class="subtitle">Transport Canada · TP 12880E Ch.9 · PPL Written Exam</p>

--- a/web-app/public/visuals/nav007-fuel-planning.html
+++ b/web-app/public/visuals/nav007-fuel-planning.html
@@ -37,6 +37,8 @@
 </style>
 </head>
 <body>
+  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:#f0c040;border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
+  <style>.container{padding-top:56px!important;}@media(max-width:480px){.container{padding-top:60px!important;}}</style>
 
 <h1>NAV-007 — Fuel Planning</h1>
 <p class="subtitle">Transport Canada · TP 12880E Ch.9 · PPL Written Exam</p>

--- a/web-app/public/visuals/nav008-cross-country-planning.html
+++ b/web-app/public/visuals/nav008-cross-country-planning.html
@@ -37,6 +37,8 @@
 </style>
 </head>
 <body>
+  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:#f0c040;border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
+  <style>.container{padding-top:56px!important;}@media(max-width:480px){.container{padding-top:60px!important;}}</style>
 
 <h1>NAV-008 — Cross-Country Planning</h1>
 <p class="subtitle">Transport Canada · TP 12880E Ch.9 · PPL Written Exam</p>

--- a/web-app/public/visuals/nav009-pilotage.html
+++ b/web-app/public/visuals/nav009-pilotage.html
@@ -32,6 +32,8 @@
 </style>
 </head>
 <body>
+  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:#f0c040;border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
+  <style>.container{padding-top:56px!important;}@media(max-width:480px){.container{padding-top:60px!important;}}</style>
 <div class="container">
   <h1>NAV-009 — Pilotage — Navigating by Ground Reference</h1>
   <div class="subtitle">Transport Canada · TP 12880E Ch.9 · PPL Written Exam</div>

--- a/web-app/public/visuals/nav010-vor-navigation.html
+++ b/web-app/public/visuals/nav010-vor-navigation.html
@@ -28,6 +28,8 @@
 </style>
 </head>
 <body>
+  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:#f0c040;border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
+  <style>.container{padding-top:56px!important;}@media(max-width:480px){.container{padding-top:60px!important;}}</style>
 <div class="container">
   <h1>NAV-010 — VOR Navigation</h1>
   <div class="subtitle">Transport Canada · TP 12880E Ch.9 · AIM RAC 1.5 · PPL Written Exam</div>

--- a/web-app/public/visuals/nav011-gps-basics.html
+++ b/web-app/public/visuals/nav011-gps-basics.html
@@ -31,6 +31,8 @@
 </style>
 </head>
 <body>
+  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:#f0c040;border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
+  <style>.container{padding-top:56px!important;}@media(max-width:480px){.container{padding-top:60px!important;}}</style>
 <div class="container">
   <h1>NAV-011 — GPS Basics</h1>
   <div class="subtitle">Transport Canada · TP 12880E Ch.9 · AIM RAC 1.7 · PPL Written Exam</div>

--- a/web-app/public/visuals/nav012-altitude-types.html
+++ b/web-app/public/visuals/nav012-altitude-types.html
@@ -27,6 +27,8 @@
 </style>
 </head>
 <body>
+  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:#f0c040;border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
+  <style>.container{padding-top:56px!important;}@media(max-width:480px){.container{padding-top:60px!important;}}</style>
 <div class="container">
   <h1>NAV-012 — Altitude Types</h1>
   <div class="subtitle">Transport Canada · TP 12880E Ch.9 · PPL Written Exam</div>

--- a/web-app/public/visuals/nav013-density-altitude.html
+++ b/web-app/public/visuals/nav013-density-altitude.html
@@ -29,6 +29,8 @@
 </style>
 </head>
 <body>
+  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:#f0c040;border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
+  <style>.container{padding-top:56px!important;}@media(max-width:480px){.container{padding-top:60px!important;}}</style>
 <div class="container">
   <h1>NAV-013 — Density Altitude</h1>
   <div class="subtitle">Transport Canada · TP 12880E Ch.9 · PPL Written Exam</div>

--- a/web-app/public/visuals/nav014-lost-procedure.html
+++ b/web-app/public/visuals/nav014-lost-procedure.html
@@ -31,6 +31,8 @@
 </style>
 </head>
 <body>
+  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:#f0c040;border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
+  <style>.container{padding-top:56px!important;}@media(max-width:480px){.container{padding-top:60px!important;}}</style>
 <div class="container">
   <h1>NAV-014 — Lost Procedure and Diversion</h1>
   <div class="subtitle">Transport Canada · TP 12880E Ch.9 · PPL Written Exam</div>


### PR DESCRIPTION
## Changes

- Added `scripts/add-visual-backlink.sh` — idempotent script that injects a fixed "← Back to lesson" button into every visual HTML file immediately after `<body>`
- Injected button into all 55 existing visuals in `web-app/public/visuals/*.html`
- Added scoped CSS that applies `padding-top: 56px` to `.container` elements (60 px on narrow viewports) to prevent content overlap with the fixed button
- Updated `docs/visuals-standards.md` with a **Back-link required** section documenting the canonical snippet, styling rules, idempotency marker, and usage instructions

**Button spec:**
- Position: `fixed; top:12px; left:12px; z-index:9999`
- Background: `rgba(13,27,42,0.9)` (dark-aviation palette)
- Text colour: `#f0c040` (amber accent)
- Font size: `14px`; touch target: `min-width:44px; min-height:44px`
- Behaviour: `window.history.back()` with `window.close()` fallback when `history.length <= 1`
- Idempotency marker: `data-backlink="true"`

Closes #171

## Test Plan

- [ ] Open any visual HTML file directly (`file://` or via Firebase Hosting) — "← Back to lesson" button appears in top-left corner
- [ ] Click the button from inside the app — navigates back to lesson view
- [ ] Open visual in a new tab with no history — `window.close()` fires
- [ ] Re-run `bash scripts/add-visual-backlink.sh` — reports 0 injected, 55 skipped (idempotent)
- [ ] `npm run build` inside `web-app/` completes without errors
- [ ] Button does not overlap page content on mobile (360 px viewport)