### PR TITLE
Design lab — Home page visual variants (A · Cockpit / B · Focus / C · Editorial)

### DIFF
--- a/web-app/public/design-lab/index.html
+++ b/web-app/public/design-lab/index.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>PPL Study — Home Page Design Variants</title>
+<style>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body { background: #0d1b2a; color: #e8edf2; font-family: system-ui, sans-serif; padding: 32px 20px; line-height: 1.6; }
+  .wrap { max-width: 720px; margin: 0 auto; }
+  h1 { font-size: 28px; color: #f0c040; margin-bottom: 8px; letter-spacing: -0.01em; }
+  p.lead { color: #9fb2c7; margin-bottom: 36px; }
+  .card { display: block; background: #152437; border: 1px solid #243d52; border-radius: 14px; padding: 22px 24px; margin-bottom: 14px; color: inherit; text-decoration: none; transition: transform 0.12s, border-color 0.12s; }
+  .card:hover { border-color: #f0c040; transform: translateY(-2px); }
+  .card h2 { font-size: 18px; color: #f0c040; margin-bottom: 6px; }
+  .card .tag { font-family: 'SF Mono', Consolas, monospace; font-size: 11px; color: #7a9ab5; letter-spacing: 0.08em; margin-bottom: 10px; text-transform: uppercase; }
+  .card p { color: #cbd7e3; font-size: 14px; }
+  .note { margin-top: 36px; padding: 16px 18px; background: #1a2a3f; border-left: 3px solid #f0c040; border-radius: 6px; font-size: 13px; color: #cbd7e3; }
+</style>
+</head>
+<body>
+<div class="wrap">
+  <h1>Home Page — Visual Direction Lab</h1>
+  <p class="lead">Three complete mockups of the PPL Study home page using your real copy and progress state. Open each on phone and desktop, pick a winner (or mix elements). The chosen direction becomes the spec for the Phase 2 token + component refresh.</p>
+
+  <a class="card" href="variant-a-cockpit.html">
+    <div class="tag">Variant A</div>
+    <h2>Cockpit Briefing</h2>
+    <p>Jeppesen / ForeFlight inspired. Altimeter-style readiness gauge, sharp corners, thin amber lines on navy, monospace tactical labels. High information density. Feels like a pre-flight briefing.</p>
+  </a>
+
+  <a class="card" href="variant-b-focus.html">
+    <div class="tag">Variant B</div>
+    <h2>Focus Study</h2>
+    <p>Linear / Arc / Raycast inspired. Soft-blur surfaces, subtle gradient backdrops, generous whitespace, one big next-action card. 20 px radii. Calm, deliberate mood.</p>
+  </a>
+
+  <a class="card" href="variant-c-editorial.html">
+    <div class="tag">Variant C</div>
+    <h2>Editorial Bold</h2>
+    <p>Stripe / Apple inspired. Huge display typography, high-contrast cards with oversized numerals, a warm accent beyond amber. Scroll-narrative layout.</p>
+  </a>
+
+  <div class="note">
+    <strong>How to decide:</strong> Don't evaluate colors — those are swappable. Judge <em>density</em>, <em>hierarchy</em>, <em>tone</em>. Which one would you actually want to open at 7am to grind through a lesson?
+  </div>
+</div>
+</body>
+</html>

--- a/web-app/public/design-lab/variant-a-cockpit.html
+++ b/web-app/public/design-lab/variant-a-cockpit.html
@@ -1,0 +1,237 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>PPL Study — Variant A · Cockpit Briefing</title>
+<style>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  :root {
+    --bg: #071020;
+    --bg-2: #0d1b2a;
+    --surface: #0f1f33;
+    --surface-2: #142a40;
+    --border: #1a3550;
+    --amber: #f0c040;
+    --amber-dim: #8b6f24;
+    --text: #e4ecf5;
+    --muted: #7a9ab5;
+    --mono: 'SF Mono', 'JetBrains Mono', Consolas, monospace;
+    --sans: 'Inter', system-ui, sans-serif;
+  }
+  body { background: var(--bg); color: var(--text); font-family: var(--sans); font-size: 14px; line-height: 1.55; min-height: 100vh; padding-bottom: 60px; }
+
+  /* Thin grid-paper backdrop */
+  body::before {
+    content: ""; position: fixed; inset: 0; pointer-events: none; z-index: 0;
+    background-image:
+      linear-gradient(rgba(26,53,80,0.15) 1px, transparent 1px),
+      linear-gradient(90deg, rgba(26,53,80,0.15) 1px, transparent 1px);
+    background-size: 40px 40px;
+  }
+
+  .back { position: fixed; top: 14px; left: 14px; background: rgba(15,31,51,0.92); color: var(--amber); border: 1px solid var(--border); padding: 8px 14px; border-radius: 4px; font-family: var(--mono); font-size: 11px; text-decoration: none; letter-spacing: 0.05em; z-index: 10; }
+  .back:hover { border-color: var(--amber); }
+
+  .container { max-width: 1100px; margin: 0 auto; padding: 48px 24px 0; position: relative; z-index: 1; }
+
+  /* Top status bar */
+  .status-bar { display: flex; justify-content: space-between; align-items: center; border-top: 1px solid var(--border); border-bottom: 1px solid var(--border); padding: 10px 0; font-family: var(--mono); font-size: 11px; color: var(--muted); letter-spacing: 0.1em; text-transform: uppercase; margin-bottom: 28px; }
+  .status-bar .dot { display: inline-block; width: 7px; height: 7px; border-radius: 50%; background: #4caf7d; margin-right: 6px; vertical-align: middle; box-shadow: 0 0 6px #4caf7d; }
+  .status-bar .seg { display: flex; gap: 18px; flex-wrap: wrap; }
+  .status-bar .seg span strong { color: var(--amber); margin-left: 6px; font-weight: 600; }
+
+  /* Hero */
+  .hero { display: grid; grid-template-columns: 1.5fr 1fr; gap: 32px; align-items: center; margin-bottom: 36px; }
+  .hero-left .kicker { font-family: var(--mono); font-size: 11px; color: var(--amber); letter-spacing: 0.15em; margin-bottom: 14px; }
+  .hero-left h1 { font-size: 44px; line-height: 1.1; letter-spacing: -0.02em; font-weight: 700; margin-bottom: 14px; }
+  .hero-left h1 .amber { color: var(--amber); }
+  .hero-left p { color: var(--muted); max-width: 460px; margin-bottom: 20px; }
+  .hero-cta { display: inline-flex; gap: 10px; align-items: center; background: var(--amber); color: #0b1726; padding: 12px 22px; border-radius: 3px; text-decoration: none; font-weight: 600; font-family: var(--mono); font-size: 13px; letter-spacing: 0.05em; text-transform: uppercase; }
+  .hero-cta::after { content: "→"; }
+  .hero-cta:hover { background: #ffd155; }
+
+  /* Readiness gauge — altimeter-style */
+  .gauge-card { background: var(--surface); border: 1px solid var(--border); border-radius: 4px; padding: 20px; }
+  .gauge-card .label { font-family: var(--mono); font-size: 10px; color: var(--muted); letter-spacing: 0.15em; margin-bottom: 10px; text-transform: uppercase; }
+  .gauge-wrap { display: flex; align-items: center; gap: 18px; }
+  .gauge-num { font-family: var(--mono); font-size: 52px; color: var(--amber); font-weight: 300; letter-spacing: -0.02em; line-height: 1; }
+  .gauge-num .unit { font-size: 20px; color: var(--muted); margin-left: 2px; }
+  .gauge-meta { font-family: var(--mono); font-size: 11px; color: var(--muted); line-height: 1.8; }
+  .gauge-meta .ok { color: #4caf7d; }
+  .gauge-meta .warn { color: var(--amber); }
+
+  /* Section headers */
+  .section-head { display: flex; align-items: baseline; justify-content: space-between; margin-bottom: 16px; margin-top: 40px; border-bottom: 1px solid var(--border); padding-bottom: 10px; }
+  .section-head h2 { font-family: var(--mono); font-size: 12px; color: var(--muted); letter-spacing: 0.18em; text-transform: uppercase; font-weight: 600; }
+  .section-head .meta { font-family: var(--mono); font-size: 11px; color: var(--amber); }
+
+  /* Topic grid — fuel-gauge style */
+  .topic-grid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 14px; }
+  .topic { background: var(--surface); border: 1px solid var(--border); border-radius: 4px; padding: 16px; position: relative; }
+  .topic .code { font-family: var(--mono); font-size: 10px; color: var(--muted); letter-spacing: 0.1em; }
+  .topic .name { font-size: 15px; font-weight: 600; margin: 6px 0 12px; }
+  .topic .bar { height: 2px; background: #1a2d3d; border-radius: 1px; overflow: hidden; margin-bottom: 8px; }
+  .topic .bar .fill { height: 100%; background: var(--amber); }
+  .topic .stats { display: flex; justify-content: space-between; font-family: var(--mono); font-size: 11px; color: var(--muted); }
+  .topic .stats strong { color: var(--amber); font-weight: 500; }
+
+  /* Next action — NOTAM-like */
+  .notam { background: var(--surface); border: 1px solid var(--amber-dim); border-left: 3px solid var(--amber); padding: 18px 22px; font-family: var(--mono); font-size: 13px; line-height: 1.9; }
+  .notam .stamp { color: var(--amber); letter-spacing: 0.15em; font-size: 10px; text-transform: uppercase; margin-bottom: 6px; }
+  .notam .title { font-size: 18px; color: var(--text); margin-bottom: 10px; font-family: var(--sans); font-weight: 600; letter-spacing: -0.01em; }
+  .notam .meta { color: var(--muted); }
+  .notam .meta span { display: inline-block; margin-right: 22px; }
+  .notam .meta strong { color: var(--text); margin-left: 4px; }
+  .notam .action { margin-top: 14px; display: inline-flex; gap: 8px; color: var(--amber); text-decoration: none; text-transform: uppercase; letter-spacing: 0.1em; font-size: 11px; }
+
+  /* Exam quick-access */
+  .exam-row { display: grid; grid-template-columns: 1fr 1fr; gap: 14px; }
+  .exam-card { background: var(--surface); border: 1px solid var(--border); border-radius: 4px; padding: 18px; text-decoration: none; color: inherit; transition: border-color 0.12s; }
+  .exam-card:hover { border-color: var(--amber); }
+  .exam-card .kind { font-family: var(--mono); font-size: 10px; color: var(--muted); letter-spacing: 0.15em; text-transform: uppercase; margin-bottom: 6px; }
+  .exam-card .title { font-size: 17px; font-weight: 600; margin-bottom: 6px; letter-spacing: -0.01em; }
+  .exam-card .desc { font-size: 12px; color: var(--muted); }
+  .exam-card .arrow { float: right; color: var(--amber); font-family: var(--mono); font-size: 16px; }
+
+  @media (max-width: 760px) {
+    .hero { grid-template-columns: 1fr; }
+    .hero-left h1 { font-size: 32px; }
+    .gauge-num { font-size: 42px; }
+    .topic-grid { grid-template-columns: repeat(2, 1fr); }
+    .exam-row { grid-template-columns: 1fr; }
+    .status-bar { flex-direction: column; gap: 8px; align-items: flex-start; }
+  }
+</style>
+</head>
+<body>
+<a class="back" href="index.html">← all variants</a>
+<div class="container">
+
+  <!-- Status bar -->
+  <div class="status-bar">
+    <div class="seg">
+      <span><span class="dot"></span>SYSTEM READY</span>
+      <span>TRANSPORT CANADA PPL<strong>AEROPLANE</strong></span>
+    </div>
+    <div class="seg">
+      <span>LESSONS<strong>47 / 60</strong></span>
+      <span>LAST SESSION<strong>2H AGO</strong></span>
+    </div>
+  </div>
+
+  <!-- Hero -->
+  <section class="hero">
+    <div class="hero-left">
+      <div class="kicker">PRE-FLIGHT BRIEFING · 20 MIN / DAY</div>
+      <h1>Pass the <span class="amber">PPL written</span><br>exam. Twenty minutes a day.</h1>
+      <p>Structured lessons covering PSTAR and the full Transport Canada syllabus. Audio-first, exam-weighted, built for the cockpit pocket.</p>
+      <a class="hero-cta" href="#">Continue lesson AL-014</a>
+    </div>
+    <div class="gauge-card">
+      <div class="label">⦿ Exam Readiness · Weighted</div>
+      <div class="gauge-wrap">
+        <!-- SVG altimeter-style gauge -->
+        <svg viewBox="0 0 120 120" width="120" height="120" style="flex-shrink: 0;">
+          <circle cx="60" cy="60" r="54" fill="none" stroke="#1a2d3d" stroke-width="1"/>
+          <circle cx="60" cy="60" r="48" fill="none" stroke="#1a3550" stroke-width="6"/>
+          <circle cx="60" cy="60" r="48" fill="none" stroke="#f0c040" stroke-width="6"
+                  stroke-dasharray="301.6" stroke-dashoffset="105.5"
+                  transform="rotate(-90 60 60)" stroke-linecap="butt"/>
+          <!-- Tick marks -->
+          <g stroke="#7a9ab5" stroke-width="1">
+            <line x1="60" y1="6" x2="60" y2="12"/>
+            <line x1="108" y1="60" x2="114" y2="60"/>
+            <line x1="60" y1="108" x2="60" y2="114"/>
+            <line x1="6" y1="60" x2="12" y2="60"/>
+          </g>
+          <!-- Numeric ticks -->
+          <text x="60" y="22" text-anchor="middle" fill="#7a9ab5" font-family="SF Mono, monospace" font-size="7">100</text>
+          <text x="100" y="63" text-anchor="middle" fill="#7a9ab5" font-family="SF Mono, monospace" font-size="7">25</text>
+          <text x="60" y="103" text-anchor="middle" fill="#7a9ab5" font-family="SF Mono, monospace" font-size="7">50</text>
+          <text x="20" y="63" text-anchor="middle" fill="#7a9ab5" font-family="SF Mono, monospace" font-size="7">75</text>
+        </svg>
+        <div>
+          <div class="gauge-num">65<span class="unit">%</span></div>
+          <div class="gauge-meta">
+            <div>AL <span class="ok">78%</span> · NAV <span class="ok">71%</span></div>
+            <div>MET <span class="warn">58%</span> · GK <span class="warn">52%</span></div>
+            <div style="margin-top: 6px; color: var(--amber);">TARGET 80 — DELTA −15</div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Next action -->
+  <div class="section-head">
+    <h2>◆ Next Action</h2>
+    <span class="meta">RESUMING · 2H PAUSE</span>
+  </div>
+  <a href="#" class="notam" style="text-decoration: none; color: inherit; display: block;">
+    <div class="stamp">▸ LESSON AL-014</div>
+    <div class="title">Emergency Procedures — Air Law</div>
+    <div class="meta">
+      <span>DUR<strong>20 MIN</strong></span>
+      <span>AUDIO<strong>READY</strong></span>
+      <span>QUESTIONS<strong>5</strong></span>
+      <span>TOPIC<strong>AIR LAW 14/18</strong></span>
+    </div>
+    <div class="action">▸ BEGIN SESSION</div>
+  </a>
+
+  <!-- Topics -->
+  <div class="section-head">
+    <h2>◆ Topic Coverage · TC Exam Weight</h2>
+    <span class="meta">4 DOMAINS</span>
+  </div>
+  <div class="topic-grid">
+    <div class="topic">
+      <div class="code">AL · 30% WEIGHT</div>
+      <div class="name">Air Law</div>
+      <div class="bar"><div class="fill" style="width: 78%;"></div></div>
+      <div class="stats"><span>14 / 18 lessons</span><strong>78%</strong></div>
+    </div>
+    <div class="topic">
+      <div class="code">NAV · 25% WEIGHT</div>
+      <div class="name">Navigation</div>
+      <div class="bar"><div class="fill" style="width: 71%;"></div></div>
+      <div class="stats"><span>10 / 14 lessons</span><strong>71%</strong></div>
+    </div>
+    <div class="topic">
+      <div class="code">MET · 25% WEIGHT</div>
+      <div class="name">Meteorology</div>
+      <div class="bar"><div class="fill" style="width: 58%;"></div></div>
+      <div class="stats"><span>8 / 14 lessons</span><strong>58%</strong></div>
+    </div>
+    <div class="topic">
+      <div class="code">GK · 20% WEIGHT</div>
+      <div class="name">General Knowledge</div>
+      <div class="bar"><div class="fill" style="width: 52%;"></div></div>
+      <div class="stats"><span>7 / 14 lessons</span><strong>52%</strong></div>
+    </div>
+  </div>
+
+  <!-- Exam quick-access -->
+  <div class="section-head">
+    <h2>◆ Practice &amp; Exam</h2>
+    <span class="meta">2 TRACKS</span>
+  </div>
+  <div class="exam-row">
+    <a class="exam-card" href="#">
+      <span class="arrow">→</span>
+      <div class="kind">★ PSTAR · PRE-SOLO</div>
+      <div class="title">PSTAR Practice Exam</div>
+      <div class="desc">50 Qs · 40 min · 90% pass mark · Core Air Law coverage</div>
+    </a>
+    <a class="exam-card" href="#">
+      <span class="arrow">→</span>
+      <div class="kind">★ PPL · WRITTEN</div>
+      <div class="title">Final Mock Exam</div>
+      <div class="desc">100 Qs · 3.5 hr · 60% pass (target 80%) · TC-weighted pool</div>
+    </a>
+  </div>
+
+</div>
+</body>
+</html>

--- a/web-app/public/design-lab/variant-b-focus.html
+++ b/web-app/public/design-lab/variant-b-focus.html
@@ -1,0 +1,239 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>PPL Study — Variant B · Focus Study</title>
+<style>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  :root {
+    --bg: #0a0e17;
+    --bg-2: #0f1524;
+    --surface: rgba(255,255,255,0.04);
+    --surface-2: rgba(255,255,255,0.07);
+    --border: rgba(255,255,255,0.08);
+    --border-hi: rgba(255,255,255,0.14);
+    --accent: #d9b36c;
+    --accent-soft: rgba(217,179,108,0.16);
+    --text: #ecedf0;
+    --muted: #8b95a8;
+    --success: #86d9a5;
+  }
+  body {
+    background: var(--bg);
+    color: var(--text);
+    font-family: 'Inter', system-ui, sans-serif;
+    font-size: 15px;
+    line-height: 1.6;
+    min-height: 100vh;
+    padding: 60px 0;
+    -webkit-font-smoothing: antialiased;
+  }
+
+  /* Soft gradient ambient backdrop */
+  body::before {
+    content: ""; position: fixed; inset: 0; pointer-events: none; z-index: 0;
+    background:
+      radial-gradient(ellipse 60% 40% at 20% 10%, rgba(217,179,108,0.08), transparent 60%),
+      radial-gradient(ellipse 50% 50% at 90% 60%, rgba(100,160,220,0.05), transparent 60%);
+  }
+
+  .back { position: fixed; top: 16px; left: 16px; background: var(--surface); color: var(--text); border: 1px solid var(--border); padding: 9px 16px; border-radius: 999px; font-size: 13px; text-decoration: none; z-index: 10; backdrop-filter: blur(20px); }
+  .back:hover { background: var(--surface-2); }
+
+  .wrap { max-width: 760px; margin: 0 auto; padding: 0 20px; position: relative; z-index: 1; }
+
+  /* Top brand row */
+  .top { display: flex; align-items: center; justify-content: space-between; margin-bottom: 56px; }
+  .brand { display: flex; align-items: center; gap: 10px; font-size: 14px; color: var(--muted); }
+  .brand .logo { width: 26px; height: 26px; border-radius: 7px; background: linear-gradient(135deg, var(--accent), #a88649); display: flex; align-items: center; justify-content: center; font-weight: 700; color: #1a1a1a; font-size: 13px; }
+  .streak { font-size: 13px; color: var(--muted); display: flex; align-items: center; gap: 8px; }
+  .streak .flame { color: var(--accent); }
+
+  /* Hero */
+  h1 { font-size: 38px; line-height: 1.15; font-weight: 500; letter-spacing: -0.025em; margin-bottom: 14px; }
+  h1 .soft { color: var(--muted); font-weight: 400; }
+  .subtitle { color: var(--muted); font-size: 16px; margin-bottom: 36px; max-width: 540px; }
+
+  /* Focus card — the hero CTA */
+  .focus {
+    background: linear-gradient(145deg, rgba(217,179,108,0.12), rgba(217,179,108,0.04));
+    border: 1px solid rgba(217,179,108,0.25);
+    border-radius: 20px;
+    padding: 28px;
+    margin-bottom: 48px;
+    position: relative;
+    overflow: hidden;
+  }
+  .focus::before { content: ""; position: absolute; top: -40%; right: -10%; width: 60%; height: 160%; background: radial-gradient(ellipse, rgba(217,179,108,0.22), transparent 60%); pointer-events: none; }
+  .focus .label { font-size: 12px; color: var(--accent); letter-spacing: 0.05em; text-transform: uppercase; margin-bottom: 10px; font-weight: 500; }
+  .focus h2 { font-size: 24px; font-weight: 500; margin-bottom: 6px; letter-spacing: -0.015em; }
+  .focus .meta { font-size: 14px; color: var(--muted); margin-bottom: 20px; }
+  .focus .btn {
+    display: inline-flex; align-items: center; gap: 10px;
+    background: var(--accent); color: #1a1a1a;
+    padding: 12px 22px; border-radius: 12px;
+    text-decoration: none; font-weight: 500; font-size: 15px;
+  }
+  .focus .btn:hover { background: #e6c07a; }
+  .focus .btn-secondary {
+    display: inline-flex; align-items: center; gap: 8px;
+    background: rgba(255,255,255,0.06); color: var(--text);
+    padding: 12px 20px; border-radius: 12px;
+    text-decoration: none; font-size: 14px; margin-left: 8px;
+    border: 1px solid var(--border);
+  }
+  .focus .btn-secondary:hover { background: rgba(255,255,255,0.1); }
+
+  /* Readiness strip */
+  .readiness { margin-bottom: 40px; }
+  .readiness-header { display: flex; justify-content: space-between; align-items: baseline; margin-bottom: 16px; }
+  .readiness-header h3 { font-size: 14px; color: var(--muted); font-weight: 500; }
+  .readiness-header .num { font-size: 16px; color: var(--text); }
+  .readiness-header .num strong { color: var(--accent); font-weight: 500; }
+  .readiness-bar { height: 6px; background: rgba(255,255,255,0.06); border-radius: 3px; overflow: hidden; margin-bottom: 10px; }
+  .readiness-bar .fill { height: 100%; background: linear-gradient(90deg, var(--accent), #e6c07a); border-radius: 3px; }
+  .readiness-hint { font-size: 13px; color: var(--muted); }
+
+  /* Topic grid */
+  .topics { margin-bottom: 48px; }
+  .topics h3 { font-size: 14px; color: var(--muted); font-weight: 500; margin-bottom: 16px; }
+  .topic-grid { display: grid; grid-template-columns: repeat(2, 1fr); gap: 10px; }
+  .topic {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 16px;
+    padding: 18px 20px;
+    text-decoration: none;
+    color: inherit;
+    transition: background 0.15s, transform 0.15s;
+  }
+  .topic:hover { background: var(--surface-2); transform: translateY(-1px); }
+  .topic .name { font-size: 15px; font-weight: 500; margin-bottom: 3px; letter-spacing: -0.01em; }
+  .topic .sub { font-size: 13px; color: var(--muted); margin-bottom: 14px; }
+  .topic .bar { height: 3px; background: rgba(255,255,255,0.06); border-radius: 2px; overflow: hidden; margin-bottom: 8px; }
+  .topic .bar .fill { height: 100%; background: var(--accent); border-radius: 2px; }
+  .topic .pct { font-size: 13px; color: var(--muted); }
+  .topic .pct strong { color: var(--text); font-weight: 500; }
+
+  /* Quick access */
+  .quick h3 { font-size: 14px; color: var(--muted); font-weight: 500; margin-bottom: 16px; }
+  .quick-grid { display: grid; grid-template-columns: repeat(2, 1fr); gap: 10px; }
+  .quick-card {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 16px;
+    padding: 18px 20px;
+    text-decoration: none;
+    color: inherit;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    transition: background 0.15s;
+  }
+  .quick-card:hover { background: var(--surface-2); }
+  .quick-card .title { font-size: 14px; font-weight: 500; margin-bottom: 3px; }
+  .quick-card .desc { font-size: 12px; color: var(--muted); }
+  .quick-card .chev { color: var(--muted); font-size: 18px; }
+
+  @media (max-width: 600px) {
+    body { padding: 40px 0; }
+    h1 { font-size: 30px; }
+    .focus h2 { font-size: 20px; }
+    .topic-grid { grid-template-columns: 1fr; }
+    .quick-grid { grid-template-columns: 1fr; }
+    .focus .btn-secondary { margin-left: 0; margin-top: 8px; display: flex; }
+  }
+</style>
+</head>
+<body>
+<a class="back" href="index.html">← variants</a>
+<div class="wrap">
+
+  <!-- Top brand row -->
+  <div class="top">
+    <div class="brand">
+      <div class="logo">P</div>
+      <span>PPL Study</span>
+    </div>
+    <div class="streak"><span class="flame">●</span> 7-day streak</div>
+  </div>
+
+  <!-- Hero -->
+  <h1>Good morning, Vadym. <span class="soft">Ready for lesson 48?</span></h1>
+  <p class="subtitle">Twenty minutes today. Four topics to mastery. Transport Canada PPL written exam in sight.</p>
+
+  <!-- Focus card -->
+  <div class="focus">
+    <div class="label">◐ Continue where you left off</div>
+    <h2>Emergency Procedures — Air Law</h2>
+    <div class="meta">AL-014 · 20 min · Audio + 5 quiz questions</div>
+    <a class="btn" href="#">Resume lesson →</a>
+    <a class="btn-secondary" href="#">Skip to quiz</a>
+  </div>
+
+  <!-- Exam readiness -->
+  <div class="readiness">
+    <div class="readiness-header">
+      <h3>Exam readiness</h3>
+      <div class="num"><strong>65%</strong> · target 80%</div>
+    </div>
+    <div class="readiness-bar"><div class="fill" style="width: 65%;"></div></div>
+    <div class="readiness-hint">Weighted across TC exam topic distribution. Three strong areas. Meteorology and General Knowledge need attention.</div>
+  </div>
+
+  <!-- Topics -->
+  <div class="topics">
+    <h3>Your topics</h3>
+    <div class="topic-grid">
+      <a class="topic" href="#">
+        <div class="name">Air Law</div>
+        <div class="sub">14 of 18 lessons</div>
+        <div class="bar"><div class="fill" style="width: 78%;"></div></div>
+        <div class="pct"><strong>78%</strong> complete · Strong</div>
+      </a>
+      <a class="topic" href="#">
+        <div class="name">Navigation</div>
+        <div class="sub">10 of 14 lessons</div>
+        <div class="bar"><div class="fill" style="width: 71%;"></div></div>
+        <div class="pct"><strong>71%</strong> complete · Strong</div>
+      </a>
+      <a class="topic" href="#">
+        <div class="name">Meteorology</div>
+        <div class="sub">8 of 14 lessons</div>
+        <div class="bar"><div class="fill" style="width: 58%;"></div></div>
+        <div class="pct"><strong>58%</strong> complete · Needs focus</div>
+      </a>
+      <a class="topic" href="#">
+        <div class="name">General Knowledge</div>
+        <div class="sub">7 of 14 lessons</div>
+        <div class="bar"><div class="fill" style="width: 52%;"></div></div>
+        <div class="pct"><strong>52%</strong> complete · Needs focus</div>
+      </a>
+    </div>
+  </div>
+
+  <!-- Quick access -->
+  <div class="quick">
+    <h3>Practice &amp; exams</h3>
+    <div class="quick-grid">
+      <a class="quick-card" href="#">
+        <div>
+          <div class="title">PSTAR practice</div>
+          <div class="desc">50 Qs · 40 min · 90% to pass</div>
+        </div>
+        <span class="chev">›</span>
+      </a>
+      <a class="quick-card" href="#">
+        <div>
+          <div class="title">Final mock exam</div>
+          <div class="desc">100 Qs · 3.5 hr · TC-weighted</div>
+        </div>
+        <span class="chev">›</span>
+      </a>
+    </div>
+  </div>
+
+</div>
+</body>
+</html>

--- a/web-app/public/design-lab/variant-c-editorial.html
+++ b/web-app/public/design-lab/variant-c-editorial.html
@@ -1,0 +1,338 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>PPL Study — Variant C · Editorial Bold</title>
+<style>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  :root {
+    --bg: #0b0d10;
+    --ink: #f4f1ec;
+    --ink-dim: #9a9893;
+    --warm: #f48258;
+    --warm-soft: rgba(244,130,88,0.12);
+    --amber: #e9b54a;
+    --paper: #141619;
+    --paper-2: #1d1f23;
+    --border: rgba(255,255,255,0.08);
+    --border-hi: rgba(255,255,255,0.18);
+  }
+  body {
+    background: var(--bg);
+    color: var(--ink);
+    font-family: 'Inter', system-ui, sans-serif;
+    font-size: 16px;
+    line-height: 1.55;
+    min-height: 100vh;
+    padding: 0 0 80px;
+    -webkit-font-smoothing: antialiased;
+  }
+
+  .back {
+    position: fixed; top: 18px; left: 18px;
+    background: var(--paper-2); color: var(--ink);
+    border: 1px solid var(--border);
+    padding: 9px 16px; border-radius: 100px;
+    font-size: 13px; text-decoration: none; z-index: 10;
+  }
+  .back:hover { border-color: var(--border-hi); }
+
+  .wrap { max-width: 1000px; margin: 0 auto; padding: 0 24px; }
+
+  /* Marquee */
+  .marquee {
+    display: flex; justify-content: space-between; align-items: center;
+    padding: 20px 0; font-size: 13px; color: var(--ink-dim);
+    border-bottom: 1px solid var(--border); margin-bottom: 80px;
+  }
+  .marquee .logo { font-weight: 700; color: var(--ink); letter-spacing: -0.02em; font-size: 16px; }
+  .marquee .meta { letter-spacing: 0.05em; text-transform: uppercase; font-size: 11px; }
+
+  /* Hero — huge display type */
+  .hero { margin-bottom: 96px; }
+  .hero .eyebrow {
+    display: inline-block;
+    font-size: 12px; letter-spacing: 0.12em; text-transform: uppercase;
+    color: var(--warm); margin-bottom: 28px;
+    padding: 4px 12px; border: 1px solid var(--warm); border-radius: 100px;
+  }
+  .hero h1 {
+    font-family: 'Georgia', 'Tiempos', serif;
+    font-size: clamp(44px, 8vw, 92px);
+    line-height: 0.98;
+    letter-spacing: -0.035em;
+    font-weight: 500;
+    margin-bottom: 28px;
+    max-width: 900px;
+  }
+  .hero h1 em { color: var(--warm); font-style: normal; }
+  .hero h1 .amp { color: var(--amber); }
+  .hero .dek {
+    font-size: 20px;
+    color: var(--ink-dim);
+    max-width: 560px;
+    margin-bottom: 40px;
+    line-height: 1.4;
+  }
+  .hero .cta-row { display: flex; align-items: center; gap: 16px; flex-wrap: wrap; }
+  .cta {
+    background: var(--ink); color: #0b0d10;
+    padding: 16px 32px; border-radius: 100px;
+    font-weight: 500; text-decoration: none; font-size: 16px;
+    display: inline-flex; align-items: center; gap: 8px;
+    transition: transform 0.15s;
+  }
+  .cta:hover { transform: translateY(-1px); }
+  .cta-link {
+    color: var(--ink); font-size: 15px; text-decoration: none;
+    display: inline-flex; align-items: center; gap: 6px;
+    padding: 16px 20px;
+  }
+  .cta-link:hover { color: var(--warm); }
+
+  /* Section heading */
+  .section { margin-bottom: 80px; }
+  .section-head { display: flex; justify-content: space-between; align-items: baseline; margin-bottom: 36px; }
+  .section-head h2 {
+    font-family: 'Georgia', serif;
+    font-size: 36px; letter-spacing: -0.02em;
+    font-weight: 500;
+  }
+  .section-head .count {
+    font-size: 13px; color: var(--ink-dim);
+    letter-spacing: 0.08em; text-transform: uppercase;
+  }
+
+  /* Continue card — editorial hero */
+  .continue {
+    background: var(--paper);
+    border: 1px solid var(--border);
+    border-radius: 28px;
+    padding: 40px;
+    display: grid; grid-template-columns: 80px 1fr auto;
+    gap: 28px; align-items: center;
+  }
+  .continue .num {
+    font-family: 'Georgia', serif;
+    font-size: 72px; line-height: 1;
+    color: var(--warm);
+    letter-spacing: -0.04em;
+    font-weight: 400;
+  }
+  .continue .body .label { font-size: 12px; color: var(--ink-dim); letter-spacing: 0.12em; text-transform: uppercase; margin-bottom: 8px; }
+  .continue .body h3 {
+    font-family: 'Georgia', serif;
+    font-size: 28px; letter-spacing: -0.02em;
+    font-weight: 500; margin-bottom: 8px;
+  }
+  .continue .body .meta { color: var(--ink-dim); font-size: 14px; }
+  .continue .arrow {
+    width: 56px; height: 56px; border-radius: 100px;
+    background: var(--warm-soft); color: var(--warm);
+    display: flex; align-items: center; justify-content: center;
+    font-size: 22px; text-decoration: none;
+    transition: background 0.15s;
+  }
+  .continue:hover .arrow { background: var(--warm); color: #0b0d10; }
+
+  /* Topic cards — numbered */
+  .topic-list { display: grid; grid-template-columns: repeat(2, 1fr); gap: 14px; }
+  .topic {
+    background: var(--paper);
+    border: 1px solid var(--border);
+    border-radius: 20px;
+    padding: 28px;
+    text-decoration: none; color: inherit;
+    display: flex; gap: 20px; align-items: center;
+    transition: border-color 0.15s, transform 0.15s;
+    position: relative;
+  }
+  .topic:hover { border-color: var(--border-hi); transform: translateY(-2px); }
+  .topic .nn {
+    font-family: 'Georgia', serif;
+    font-size: 42px; font-weight: 400; letter-spacing: -0.03em;
+    color: var(--amber);
+    line-height: 1; width: 60px; flex-shrink: 0;
+  }
+  .topic .info { flex: 1; }
+  .topic .info .name { font-size: 19px; font-weight: 500; letter-spacing: -0.01em; margin-bottom: 4px; }
+  .topic .info .meta { font-size: 13px; color: var(--ink-dim); margin-bottom: 12px; }
+  .topic .info .bar { height: 2px; background: rgba(255,255,255,0.08); border-radius: 2px; overflow: hidden; }
+  .topic .info .bar .fill { height: 100%; background: var(--warm); }
+  .topic .pct {
+    font-family: 'Georgia', serif;
+    font-size: 28px; font-weight: 400; letter-spacing: -0.02em;
+    color: var(--ink);
+  }
+
+  /* Readiness strip — pull quote style */
+  .pull {
+    background: none;
+    padding: 40px 0;
+    border-top: 1px solid var(--border);
+    border-bottom: 1px solid var(--border);
+    margin-bottom: 80px;
+  }
+  .pull .label { font-size: 12px; letter-spacing: 0.12em; text-transform: uppercase; color: var(--ink-dim); margin-bottom: 18px; }
+  .pull .big {
+    font-family: 'Georgia', serif;
+    font-size: 56px; letter-spacing: -0.03em; font-weight: 400;
+    line-height: 1.05;
+    margin-bottom: 18px;
+  }
+  .pull .big em { color: var(--warm); font-style: normal; }
+  .pull .fine { color: var(--ink-dim); font-size: 15px; max-width: 520px; }
+
+  /* Exam row */
+  .exam-list { display: grid; grid-template-columns: repeat(2, 1fr); gap: 14px; }
+  .exam {
+    background: var(--paper);
+    border: 1px solid var(--border);
+    border-radius: 20px;
+    padding: 28px;
+    text-decoration: none; color: inherit;
+    transition: border-color 0.15s;
+  }
+  .exam:hover { border-color: var(--warm); }
+  .exam .tag { display: inline-block; font-size: 11px; letter-spacing: 0.12em; text-transform: uppercase; color: var(--warm); border: 1px solid var(--warm); border-radius: 100px; padding: 3px 10px; margin-bottom: 16px; }
+  .exam h4 {
+    font-family: 'Georgia', serif;
+    font-size: 24px; font-weight: 500; letter-spacing: -0.02em;
+    margin-bottom: 8px;
+  }
+  .exam .specs { color: var(--ink-dim); font-size: 14px; margin-bottom: 16px; }
+  .exam .go { color: var(--ink); font-size: 14px; display: inline-flex; align-items: center; gap: 6px; }
+
+  @media (max-width: 720px) {
+    .hero { margin-bottom: 64px; }
+    .hero h1 { font-size: 44px; }
+    .hero .dek { font-size: 17px; }
+    .section-head h2 { font-size: 26px; }
+    .continue { grid-template-columns: 1fr; padding: 28px; text-align: left; }
+    .continue .num { font-size: 52px; }
+    .continue .body h3 { font-size: 22px; }
+    .topic-list { grid-template-columns: 1fr; }
+    .topic .nn { font-size: 32px; width: 44px; }
+    .topic .pct { font-size: 22px; }
+    .pull .big { font-size: 34px; }
+    .exam-list { grid-template-columns: 1fr; }
+  }
+</style>
+</head>
+<body>
+<a class="back" href="index.html">← variants</a>
+<div class="wrap">
+
+  <!-- Marquee -->
+  <div class="marquee">
+    <div class="logo">PPL Study</div>
+    <div class="meta">Transport Canada · Private Pilot · Aeroplane</div>
+  </div>
+
+  <!-- Hero -->
+  <section class="hero">
+    <span class="eyebrow">◐ 20 min · 7-day streak</span>
+    <h1>Serious tools<br>for serious <em>pilots.</em></h1>
+    <p class="dek">Every lesson, every question, every chart you need to pass the Canadian PPL written. Twenty minutes a day to wings.</p>
+    <div class="cta-row">
+      <a class="cta" href="#">Continue lesson 48 →</a>
+      <a class="cta-link" href="#">Browse curriculum ↗</a>
+    </div>
+  </section>
+
+  <!-- Continue -->
+  <section class="section">
+    <div class="section-head">
+      <h2>Pick up where you left off.</h2>
+      <span class="count">Last · 2 hr ago</span>
+    </div>
+    <a class="continue" href="#" style="text-decoration: none; color: inherit;">
+      <div class="num">14</div>
+      <div class="body">
+        <div class="label">Air Law · Lesson 14 of 18</div>
+        <h3>Emergency Procedures</h3>
+        <div class="meta">20 min · audio + 5 quiz questions · TP 12880E §8</div>
+      </div>
+      <span class="arrow">→</span>
+    </a>
+  </section>
+
+  <!-- Readiness pull -->
+  <section class="pull">
+    <div class="label">◆ Exam readiness · weighted</div>
+    <div class="big"><em>Sixty-five percent.</em> Fifteen points from your 80% target.</div>
+    <div class="fine">Strong on Air Law and Navigation. Meteorology and General Knowledge remain the path forward. Ten more focused sessions should close the gap.</div>
+  </section>
+
+  <!-- Topics -->
+  <section class="section">
+    <div class="section-head">
+      <h2>Four topics. Four mountains.</h2>
+      <span class="count">TC exam weighting</span>
+    </div>
+    <div class="topic-list">
+      <a class="topic" href="#">
+        <div class="nn">01</div>
+        <div class="info">
+          <div class="name">Air Law</div>
+          <div class="meta">30% of written · 14 of 18 lessons</div>
+          <div class="bar"><div class="fill" style="width: 78%;"></div></div>
+        </div>
+        <div class="pct">78%</div>
+      </a>
+      <a class="topic" href="#">
+        <div class="nn">02</div>
+        <div class="info">
+          <div class="name">Navigation</div>
+          <div class="meta">25% of written · 10 of 14 lessons</div>
+          <div class="bar"><div class="fill" style="width: 71%;"></div></div>
+        </div>
+        <div class="pct">71%</div>
+      </a>
+      <a class="topic" href="#">
+        <div class="nn">03</div>
+        <div class="info">
+          <div class="name">Meteorology</div>
+          <div class="meta">25% of written · 8 of 14 lessons</div>
+          <div class="bar"><div class="fill" style="width: 58%;"></div></div>
+        </div>
+        <div class="pct">58%</div>
+      </a>
+      <a class="topic" href="#">
+        <div class="nn">04</div>
+        <div class="info">
+          <div class="name">General Knowledge</div>
+          <div class="meta">20% of written · 7 of 14 lessons</div>
+          <div class="bar"><div class="fill" style="width: 52%;"></div></div>
+        </div>
+        <div class="pct">52%</div>
+      </a>
+    </div>
+  </section>
+
+  <!-- Exams -->
+  <section class="section">
+    <div class="section-head">
+      <h2>When you're ready.</h2>
+      <span class="count">2 exam modes</span>
+    </div>
+    <div class="exam-list">
+      <a class="exam" href="#">
+        <span class="tag">Pre-solo</span>
+        <h4>PSTAR practice</h4>
+        <p class="specs">50 questions · 40 minutes · 90% to pass</p>
+        <span class="go">Start practice →</span>
+      </a>
+      <a class="exam" href="#">
+        <span class="tag">PPL written</span>
+        <h4>Final mock exam</h4>
+        <p class="specs">100 questions · 3.5 hours · TC-weighted pool</p>
+        <span class="go">Enter exam mode →</span>
+      </a>
+    </div>
+  </section>
+
+</div>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Three standalone HTML mockups of the Home page at \`/design-lab/\` so you can visually evaluate the redesign direction on phone + desktop before committing to implementation.

- \`/design-lab/\` — index with links to all three
- \`/design-lab/variant-a-cockpit.html\` — Jeppesen / ForeFlight inspired, dense, altimeter gauge, monospace tactical labels
- \`/design-lab/variant-b-focus.html\` — Linear / Arc inspired, soft blurs, gradient backdrop, one big focus card, calm
- \`/design-lab/variant-c-editorial.html\` — Stripe / Apple inspired, serif display type, warm accent, editorial rhythm

Each renders with your real copy ("Pass the PPL written…") and plausible progress state (65% ready, AL 78%, etc.) so judgments are grounded.

## Test plan
- [x] \`npm run build\` not affected — files are in \`public/\`, served as-is
- [ ] Open \`/design-lab/\` on phone (375px) and desktop (≥1200px), pick winner or describe a mix

## Next
Once you pick, I translate that direction into the Phase 2 token + component refresh ticket, ASDLC implements, other pages inherit via the theme. Delete \`/design-lab/\` after lock-in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)