### PR TITLE
[PPL-187] Implement Variant A Cockpit Briefing Home page

### DIFF
--- a/web-app/src/components/home/NextActionCard.tsx
+++ b/web-app/src/components/home/NextActionCard.tsx
@@ -1,0 +1,117 @@
+import { Link as RouterLink } from 'react-router-dom';
+import Box from '@mui/material/Box';
+import { typographyTokens } from '../../tokens';
+
+const MONO = typographyTokens.fontFamily.mono;
+
+export interface NextLesson {
+  id: string;
+  title: string;
+  topic: string;
+  slug: string;
+  durationMin: number;
+  hasAudio: boolean;
+  questionCount: number;
+}
+
+const TOPIC_LABELS: Record<string, string> = {
+  'air-law': 'Air Law',
+  navigation: 'Navigation',
+  meteorology: 'Meteorology',
+  'general-knowledge': 'General Knowledge',
+};
+
+interface Props {
+  lesson: NextLesson | null;
+  lastSessionAgo: string;
+}
+
+export default function NextActionCard({ lesson, lastSessionAgo }: Props) {
+  if (!lesson) return null;
+
+  const topicLabel = (TOPIC_LABELS[lesson.topic] ?? lesson.topic).toUpperCase();
+
+  return (
+    <Box
+      component={RouterLink}
+      to={`/lessons/${lesson.topic}/${lesson.slug}`}
+      sx={(theme) => ({
+        display: 'block',
+        bgcolor: 'background.paper',
+        borderTop: `1px solid ${theme.palette.primary.main}55`,
+        borderRight: `1px solid ${theme.palette.primary.main}55`,
+        borderBottom: `1px solid ${theme.palette.primary.main}55`,
+        borderLeft: `3px solid ${theme.palette.primary.main}`,
+        p: '18px 22px',
+        fontFamily: MONO,
+        fontSize: '13px',
+        lineHeight: 1.9,
+        textDecoration: 'none',
+        color: 'text.primary',
+        minHeight: 48,
+        '&:hover': { opacity: 0.88 },
+      })}
+    >
+      <Box
+        sx={{
+          color: 'primary.main',
+          letterSpacing: '0.15em',
+          fontSize: '10px',
+          textTransform: 'uppercase',
+          mb: '6px',
+        }}
+      >
+        ▸ Lesson {lesson.id}
+      </Box>
+      <Box
+        sx={{
+          fontSize: '18px',
+          color: 'text.primary',
+          mb: '10px',
+          fontFamily: typographyTokens.fontFamily.sans,
+          fontWeight: 600,
+          letterSpacing: '-0.01em',
+        }}
+      >
+        {lesson.title}
+      </Box>
+      <Box sx={{ color: 'text.secondary', flexWrap: 'wrap', display: 'flex', gap: '0 22px' }}>
+        <Box component="span">
+          Dur
+          <Box component="strong" sx={{ color: 'text.primary', ml: '4px' }}>
+            {lesson.durationMin} Min
+          </Box>
+        </Box>
+        <Box component="span">
+          Audio
+          <Box component="strong" sx={{ color: 'text.primary', ml: '4px' }}>
+            {lesson.hasAudio ? 'Ready' : '—'}
+          </Box>
+        </Box>
+        <Box component="span">
+          Questions
+          <Box component="strong" sx={{ color: 'text.primary', ml: '4px' }}>
+            {lesson.questionCount}
+          </Box>
+        </Box>
+        <Box component="span">
+          Topic
+          <Box component="strong" sx={{ color: 'text.primary', ml: '4px' }}>
+            {topicLabel}
+          </Box>
+        </Box>
+      </Box>
+      <Box
+        sx={{
+          mt: '14px',
+          color: 'primary.main',
+          textTransform: 'uppercase',
+          letterSpacing: '0.1em',
+          fontSize: '11px',
+        }}
+      >
+        ▸ {lastSessionAgo === '—' ? 'Begin Session' : 'Resume Session'}
+      </Box>
+    </Box>
+  );
+}

--- a/web-app/src/components/home/ReadinessGauge.tsx
+++ b/web-app/src/components/home/ReadinessGauge.tsx
@@ -1,0 +1,130 @@
+import Box from '@mui/material/Box';
+import { typographyTokens } from '../../tokens';
+
+const MONO = typographyTokens.fontFamily.mono;
+const R = 48;
+const CIRCUMFERENCE = 2 * Math.PI * R;
+
+export interface TopicStat {
+  code: string;
+  label: string;
+  weight: number;
+  pct: number;
+  done: number;
+  total: number;
+}
+
+interface Props {
+  weightedPct: number;
+  topicStats: TopicStat[];
+}
+
+export default function ReadinessGauge({ weightedPct, topicStats }: Props) {
+  const dashoffset = CIRCUMFERENCE * (1 - weightedPct / 100);
+  const delta = Math.round(weightedPct - 80);
+  const row1 = topicStats.slice(0, 2);
+  const row2 = topicStats.slice(2, 4);
+
+  return (
+    <Box
+      sx={{
+        bgcolor: 'background.paper',
+        border: '1px solid',
+        borderColor: 'divider',
+        borderRadius: 1,
+        p: 2.5,
+      }}
+    >
+      <Box
+        sx={{
+          fontFamily: MONO,
+          fontSize: '10px',
+          color: 'text.secondary',
+          letterSpacing: '0.15em',
+          mb: 1.25,
+          textTransform: 'uppercase',
+        }}
+      >
+        ⦿ Exam Readiness · Weighted
+      </Box>
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: '18px', flexWrap: 'wrap' }}>
+        <Box
+          component="svg"
+          viewBox="0 0 120 120"
+          width={110}
+          height={110}
+          sx={{ flexShrink: 0 }}
+        >
+          <circle cx="60" cy="60" r="54" fill="none" stroke="rgba(26,53,80,0.6)" strokeWidth="1" />
+          <circle cx="60" cy="60" r={R} fill="none" stroke="rgba(26,53,80,0.8)" strokeWidth="6" />
+          <circle
+            cx="60"
+            cy="60"
+            r={R}
+            fill="none"
+            stroke="#f5a623"
+            strokeWidth="6"
+            strokeDasharray={CIRCUMFERENCE}
+            strokeDashoffset={dashoffset}
+            transform="rotate(-90 60 60)"
+            strokeLinecap="butt"
+          />
+          <g stroke="rgba(122,154,181,0.7)" strokeWidth="1">
+            <line x1="60" y1="6" x2="60" y2="12" />
+            <line x1="108" y1="60" x2="114" y2="60" />
+            <line x1="60" y1="108" x2="60" y2="114" />
+            <line x1="6" y1="60" x2="12" y2="60" />
+          </g>
+          <text x="60" y="22" textAnchor="middle" fill="rgba(122,154,181,0.7)" fontFamily="monospace" fontSize="7">100</text>
+          <text x="100" y="63" textAnchor="middle" fill="rgba(122,154,181,0.7)" fontFamily="monospace" fontSize="7">25</text>
+          <text x="60" y="103" textAnchor="middle" fill="rgba(122,154,181,0.7)" fontFamily="monospace" fontSize="7">50</text>
+          <text x="20" y="63" textAnchor="middle" fill="rgba(122,154,181,0.7)" fontFamily="monospace" fontSize="7">75</text>
+        </Box>
+        <Box>
+          <Box
+            sx={{
+              fontFamily: MONO,
+              fontSize: { xs: '38px', md: '48px' },
+              color: 'primary.main',
+              fontWeight: 300,
+              letterSpacing: '-0.02em',
+              lineHeight: 1,
+            }}
+          >
+            {Math.round(weightedPct)}
+            <Box component="span" sx={{ fontSize: '18px', color: 'text.secondary', ml: '2px' }}>
+              %
+            </Box>
+          </Box>
+          <Box sx={{ fontFamily: MONO, fontSize: '11px', color: 'text.secondary', lineHeight: 1.9, mt: 0.75 }}>
+            <Box>
+              {row1.map((s, i) => (
+                <Box key={s.code} component="span">
+                  {s.code}{' '}
+                  <Box component="span" sx={{ color: s.pct >= 70 ? 'success.main' : 'primary.main' }}>
+                    {s.pct}%
+                  </Box>
+                  {i < row1.length - 1 && <Box component="span"> · </Box>}
+                </Box>
+              ))}
+            </Box>
+            <Box>
+              {row2.map((s, i) => (
+                <Box key={s.code} component="span">
+                  {s.code}{' '}
+                  <Box component="span" sx={{ color: s.pct >= 70 ? 'success.main' : 'primary.main' }}>
+                    {s.pct}%
+                  </Box>
+                  {i < row2.length - 1 && <Box component="span"> · </Box>}
+                </Box>
+              ))}
+            </Box>
+            <Box sx={{ mt: '6px', color: delta >= 0 ? 'success.main' : 'primary.main' }}>
+              Target 80 — Delta {delta >= 0 ? '+' : ''}{delta}
+            </Box>
+          </Box>
+        </Box>
+      </Box>
+    </Box>
+  );
+}

--- a/web-app/src/components/home/ReadinessGauge.tsx
+++ b/web-app/src/components/home/ReadinessGauge.tsx
@@ -1,4 +1,6 @@
 import Box from '@mui/material/Box';
+import { useTheme } from '@mui/material/styles';
+import { alpha } from '@mui/material/styles';
 import { typographyTokens } from '../../tokens';
 
 const MONO = typographyTokens.fontFamily.mono;
@@ -20,6 +22,7 @@ interface Props {
 }
 
 export default function ReadinessGauge({ weightedPct, topicStats }: Props) {
+  const theme = useTheme();
   const dashoffset = CIRCUMFERENCE * (1 - weightedPct / 100);
   const delta = Math.round(weightedPct - 80);
   const row1 = topicStats.slice(0, 2);
@@ -55,30 +58,30 @@ export default function ReadinessGauge({ weightedPct, topicStats }: Props) {
           height={110}
           sx={{ flexShrink: 0 }}
         >
-          <circle cx="60" cy="60" r="54" fill="none" stroke="rgba(26,53,80,0.6)" strokeWidth="1" />
-          <circle cx="60" cy="60" r={R} fill="none" stroke="rgba(26,53,80,0.8)" strokeWidth="6" />
+          <circle cx="60" cy="60" r="54" fill="none" stroke={alpha(theme.palette.divider, 0.6)} strokeWidth="1" />
+          <circle cx="60" cy="60" r={R} fill="none" stroke={theme.palette.divider} strokeWidth="6" />
           <circle
             cx="60"
             cy="60"
             r={R}
             fill="none"
-            stroke="#f5a623"
+            stroke={theme.palette.primary.main}
             strokeWidth="6"
             strokeDasharray={CIRCUMFERENCE}
             strokeDashoffset={dashoffset}
             transform="rotate(-90 60 60)"
             strokeLinecap="butt"
           />
-          <g stroke="rgba(122,154,181,0.7)" strokeWidth="1">
+          <g stroke={alpha(theme.palette.text.secondary, 0.7)} strokeWidth="1">
             <line x1="60" y1="6" x2="60" y2="12" />
             <line x1="108" y1="60" x2="114" y2="60" />
             <line x1="60" y1="108" x2="60" y2="114" />
             <line x1="6" y1="60" x2="12" y2="60" />
           </g>
-          <text x="60" y="22" textAnchor="middle" fill="rgba(122,154,181,0.7)" fontFamily="monospace" fontSize="7">100</text>
-          <text x="100" y="63" textAnchor="middle" fill="rgba(122,154,181,0.7)" fontFamily="monospace" fontSize="7">25</text>
-          <text x="60" y="103" textAnchor="middle" fill="rgba(122,154,181,0.7)" fontFamily="monospace" fontSize="7">50</text>
-          <text x="20" y="63" textAnchor="middle" fill="rgba(122,154,181,0.7)" fontFamily="monospace" fontSize="7">75</text>
+          <text x="60" y="22" textAnchor="middle" fill={alpha(theme.palette.text.secondary, 0.7)} fontFamily={MONO} fontSize="7">100</text>
+          <text x="100" y="63" textAnchor="middle" fill={alpha(theme.palette.text.secondary, 0.7)} fontFamily={MONO} fontSize="7">25</text>
+          <text x="60" y="103" textAnchor="middle" fill={alpha(theme.palette.text.secondary, 0.7)} fontFamily={MONO} fontSize="7">50</text>
+          <text x="20" y="63" textAnchor="middle" fill={alpha(theme.palette.text.secondary, 0.7)} fontFamily={MONO} fontSize="7">75</text>
         </Box>
         <Box>
           <Box

--- a/web-app/src/components/home/StatusBar.tsx
+++ b/web-app/src/components/home/StatusBar.tsx
@@ -1,0 +1,81 @@
+import Box from '@mui/material/Box';
+import { typographyTokens } from '../../tokens';
+
+const MONO = typographyTokens.fontFamily.mono;
+export const LAST_SESSION_KEY = 'ppl-last-session';
+
+function formatLastSession(iso: string | null): string {
+  if (!iso) return '—';
+  const mins = Math.round((Date.now() - new Date(iso).getTime()) / 60000);
+  if (mins < 1) return 'JUST NOW';
+  if (mins < 60) return `${mins}M AGO`;
+  if (mins < 1440) return `${Math.round(mins / 60)}H AGO`;
+  return `${Math.round(mins / 1440)}D AGO`;
+}
+
+interface Props {
+  completedCount: number;
+  totalLessons: number;
+  lastSession: string | null;
+}
+
+export default function StatusBar({ completedCount, totalLessons, lastSession }: Props) {
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        justifyContent: 'space-between',
+        alignItems: 'center',
+        borderTop: '1px solid',
+        borderBottom: '1px solid',
+        borderColor: 'divider',
+        py: '10px',
+        fontFamily: MONO,
+        fontSize: '11px',
+        color: 'text.secondary',
+        letterSpacing: '0.1em',
+        textTransform: 'uppercase',
+        mb: '28px',
+        flexWrap: 'wrap',
+        gap: 1,
+      }}
+    >
+      <Box sx={{ display: 'flex', gap: '18px', flexWrap: 'wrap', alignItems: 'center' }}>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
+          <Box
+            component="span"
+            sx={{
+              display: 'inline-block',
+              width: 7,
+              height: 7,
+              borderRadius: '50%',
+              bgcolor: 'success.main',
+              flexShrink: 0,
+            }}
+          />
+          System Ready
+        </Box>
+        <Box component="span">
+          Transport Canada PPL
+          <Box component="strong" sx={{ color: 'primary.main', ml: '6px', fontWeight: 600 }}>
+            Aeroplane
+          </Box>
+        </Box>
+      </Box>
+      <Box sx={{ display: 'flex', gap: '18px', flexWrap: 'wrap' }}>
+        <Box component="span">
+          Lessons
+          <Box component="strong" sx={{ color: 'primary.main', ml: '6px', fontWeight: 600 }}>
+            {completedCount} / {totalLessons}
+          </Box>
+        </Box>
+        <Box component="span">
+          Last Session
+          <Box component="strong" sx={{ color: 'primary.main', ml: '6px', fontWeight: 600 }}>
+            {formatLastSession(lastSession)}
+          </Box>
+        </Box>
+      </Box>
+    </Box>
+  );
+}

--- a/web-app/src/components/home/TopicCoverageGrid.tsx
+++ b/web-app/src/components/home/TopicCoverageGrid.tsx
@@ -1,0 +1,64 @@
+import Box from '@mui/material/Box';
+import { typographyTokens } from '../../tokens';
+import type { TopicStat } from './ReadinessGauge';
+
+const MONO = typographyTokens.fontFamily.mono;
+
+interface Props {
+  stats: TopicStat[];
+}
+
+export default function TopicCoverageGrid({ stats }: Props) {
+  return (
+    <Box
+      sx={{
+        display: 'grid',
+        gridTemplateColumns: { xs: 'repeat(2, 1fr)', md: 'repeat(4, 1fr)' },
+        gap: '14px',
+      }}
+    >
+      {stats.map((s) => (
+        <Box
+          key={s.code}
+          sx={{
+            bgcolor: 'background.paper',
+            border: '1px solid',
+            borderColor: 'divider',
+            borderRadius: 1,
+            p: 2,
+          }}
+        >
+          <Box sx={{ fontFamily: MONO, fontSize: '10px', color: 'text.secondary', letterSpacing: '0.1em' }}>
+            {s.code} · {Math.round(s.weight * 100)}% Weight
+          </Box>
+          <Box sx={{ fontSize: '15px', fontWeight: 600, mt: '6px', mb: '12px' }}>
+            {s.label}
+          </Box>
+          <Box
+            sx={{
+              height: '2px',
+              bgcolor: 'divider',
+              borderRadius: '1px',
+              overflow: 'hidden',
+              mb: 1,
+            }}
+          >
+            <Box sx={{ height: '100%', bgcolor: 'primary.main', width: `${s.pct}%`, transition: 'width 0.3s' }} />
+          </Box>
+          <Box
+            sx={{
+              display: 'flex',
+              justifyContent: 'space-between',
+              fontFamily: MONO,
+              fontSize: '11px',
+              color: 'text.secondary',
+            }}
+          >
+            <Box component="span">{s.done} / {s.total} lessons</Box>
+            <Box component="strong" sx={{ color: 'primary.main', fontWeight: 500 }}>{s.pct}%</Box>
+          </Box>
+        </Box>
+      ))}
+    </Box>
+  );
+}

--- a/web-app/src/pages/Home.tsx
+++ b/web-app/src/pages/Home.tsx
@@ -53,7 +53,6 @@ export default function Home() {
   const [lastSession] = useState<string | null>(() => localStorage.getItem(LAST_SESSION_KEY));
 
   const allLessons = useMemo(() => getAllLessons(), []);
-  const authoredIds = useMemo(() => new Set(allLessons.map((l) => l.id)), [allLessons]);
 
   const topicStats: TopicStat[] = useMemo(() =>
     TOPIC_CONFIG.map(({ key, code, label, weight }) => {

--- a/web-app/src/pages/Home.tsx
+++ b/web-app/src/pages/Home.tsx
@@ -1,218 +1,209 @@
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import { Link as RouterLink } from 'react-router-dom';
 import Box from '@mui/material/Box';
-import Button from '@mui/material/Button';
-import Card from '@mui/material/Card';
-import CardContent from '@mui/material/CardContent';
 import Container from '@mui/material/Container';
-import LinearProgress from '@mui/material/LinearProgress';
 import Typography from '@mui/material/Typography';
-
-import HeroMotif from '../components/HeroMotif';
-import { CURRICULUM, TOPIC_LABELS, TOPICS } from '../lib/curriculum';
+import { typographyTokens } from '../tokens';
+import { CURRICULUM } from '../lib/curriculum';
 import { getAllLessons } from '../lib/lesson-loader';
 import { useProgress } from '../lib/progress';
+import StatusBar, { LAST_SESSION_KEY } from '../components/home/StatusBar';
+import ReadinessGauge from '../components/home/ReadinessGauge';
+import TopicCoverageGrid from '../components/home/TopicCoverageGrid';
+import NextActionCard from '../components/home/NextActionCard';
+import type { TopicStat } from '../components/home/ReadinessGauge';
+import type { NextLesson } from '../components/home/NextActionCard';
+
+const MONO = typographyTokens.fontFamily.mono;
+
+const TOPIC_CONFIG = [
+  { key: 'air-law' as const, code: 'AL', label: 'Air Law', weight: 0.30 },
+  { key: 'navigation' as const, code: 'NAV', label: 'Navigation', weight: 0.25 },
+  { key: 'meteorology' as const, code: 'MET', label: 'Meteorology', weight: 0.25 },
+  { key: 'general-knowledge' as const, code: 'GK', label: 'General Knowledge', weight: 0.20 },
+];
+
+function SectionHead({ title, meta }: { title: string; meta: string }) {
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        alignItems: 'baseline',
+        justifyContent: 'space-between',
+        mt: '40px',
+        mb: '16px',
+        borderBottom: '1px solid',
+        borderColor: 'divider',
+        pb: '10px',
+      }}
+    >
+      <Typography
+        component="h2"
+        sx={{ fontFamily: MONO, fontSize: '12px', color: 'text.secondary', letterSpacing: '0.18em', textTransform: 'uppercase', fontWeight: 600 }}
+      >
+        ◆ {title}
+      </Typography>
+      <Box sx={{ fontFamily: MONO, fontSize: '11px', color: 'primary.main' }}>{meta}</Box>
+    </Box>
+  );
+}
 
 export default function Home() {
-  const { progress, isComplete } = useProgress();
+  const { isComplete } = useProgress();
+  const [lastSession] = useState<string | null>(() => localStorage.getItem(LAST_SESSION_KEY));
 
-  const authoredIds = useMemo(
-    () => new Set(getAllLessons().map((l) => l.id)),
-    [],
+  const allLessons = useMemo(() => getAllLessons(), []);
+  const authoredIds = useMemo(() => new Set(allLessons.map((l) => l.id)), [allLessons]);
+
+  const topicStats: TopicStat[] = useMemo(() =>
+    TOPIC_CONFIG.map(({ key, code, label, weight }) => {
+      const slots = CURRICULUM.filter((s) => s.topic === key);
+      const done = slots.filter((s) => isComplete(s.id)).length;
+      const pct = slots.length > 0 ? Math.round((done / slots.length) * 100) : 0;
+      return { code, label, weight, pct, done, total: slots.length };
+    }),
+    [isComplete],
+  );
+
+  const weightedPct = useMemo(
+    () => Math.round(topicStats.reduce((sum, s) => sum + s.pct * s.weight, 0)),
+    [topicStats],
   );
 
   const totalLessons = CURRICULUM.length;
   const completedCount = CURRICULUM.filter((s) => isComplete(s.id)).length;
-  const overallPercent = totalLessons > 0 ? Math.round((completedCount / totalLessons) * 100) : 0;
 
-  const nextUp = useMemo(() => {
-    const allLessons = getAllLessons();
-    return allLessons.find((l) => !progress.completed.includes(l.id)) ?? null;
-  }, [progress.completed]);
+  const nextLesson: NextLesson | null = useMemo(() => {
+    const lesson = allLessons.find((l) => !isComplete(l.id)) ?? null;
+    if (!lesson) return null;
+    return {
+      id: lesson.id,
+      title: lesson.title,
+      topic: lesson.topic,
+      slug: lesson.slug,
+      durationMin: lesson.duration_min,
+      hasAudio: !!lesson.audio,
+      questionCount: lesson.questions.length,
+    };
+  }, [allLessons, isComplete]);
 
-  const hasProgress = progress.completed.length > 0;
+  const lastSessionAgo = useMemo((): string => {
+    if (!lastSession) return '—';
+    const mins = Math.round((Date.now() - new Date(lastSession).getTime()) / 60000);
+    if (mins < 1) return 'JUST NOW';
+    if (mins < 60) return `${mins}M AGO`;
+    if (mins < 1440) return `${Math.round(mins / 60)}H AGO`;
+    return `${Math.round(mins / 1440)}D AGO`;
+  }, [lastSession]);
+
+  const ctaTo = nextLesson
+    ? `/lessons/${nextLesson.topic}/${nextLesson.slug}`
+    : '/lessons';
+  const ctaLabel = nextLesson ? `Continue lesson ${nextLesson.id}` : 'Start studying';
 
   return (
-    <>
-      {/* Hero — full-width, above fold on 375 px mobile */}
-      <Box id="main-content" tabIndex={-1} sx={{ position: 'relative', overflow: 'hidden', pt: { xs: 6, md: 10 }, pb: { xs: 4, md: 6 } }}>
-        {/* Heading-rose motif — decorative background */}
-        <Box
-          aria-hidden="true"
-          sx={{
-            position: 'absolute',
-            top: '50%',
-            right: { xs: '-10%', md: '2%' },
-            transform: 'translateY(-50%)',
-            pointerEvents: 'none',
-          }}
-        >
-          <HeroMotif />
-        </Box>
-        <Container maxWidth="lg" sx={{ position: 'relative' }}>
-          <Typography
-            variant="h3"
-            component="h1"
-            sx={{ fontWeight: 700, mb: 2, lineHeight: 1.2, fontSize: { xs: '1.875rem', md: '3rem' } }}
-          >
-            Pass the Canadian PPL written exam — 20 minutes a day
-          </Typography>
-          <Typography
-            variant="subtitle1"
-            component="p"
-            color="text.secondary"
-            sx={{ mb: 1, maxWidth: 560 }}
-          >
-            Structured lessons covering PSTAR and the full Transport Canada PPL syllabus.
-          </Typography>
-          <Typography
-            component="p"
-            sx={{
-              mb: 2,
-              fontFamily: 'monospace',
-              fontSize: '0.625rem',
-              letterSpacing: '0.15em',
-              color: 'text.secondary',
-              opacity: 0.75,
-            }}
-          >
-            TRANSPORT CANADA PPL
-          </Typography>
-          <Button
-            component={RouterLink}
-            to="/lessons"
-            variant="contained"
-            size="large"
-            sx={{ width: { xs: '100%', sm: 'auto' } }}
-          >
-            Start studying
-          </Button>
-        </Container>
-      </Box>
+    <Box id="main-content" tabIndex={-1} sx={{ minHeight: '100vh', pb: 8 }}>
+      <Container maxWidth="lg" sx={{ pt: { xs: 3, md: 5 } }}>
 
-      {/* Credibility strip */}
-      <Box sx={{ bgcolor: 'background.paper', py: 2 }}>
-        <Container maxWidth="lg">
-          <Box sx={{ display: 'flex', gap: { xs: 2, md: 4 }, flexWrap: 'wrap', justifyContent: 'center' }}>
-            <Typography variant="body2" color="text.secondary">Covers PSTAR &amp; PPL written exam</Typography>
-            <Typography variant="body2" color="text.secondary">Transport Canada syllabus aligned</Typography>
-            <Typography variant="body2" color="text.secondary">Target 80%+ on your written</Typography>
-          </Box>
-        </Container>
-      </Box>
+        <StatusBar completedCount={completedCount} totalLessons={totalLessons} lastSession={lastSession} />
 
-      {/* Progress section — only when at least one lesson is complete */}
-      {hasProgress && (
-        <Container maxWidth="md" sx={{ py: 4 }}>
-          <Box sx={{ mb: 3 }}>
-            <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 0.5 }}>
-              <Typography variant="body2" color="text.secondary">Overall progress</Typography>
-              <Typography variant="body2" color="text.secondary">
-                {completedCount} / {totalLessons} · {overallPercent}%
-              </Typography>
+        {/* Hero */}
+        <Box sx={{ display: 'grid', gridTemplateColumns: { xs: '1fr', md: '1.5fr 1fr' }, gap: 4, alignItems: 'center', mb: '36px' }}>
+          <Box>
+            <Box sx={{ fontFamily: MONO, fontSize: '11px', color: 'primary.main', letterSpacing: '0.15em', mb: '14px', textTransform: 'uppercase' }}>
+              Pre-Flight Briefing · 20 Min / Day
             </Box>
-            <LinearProgress variant="determinate" value={overallPercent} sx={{ height: 10, borderRadius: 5 }} />
-          </Box>
-          <Box
-            sx={{
-              p: 2,
-              borderRadius: 2,
-              border: '1px solid',
-              borderColor: nextUp ? 'primary.main' : 'success.main',
-              bgcolor: 'background.paper',
-            }}
-          >
-            {nextUp ? (
-              <>
-                <Typography variant="overline" color="primary.main">Next Up</Typography>
-                <Typography variant="body1" sx={{ mb: 1 }}>{nextUp.id} — {nextUp.title}</Typography>
-                {authoredIds.has(nextUp.id) ? (
-                  <Button
-                    component={RouterLink}
-                    to={`/lessons/${nextUp.topic}/${nextUp.slug}`}
-                    variant="contained"
-                    size="small"
-                  >
-                    Start lesson
-                  </Button>
-                ) : (
-                  <Typography variant="body2" color="text.disabled">Lesson coming soon</Typography>
-                )}
-              </>
-            ) : (
-              <>
-                <Typography variant="overline" color="success.main">All done!</Typography>
-                <Typography variant="body1">
-                  You&apos;ve completed all available lessons. Good luck on the exam!
-                </Typography>
-              </>
-            )}
-          </Box>
-        </Container>
-      )}
-
-      {/* Final Exam CTA — shown when ≥50 lessons completed */}
-      {completedCount >= 50 && (
-        <Container maxWidth="md" sx={{ pb: 2 }}>
-          <Box
-            sx={{
-              p: 3,
-              borderRadius: 2,
-              border: '1px solid',
-              borderColor: 'primary.main',
-              bgcolor: 'background.paper',
-              display: 'flex',
-              flexDirection: { xs: 'column', sm: 'row' },
-              alignItems: { sm: 'center' },
-              gap: 2,
-            }}
-          >
-            <Box sx={{ flex: 1 }}>
-              <Typography variant="h6" sx={{ mb: 0.5 }}>
-                Ready for the final?
-              </Typography>
-              <Typography variant="body2" color="text.secondary">
-                You&apos;ve completed {completedCount} lessons. Put your knowledge to the test with a
-                full Transport Canada PPL practice exam.
-              </Typography>
-            </Box>
-            <Button
-              component={RouterLink}
-              to="/final-exam"
-              variant="contained"
-              size="large"
-              sx={{ flexShrink: 0, width: { xs: '100%', sm: 'auto' } }}
+            <Typography
+              variant="h1"
+              component="h1"
+              sx={{ mb: '14px' }}
             >
-              Take Final Exam
-            </Button>
+              Pass the{' '}
+              <Box component="span" sx={{ color: 'primary.main' }}>PPL written</Box>
+              <br />
+              exam. Twenty minutes a day.
+            </Typography>
+            <Typography variant="body1" color="text.secondary" sx={{ mb: 2.5, maxWidth: 460 }}>
+              Structured lessons covering PSTAR and the full Transport Canada syllabus. Audio-first, exam-weighted.
+            </Typography>
+            <Box
+              component={RouterLink}
+              to={ctaTo}
+              sx={(theme) => ({
+                display: 'inline-flex',
+                alignItems: 'center',
+                gap: '10px',
+                bgcolor: 'primary.main',
+                color: theme.palette.text.onAccent,
+                px: '22px',
+                py: '12px',
+                minHeight: 48,
+                borderRadius: 1,
+                textDecoration: 'none',
+                fontWeight: 600,
+                fontFamily: MONO,
+                fontSize: '13px',
+                letterSpacing: '0.05em',
+                textTransform: 'uppercase',
+                '&:hover': { opacity: 0.9 },
+                '&::after': { content: '"→"' },
+              })}
+            >
+              {ctaLabel}
+            </Box>
           </Box>
-        </Container>
-      )}
-
-      {/* Topic cards — 2-col ≥600 px, single-col xs */}
-      <Container maxWidth="md" sx={{ py: 4 }}>
-        <Box sx={{ display: 'grid', gridTemplateColumns: { xs: '1fr', sm: '1fr 1fr' }, gap: 2 }}>
-          {TOPICS.map((topic) => {
-            const slots = CURRICULUM.filter((s) => s.topic === topic);
-            const done = slots.filter((s) => isComplete(s.id)).length;
-            const pct = slots.length > 0 ? Math.round((done / slots.length) * 100) : 0;
-            return (
-              <Card key={topic} variant="outlined">
-                <CardContent>
-                  <Typography variant="h6" gutterBottom>{TOPIC_LABELS[topic]}</Typography>
-                  <Typography variant="body2" color="text.secondary" gutterBottom>
-                    {done} / {slots.length} lessons · {pct}%
-                  </Typography>
-                  <LinearProgress variant="determinate" value={pct} sx={{ height: 6, borderRadius: 3, mb: 1.5 }} />
-                  <Button component={RouterLink} to={`/lessons#${topic}`} size="small" variant="outlined">
-                    View lessons
-                  </Button>
-                </CardContent>
-              </Card>
-            );
-          })}
+          <ReadinessGauge weightedPct={weightedPct} topicStats={topicStats} />
         </Box>
+
+        {/* Next Action */}
+        {nextLesson && (
+          <>
+            <SectionHead title="Next Action" meta={lastSessionAgo !== '—' ? `Resuming · ${lastSessionAgo} Pause` : 'First Session'} />
+            <NextActionCard lesson={nextLesson} lastSessionAgo={lastSessionAgo} />
+          </>
+        )}
+
+        {/* Topic Coverage */}
+        <SectionHead title="Topic Coverage · TC Exam Weight" meta="4 Domains" />
+        <TopicCoverageGrid stats={topicStats} />
+
+        {/* Practice & Exam */}
+        <SectionHead title="Practice &amp; Exam" meta="2 Tracks" />
+        <Box sx={{ display: 'grid', gridTemplateColumns: { xs: '1fr', sm: '1fr 1fr' }, gap: '14px' }}>
+          {[
+            { to: '/pstar-exam', kind: '★ PSTAR · Pre-Solo', title: 'PSTAR Practice Exam', desc: '50 Qs · 40 min · 90% pass mark · Core Air Law coverage' },
+            { to: '/final-exam', kind: '★ PPL · Written', title: 'Final Mock Exam', desc: '100 Qs · 3.5 hr · 60% pass (target 80%) · TC-weighted pool' },
+          ].map((card) => (
+            <Box
+              key={card.to}
+              component={RouterLink}
+              to={card.to}
+              sx={(theme) => ({
+                display: 'block',
+                bgcolor: 'background.paper',
+                border: `1px solid ${theme.palette.divider}`,
+                borderRadius: 1,
+                p: '18px',
+                textDecoration: 'none',
+                color: 'text.primary',
+                minHeight: 48,
+                transition: 'border-color 0.12s',
+                '&:hover': { borderColor: 'primary.main' },
+              })}
+            >
+              <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start' }}>
+                <Box sx={{ fontFamily: MONO, fontSize: '10px', color: 'text.secondary', letterSpacing: '0.15em', textTransform: 'uppercase', mb: '6px' }}>
+                  {card.kind}
+                </Box>
+                <Box sx={{ color: 'primary.main', fontFamily: MONO, fontSize: '16px' }}>→</Box>
+              </Box>
+              <Box sx={{ fontSize: '17px', fontWeight: 600, mb: '6px', letterSpacing: '-0.01em' }}>{card.title}</Box>
+              <Box sx={{ fontSize: '12px', color: 'text.secondary' }}>{card.desc}</Box>
+            </Box>
+          ))}
+        </Box>
+
       </Container>
-    </>
+    </Box>
   );
 }

--- a/web-app/src/pages/LessonDetail.tsx
+++ b/web-app/src/pages/LessonDetail.tsx
@@ -15,6 +15,7 @@ import SourceList from '../components/SourceList';
 import { getLessonBySlug, getAdjacentLessons } from '../lib/lesson-loader';
 import { useProgress } from '../lib/progress';
 import { TOPIC_LABELS } from '../lib/curriculum';
+import { LAST_SESSION_KEY } from '../components/home/StatusBar';
 
 function MarkdownTable({ children }: { children?: ReactNode }) {
   return (
@@ -87,6 +88,12 @@ export default function LessonDetail() {
   const { prev, next } = topic && slug && lesson
     ? getAdjacentLessons(topic, slug)
     : { prev: null, next: null };
+
+  useEffect(() => {
+    return () => {
+      localStorage.setItem(LAST_SESSION_KEY, new Date().toISOString());
+    };
+  }, []);
 
   useEffect(() => {
     function handleKeyDown(e: KeyboardEvent) {


### PR DESCRIPTION
## Summary

- Replaces `Home.tsx` with full cockpit-briefing layout matching the Variant A mockup (`design-lab/variant-a-cockpit.html`)
- Extracts four sub-components under `web-app/src/components/home/`: `StatusBar`, `ReadinessGauge`, `TopicCoverageGrid`, `NextActionCard`
- Wires all progress numbers to live `useProgress` / `getAllLessons` data with TC-weighted readiness gauge (AL 30%, NAV 25%, MET 25%, GK 20%)
- Adds `localStorage` last-session timestamp write on `LessonDetail` unmount
- `Home.tsx` is 209 lines (≤280 limit); `npm run build` passes

## Test plan

- [ ] Open `/` — StatusBar shows live lesson count and last-session time
- [ ] ReadinessGauge SVG fills correctly for current completion percentage
- [ ] TopicCoverageGrid bars match per-topic completion (4 topics, correct weights shown)
- [ ] NextActionCard links to correct next uncompleted lesson
- [ ] Exam row links to `/pstar-exam` and `/final-exam`
- [ ] Visit a lesson page, navigate away — re-open Home and verify "Last Session" updates
- [ ] Resize to 360 px: all tap targets ≥48px, layout stacks correctly; topic grid stays 2-col
- [ ] Dark theme renders correctly (no hardcoded light colours)

Closes #187

🤖 Generated with [Claude Code](https://claude.com/claude-code)