### PR TITLE
[PPL-195] Add variable speed control to audio players

### DIFF
--- a/web-app/src/components/AudioPlayer.tsx
+++ b/web-app/src/components/AudioPlayer.tsx
@@ -1,12 +1,46 @@
+import { useEffect, useRef, useState } from 'react';
 import Box from '@mui/material/Box';
 import Chip from '@mui/material/Chip';
+import MenuItem from '@mui/material/MenuItem';
+import Select from '@mui/material/Select';
+import type { SelectChangeEvent } from '@mui/material/Select';
 import Typography from '@mui/material/Typography';
+import { readSpeed, writeSpeed } from '../lib/audio-state';
+
+const SPEEDS = [0.75, 1, 1.1, 1.25, 1.5, 1.75, 2] as const;
+type Speed = (typeof SPEEDS)[number];
+
+const MONO = "'SF Mono', 'JetBrains Mono', Consolas, monospace";
 
 interface AudioPlayerProps {
   src: string | null;
 }
 
 export default function AudioPlayer({ src }: AudioPlayerProps) {
+  const [speed, setSpeed] = useState<Speed>(() => {
+    const saved = readSpeed();
+    return (SPEEDS as readonly number[]).includes(saved) ? (saved as Speed) : 1;
+  });
+  const audioRef = useRef<HTMLAudioElement>(null);
+
+  useEffect(() => {
+    if (audioRef.current) {
+      audioRef.current.playbackRate = speed;
+    }
+  }, [speed]);
+
+  function handleLoaded() {
+    if (audioRef.current) {
+      audioRef.current.playbackRate = speed;
+    }
+  }
+
+  function handleSpeedChange(e: SelectChangeEvent<Speed>) {
+    const val = Number(e.target.value) as Speed;
+    setSpeed(val);
+    writeSpeed(val);
+  }
+
   if (!src) {
     return (
       <Chip
@@ -20,22 +54,63 @@ export default function AudioPlayer({ src }: AudioPlayerProps) {
 
   return (
     <Box sx={{ my: 2 }}>
-      <Typography
-        variant="caption"
-        color="text.secondary"
+      <Box
         sx={{
-          display: 'block',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
           mb: 1,
-          textTransform: 'uppercase',
-          letterSpacing: 0.5,
-          fontSize: 11,
+          flexWrap: 'wrap',
+          gap: 1,
         }}
       >
-        Lesson Audio
-      </Typography>
+        <Typography
+          variant="caption"
+          color="text.secondary"
+          sx={{
+            textTransform: 'uppercase',
+            letterSpacing: 0.5,
+            fontSize: 11,
+          }}
+        >
+          Lesson Audio
+        </Typography>
+        <Select<Speed>
+          value={speed}
+          onChange={handleSpeedChange}
+          size="small"
+          inputProps={{ 'aria-label': 'Playback speed' }}
+          renderValue={(v: Speed) => `${v}×`}
+          sx={{
+            fontFamily: MONO,
+            fontSize: 11,
+            fontWeight: 500,
+            letterSpacing: '0.1em',
+            minWidth: 72,
+            minHeight: 48,
+            borderRadius: '3px',
+            '& .MuiSelect-select': {
+              fontFamily: MONO,
+              py: '13px',
+            },
+          }}
+        >
+          {SPEEDS.map((s) => (
+            <MenuItem
+              key={s}
+              value={s}
+              sx={{ fontFamily: MONO, fontSize: 12, letterSpacing: '0.08em' }}
+            >
+              {s}×
+            </MenuItem>
+          ))}
+        </Select>
+      </Box>
       <audio
+        ref={audioRef}
         controls
         preload="none"
+        onLoadedMetadata={handleLoaded}
         style={{ width: '100%', display: 'block' }}
       >
         <source src={src} type="audio/mp4" />

--- a/web-app/src/components/PlaylistPlayer.tsx
+++ b/web-app/src/components/PlaylistPlayer.tsx
@@ -1,11 +1,20 @@
 import { useEffect, useRef, useState } from 'react';
 import Box from '@mui/material/Box';
 import IconButton from '@mui/material/IconButton';
+import MenuItem from '@mui/material/MenuItem';
+import Select from '@mui/material/Select';
+import type { SelectChangeEvent } from '@mui/material/Select';
 import Typography from '@mui/material/Typography';
 import SkipPreviousIcon from '@mui/icons-material/SkipPrevious';
 import SkipNextIcon from '@mui/icons-material/SkipNext';
 import type { Lesson } from '../lib/types';
 import { TOPIC_LABELS } from '../lib/curriculum';
+import { readSpeed, writeSpeed } from '../lib/audio-state';
+
+const SPEEDS = [0.75, 1, 1.1, 1.25, 1.5, 1.75, 2] as const;
+type Speed = (typeof SPEEDS)[number];
+
+const MONO = "'SF Mono', 'JetBrains Mono', Consolas, monospace";
 
 interface PlaylistPlayerProps {
   lessons: Lesson[];
@@ -14,14 +23,25 @@ interface PlaylistPlayerProps {
 export default function PlaylistPlayer({ lessons }: PlaylistPlayerProps) {
   const [playlist] = useState<Lesson[]>(() => lessons.filter((l) => l.audio !== null));
   const [currentIndex, setCurrentIndex] = useState(0);
+  const [speed, setSpeed] = useState<Speed>(() => {
+    const saved = readSpeed();
+    return (SPEEDS as readonly number[]).includes(saved) ? (saved as Speed) : 1;
+  });
   const audioRef = useRef<HTMLAudioElement>(null);
 
   useEffect(() => {
     const audio = audioRef.current;
     if (!audio) return;
     audio.load();
+    audio.playbackRate = speed;
     audio.play().catch(() => {});
-  }, [currentIndex]);
+  }, [currentIndex]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  useEffect(() => {
+    if (audioRef.current) {
+      audioRef.current.playbackRate = speed;
+    }
+  }, [speed]);
 
   if (playlist.length === 0) return null;
 
@@ -39,6 +59,12 @@ export default function PlaylistPlayer({ lessons }: PlaylistPlayerProps) {
     if (currentIndex < playlist.length - 1) {
       setCurrentIndex((i) => i + 1);
     }
+  }
+
+  function handleSpeedChange(e: SelectChangeEvent<Speed>) {
+    const val = Number(e.target.value) as Speed;
+    setSpeed(val);
+    writeSpeed(val);
   }
 
   return (
@@ -66,7 +92,7 @@ export default function PlaylistPlayer({ lessons }: PlaylistPlayerProps) {
       <Typography variant="subtitle1" sx={{ mb: 1 }}>
         {current.title}
       </Typography>
-      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1 }}>
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1, flexWrap: 'wrap' }}>
         <IconButton
           onClick={handlePrev}
           disabled={currentIndex === 0}
@@ -86,6 +112,36 @@ export default function PlaylistPlayer({ lessons }: PlaylistPlayerProps) {
         >
           <SkipNextIcon />
         </IconButton>
+        <Select<Speed>
+          value={speed}
+          onChange={handleSpeedChange}
+          size="small"
+          inputProps={{ 'aria-label': 'Playback speed' }}
+          renderValue={(v) => `${v}×`}
+          sx={{
+            fontFamily: MONO,
+            fontSize: 11,
+            fontWeight: 500,
+            letterSpacing: '0.1em',
+            minWidth: 72,
+            minHeight: 48,
+            borderRadius: '3px',
+            '& .MuiSelect-select': {
+              fontFamily: MONO,
+              py: '13px',
+            },
+          }}
+        >
+          {SPEEDS.map((s) => (
+            <MenuItem
+              key={s}
+              value={s}
+              sx={{ fontFamily: MONO, fontSize: 12, letterSpacing: '0.08em' }}
+            >
+              {s}×
+            </MenuItem>
+          ))}
+        </Select>
       </Box>
       <audio
         ref={audioRef}

--- a/web-app/src/lib/audio-state.ts
+++ b/web-app/src/lib/audio-state.ts
@@ -1,0 +1,21 @@
+const KEY = 'ppl.audio.speed';
+const DEFAULT_SPEED = 1;
+
+export function readSpeed(): number {
+  try {
+    const raw = localStorage.getItem(KEY);
+    if (raw === null) return DEFAULT_SPEED;
+    const val = parseFloat(raw);
+    return isNaN(val) ? DEFAULT_SPEED : val;
+  } catch {
+    return DEFAULT_SPEED;
+  }
+}
+
+export function writeSpeed(speed: number): void {
+  try {
+    localStorage.setItem(KEY, String(speed));
+  } catch {
+    // ignore storage errors (private browsing, quota)
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `web-app/src/lib/audio-state.ts` with `readSpeed`/`writeSpeed` helpers persisting to `localStorage` key `ppl.audio.speed` (default 1)
- Adds speed dropdown (0.75×/1×/1.1×/1.25×/1.5×/1.75×/2×) to `PlaylistPlayer` and `AudioPlayer`
- Speed label rendered in monospace per DESIGN-SYSTEM.md §3.2 (tactical label style)
- Tap target ≥ 48 × 48 px; works in dark + light modes
- Persists selection across sessions; restores on mount and applies immediately via `audioElement.playbackRate`

Closes #195

Adheres to docs/design/DESIGN-SYSTEM.md

## Test plan

- [ ] Load a lesson page with audio; verify speed selector appears labeled `1×` by default
- [ ] Change speed; verify audio playback rate changes immediately
- [ ] Reload page; verify speed preference is restored from localStorage
- [ ] Test in dark and light mode; verify styling is consistent
- [ ] Test at 360 px viewport width; verify no horizontal scroll and selector is tappable

🤖 Generated with [Claude Code](https://claude.com/claude-code)