### PR TITLE
[PPL-204] Smart playlists: weakest-topic-first + due-for-review

### DIFF
--- a/web-app/src/App.tsx
+++ b/web-app/src/App.tsx
@@ -13,6 +13,7 @@ import FinalExam from './pages/FinalExam';
 import PSTARExam from './pages/PSTARExam';
 import Plan from './pages/Plan';
 import Playlist from './pages/Playlist';
+import SmartPlaylist from './pages/SmartPlaylist';
 import PSTARPath from './pages/PSTARPath';
 
 const RAIL_EXPANDED = 240;
@@ -101,6 +102,7 @@ export default function App() {
               <Route path="/pstar-exam" element={<PSTARExam />} />
               <Route path="/plan" element={<Plan />} />
               <Route path="/playlist" element={<Playlist />} />
+              <Route path="/playlist/smart/:kind" element={<SmartPlaylist />} />
               <Route path="/playlist/:topic" element={<Playlist />} />
               <Route path="/pstar" element={<PSTARPath />} />
             </Routes>

--- a/web-app/src/lib/smart-playlists.ts
+++ b/web-app/src/lib/smart-playlists.ts
@@ -1,0 +1,70 @@
+import { getAllLessons } from './lesson-loader';
+import type { Lesson, Progress } from './types';
+import { TOPICS } from './curriculum';
+
+// Returns incomplete lessons interleaved round-robin, weakest topic (lowest completion %) first.
+export function weakestTopicFirst(progress: Progress): Lesson[] {
+  const all = getAllLessons();
+  const completed = new Set(progress.completed);
+
+  const available = (topic: string): Lesson[] =>
+    all.filter(
+      (l) =>
+        l.topic === topic &&
+        l.status !== 'planning' &&
+        l.audio !== null &&
+        !completed.has(l.id),
+    );
+
+  const completionRate = (topic: string): number => {
+    const pool = all.filter(
+      (l) => l.topic === topic && l.status !== 'planning' && l.audio !== null,
+    );
+    if (pool.length === 0) return 1;
+    return pool.filter((l) => completed.has(l.id)).length / pool.length;
+  };
+
+  // Sort topics weakest (lowest completion) first, stable across equal rates
+  const sortedTopics = [...TOPICS].sort((a, b) => completionRate(a) - completionRate(b));
+
+  // Mutable queues per topic
+  const queues = Object.fromEntries(sortedTopics.map((t) => [t, available(t)]));
+
+  // Round-robin until all queues empty
+  const result: Lesson[] = [];
+  let anyLeft = true;
+  while (anyLeft) {
+    anyLeft = false;
+    for (const topic of sortedTopics) {
+      const lesson = queues[topic].shift();
+      if (lesson) {
+        result.push(lesson);
+        anyLeft = true;
+      }
+    }
+  }
+  return result;
+}
+
+// Returns completed lessons whose last quiz attempt is older than 7 days (or never attempted).
+export function dueForReview(progress: Progress): Lesson[] {
+  const all = getAllLessons();
+  const completed = new Set(progress.completed);
+  const sevenDaysMs = 7 * 24 * 60 * 60 * 1000;
+  const now = Date.now();
+
+  // Latest quiz timestamp per lesson
+  const latestQuiz: Record<string, number> = {};
+  for (const attempt of progress.quizHistory) {
+    const ts = new Date(attempt.timestamp).getTime();
+    if (!latestQuiz[attempt.lessonId] || ts > latestQuiz[attempt.lessonId]) {
+      latestQuiz[attempt.lessonId] = ts;
+    }
+  }
+
+  return all.filter((l) => {
+    if (!completed.has(l.id) || l.audio === null) return false;
+    const lastReviewed = latestQuiz[l.id] ?? 0;
+    return now - lastReviewed > sevenDaysMs;
+  });
+}

--- a/web-app/src/pages/SmartPlaylist.tsx
+++ b/web-app/src/pages/SmartPlaylist.tsx
@@ -1,0 +1,62 @@
+import { useParams } from 'react-router-dom';
+import Container from '@mui/material/Container';
+import Typography from '@mui/material/Typography';
+import PlaylistPlayer from '../components/PlaylistPlayer';
+import { useProgress } from '../lib/progress';
+import { weakestTopicFirst, dueForReview } from '../lib/smart-playlists';
+
+const KIND_META: Record<string, { label: string; description: string; empty: string }> = {
+  weakest: {
+    label: 'Weakest Topic First',
+    description:
+      "Incomplete lessons interleaved across topics — the topic you've covered least comes first.",
+    empty:
+      "No incomplete lessons with audio are available. You've covered everything — great work!",
+  },
+  review: {
+    label: 'Due for Review',
+    description: 'Lessons you completed more than 7 days ago. Time to keep them fresh.',
+    empty: 'No lessons are due for review right now. Check back in a few days!',
+  },
+};
+
+export default function SmartPlaylist() {
+  const { kind } = useParams<{ kind: string }>();
+  const { progress } = useProgress();
+
+  const meta = kind ? KIND_META[kind] : undefined;
+
+  if (!meta) {
+    return (
+      <Container maxWidth="md" sx={{ py: 4 }}>
+        <Typography variant="h4" gutterBottom>
+          Smart Playlist
+        </Typography>
+        <Typography color="text.secondary">Unknown playlist type.</Typography>
+      </Container>
+    );
+  }
+
+  const lessons =
+    kind === 'weakest'
+      ? weakestTopicFirst(progress)
+      : kind === 'review'
+        ? dueForReview(progress)
+        : [];
+
+  return (
+    <Container maxWidth="md" sx={{ py: 4 }}>
+      <Typography variant="h4" gutterBottom>
+        {meta.label}
+      </Typography>
+      <Typography variant="body1" color="text.secondary" sx={{ mb: 3 }}>
+        {meta.description}
+      </Typography>
+      {lessons.length === 0 ? (
+        <Typography color="text.secondary">{meta.empty}</Typography>
+      ) : (
+        <PlaylistPlayer lessons={lessons} />
+      )}
+    </Container>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds `web-app/src/lib/smart-playlists.ts` with `weakestTopicFirst()` (round-robin by topic, lowest-completion topic first, incomplete lessons only) and `dueForReview()` (completed lessons with no quiz attempt or last quiz > 7 days ago)
- Adds `web-app/src/pages/SmartPlaylist.tsx` page rendering `PlaylistPlayer` with the generated list; includes friendly empty-state messages for each kind
- Adds `/playlist/smart/:kind` route in `App.tsx` (placed before the `/:topic` wildcard to prevent shadowing)

Closes #204

## Test plan
- [ ] Visit `/playlist/smart/weakest` with no progress — all lessons should appear round-robined, weakest topic first
- [ ] Visit `/playlist/smart/weakest` after marking some lessons complete — completed lessons excluded, topic order updates
- [ ] Visit `/playlist/smart/review` with no completed lessons — empty state: "No lessons are due for review right now."
- [ ] Visit `/playlist/smart/review` with completed lessons quizzed > 7 days ago — those lessons appear
- [ ] Visit `/playlist/smart/unknown` — shows "Unknown playlist type." fallback
- [ ] `PlaylistPlayer` auto-advances and prev/next work normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)