### PR TITLE
[PPL-196] Add ±15s skip buttons to audio players

### DIFF
--- a/web-app/src/components/AudioPlayer.tsx
+++ b/web-app/src/components/AudioPlayer.tsx
@@ -1,10 +1,13 @@
 import { useEffect, useRef, useState } from 'react';
 import Box from '@mui/material/Box';
 import Chip from '@mui/material/Chip';
+import IconButton from '@mui/material/IconButton';
 import MenuItem from '@mui/material/MenuItem';
 import Select from '@mui/material/Select';
 import type { SelectChangeEvent } from '@mui/material/Select';
 import Typography from '@mui/material/Typography';
+import FastForwardIcon from '@mui/icons-material/FastForward';
+import FastRewindIcon from '@mui/icons-material/FastRewind';
 import { readSpeed, writeSpeed } from '../lib/audio-state';
 import { useMediaSession } from './MediaSessionBridge';
 
@@ -44,6 +47,29 @@ export default function AudioPlayer({ src, title, topic }: AudioPlayerProps) {
     }
   }
 
+  function handleSkipBack() {
+    const audio = audioRef.current;
+    if (!audio) return;
+    audio.currentTime = Math.max(0, audio.currentTime - 15);
+  }
+
+  function handleSkipForward() {
+    const audio = audioRef.current;
+    if (!audio) return;
+    const dur = isFinite(audio.duration) ? audio.duration : 0;
+    audio.currentTime = Math.min(dur, audio.currentTime + 15);
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent) {
+    if (e.key === 'ArrowLeft') {
+      e.preventDefault();
+      handleSkipBack();
+    } else if (e.key === 'ArrowRight') {
+      e.preventDefault();
+      handleSkipForward();
+    }
+  }
+
   function handleSpeedChange(e: SelectChangeEvent<Speed>) {
     const val = Number(e.target.value) as Speed;
     setSpeed(val);
@@ -62,7 +88,7 @@ export default function AudioPlayer({ src, title, topic }: AudioPlayerProps) {
   }
 
   return (
-    <Box sx={{ my: 2 }}>
+    <Box tabIndex={0} onKeyDown={handleKeyDown} sx={{ my: 2, outline: 'none' }}>
       <Box
         sx={{
           display: 'flex',
@@ -115,16 +141,43 @@ export default function AudioPlayer({ src, title, topic }: AudioPlayerProps) {
           ))}
         </Select>
       </Box>
-      <audio
-        ref={audioRef}
-        controls
-        preload="none"
-        onLoadedMetadata={handleLoaded}
-        style={{ width: '100%', display: 'block' }}
-      >
-        <source src={src} type="audio/mp4" />
-        Your browser does not support the audio element.
-      </audio>
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+        <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
+          <IconButton
+            onClick={handleSkipBack}
+            aria-label="Skip back 15 seconds"
+            sx={{ width: 48, height: 48 }}
+          >
+            <FastRewindIcon />
+          </IconButton>
+          <Typography variant="caption" color="text.secondary" sx={{ fontSize: 10, lineHeight: 1 }}>
+            −15s
+          </Typography>
+        </Box>
+        <audio
+          ref={audioRef}
+          controls
+          preload="none"
+          onLoadedMetadata={handleLoaded}
+          onKeyDown={handleKeyDown}
+          style={{ flex: 1, display: 'block', minWidth: 0 }}
+        >
+          <source src={src} type="audio/mp4" />
+          Your browser does not support the audio element.
+        </audio>
+        <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
+          <IconButton
+            onClick={handleSkipForward}
+            aria-label="Skip forward 15 seconds"
+            sx={{ width: 48, height: 48 }}
+          >
+            <FastForwardIcon />
+          </IconButton>
+          <Typography variant="caption" color="text.secondary" sx={{ fontSize: 10, lineHeight: 1 }}>
+            +15s
+          </Typography>
+        </Box>
+      </Box>
     </Box>
   );
 }

--- a/web-app/src/components/PlaylistPlayer.tsx
+++ b/web-app/src/components/PlaylistPlayer.tsx
@@ -5,6 +5,10 @@ import MenuItem from '@mui/material/MenuItem';
 import Select from '@mui/material/Select';
 import type { SelectChangeEvent } from '@mui/material/Select';
 import Typography from '@mui/material/Typography';
+import FastForwardIcon from '@mui/icons-material/FastForward';
+import FastRewindIcon from '@mui/icons-material/FastRewind';
+import PauseIcon from '@mui/icons-material/Pause';
+import PlayArrowIcon from '@mui/icons-material/PlayArrow';
 import SkipPreviousIcon from '@mui/icons-material/SkipPrevious';
 import SkipNextIcon from '@mui/icons-material/SkipNext';
 import type { Lesson } from '../lib/types';
@@ -26,6 +30,7 @@ export default function PlaylistPlayer({ lessons }: PlaylistPlayerProps) {
   const [playlist] = useState<Lesson[]>(() => lessons.filter((l) => l.audio !== null));
   const [currentIndex, setCurrentIndex] = useState(0);
   const [playedIndices, setPlayedIndices] = useState<ReadonlySet<number>>(() => new Set());
+  const [isPlaying, setIsPlaying] = useState(false);
   const [speed, setSpeed] = useState<Speed>(() => {
     const saved = readSpeed();
     return (SPEEDS as readonly number[]).includes(saved) ? (saved as Speed) : 1;
@@ -119,6 +124,40 @@ export default function PlaylistPlayer({ lessons }: PlaylistPlayerProps) {
     if (currentIndex < playlist.length - 1) {
       setCurrentIndex((i: number) => i + 1);
     }
+    setIsPlaying(false);
+  }
+
+  function handlePlayPause() {
+    const audio = audioRef.current;
+    if (!audio) return;
+    if (isPlaying) {
+      audio.pause();
+    } else {
+      audio.play().catch(() => {});
+    }
+  }
+
+  function handleSkipBack() {
+    const audio = audioRef.current;
+    if (!audio) return;
+    audio.currentTime = Math.max(0, audio.currentTime - 15);
+  }
+
+  function handleSkipForward() {
+    const audio = audioRef.current;
+    if (!audio) return;
+    const dur = isFinite(audio.duration) ? audio.duration : 0;
+    audio.currentTime = Math.min(dur, audio.currentTime + 15);
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent) {
+    if (e.key === 'ArrowLeft') {
+      e.preventDefault();
+      handleSkipBack();
+    } else if (e.key === 'ArrowRight') {
+      e.preventDefault();
+      handleSkipForward();
+    }
   }
 
   function handleSpeedChange(e: SelectChangeEvent<Speed>) {
@@ -128,7 +167,7 @@ export default function PlaylistPlayer({ lessons }: PlaylistPlayerProps) {
   }
 
   return (
-    <Box sx={{ my: 2, width: '100%' }}>
+    <Box tabIndex={0} onKeyDown={handleKeyDown} sx={{ my: 2, width: '100%', outline: 'none' }}>
       <Typography
         variant="caption"
         color="text.secondary"
@@ -203,10 +242,50 @@ export default function PlaylistPlayer({ lessons }: PlaylistPlayerProps) {
           ))}
         </Select>
       </Box>
+      <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 1, mb: 1 }}>
+        <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
+          <IconButton
+            onClick={handleSkipBack}
+            aria-label="Skip back 15 seconds"
+            sx={{ width: 48, height: 48 }}
+          >
+            <FastRewindIcon />
+          </IconButton>
+          <Typography variant="caption" color="text.secondary" sx={{ fontSize: 10, lineHeight: 1 }}>
+            −15s
+          </Typography>
+        </Box>
+        <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
+          <IconButton
+            onClick={handlePlayPause}
+            aria-label={isPlaying ? 'Pause' : 'Play'}
+            sx={{ width: 48, height: 48 }}
+          >
+            {isPlaying ? <PauseIcon /> : <PlayArrowIcon />}
+          </IconButton>
+          <Typography variant="caption" color="text.secondary" sx={{ fontSize: 10, lineHeight: 1 }}>
+            {isPlaying ? 'Pause' : 'Play'}
+          </Typography>
+        </Box>
+        <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
+          <IconButton
+            onClick={handleSkipForward}
+            aria-label="Skip forward 15 seconds"
+            sx={{ width: 48, height: 48 }}
+          >
+            <FastForwardIcon />
+          </IconButton>
+          <Typography variant="caption" color="text.secondary" sx={{ fontSize: 10, lineHeight: 1 }}>
+            +15s
+          </Typography>
+        </Box>
+      </Box>
       <audio
         ref={audioRef}
         preload="none"
         onEnded={handleEnded}
+        onPlay={() => setIsPlaying(true)}
+        onPause={() => setIsPlaying(false)}
         style={{ width: '100%', display: 'block' }}
       >
         <source src={current.audio!} type="audio/mp4" />


### PR DESCRIPTION
## Summary

- **PlaylistPlayer**: adds a custom `[←15s] [▶/⏸] [+15s]` control row; `isPlaying` state tracked via `onPlay`/`onPause` audio events; play/pause reflects current state
- **AudioPlayer**: custom skip buttons flank the native `<audio controls>` element (left = −15s, right = +15s) with 48×48 px tap targets and "−15s" / "+15s" mobile text labels
- Both players: rewind clamped at 0, forward clamped at `audio.duration`; ←/→ keyboard shortcuts active when player container (`tabIndex={0}`) has focus; `onKeyDown` also added to `<audio>` element in AudioPlayer to intercept native browser seek behaviour

## Test plan

- [ ] PlaylistPlayer: click skip buttons during playback — verify ±15s jump, no overshoot past 0 or end
- [ ] PlaylistPlayer: click play/pause, confirm button icon and label toggle
- [ ] AudioPlayer: click −15s / +15s buttons flanking the native player bar
- [ ] Both: tab-focus the player container, press ← / → — confirm skip fires
- [ ] Both: verify tap targets are at least 48×48 px on mobile viewport
- [ ] Edge: skip forward when < 15s remaining — confirm clamp to duration

Closes #196

🤖 Generated with [Claude Code](https://claude.com/claude-code)