### PR TITLE
[PPL-199] Add playlist queue below audio player

### DIFF
--- a/web-app/src/components/PlaylistPlayer.tsx
+++ b/web-app/src/components/PlaylistPlayer.tsx
@@ -9,7 +9,8 @@ import SkipPreviousIcon from '@mui/icons-material/SkipPrevious';
 import SkipNextIcon from '@mui/icons-material/SkipNext';
 import type { Lesson } from '../lib/types';
 import { TOPIC_LABELS } from '../lib/curriculum';
-import { readSpeed, writeSpeed } from '../lib/audio-state';
+import { readSpeed, writeSpeed, readPosition, writePosition } from '../lib/audio-state';
+import PlaylistQueue from './player/PlaylistQueue';
 
 const SPEEDS = [0.75, 1, 1.1, 1.25, 1.5, 1.75, 2] as const;
 type Speed = (typeof SPEEDS)[number];
@@ -23,18 +24,39 @@ interface PlaylistPlayerProps {
 export default function PlaylistPlayer({ lessons }: PlaylistPlayerProps) {
   const [playlist] = useState<Lesson[]>(() => lessons.filter((l) => l.audio !== null));
   const [currentIndex, setCurrentIndex] = useState(0);
+  const [playedIndices, setPlayedIndices] = useState<ReadonlySet<number>>(() => new Set());
   const [speed, setSpeed] = useState<Speed>(() => {
     const saved = readSpeed();
     return (SPEEDS as readonly number[]).includes(saved) ? (saved as Speed) : 1;
   });
   const audioRef = useRef<HTMLAudioElement>(null);
+  const savePositionRef = useRef<() => void>(() => {});
+
+  // Keep savePositionRef current without recreating effects
+  savePositionRef.current = () => {
+    const audio = audioRef.current;
+    const lesson = playlist[currentIndex];
+    if (audio && lesson) {
+      writePosition(lesson.id, audio.currentTime);
+    }
+  };
 
   useEffect(() => {
     const audio = audioRef.current;
     if (!audio) return;
     audio.load();
     audio.playbackRate = speed;
-    audio.play().catch(() => {});
+    const savedPos = readPosition(playlist[currentIndex]?.id ?? '');
+    const onCanPlay = () => {
+      if (savedPos > 0) {
+        audio.currentTime = savedPos;
+      }
+      audio.play().catch(() => {});
+    };
+    audio.addEventListener('canplay', onCanPlay, { once: true });
+    return () => {
+      audio.removeEventListener('canplay', onCanPlay);
+    };
   }, [currentIndex]); // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
@@ -43,21 +65,50 @@ export default function PlaylistPlayer({ lessons }: PlaylistPlayerProps) {
     }
   }, [speed]);
 
+  // Save position periodically and on pause
+  useEffect(() => {
+    const audio = audioRef.current;
+    if (!audio) return;
+    const onTimeUpdate = () => savePositionRef.current();
+    const onPause = () => savePositionRef.current();
+    audio.addEventListener('timeupdate', onTimeUpdate);
+    audio.addEventListener('pause', onPause);
+    return () => {
+      audio.removeEventListener('timeupdate', onTimeUpdate);
+      audio.removeEventListener('pause', onPause);
+    };
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
   if (playlist.length === 0) return null;
 
   const current = playlist[currentIndex];
 
+  function jumpTo(index: number) {
+    savePositionRef.current();
+    setPlayedIndices((prev: ReadonlySet<number>) => {
+      const next = new Set(prev);
+      next.add(currentIndex);
+      return next;
+    });
+    setCurrentIndex(index);
+  }
+
   function handlePrev() {
-    setCurrentIndex((i) => Math.max(0, i - 1));
+    jumpTo(Math.max(0, currentIndex - 1));
   }
 
   function handleNext() {
-    setCurrentIndex((i) => Math.min(playlist.length - 1, i + 1));
+    jumpTo(Math.min(playlist.length - 1, currentIndex + 1));
   }
 
   function handleEnded() {
+    setPlayedIndices((prev: ReadonlySet<number>) => {
+      const next = new Set(prev);
+      next.add(currentIndex);
+      return next;
+    });
     if (currentIndex < playlist.length - 1) {
-      setCurrentIndex((i) => i + 1);
+      setCurrentIndex((i: number) => i + 1);
     }
   }
 
@@ -152,6 +203,12 @@ export default function PlaylistPlayer({ lessons }: PlaylistPlayerProps) {
         <source src={current.audio!} type="audio/mp4" />
         Your browser does not support the audio element.
       </audio>
+      <PlaylistQueue
+        playlist={playlist}
+        currentIndex={currentIndex}
+        playedIndices={playedIndices}
+        onJump={jumpTo}
+      />
     </Box>
   );
 }

--- a/web-app/src/components/player/PlaylistQueue.tsx
+++ b/web-app/src/components/player/PlaylistQueue.tsx
@@ -1,0 +1,156 @@
+import { useEffect, useRef, type KeyboardEvent } from 'react';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import type { Lesson } from '../../lib/types';
+import { typographyTokens } from '../../tokens';
+
+const MONO = typographyTokens.fontFamily.mono;
+
+interface PlaylistQueueProps {
+  playlist: Lesson[];
+  currentIndex: number;
+  playedIndices: ReadonlySet<number>;
+  onJump: (index: number) => void;
+}
+
+export default function PlaylistQueue({
+  playlist,
+  currentIndex,
+  playedIndices,
+  onJump,
+}: PlaylistQueueProps) {
+  const rowRefs = useRef<(HTMLDivElement | null)[]>([]);
+
+  useEffect(() => {
+    rowRefs.current[currentIndex]?.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
+  }, [currentIndex]);
+
+  function handleKeyDown(e: KeyboardEvent<HTMLDivElement>, index: number) {
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      const next = Math.min(playlist.length - 1, index + 1);
+      rowRefs.current[next]?.focus();
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      const prev = Math.max(0, index - 1);
+      rowRefs.current[prev]?.focus();
+    } else if (e.key === 'Enter') {
+      e.preventDefault();
+      onJump(index);
+    }
+  }
+
+  return (
+    <Box
+      role="list"
+      aria-label="Playlist queue"
+      sx={{
+        mt: 1,
+        border: '1px solid',
+        borderColor: 'divider',
+        borderRadius: '4px',
+        overflow: 'hidden',
+        maxHeight: 320,
+        overflowY: 'auto',
+      }}
+    >
+      {playlist.map((lesson, index) => {
+        const isCurrent = index === currentIndex;
+        const isPlayed = playedIndices.has(index);
+        const icon = isCurrent ? '▶' : isPlayed ? '✓' : '·';
+
+        return (
+          <Box
+            key={lesson.id}
+            ref={(el: HTMLDivElement | null) => {
+              rowRefs.current[index] = el;
+            }}
+            role="listitem"
+            tabIndex={0}
+            onClick={() => onJump(index)}
+            onKeyDown={(e) => handleKeyDown(e, index)}
+            aria-label={`${lesson.id} ${lesson.title}${isCurrent ? ', currently playing' : isPlayed ? ', played' : ''}`}
+            aria-current={isCurrent ? 'true' : undefined}
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 1.5,
+              px: 2,
+              minHeight: 48,
+              cursor: 'pointer',
+              borderLeft: '3px solid',
+              borderLeftColor: isCurrent ? 'primary.main' : 'transparent',
+              backgroundColor: isCurrent ? 'action.selected' : 'transparent',
+              borderBottom: index < playlist.length - 1 ? '1px solid' : 'none',
+              borderBottomColor: 'divider',
+              transition: 'background-color 150ms ease-out, border-color 150ms ease-out',
+              '&:hover': {
+                backgroundColor: 'action.hover',
+              },
+              '&:focus-visible': {
+                outline: '2px solid',
+                outlineColor: 'primary.main',
+                outlineOffset: '-2px',
+              },
+            }}
+          >
+            <Typography
+              component="span"
+              sx={{
+                fontFamily: MONO,
+                fontSize: 11,
+                fontWeight: 500,
+                color: isCurrent ? 'primary.main' : 'text.secondary',
+                minWidth: 14,
+                textAlign: 'center',
+                flexShrink: 0,
+              }}
+            >
+              {icon}
+            </Typography>
+            <Typography
+              component="span"
+              sx={{
+                fontFamily: MONO,
+                fontSize: 11,
+                fontWeight: 500,
+                letterSpacing: '0.1em',
+                color: isCurrent ? 'primary.main' : 'text.secondary',
+                textTransform: 'uppercase',
+                flexShrink: 0,
+                minWidth: 60,
+              }}
+            >
+              {lesson.id}
+            </Typography>
+            <Typography
+              component="span"
+              sx={{
+                fontSize: 13,
+                color: isCurrent ? 'text.primary' : isPlayed ? 'text.secondary' : 'text.primary',
+                flex: 1,
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+                whiteSpace: 'nowrap',
+              }}
+            >
+              {lesson.title}
+            </Typography>
+            <Typography
+              component="span"
+              sx={{
+                fontFamily: MONO,
+                fontSize: 11,
+                color: 'text.secondary',
+                flexShrink: 0,
+                letterSpacing: '0.08em',
+              }}
+            >
+              {lesson.duration_min}&nbsp;MIN
+            </Typography>
+          </Box>
+        );
+      })}
+    </Box>
+  );
+}

--- a/web-app/src/lib/audio-state.ts
+++ b/web-app/src/lib/audio-state.ts
@@ -1,5 +1,6 @@
 const KEY = 'ppl.audio.speed';
 const DEFAULT_SPEED = 1;
+const POS_PREFIX = 'ppl.audio.pos.';
 
 export function readSpeed(): number {
   try {
@@ -15,6 +16,25 @@ export function readSpeed(): number {
 export function writeSpeed(speed: number): void {
   try {
     localStorage.setItem(KEY, String(speed));
+  } catch {
+    // ignore storage errors (private browsing, quota)
+  }
+}
+
+export function readPosition(lessonId: string): number {
+  try {
+    const raw = localStorage.getItem(POS_PREFIX + lessonId);
+    if (raw === null) return 0;
+    const val = parseFloat(raw);
+    return isNaN(val) ? 0 : val;
+  } catch {
+    return 0;
+  }
+}
+
+export function writePosition(lessonId: string, time: number): void {
+  try {
+    localStorage.setItem(POS_PREFIX + lessonId, String(time));
   } catch {
     // ignore storage errors (private browsing, quota)
   }


### PR DESCRIPTION
## Summary
- Extracts `PlaylistQueue` component to `web-app/src/components/player/PlaylistQueue.tsx` showing all playlist lessons in a scrollable list below the audio player
- Each row displays: played/playing/unplayed icon (`▶`/`✓`/`·`), lesson ID in monospace, title, and duration
- Current row gets the amber left-border treatment per DESIGN-SYSTEM.md §5.3
- Tap/click jumps to that lesson; keyboard `↑`/`↓` moves focus, `Enter` jumps
- Adds `readPosition`/`writePosition` to `audio-state.ts` so saved playback positions are restored when jumping to a lesson
- All colors via MUI theme tokens (`primary.main`, `text.secondary`, `divider`, `action.selected`) — no hardcoded hex

## Test plan
- [ ] Playlist queue renders below the audio element
- [ ] Current lesson row has amber left border; others have transparent border
- [ ] Clicking a row jumps playback to that lesson (restores saved position if present)
- [ ] Keyboard: `↑`/`↓` moves focus between rows; `Enter` triggers jump
- [ ] Played lessons show `✓` icon; current shows `▶`; unplayed shows `·`
- [ ] Rows are ≥ 48 px tall (tap target requirement)
- [ ] Works in both dark and light mode without hardcoded colors
- [ ] No horizontal scroll at 360 px

Adheres to docs/design/DESIGN-SYSTEM.md

Closes #199

🤖 Generated with [Claude Code](https://claude.com/claude-code)