### PR TITLE
[PPL-201] Add sleep timer to playlist player

### DIFF
--- a/web-app/src/components/PlaylistPlayer.tsx
+++ b/web-app/src/components/PlaylistPlayer.tsx
@@ -16,6 +16,7 @@ import { TOPIC_LABELS } from '../lib/curriculum';
 import { readSpeed, writeSpeed, readPosition, writePosition, clearAudioPosition } from '../lib/audio-state';
 import PlaylistQueue from './player/PlaylistQueue';
 import { useMediaSession } from './MediaSessionBridge';
+import SleepTimer from './player/SleepTimer';
 
 const SPEEDS = [0.75, 1, 1.1, 1.25, 1.5, 1.75, 2] as const;
 type Speed = (typeof SPEEDS)[number];
@@ -215,6 +216,7 @@ export default function PlaylistPlayer({ lessons }: PlaylistPlayerProps) {
         >
           <SkipNextIcon />
         </IconButton>
+        <SleepTimer audioRef={audioRef} />
         <Select<Speed>
           value={speed}
           onChange={handleSpeedChange}

--- a/web-app/src/components/player/SleepTimer.tsx
+++ b/web-app/src/components/player/SleepTimer.tsx
@@ -18,7 +18,7 @@ const SLEEP_OPTIONS = [
 type SleepOption = (typeof SLEEP_OPTIONS)[number]['value'];
 
 interface SleepTimerProps {
-  audioRef: React.RefObject<HTMLAudioElement>;
+  audioRef: React.RefObject<HTMLAudioElement | null>;
 }
 
 const MONO = "'SF Mono', 'JetBrains Mono', Consolas, monospace";

--- a/web-app/src/components/player/SleepTimer.tsx
+++ b/web-app/src/components/player/SleepTimer.tsx
@@ -1,0 +1,174 @@
+import { useEffect, useRef, useState } from 'react';
+import Box from '@mui/material/Box';
+import IconButton from '@mui/material/IconButton';
+import Menu from '@mui/material/Menu';
+import MenuItem from '@mui/material/MenuItem';
+import Typography from '@mui/material/Typography';
+import BedtimeIcon from '@mui/icons-material/Bedtime';
+
+const SLEEP_OPTIONS = [
+  { label: 'Off', value: 'off' as const },
+  { label: '5 min', value: 5 },
+  { label: '15 min', value: 15 },
+  { label: '30 min', value: 30 },
+  { label: '60 min', value: 60 },
+  { label: 'End of lesson', value: 'lesson' as const },
+] as const;
+
+type SleepOption = (typeof SLEEP_OPTIONS)[number]['value'];
+
+interface SleepTimerProps {
+  audioRef: React.RefObject<HTMLAudioElement>;
+}
+
+const MONO = "'SF Mono', 'JetBrains Mono', Consolas, monospace";
+
+function formatCountdown(seconds: number): string {
+  const m = Math.floor(seconds / 60)
+    .toString()
+    .padStart(2, '0');
+  const s = (seconds % 60).toString().padStart(2, '0');
+  return `sleep in ${m}:${s}`;
+}
+
+export default function SleepTimer({ audioRef }: SleepTimerProps) {
+  const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
+  const [remaining, setRemaining] = useState<number | null>(null);
+  const remainingRef = useRef<number | null>(null);
+  const tickRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const fadeRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  function cancelAll() {
+    if (tickRef.current) {
+      clearInterval(tickRef.current);
+      tickRef.current = null;
+    }
+    if (fadeRef.current) {
+      clearInterval(fadeRef.current);
+      fadeRef.current = null;
+    }
+    const audio = audioRef.current;
+    if (audio) audio.volume = 1;
+    remainingRef.current = null;
+    setRemaining(null);
+  }
+
+  function startFade() {
+    if (fadeRef.current) return;
+    const audio = audioRef.current;
+    const steps = 100; // 100ms × 100 = 10s
+    let step = 0;
+    fadeRef.current = setInterval(() => {
+      step++;
+      if (audio) audio.volume = Math.max(0, 1 - step / steps);
+      if (step >= steps) {
+        clearInterval(fadeRef.current!);
+        fadeRef.current = null;
+        if (audio) {
+          audio.pause();
+          audio.volume = 1;
+        }
+        remainingRef.current = null;
+        setRemaining(null);
+      }
+    }, 100);
+  }
+
+  function startTimer(seconds: number) {
+    cancelAll();
+    remainingRef.current = seconds;
+    setRemaining(seconds);
+    tickRef.current = setInterval(() => {
+      if (remainingRef.current === null) return;
+      remainingRef.current -= 1;
+      if (remainingRef.current <= 0) {
+        clearInterval(tickRef.current!);
+        tickRef.current = null;
+        setRemaining(0);
+        startFade();
+      } else {
+        setRemaining(remainingRef.current);
+      }
+    }, 1000);
+  }
+
+  function handleSelect(value: SleepOption) {
+    setAnchorEl(null);
+    if (value === 'off') {
+      cancelAll();
+      return;
+    }
+    if (value === 'lesson') {
+      const audio = audioRef.current;
+      const secs =
+        audio && isFinite(audio.duration)
+          ? Math.max(1, Math.floor(audio.duration - audio.currentTime))
+          : 0;
+      if (secs > 0) startTimer(secs);
+      return;
+    }
+    startTimer(value * 60);
+  }
+
+  useEffect(() => {
+    return () => {
+      if (tickRef.current) clearInterval(tickRef.current);
+      if (fadeRef.current) clearInterval(fadeRef.current);
+      const audio = audioRef.current;
+      if (audio) audio.volume = 1;
+    };
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const isActive = remaining !== null;
+
+  return (
+    <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+      {isActive && (
+        <Typography
+          sx={{
+            fontFamily: MONO,
+            fontSize: 11,
+            fontWeight: 500,
+            letterSpacing: '0.05em',
+            color: 'primary.main',
+            userSelect: 'none',
+          }}
+        >
+          {formatCountdown(remaining!)}
+        </Typography>
+      )}
+      <IconButton
+        size="small"
+        onClick={(e) => setAnchorEl(e.currentTarget)}
+        aria-label="Sleep timer"
+        aria-haspopup="true"
+        sx={{
+          minWidth: 48,
+          minHeight: 48,
+          color: isActive ? 'primary.main' : 'text.secondary',
+          transition: 'color 150ms ease-out',
+          '&:hover': { color: 'primary.main' },
+        }}
+      >
+        <BedtimeIcon fontSize="small" />
+      </IconButton>
+      <Menu
+        anchorEl={anchorEl}
+        open={Boolean(anchorEl)}
+        onClose={() => setAnchorEl(null)}
+        anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
+        transformOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+      >
+        {SLEEP_OPTIONS.map(({ label, value }) => (
+          <MenuItem
+            key={String(value)}
+            onClick={() => handleSelect(value)}
+            sx={{ fontFamily: MONO, fontSize: 12, letterSpacing: '0.05em' }}
+          >
+            {label}
+          </MenuItem>
+        ))}
+      </Menu>
+    </Box>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds `SleepTimer` component (`web-app/src/components/player/SleepTimer.tsx`) with moon icon button and dropdown menu
- Menu options: Off / 5 min / 15 min / 30 min / 60 min / End of lesson
- Shows live countdown in `sleep in MM:SS` format when a timer is active
- On expiry: fades `audio.volume` from 1 → 0 over 10 s, then calls `audio.pause()` and restores volume
- "End of lesson" snapshots `duration − currentTime` at activation time
- "Off" cancels any active timer and restores volume immediately
- Integrated into `PlaylistPlayer.tsx` controls row; Media Session code untouched

Closes #201

## Test plan
- [ ] Set a 5-min timer; countdown shows and decrements each second
- [ ] Let timer expire; audio fades out over ~10 s and pauses
- [ ] Set "End of lesson" while audio is playing; timer counts down remaining duration
- [ ] Click Off while timer running; countdown disappears, volume stays at 1
- [ ] Click Off while audio is fading; fade stops, volume restores, audio continues
- [ ] Verify dark and light mode rendering

🤖 Generated with [Claude Code](https://claude.com/claude-code)