### PR TITLE
[PPL-216] Migrate GK visuals to shared _common.css

### DIFF
--- a/docs/visuals-standards.md
+++ b/docs/visuals-standards.md
@@ -16,11 +16,25 @@ authoring a new one.
 
 ## Format
 
-**Standalone dark-aviation HTML** — a complete `<!DOCTYPE html>` document with all
-CSS inlined in a `<style>` block inside `<head>`. No external stylesheets, no
-JavaScript frameworks, no `<link>` or `<script src>` tags pointing outside the
-document. The file must render correctly when opened directly from the filesystem
-(`file://`) without a server.
+**Standalone dark-aviation HTML** — a complete `<!DOCTYPE html>` document.
+JavaScript frameworks and `<script src>` tags pointing outside the document are
+prohibited.
+
+**CSS:** New topic visuals (al, met, nav) must inline all CSS in a `<style>` block
+in `<head>`. **GK visuals** (`gk*.html`) are the sole exception — they link the
+shared token sheet and keep only file-specific rules inline:
+
+```html
+<link rel="stylesheet" href="_common.css">
+<style>
+  /* file-specific rules only */
+</style>
+```
+
+`_common.css` lives in the same `web-app/public/visuals/` directory, so it loads
+correctly from Firebase Hosting. GK files will not render correctly when opened via
+`file://` without a local server — this is an acceptable trade-off for the dedup
+benefit. All other topic visuals remain fully self-contained.
 
 ## Viewport and dimensions
 

--- a/web-app/public/visuals/_common.css
+++ b/web-app/public/visuals/_common.css
@@ -1,0 +1,27 @@
+/* Shared design tokens for PPL Study GK visuals.
+   Link this file from gk*.html; do not link from other topic visuals. */
+
+* { box-sizing: border-box; margin: 0; padding: 0; }
+body { background: #0d1b2a; color: #e8edf2; font-family: 'Segoe UI', system-ui, sans-serif; padding: 32px; }
+h1 { font-size: 22px; color: #f0c040; letter-spacing: 1px; margin-bottom: 6px; }
+.subtitle { font-size: 13px; color: #7a9ab5; margin-bottom: 32px; letter-spacing: 0.5px; }
+.container { max-width: 900px; margin: 0 auto; }
+.section-title { font-size: 14px; color: #f0c040; letter-spacing: 1px; text-transform: uppercase; margin-bottom: 14px; margin-top: 32px; }
+
+svg text { font-family: 'Segoe UI', system-ui, sans-serif; }
+
+table { width: 100%; border-collapse: collapse; margin-bottom: 20px; }
+th { background: #1a2d3d; color: #f0c040; font-size: 12px; text-align: left; padding: 10px 14px; letter-spacing: 0.5px; }
+td { font-size: 13px; color: #e8edf2; padding: 9px 14px; border-bottom: 1px solid #1a2d3d; vertical-align: top; }
+tr:last-child td { border-bottom: none; }
+
+/* Card backdrop used by most GK diagrams */
+.diagram-box { background: #1a2d3d; border: 1px solid #243d52; border-radius: 8px; padding: 16px; }
+
+/* Note / exam-tip callout (amber border by default; override border-left for other colours) */
+.note-box { background: #1a2d3d; border-left: 3px solid #f0c040; border-radius: 4px; padding: 14px 18px; margin-top: 20px; font-size: 13px; color: #e8edf2; line-height: 1.6; }
+
+/* Memory-hook card (gk002 and future files) */
+.memory-box { background: #1a2d3d; border: 1px solid #f0c040; border-radius: 8px; padding: 20px; margin-top: 24px; }
+.memory-title { color: #f0c040; font-size: 13px; font-weight: bold; letter-spacing: 0.5px; margin-bottom: 10px; }
+.memory-item { font-size: 13px; color: #e8edf2; margin-bottom: 6px; padding-left: 12px; }

--- a/web-app/public/visuals/gk001-aircraft-parts-controls.html
+++ b/web-app/public/visuals/gk001-aircraft-parts-controls.html
@@ -4,21 +4,11 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>GK-001: Aircraft Parts and Controls</title>
+<link rel="stylesheet" href="_common.css">
 <style>
-  * { box-sizing: border-box; margin: 0; padding: 0; }
-  body { background: #0d1b2a; color: #e8edf2; font-family: 'Segoe UI', system-ui, sans-serif; padding: 32px; }
-  h1 { font-size: 22px; color: #f0c040; letter-spacing: 1px; margin-bottom: 6px; }
-  .subtitle { font-size: 13px; color: #7a9ab5; margin-bottom: 32px; letter-spacing: 0.5px; }
-  .container { max-width: 900px; margin: 0 auto; }
-  .section-title { font-size: 14px; color: #f0c040; letter-spacing: 1px; text-transform: uppercase; margin-bottom: 14px; margin-top: 32px; }
   .diagrams { display: grid; grid-template-columns: 1fr 1fr; gap: 24px; margin-bottom: 32px; }
-  .diagram-box { background: #1a2d3d; border: 1px solid #1a2d3d; border-radius: 8px; padding: 16px; }
+  .diagram-box { border-color: #1a2d3d; }
   .diagram-label { font-size: 12px; color: #7a9ab5; text-align: center; margin-bottom: 10px; letter-spacing: 0.5px; }
-  svg text { font-family: 'Segoe UI', system-ui, sans-serif; }
-  table { width: 100%; border-collapse: collapse; margin-bottom: 20px; }
-  th { background: #1a2d3d; color: #f0c040; font-size: 12px; text-align: left; padding: 10px 14px; letter-spacing: 0.5px; }
-  td { font-size: 13px; color: #e8edf2; padding: 9px 14px; border-bottom: 1px solid #1a2d3d; vertical-align: top; }
-  tr:last-child td { border-bottom: none; }
   .tag-primary { display: inline-block; background: #0d2a1a; color: #4caf7d; font-size: 11px; padding: 2px 8px; border-radius: 3px; border: 1px solid #4caf7d; }
   .tag-secondary { display: inline-block; background: #2a1a0d; color: #f0a040; font-size: 11px; padding: 2px 8px; border-radius: 3px; border: 1px solid #f0a040; }
   .tables-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 24px; }

--- a/web-app/public/visuals/gk002-four-forces.html
+++ b/web-app/public/visuals/gk002-four-forces.html
@@ -4,23 +4,9 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>GK-002: Four Forces of Flight</title>
+<link rel="stylesheet" href="_common.css">
 <style>
-  * { box-sizing: border-box; margin: 0; padding: 0; }
-  body { background: #0d1b2a; color: #e8edf2; font-family: 'Segoe UI', system-ui, sans-serif; padding: 32px; }
-  h1 { font-size: 22px; color: #f0c040; letter-spacing: 1px; margin-bottom: 6px; }
-  .subtitle { font-size: 13px; color: #7a9ab5; margin-bottom: 32px; letter-spacing: 0.5px; }
-  .container { max-width: 900px; margin: 0 auto; }
-  .section-title { font-size: 14px; color: #f0c040; letter-spacing: 1px; text-transform: uppercase; margin-bottom: 14px; margin-top: 32px; }
   .layout { display: grid; grid-template-columns: 1fr 1fr; gap: 24px; align-items: start; }
-  .diagram-box { background: #1a2d3d; border: 1px solid #243d52; border-radius: 8px; padding: 16px; }
-  svg text { font-family: 'Segoe UI', system-ui, sans-serif; }
-  table { width: 100%; border-collapse: collapse; margin-bottom: 20px; }
-  th { background: #1a2d3d; color: #f0c040; font-size: 12px; text-align: left; padding: 10px 14px; letter-spacing: 0.5px; }
-  td { font-size: 13px; color: #e8edf2; padding: 9px 14px; border-bottom: 1px solid #1a2d3d; vertical-align: top; }
-  tr:last-child td { border-bottom: none; }
-  .memory-box { background: #1a2d3d; border: 1px solid #f0c040; border-radius: 8px; padding: 20px; margin-top: 24px; }
-  .memory-title { color: #f0c040; font-size: 13px; font-weight: bold; letter-spacing: 0.5px; margin-bottom: 10px; }
-  .memory-item { font-size: 13px; color: #e8edf2; margin-bottom: 6px; padding-left: 12px; }
   .force-amber { color: #f0c040; font-weight: bold; }
   .force-blue { color: #5b9bd5; font-weight: bold; }
   .force-green { color: #4caf7d; font-weight: bold; }

--- a/web-app/public/visuals/gk003-piston-engines.html
+++ b/web-app/public/visuals/gk003-piston-engines.html
@@ -4,13 +4,8 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>GK-003: Piston Engine Four-Stroke Cycle</title>
+<link rel="stylesheet" href="_common.css">
 <style>
-  * { box-sizing: border-box; margin: 0; padding: 0; }
-  body { background: #0d1b2a; color: #e8edf2; font-family: 'Segoe UI', system-ui, sans-serif; padding: 32px; }
-  h1 { font-size: 22px; color: #f0c040; letter-spacing: 1px; margin-bottom: 6px; }
-  .subtitle { font-size: 13px; color: #7a9ab5; margin-bottom: 32px; letter-spacing: 0.5px; }
-  .container { max-width: 900px; margin: 0 auto; }
-  .section-title { font-size: 14px; color: #f0c040; letter-spacing: 1px; text-transform: uppercase; margin-bottom: 14px; margin-top: 32px; }
   .strokes-grid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 16px; margin-bottom: 32px; }
   .stroke-card { background: #1a2d3d; border: 1px solid #243d52; border-radius: 8px; padding: 14px; text-align: center; }
   .stroke-number { font-size: 11px; color: #7a9ab5; letter-spacing: 1px; text-transform: uppercase; margin-bottom: 6px; }
@@ -19,12 +14,6 @@
   .valve-state { font-size: 11px; padding: 4px 8px; border-radius: 4px; margin: 2px 0; }
   .valve-open { background: #0d2a1a; color: #4caf7d; border: 1px solid #4caf7d; }
   .valve-closed { background: #2a1a1a; color: #e05050; border: 1px solid #e05050; }
-  svg text { font-family: 'Segoe UI', system-ui, sans-serif; }
-  table { width: 100%; border-collapse: collapse; margin-bottom: 20px; }
-  th { background: #1a2d3d; color: #f0c040; font-size: 12px; text-align: left; padding: 10px 14px; letter-spacing: 0.5px; }
-  td { font-size: 13px; color: #e8edf2; padding: 9px 14px; border-bottom: 1px solid #1a2d3d; vertical-align: top; }
-  tr:last-child td { border-bottom: none; }
-  .note-box { background: #1a2d3d; border-left: 3px solid #f0c040; border-radius: 4px; padding: 14px 18px; margin-top: 20px; font-size: 13px; color: #e8edf2; line-height: 1.6; }
 </style>
 </head>
 <body>

--- a/web-app/public/visuals/gk004-fuel-system.html
+++ b/web-app/public/visuals/gk004-fuel-system.html
@@ -4,20 +4,9 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>GK-004: Fuel System</title>
+<link rel="stylesheet" href="_common.css">
 <style>
-  * { box-sizing: border-box; margin: 0; padding: 0; }
-  body { background: #0d1b2a; color: #e8edf2; font-family: 'Segoe UI', system-ui, sans-serif; padding: 32px; }
-  h1 { font-size: 22px; color: #f0c040; letter-spacing: 1px; margin-bottom: 6px; }
-  .subtitle { font-size: 13px; color: #7a9ab5; margin-bottom: 32px; letter-spacing: 0.5px; }
-  .container { max-width: 900px; margin: 0 auto; }
-  .section-title { font-size: 14px; color: #f0c040; letter-spacing: 1px; text-transform: uppercase; margin-bottom: 14px; margin-top: 32px; }
   .layout { display: grid; grid-template-columns: 1fr 1fr; gap: 24px; align-items: start; }
-  .diagram-box { background: #1a2d3d; border: 1px solid #243d52; border-radius: 8px; padding: 16px; }
-  svg text { font-family: 'Segoe UI', system-ui, sans-serif; }
-  table { width: 100%; border-collapse: collapse; margin-bottom: 20px; }
-  th { background: #1a2d3d; color: #f0c040; font-size: 12px; text-align: left; padding: 10px 14px; letter-spacing: 0.5px; }
-  td { font-size: 13px; color: #e8edf2; padding: 9px 14px; border-bottom: 1px solid #1a2d3d; vertical-align: top; }
-  tr:last-child td { border-bottom: none; }
   .badge { display: inline-block; font-size: 11px; font-weight: bold; padding: 2px 10px; border-radius: 12px; }
   .badge-blue { background: #0d1a3a; color: #5b9bd5; border: 1px solid #5b9bd5; }
   .badge-red { background: #2a0d0d; color: #e05050; border: 1px solid #e05050; }

--- a/web-app/public/visuals/gk005-electrical-system.html
+++ b/web-app/public/visuals/gk005-electrical-system.html
@@ -4,21 +4,10 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>GK-005: Electrical System</title>
+<link rel="stylesheet" href="_common.css">
 <style>
-  * { box-sizing: border-box; margin: 0; padding: 0; }
-  body { background: #0d1b2a; color: #e8edf2; font-family: 'Segoe UI', system-ui, sans-serif; padding: 32px; }
-  h1 { font-size: 22px; color: #f0c040; letter-spacing: 1px; margin-bottom: 6px; }
-  .subtitle { font-size: 13px; color: #7a9ab5; margin-bottom: 32px; letter-spacing: 0.5px; }
-  .container { max-width: 900px; margin: 0 auto; }
-  .section-title { font-size: 14px; color: #f0c040; letter-spacing: 1px; text-transform: uppercase; margin-bottom: 14px; margin-top: 32px; }
-  .diagram-box { background: #1a2d3d; border: 1px solid #243d52; border-radius: 8px; padding: 16px; margin-bottom: 24px; }
-  svg text { font-family: 'Segoe UI', system-ui, sans-serif; }
-  table { width: 100%; border-collapse: collapse; margin-bottom: 20px; }
-  th { background: #1a2d3d; color: #f0c040; font-size: 12px; text-align: left; padding: 10px 14px; letter-spacing: 0.5px; }
-  td { font-size: 13px; color: #e8edf2; padding: 9px 14px; border-bottom: 1px solid #1a2d3d; vertical-align: top; }
-  tr:last-child td { border-bottom: none; }
+  .diagram-box { margin-bottom: 24px; }
   .layout { display: grid; grid-template-columns: 1fr 1fr; gap: 24px; align-items: start; }
-  .note-box { background: #1a2d3d; border-left: 3px solid #f0c040; border-radius: 4px; padding: 14px 18px; margin-top: 20px; font-size: 13px; color: #e8edf2; line-height: 1.6; }
 </style>
 </head>
 <body>

--- a/web-app/public/visuals/gk006-pitot-static-instruments.html
+++ b/web-app/public/visuals/gk006-pitot-static-instruments.html
@@ -4,23 +4,13 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>GK-006: Pitot-Static System</title>
+<link rel="stylesheet" href="_common.css">
 <style>
-  * { box-sizing: border-box; margin: 0; padding: 0; }
-  body { background: #0d1b2a; color: #e8edf2; font-family: 'Segoe UI', system-ui, sans-serif; padding: 32px; }
-  h1 { font-size: 22px; color: #f0c040; letter-spacing: 1px; margin-bottom: 6px; }
-  .subtitle { font-size: 13px; color: #7a9ab5; margin-bottom: 32px; letter-spacing: 0.5px; }
-  .container { max-width: 900px; margin: 0 auto; }
-  .section-title { font-size: 14px; color: #f0c040; letter-spacing: 1px; text-transform: uppercase; margin-bottom: 14px; margin-top: 32px; }
-  .diagram-box { background: #1a2d3d; border: 1px solid #243d52; border-radius: 8px; padding: 16px; margin-bottom: 24px; }
-  svg text { font-family: 'Segoe UI', system-ui, sans-serif; }
-  table { width: 100%; border-collapse: collapse; margin-bottom: 20px; }
-  th { background: #1a2d3d; color: #f0c040; font-size: 12px; text-align: left; padding: 10px 14px; letter-spacing: 0.5px; }
-  td { font-size: 13px; color: #e8edf2; padding: 9px 14px; border-bottom: 1px solid #1a2d3d; vertical-align: top; }
-  tr:last-child td { border-bottom: none; }
+  .diagram-box { margin-bottom: 24px; }
   .layout { display: grid; grid-template-columns: 1fr 1fr; gap: 24px; align-items: start; }
   .arc-row { display: flex; align-items: center; gap: 10px; margin-bottom: 8px; font-size: 13px; }
   .arc-swatch { width: 32px; height: 14px; border-radius: 3px; flex-shrink: 0; }
-  .note-box { background: #1a2d3d; border-left: 3px solid #e05050; border-radius: 4px; padding: 14px 18px; margin-top: 20px; font-size: 13px; color: #e8edf2; line-height: 1.6; }
+  .note-box { border-left-color: #e05050; }
 </style>
 </head>
 <body>

--- a/web-app/public/visuals/gk007-gyroscopic-instruments.html
+++ b/web-app/public/visuals/gk007-gyroscopic-instruments.html
@@ -4,24 +4,13 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>GK-007: Gyroscopic Instruments</title>
+<link rel="stylesheet" href="_common.css">
 <style>
-  * { box-sizing: border-box; margin: 0; padding: 0; }
-  body { background: #0d1b2a; color: #e8edf2; font-family: 'Segoe UI', system-ui, sans-serif; padding: 32px; }
-  h1 { font-size: 22px; color: #f0c040; letter-spacing: 1px; margin-bottom: 6px; }
-  .subtitle { font-size: 13px; color: #7a9ab5; margin-bottom: 32px; letter-spacing: 0.5px; }
-  .container { max-width: 900px; margin: 0 auto; }
-  .section-title { font-size: 14px; color: #f0c040; letter-spacing: 1px; text-transform: uppercase; margin-bottom: 14px; margin-top: 32px; }
   .instruments-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 20px; margin-bottom: 32px; }
   .instrument-card { background: #1a2d3d; border: 1px solid #243d52; border-radius: 8px; padding: 16px; text-align: center; }
   .inst-name { font-size: 14px; color: #f0c040; font-weight: bold; margin-bottom: 4px; }
   .inst-abbr { font-size: 11px; color: #7a9ab5; margin-bottom: 12px; letter-spacing: 1px; }
   .inst-desc { font-size: 12px; color: #e8edf2; line-height: 1.5; margin-top: 10px; text-align: left; }
-  svg text { font-family: 'Segoe UI', system-ui, sans-serif; }
-  table { width: 100%; border-collapse: collapse; margin-bottom: 20px; }
-  th { background: #1a2d3d; color: #f0c040; font-size: 12px; text-align: left; padding: 10px 14px; letter-spacing: 0.5px; }
-  td { font-size: 13px; color: #e8edf2; padding: 9px 14px; border-bottom: 1px solid #1a2d3d; vertical-align: top; }
-  tr:last-child td { border-bottom: none; }
-  .note-box { background: #1a2d3d; border-left: 3px solid #f0c040; border-radius: 4px; padding: 14px 18px; margin-top: 20px; font-size: 13px; color: #e8edf2; line-height: 1.6; }
   .warn { color: #e05050; font-weight: bold; }
 </style>
 </head>

--- a/web-app/public/visuals/gk008-engine-instruments.html
+++ b/web-app/public/visuals/gk008-engine-instruments.html
@@ -4,26 +4,16 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>GK-008: Engine Instruments</title>
+<link rel="stylesheet" href="_common.css">
 <style>
-  * { box-sizing: border-box; margin: 0; padding: 0; }
-  body { background: #0d1b2a; color: #e8edf2; font-family: 'Segoe UI', system-ui, sans-serif; padding: 32px; }
-  h1 { font-size: 22px; color: #f0c040; letter-spacing: 1px; margin-bottom: 6px; }
-  .subtitle { font-size: 13px; color: #7a9ab5; margin-bottom: 32px; letter-spacing: 0.5px; }
-  .container { max-width: 900px; margin: 0 auto; }
-  .section-title { font-size: 14px; color: #f0c040; letter-spacing: 1px; text-transform: uppercase; margin-bottom: 14px; margin-top: 32px; }
   .panel-grid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 14px; margin-bottom: 32px; }
   .gauge-card { background: #1a2d3d; border: 1px solid #243d52; border-radius: 8px; padding: 12px; text-align: center; }
   .gauge-name { font-size: 11px; color: #f0c040; font-weight: bold; letter-spacing: 0.5px; margin-bottom: 4px; }
   .gauge-abbr { font-size: 10px; color: #7a9ab5; margin-bottom: 8px; }
-  svg text { font-family: 'Segoe UI', system-ui, sans-serif; }
-  table { width: 100%; border-collapse: collapse; margin-bottom: 20px; }
-  th { background: #1a2d3d; color: #f0c040; font-size: 12px; text-align: left; padding: 10px 14px; letter-spacing: 0.5px; }
-  td { font-size: 13px; color: #e8edf2; padding: 9px 14px; border-bottom: 1px solid #1a2d3d; vertical-align: top; }
-  tr:last-child td { border-bottom: none; }
   .arc-green { color: #4caf7d; font-weight: bold; }
   .arc-yellow { color: #f0c040; font-weight: bold; }
   .arc-red { color: #e05050; font-weight: bold; }
-  .note-box { background: #1a2d3d; border-left: 3px solid #e05050; border-radius: 4px; padding: 14px 18px; margin-top: 20px; font-size: 13px; color: #e8edf2; line-height: 1.6; }
+  .note-box { border-left-color: #e05050; }
 </style>
 </head>
 <body>

--- a/web-app/public/visuals/gk009-weight-and-balance.html
+++ b/web-app/public/visuals/gk009-weight-and-balance.html
@@ -4,26 +4,15 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>GK-009: Weight and Balance</title>
+<link rel="stylesheet" href="_common.css">
 <style>
-  * { box-sizing: border-box; margin: 0; padding: 0; }
-  body { background: #0d1b2a; color: #e8edf2; font-family: 'Segoe UI', system-ui, sans-serif; padding: 32px; }
-  h1 { font-size: 22px; color: #f0c040; letter-spacing: 1px; margin-bottom: 6px; }
-  .subtitle { font-size: 13px; color: #7a9ab5; margin-bottom: 32px; letter-spacing: 0.5px; }
-  .container { max-width: 900px; margin: 0 auto; }
-  .section-title { font-size: 14px; color: #f0c040; letter-spacing: 1px; text-transform: uppercase; margin-bottom: 14px; margin-top: 32px; }
   .layout { display: grid; grid-template-columns: 1fr 1fr; gap: 24px; align-items: start; }
-  .diagram-box { background: #1a2d3d; border: 1px solid #243d52; border-radius: 8px; padding: 16px; }
-  svg text { font-family: 'Segoe UI', system-ui, sans-serif; }
-  table { width: 100%; border-collapse: collapse; margin-bottom: 20px; }
-  th { background: #1a2d3d; color: #f0c040; font-size: 12px; text-align: left; padding: 10px 14px; letter-spacing: 0.5px; }
-  td { font-size: 13px; color: #e8edf2; padding: 9px 14px; border-bottom: 1px solid #1a2d3d; vertical-align: top; text-align: right; }
+  td { text-align: right; }
   td:first-child { text-align: left; }
-  tr:last-child td { border-bottom: none; }
   .formula-box { background: #1a2d3d; border: 1px solid #f0c040; border-radius: 8px; padding: 18px; margin-bottom: 20px; text-align: center; }
   .formula { font-size: 18px; color: #f0c040; font-weight: bold; letter-spacing: 1px; margin-bottom: 6px; }
   .formula-sub { font-size: 12px; color: #7a9ab5; }
   .total-row td { background: #243d52; color: #f0c040; font-weight: bold; }
-  .note-box { background: #1a2d3d; border-left: 3px solid #f0c040; border-radius: 4px; padding: 14px 18px; margin-top: 20px; font-size: 13px; color: #e8edf2; line-height: 1.6; }
   .warning { color: #e05050; font-weight: bold; }
 </style>
 </head>

--- a/web-app/public/visuals/gk010-performance-charts.html
+++ b/web-app/public/visuals/gk010-performance-charts.html
@@ -4,22 +4,15 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>GK-010: Performance Charts Reference</title>
+<link rel="stylesheet" href="_common.css">
 <style>
-  * { box-sizing: border-box; margin: 0; padding: 0; }
-  body { background: #0d1b2a; color: #e8edf2; font-family: 'Segoe UI', system-ui, sans-serif; padding: 32px; }
-  h1 { font-size: 22px; color: #f0c040; letter-spacing: 1px; margin-bottom: 6px; }
-  .subtitle { font-size: 13px; color: #7a9ab5; margin-bottom: 32px; letter-spacing: 0.5px; }
-  .container { max-width: 900px; margin: 0 auto; }
-  .section-title { font-size: 14px; color: #f0c040; letter-spacing: 1px; text-transform: uppercase; margin-bottom: 14px; margin-top: 32px; }
+  table { margin-bottom: 0; }
+  th { padding: 9px 12px; }
+  td { font-size: 12px; padding: 8px 12px; }
   .grid-2 { display: grid; grid-template-columns: 1fr 1fr; gap: 24px; margin-bottom: 24px; }
   .grid-4 { display: grid; grid-template-columns: repeat(4, 1fr); gap: 16px; margin-bottom: 24px; }
   .card { background: #1a2d3d; border: 1px solid #243d52; border-radius: 8px; padding: 16px; }
   .card-title { font-size: 12px; color: #f0c040; font-weight: bold; letter-spacing: 0.5px; margin-bottom: 10px; text-transform: uppercase; }
-  svg text { font-family: 'Segoe UI', system-ui, sans-serif; }
-  table { width: 100%; border-collapse: collapse; margin-bottom: 0; }
-  th { background: #1a2d3d; color: #f0c040; font-size: 12px; text-align: left; padding: 9px 12px; letter-spacing: 0.5px; }
-  td { font-size: 12px; color: #e8edf2; padding: 8px 12px; border-bottom: 1px solid #1a2d3d; vertical-align: top; }
-  tr:last-child td { border-bottom: none; }
   .isa-box { background: #0d2040; border: 2px solid #5b9bd5; border-radius: 8px; padding: 18px; text-align: center; margin-bottom: 24px; }
   .isa-main { font-size: 18px; color: #5b9bd5; font-weight: bold; margin-bottom: 4px; }
   .isa-sub { font-size: 12px; color: #7a9ab5; line-height: 1.6; }

--- a/web-app/public/visuals/gk011-takeoff-landing-perf.html
+++ b/web-app/public/visuals/gk011-takeoff-landing-perf.html
@@ -4,26 +4,15 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>GK-011: Takeoff and Landing Performance</title>
+<link rel="stylesheet" href="_common.css">
 <style>
-  * { box-sizing: border-box; margin: 0; padding: 0; }
-  body { background: #0d1b2a; color: #e8edf2; font-family: 'Segoe UI', system-ui, sans-serif; padding: 32px; }
-  h1 { font-size: 22px; color: #f0c040; letter-spacing: 1px; margin-bottom: 6px; }
-  .subtitle { font-size: 13px; color: #7a9ab5; margin-bottom: 32px; letter-spacing: 0.5px; }
-  .container { max-width: 900px; margin: 0 auto; }
-  .section-title { font-size: 14px; color: #f0c040; letter-spacing: 1px; text-transform: uppercase; margin-bottom: 14px; margin-top: 32px; }
   .layout { display: grid; grid-template-columns: 1fr 1fr; gap: 24px; align-items: start; }
-  .diagram-box { background: #1a2d3d; border: 1px solid #243d52; border-radius: 8px; padding: 16px; margin-bottom: 24px; }
-  svg text { font-family: 'Segoe UI', system-ui, sans-serif; }
-  table { width: 100%; border-collapse: collapse; margin-bottom: 20px; }
-  th { background: #1a2d3d; color: #f0c040; font-size: 12px; text-align: left; padding: 10px 14px; letter-spacing: 0.5px; }
-  td { font-size: 13px; color: #e8edf2; padding: 9px 14px; border-bottom: 1px solid #1a2d3d; vertical-align: top; }
-  tr:last-child td { border-bottom: none; }
+  .diagram-box { margin-bottom: 24px; }
   .speeds-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 14px; margin-bottom: 24px; }
   .speed-card { background: #1a2d3d; border: 1px solid #243d52; border-radius: 8px; padding: 14px; text-align: center; }
   .speed-label { font-size: 22px; color: #f0c040; font-weight: bold; margin-bottom: 4px; }
   .speed-name { font-size: 11px; color: #7a9ab5; margin-bottom: 8px; letter-spacing: 0.5px; }
   .speed-desc { font-size: 12px; color: #e8edf2; line-height: 1.5; }
-  .note-box { background: #1a2d3d; border-left: 3px solid #f0c040; border-radius: 4px; padding: 14px 18px; margin-top: 20px; font-size: 13px; color: #e8edf2; line-height: 1.6; }
 </style>
 </head>
 <body>

--- a/web-app/public/visuals/gk012-stalls-spins.html
+++ b/web-app/public/visuals/gk012-stalls-spins.html
@@ -4,20 +4,9 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>GK-012: Stalls and Spins</title>
+<link rel="stylesheet" href="_common.css">
 <style>
-  * { box-sizing: border-box; margin: 0; padding: 0; }
-  body { background: #0d1b2a; color: #e8edf2; font-family: 'Segoe UI', system-ui, sans-serif; padding: 32px; }
-  h1 { font-size: 22px; color: #f0c040; letter-spacing: 1px; margin-bottom: 6px; }
-  .subtitle { font-size: 13px; color: #7a9ab5; margin-bottom: 32px; letter-spacing: 0.5px; }
-  .container { max-width: 900px; margin: 0 auto; }
-  .section-title { font-size: 14px; color: #f0c040; letter-spacing: 1px; text-transform: uppercase; margin-bottom: 14px; margin-top: 32px; }
   .layout { display: grid; grid-template-columns: 1fr 1fr; gap: 24px; align-items: start; }
-  .diagram-box { background: #1a2d3d; border: 1px solid #243d52; border-radius: 8px; padding: 16px; }
-  svg text { font-family: 'Segoe UI', system-ui, sans-serif; }
-  table { width: 100%; border-collapse: collapse; margin-bottom: 20px; }
-  th { background: #1a2d3d; color: #f0c040; font-size: 12px; text-align: left; padding: 10px 14px; letter-spacing: 0.5px; }
-  td { font-size: 13px; color: #e8edf2; padding: 9px 14px; border-bottom: 1px solid #1a2d3d; vertical-align: top; }
-  tr:last-child td { border-bottom: none; }
   .recovery-steps { background: #1a2d3d; border: 1px solid #243d52; border-radius: 8px; padding: 16px; }
   .step { display: flex; gap: 12px; margin-bottom: 12px; align-items: flex-start; }
   .step:last-child { margin-bottom: 0; }
@@ -28,7 +17,7 @@
   .pare-title { font-size: 13px; color: #f0c040; font-weight: bold; margin-bottom: 10px; letter-spacing: 1px; }
   .pare-row { display: flex; gap: 10px; align-items: center; margin-bottom: 8px; font-size: 13px; }
   .pare-letter { font-size: 22px; color: #f0c040; font-weight: bold; width: 28px; flex-shrink: 0; }
-  .note-box { background: #1a2d3d; border-left: 3px solid #e05050; border-radius: 4px; padding: 14px 18px; margin-top: 20px; font-size: 13px; color: #e8edf2; line-height: 1.6; }
+  .note-box { border-left-color: #e05050; }
 </style>
 </head>
 <body>

--- a/web-app/public/visuals/gk013-load-factor.html
+++ b/web-app/public/visuals/gk013-load-factor.html
@@ -4,27 +4,15 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>GK-013: Load Factor and Maneuvering Speed</title>
+<link rel="stylesheet" href="_common.css">
 <style>
-  * { box-sizing: border-box; margin: 0; padding: 0; }
-  body { background: #0d1b2a; color: #e8edf2; font-family: 'Segoe UI', system-ui, sans-serif; padding: 32px; }
-  h1 { font-size: 22px; color: #f0c040; letter-spacing: 1px; margin-bottom: 6px; }
-  .subtitle { font-size: 13px; color: #7a9ab5; margin-bottom: 32px; letter-spacing: 0.5px; }
-  .container { max-width: 900px; margin: 0 auto; }
-  .section-title { font-size: 14px; color: #f0c040; letter-spacing: 1px; text-transform: uppercase; margin-bottom: 14px; margin-top: 32px; }
   .layout { display: grid; grid-template-columns: 1fr 1fr; gap: 24px; align-items: start; }
-  .diagram-box { background: #1a2d3d; border: 1px solid #243d52; border-radius: 8px; padding: 16px; }
-  svg text { font-family: 'Segoe UI', system-ui, sans-serif; }
-  table { width: 100%; border-collapse: collapse; margin-bottom: 20px; }
-  th { background: #1a2d3d; color: #f0c040; font-size: 12px; text-align: left; padding: 10px 14px; letter-spacing: 0.5px; }
-  td { font-size: 13px; color: #e8edf2; padding: 9px 14px; border-bottom: 1px solid #1a2d3d; vertical-align: top; }
-  tr:last-child td { border-bottom: none; }
   .bank-grid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 12px; margin-bottom: 24px; }
   .bank-card { background: #1a2d3d; border: 1px solid #243d52; border-radius: 8px; padding: 14px; text-align: center; }
   .bank-angle { font-size: 20px; color: #f0c040; font-weight: bold; margin-bottom: 2px; }
   .bank-bank { font-size: 11px; color: #7a9ab5; margin-bottom: 8px; }
   .bank-g { font-size: 16px; color: #4caf7d; font-weight: bold; }
   .bank-g-label { font-size: 10px; color: #7a9ab5; }
-  .note-box { background: #1a2d3d; border-left: 3px solid #f0c040; border-radius: 4px; padding: 14px 18px; margin-top: 20px; font-size: 13px; color: #e8edf2; line-height: 1.6; }
   .limit-normal { color: #4caf7d; font-weight: bold; }
   .limit-utility { color: #f0c040; font-weight: bold; }
   .limit-acro { color: #e05050; font-weight: bold; }

--- a/web-app/public/visuals/gk014-preflight-inspection.html
+++ b/web-app/public/visuals/gk014-preflight-inspection.html
@@ -4,20 +4,10 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>GK-014: Preflight Inspection</title>
+<link rel="stylesheet" href="_common.css">
 <style>
-  * { box-sizing: border-box; margin: 0; padding: 0; }
-  body { background: #0d1b2a; color: #e8edf2; font-family: 'Segoe UI', system-ui, sans-serif; padding: 32px; }
-  h1 { font-size: 22px; color: #f0c040; letter-spacing: 1px; margin-bottom: 6px; }
-  .subtitle { font-size: 13px; color: #7a9ab5; margin-bottom: 32px; letter-spacing: 0.5px; }
-  .container { max-width: 900px; margin: 0 auto; }
-  .section-title { font-size: 14px; color: #f0c040; letter-spacing: 1px; text-transform: uppercase; margin-bottom: 14px; margin-top: 32px; }
   .layout { display: grid; grid-template-columns: 1fr 1fr; gap: 24px; align-items: start; }
-  .diagram-box { background: #1a2d3d; border: 1px solid #243d52; border-radius: 8px; padding: 16px; }
-  svg text { font-family: 'Segoe UI', system-ui, sans-serif; }
-  table { width: 100%; border-collapse: collapse; margin-bottom: 20px; }
-  th { background: #1a2d3d; color: #f0c040; font-size: 12px; text-align: left; padding: 10px 14px; letter-spacing: 0.5px; }
-  td { font-size: 12px; color: #e8edf2; padding: 8px 12px; border-bottom: 1px solid #1a2d3d; vertical-align: top; }
-  tr:last-child td { border-bottom: none; }
+  td { font-size: 12px; padding: 8px 12px; }
   .zone-num { display: inline-flex; align-items: center; justify-content: center; width: 22px; height: 22px; background: #f0c040; color: #0d1b2a; border-radius: 50%; font-size: 11px; font-weight: bold; margin-right: 6px; flex-shrink: 0; }
   .zone-title { display: flex; align-items: center; font-size: 13px; color: #f0c040; font-weight: bold; margin-bottom: 6px; }
   .checklist-item { font-size: 12px; color: #e8edf2; padding: 3px 0 3px 28px; display: flex; align-items: flex-start; gap: 6px; }
@@ -27,7 +17,7 @@
   .arrow-title { font-size: 13px; color: #f0c040; font-weight: bold; letter-spacing: 1px; margin-bottom: 10px; }
   .arrow-row { display: flex; gap: 10px; align-items: center; margin-bottom: 8px; font-size: 13px; }
   .arrow-letter { font-size: 22px; color: #f0c040; font-weight: bold; width: 28px; flex-shrink: 0; }
-  .note-box { background: #1a2d3d; border-left: 3px solid #4caf7d; border-radius: 4px; padding: 14px 18px; margin-top: 20px; font-size: 13px; color: #e8edf2; line-height: 1.6; }
+  .note-box { border-left-color: #4caf7d; }
 </style>
 </head>
 <body>


### PR DESCRIPTION
## Summary

- Creates `web-app/public/visuals/_common.css` with shared design tokens: CSS reset, body/palette, `h1`, `.container`, `.section-title`, table/`th`/`td`, `.diagram-box`, `.note-box`, `.memory-box`
- Migrates all 14 `gk*.html` visuals to `<link rel="stylesheet" href="_common.css">`, keeping only file-specific styles inline (SVG positioning, bespoke components, per-file border-color overrides)
- Removes ~15–18 duplicate rule declarations per file (182 lines deleted, 73 added net)
- Updates `docs/visuals-standards.md` to document the GK-only external-CSS exception per CLAUDE.md enforcement rule
- All visual content (text, diagrams, SVGs, back-link button) is unchanged — CSS refactor only
- `npm run build` passes ✓

Closes #216

## Test plan

- [ ] Open each `gk*.html` via Firebase Hosting (`/visuals/gk001-aircraft-parts-controls.html` etc.) and verify dark-aviation appearance is correct
- [ ] Confirm back-link button present and functional on all 14 files
- [ ] Confirm `npm run build` passes in `web-app/`
- [ ] Verify no regressions on `al*`, `met*`, `nav*` visuals (those are unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)