### PR TITLE
[PPL-215] Migrate MET visuals to shared _common.css

### DIFF
--- a/web-app/public/visuals/met002-temp-pressure-humidity.html
+++ b/web-app/public/visuals/met002-temp-pressure-humidity.html
@@ -4,25 +4,11 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>MET-002: Temperature, Pressure, Humidity</title>
+<link rel="stylesheet" href="/visuals/_common.css">
 <style>
-  * { box-sizing: border-box; margin: 0; padding: 0; }
-  body { background: #0d1b2a; color: #e8edf2; font-family: 'Segoe UI', system-ui, sans-serif; padding: 32px; }
-  h1 { font-size: 22px; color: #f0c040; letter-spacing: 1px; margin-bottom: 6px; }
-  .subtitle { font-size: 13px; color: #7a9ab5; margin-bottom: 32px; letter-spacing: 0.5px; }
-  .container { max-width: 900px; margin: 0 auto; }
-  .section-title { font-size: 14px; color: #f0c040; letter-spacing: 1px; text-transform: uppercase; margin: 32px 0 14px; }
   .layout { display: grid; grid-template-columns: 1fr 1fr; gap: 24px; align-items: start; }
-  .diagram-box { background: #1a2d3d; border: 1px solid #243d52; border-radius: 8px; padding: 16px; }
-  svg text { font-family: 'Segoe UI', system-ui, sans-serif; }
-  table { width: 100%; border-collapse: collapse; margin-bottom: 20px; }
-  th { background: #1a2d3d; color: #f0c040; font-size: 12px; text-align: left; padding: 10px 14px; letter-spacing: 0.5px; }
-  td { font-size: 13px; color: #e8edf2; padding: 9px 14px; border-bottom: 1px solid #1a2d3d; vertical-align: top; }
-  tr:last-child td { border-bottom: none; }
-  .memory-hook { background: #1a2a1a; border: 1px solid #2d5a2d; border-radius: 8px; padding: 14px 18px; margin-top: 24px; font-size: 13px; line-height: 1.6; }
-  .memory-hook .badge { display: inline-block; background: #2d5a2d; color: #e8edf2; font-size: 10px; letter-spacing: 1px; padding: 2px 8px; border-radius: 3px; margin-bottom: 6px; }
   .caption { font-size: 12px; color: #7a9ab5; text-align: center; margin-top: 8px; }
   @media (max-width: 640px) {
-    body { padding: 16px; }
     .layout { grid-template-columns: 1fr; }
   }
 </style>

--- a/web-app/public/visuals/met003-clouds-types.html
+++ b/web-app/public/visuals/met003-clouds-types.html
@@ -4,13 +4,8 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>MET-003: Cloud Types</title>
+<link rel="stylesheet" href="/visuals/_common.css">
 <style>
-  * { box-sizing: border-box; margin: 0; padding: 0; }
-  body { background: #0d1b2a; color: #e8edf2; font-family: 'Segoe UI', system-ui, sans-serif; padding: 32px; }
-  h1 { font-size: 22px; color: #f0c040; letter-spacing: 1px; margin-bottom: 6px; }
-  .subtitle { font-size: 13px; color: #7a9ab5; margin-bottom: 32px; letter-spacing: 0.5px; }
-  .container { max-width: 900px; margin: 0 auto; }
-  .section-title { font-size: 14px; color: #f0c040; letter-spacing: 1px; text-transform: uppercase; margin: 32px 0 14px; }
   .tier { display: grid; grid-template-columns: 160px 1fr; gap: 16px; align-items: stretch; margin-bottom: 10px; }
   .tier-label { background: #1a2d3d; border: 1px solid #243d52; border-radius: 8px; padding: 14px; }
   .tier-label .alt { font-size: 11px; color: #7a9ab5; letter-spacing: 0.5px; text-transform: uppercase; }
@@ -21,18 +16,11 @@
   .cloud-card .cname { font-size: 13px; color: #f0c040; font-weight: bold; margin-bottom: 4px; }
   .cloud-card .cabbr { font-size: 10px; color: #7a9ab5; letter-spacing: 1px; }
   .cloud-card .cnote { font-size: 11px; color: #e8edf2; margin-top: 6px; line-height: 1.45; }
-  table { width: 100%; border-collapse: collapse; margin-bottom: 20px; }
-  th { background: #1a2d3d; color: #f0c040; font-size: 12px; text-align: left; padding: 10px 14px; letter-spacing: 0.5px; }
-  td { font-size: 13px; color: #e8edf2; padding: 9px 14px; border-bottom: 1px solid #1a2d3d; vertical-align: top; }
-  tr:last-child td { border-bottom: none; }
   .stability-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; }
   .stab-card { background: #1a2d3d; border: 1px solid #243d52; border-radius: 8px; padding: 14px; }
   .stab-card h3 { font-size: 13px; color: #f0c040; margin-bottom: 8px; letter-spacing: 0.5px; }
   .stab-card ul { margin-left: 18px; color: #e8edf2; font-size: 12px; line-height: 1.7; }
-  .memory-hook { background: #1a2a1a; border: 1px solid #2d5a2d; border-radius: 8px; padding: 14px 18px; margin-top: 24px; font-size: 13px; line-height: 1.6; }
-  .memory-hook .badge { display: inline-block; background: #2d5a2d; color: #e8edf2; font-size: 10px; letter-spacing: 1px; padding: 2px 8px; border-radius: 3px; margin-bottom: 6px; }
   @media (max-width: 640px) {
-    body { padding: 16px; }
     .tier { grid-template-columns: 1fr; }
     .stability-grid { grid-template-columns: 1fr; }
   }

--- a/web-app/public/visuals/met004-fog-types.html
+++ b/web-app/public/visuals/met004-fog-types.html
@@ -4,26 +4,14 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>MET-004: Fog Types</title>
+<link rel="stylesheet" href="/visuals/_common.css">
 <style>
-  * { box-sizing: border-box; margin: 0; padding: 0; }
-  body { background: #0d1b2a; color: #e8edf2; font-family: 'Segoe UI', system-ui, sans-serif; padding: 32px; }
-  h1 { font-size: 22px; color: #f0c040; letter-spacing: 1px; margin-bottom: 6px; }
-  .subtitle { font-size: 13px; color: #7a9ab5; margin-bottom: 32px; letter-spacing: 0.5px; }
-  .container { max-width: 900px; margin: 0 auto; }
-  .section-title { font-size: 14px; color: #f0c040; letter-spacing: 1px; text-transform: uppercase; margin: 32px 0 14px; }
   .grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); gap: 14px; }
   .card { background: #1a2d3d; border: 1px solid #243d52; border-radius: 8px; padding: 16px; }
   .card h3 { font-size: 14px; color: #f0c040; margin-bottom: 6px; letter-spacing: 0.5px; }
   .card .tag { display: inline-block; font-size: 10px; background: #243d52; color: #e8edf2; padding: 2px 7px; border-radius: 3px; letter-spacing: 0.5px; margin-bottom: 8px; }
   .card .row { font-size: 12px; color: #e8edf2; margin-bottom: 4px; line-height: 1.5; }
   .card .row .label { color: #7a9ab5; font-size: 10px; letter-spacing: 0.5px; text-transform: uppercase; display: block; margin-top: 6px; }
-  table { width: 100%; border-collapse: collapse; margin-bottom: 20px; }
-  th { background: #1a2d3d; color: #f0c040; font-size: 12px; text-align: left; padding: 10px 14px; letter-spacing: 0.5px; }
-  td { font-size: 13px; color: #e8edf2; padding: 9px 14px; border-bottom: 1px solid #1a2d3d; vertical-align: top; }
-  tr:last-child td { border-bottom: none; }
-  .memory-hook { background: #1a2a1a; border: 1px solid #2d5a2d; border-radius: 8px; padding: 14px 18px; margin-top: 24px; font-size: 13px; line-height: 1.6; }
-  .memory-hook .badge { display: inline-block; background: #2d5a2d; color: #e8edf2; font-size: 10px; letter-spacing: 1px; padding: 2px 8px; border-radius: 3px; margin-bottom: 6px; }
-  @media (max-width: 640px) { body { padding: 16px; } }
 </style>
 </head>
 <body>

--- a/web-app/public/visuals/met005-metar-decoding.html
+++ b/web-app/public/visuals/met005-metar-decoding.html
@@ -4,13 +4,8 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>MET-005: METAR Decoding</title>
+<link rel="stylesheet" href="/visuals/_common.css">
 <style>
-  * { box-sizing: border-box; margin: 0; padding: 0; }
-  body { background: #0d1b2a; color: #e8edf2; font-family: 'Segoe UI', system-ui, sans-serif; padding: 32px; }
-  h1 { font-size: 22px; color: #f0c040; letter-spacing: 1px; margin-bottom: 6px; }
-  .subtitle { font-size: 13px; color: #7a9ab5; margin-bottom: 32px; letter-spacing: 0.5px; }
-  .container { max-width: 900px; margin: 0 auto; }
-  .section-title { font-size: 14px; color: #f0c040; letter-spacing: 1px; text-transform: uppercase; margin: 32px 0 14px; }
   .metar-sample { background: #1a2d3d; border: 1px solid #243d52; border-radius: 8px; padding: 18px 20px; font-family: 'Consolas', 'Menlo', monospace; font-size: 15px; line-height: 1.9; margin-bottom: 14px; word-break: break-word; }
   .seg { padding: 2px 6px; border-radius: 3px; margin: 0 2px; display: inline-block; }
   .s-type { background: #2d3e50; color: #e8edf2; }
@@ -23,19 +18,13 @@
   .s-temp { background: #3a5a7a; color: #e8edf2; }
   .s-alt  { background: #6a4a7a; color: #e8edf2; }
   .s-rmk  { background: #3d3d3d; color: #e8edf2; }
-  table { width: 100%; border-collapse: collapse; margin-bottom: 20px; }
-  th { background: #1a2d3d; color: #f0c040; font-size: 12px; text-align: left; padding: 10px 14px; letter-spacing: 0.5px; }
-  td { font-size: 13px; color: #e8edf2; padding: 9px 14px; border-bottom: 1px solid #1a2d3d; vertical-align: top; }
-  tr:last-child td { border-bottom: none; }
   td code { font-family: 'Consolas', 'Menlo', monospace; background: #0d1b2a; color: #f0c040; padding: 1px 6px; border-radius: 3px; font-size: 12px; }
   .sky-grid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 10px; }
   .sky-card { background: #1a2d3d; border: 1px solid #243d52; border-radius: 8px; padding: 12px; text-align: center; }
   .sky-code { font-size: 18px; color: #f0c040; font-weight: bold; font-family: 'Consolas', monospace; }
   .sky-name { font-size: 11px; color: #e8edf2; margin-top: 4px; }
   .sky-oktas { font-size: 10px; color: #7a9ab5; margin-top: 2px; }
-  .memory-hook { background: #1a2a1a; border: 1px solid #2d5a2d; border-radius: 8px; padding: 14px 18px; margin-top: 24px; font-size: 13px; line-height: 1.6; }
-  .memory-hook .badge { display: inline-block; background: #2d5a2d; color: #e8edf2; font-size: 10px; letter-spacing: 1px; padding: 2px 8px; border-radius: 3px; margin-bottom: 6px; }
-  @media (max-width: 640px) { body { padding: 16px; } .sky-grid { grid-template-columns: repeat(2, 1fr); } }
+  @media (max-width: 640px) { .sky-grid { grid-template-columns: repeat(2, 1fr); } }
 </style>
 </head>
 <body>

--- a/web-app/public/visuals/met006-taf-decoding.html
+++ b/web-app/public/visuals/met006-taf-decoding.html
@@ -4,13 +4,8 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>MET-006: TAF Decoding</title>
+<link rel="stylesheet" href="/visuals/_common.css">
 <style>
-  * { box-sizing: border-box; margin: 0; padding: 0; }
-  body { background: #0d1b2a; color: #e8edf2; font-family: 'Segoe UI', system-ui, sans-serif; padding: 32px; }
-  h1 { font-size: 22px; color: #f0c040; letter-spacing: 1px; margin-bottom: 6px; }
-  .subtitle { font-size: 13px; color: #7a9ab5; margin-bottom: 32px; letter-spacing: 0.5px; }
-  .container { max-width: 900px; margin: 0 auto; }
-  .section-title { font-size: 14px; color: #f0c040; letter-spacing: 1px; text-transform: uppercase; margin: 32px 0 14px; }
   .taf-sample { background: #1a2d3d; border: 1px solid #243d52; border-radius: 8px; padding: 18px 20px; font-family: 'Consolas', 'Menlo', monospace; font-size: 14px; line-height: 1.9; margin-bottom: 14px; word-break: break-word; }
   .seg { padding: 2px 6px; border-radius: 3px; margin: 0 2px; display: inline-block; }
   .s-hdr  { background: #2d3e50; color: #e8edf2; }
@@ -20,10 +15,6 @@
   .s-tmp  { background: #903a3a; color: #e8edf2; }
   .s-fm   { background: #5a7a3a; color: #e8edf2; }
   .s-prob { background: #6a4a7a; color: #e8edf2; }
-  table { width: 100%; border-collapse: collapse; margin-bottom: 20px; }
-  th { background: #1a2d3d; color: #f0c040; font-size: 12px; text-align: left; padding: 10px 14px; letter-spacing: 0.5px; }
-  td { font-size: 13px; color: #e8edf2; padding: 9px 14px; border-bottom: 1px solid #1a2d3d; vertical-align: top; }
-  tr:last-child td { border-bottom: none; }
   td code { font-family: 'Consolas', 'Menlo', monospace; background: #0d1b2a; color: #f0c040; padding: 1px 6px; border-radius: 3px; font-size: 12px; }
   .timeline { background: #1a2d3d; border: 1px solid #243d52; border-radius: 8px; padding: 14px 16px; margin-bottom: 14px; }
   .t-bar { display: flex; height: 46px; border-radius: 4px; overflow: hidden; border: 1px solid #243d52; }
@@ -36,9 +27,6 @@
   .t-block.fm   { background: #5a7a3a; }
   .t-legend { margin-top: 10px; font-size: 11px; color: #7a9ab5; display: flex; gap: 14px; flex-wrap: wrap; }
   .t-legend .sw { display: inline-block; width: 12px; height: 12px; border-radius: 2px; vertical-align: middle; margin-right: 4px; }
-  .memory-hook { background: #1a2a1a; border: 1px solid #2d5a2d; border-radius: 8px; padding: 14px 18px; margin-top: 24px; font-size: 13px; line-height: 1.6; }
-  .memory-hook .badge { display: inline-block; background: #2d5a2d; color: #e8edf2; font-size: 10px; letter-spacing: 1px; padding: 2px 8px; border-radius: 3px; margin-bottom: 6px; }
-  @media (max-width: 640px) { body { padding: 16px; } }
 </style>
 </head>
 <body>

--- a/web-app/public/visuals/met007-gfa.html
+++ b/web-app/public/visuals/met007-gfa.html
@@ -4,13 +4,8 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>MET-007: GFA</title>
+<link rel="stylesheet" href="/visuals/_common.css">
 <style>
-  * { box-sizing: border-box; margin: 0; padding: 0; }
-  body { background: #0d1b2a; color: #e8edf2; font-family: 'Segoe UI', system-ui, sans-serif; padding: 32px; }
-  h1 { font-size: 22px; color: #f0c040; letter-spacing: 1px; margin-bottom: 6px; }
-  .subtitle { font-size: 13px; color: #7a9ab5; margin-bottom: 32px; letter-spacing: 0.5px; }
-  .container { max-width: 900px; margin: 0 auto; }
-  .section-title { font-size: 14px; color: #f0c040; letter-spacing: 1px; text-transform: uppercase; margin: 32px 0 14px; }
   .chart-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; }
   .chart-card { background: #1a2d3d; border: 1px solid #243d52; border-radius: 8px; padding: 16px; }
   .chart-card h3 { font-size: 14px; color: #f0c040; margin-bottom: 4px; letter-spacing: 0.5px; }
@@ -21,14 +16,8 @@
   .t-panel .t-label { font-size: 11px; color: #7a9ab5; letter-spacing: 0.5px; }
   .t-panel .t-time  { font-size: 18px; color: #f0c040; font-weight: bold; margin: 4px 0 2px; }
   .t-panel .t-use   { font-size: 11px; color: #e8edf2; }
-  table { width: 100%; border-collapse: collapse; margin-bottom: 20px; }
-  th { background: #1a2d3d; color: #f0c040; font-size: 12px; text-align: left; padding: 10px 14px; letter-spacing: 0.5px; }
-  td { font-size: 13px; color: #e8edf2; padding: 9px 14px; border-bottom: 1px solid #1a2d3d; vertical-align: top; }
-  tr:last-child td { border-bottom: none; }
   .symbol { display: inline-block; min-width: 28px; text-align: center; font-weight: bold; color: #f0c040; font-family: 'Consolas', monospace; }
-  .memory-hook { background: #1a2a1a; border: 1px solid #2d5a2d; border-radius: 8px; padding: 14px 18px; margin-top: 24px; font-size: 13px; line-height: 1.6; }
-  .memory-hook .badge { display: inline-block; background: #2d5a2d; color: #e8edf2; font-size: 10px; letter-spacing: 1px; padding: 2px 8px; border-radius: 3px; margin-bottom: 6px; }
-  @media (max-width: 640px) { body { padding: 16px; } .chart-grid { grid-template-columns: 1fr; } .timeline { grid-template-columns: repeat(2, 1fr); } }
+  @media (max-width: 640px) { .chart-grid { grid-template-columns: 1fr; } .timeline { grid-template-columns: repeat(2, 1fr); } }
 </style>
 </head>
 <body>

--- a/web-app/public/visuals/met008-pireps.html
+++ b/web-app/public/visuals/met008-pireps.html
@@ -4,20 +4,11 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>MET-008: PIREPs</title>
+<link rel="stylesheet" href="/visuals/_common.css">
 <style>
-  * { box-sizing: border-box; margin: 0; padding: 0; }
-  body { background: #0d1b2a; color: #e8edf2; font-family: 'Segoe UI', system-ui, sans-serif; padding: 32px; }
-  h1 { font-size: 22px; color: #f0c040; letter-spacing: 1px; margin-bottom: 6px; }
-  .subtitle { font-size: 13px; color: #7a9ab5; margin-bottom: 32px; letter-spacing: 0.5px; }
-  .container { max-width: 900px; margin: 0 auto; }
-  .section-title { font-size: 14px; color: #f0c040; letter-spacing: 1px; text-transform: uppercase; margin: 32px 0 14px; }
   .pirep-sample { background: #1a2d3d; border: 1px solid #243d52; border-radius: 8px; padding: 18px 20px; font-family: 'Consolas', 'Menlo', monospace; font-size: 14px; line-height: 1.9; margin-bottom: 14px; word-break: break-word; }
   .seg { padding: 2px 6px; border-radius: 3px; margin: 0 2px; display: inline-block; }
   .sh { background: #3d5a80; color: #e8edf2; }
-  table { width: 100%; border-collapse: collapse; margin-bottom: 20px; }
-  th { background: #1a2d3d; color: #f0c040; font-size: 12px; text-align: left; padding: 10px 14px; letter-spacing: 0.5px; }
-  td { font-size: 13px; color: #e8edf2; padding: 9px 14px; border-bottom: 1px solid #1a2d3d; vertical-align: top; }
-  tr:last-child td { border-bottom: none; }
   td code { font-family: 'Consolas', 'Menlo', monospace; background: #0d1b2a; color: #f0c040; padding: 1px 6px; border-radius: 3px; font-size: 12px; }
   .intensity-grid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 10px; }
   .int-card { background: #1a2d3d; border: 1px solid #243d52; border-radius: 8px; padding: 12px; text-align: center; }
@@ -32,9 +23,7 @@
   .adv-card { background: #1a2d3d; border: 1px solid #243d52; border-radius: 8px; padding: 14px; }
   .adv-card h3 { font-size: 13px; color: #f0c040; margin-bottom: 6px; letter-spacing: 0.5px; }
   .adv-card p { font-size: 11px; color: #e8edf2; line-height: 1.5; }
-  .memory-hook { background: #1a2a1a; border: 1px solid #2d5a2d; border-radius: 8px; padding: 14px 18px; margin-top: 24px; font-size: 13px; line-height: 1.6; }
-  .memory-hook .badge { display: inline-block; background: #2d5a2d; color: #e8edf2; font-size: 10px; letter-spacing: 1px; padding: 2px 8px; border-radius: 3px; margin-bottom: 6px; }
-  @media (max-width: 640px) { body { padding: 16px; } .intensity-grid { grid-template-columns: repeat(2, 1fr); } .advisory-grid { grid-template-columns: 1fr; } }
+  @media (max-width: 640px) { .intensity-grid { grid-template-columns: repeat(2, 1fr); } .advisory-grid { grid-template-columns: 1fr; } }
 </style>
 </head>
 <body>

--- a/web-app/public/visuals/met009-thunderstorms.html
+++ b/web-app/public/visuals/met009-thunderstorms.html
@@ -4,19 +4,8 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>MET-009: Thunderstorms</title>
+<link rel="stylesheet" href="/visuals/_common.css">
 <style>
-  * { box-sizing: border-box; margin: 0; padding: 0; }
-  body { background: #0d1b2a; color: #e8edf2; font-family: 'Segoe UI', system-ui, sans-serif; padding: 32px; }
-  h1 { font-size: 22px; color: #f0c040; letter-spacing: 1px; margin-bottom: 6px; }
-  .subtitle { font-size: 13px; color: #7a9ab5; margin-bottom: 32px; letter-spacing: 0.5px; }
-  .container { max-width: 900px; margin: 0 auto; }
-  .section-title { font-size: 14px; color: #f0c040; letter-spacing: 1px; text-transform: uppercase; margin: 32px 0 14px; }
-  .diagram-box { background: #1a2d3d; border: 1px solid #243d52; border-radius: 8px; padding: 16px; }
-  svg text { font-family: 'Segoe UI', system-ui, sans-serif; }
-  table { width: 100%; border-collapse: collapse; margin-bottom: 20px; }
-  th { background: #1a2d3d; color: #f0c040; font-size: 12px; text-align: left; padding: 10px 14px; letter-spacing: 0.5px; }
-  td { font-size: 13px; color: #e8edf2; padding: 9px 14px; border-bottom: 1px solid #1a2d3d; vertical-align: top; }
-  tr:last-child td { border-bottom: none; }
   .ingredients { display: grid; grid-template-columns: repeat(3, 1fr); gap: 12px; margin-bottom: 14px; }
   .ing-card { background: #1a2d3d; border: 1px solid #243d52; border-radius: 8px; padding: 14px; text-align: center; }
   .ing-card .n { font-size: 20px; color: #f0c040; font-weight: bold; }
@@ -24,9 +13,7 @@
   .hazards-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 10px; }
   .haz-card { background: #1a2d3d; border-left: 3px solid #e05050; padding: 10px 14px; font-size: 12px; color: #e8edf2; line-height: 1.5; }
   .haz-card strong { color: #e05050; }
-  .memory-hook { background: #1a2a1a; border: 1px solid #2d5a2d; border-radius: 8px; padding: 14px 18px; margin-top: 24px; font-size: 13px; line-height: 1.6; }
-  .memory-hook .badge { display: inline-block; background: #2d5a2d; color: #e8edf2; font-size: 10px; letter-spacing: 1px; padding: 2px 8px; border-radius: 3px; margin-bottom: 6px; }
-  @media (max-width: 640px) { body { padding: 16px; } .ingredients { grid-template-columns: 1fr; } .hazards-grid { grid-template-columns: 1fr; } }
+  @media (max-width: 640px) { .ingredients { grid-template-columns: 1fr; } .hazards-grid { grid-template-columns: 1fr; } }
 </style>
 </head>
 <body>

--- a/web-app/public/visuals/met010-icing.html
+++ b/web-app/public/visuals/met010-icing.html
@@ -4,19 +4,8 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>MET-010: Icing</title>
+<link rel="stylesheet" href="/visuals/_common.css">
 <style>
-  * { box-sizing: border-box; margin: 0; padding: 0; }
-  body { background: #0d1b2a; color: #e8edf2; font-family: 'Segoe UI', system-ui, sans-serif; padding: 32px; }
-  h1 { font-size: 22px; color: #f0c040; letter-spacing: 1px; margin-bottom: 6px; }
-  .subtitle { font-size: 13px; color: #7a9ab5; margin-bottom: 32px; letter-spacing: 0.5px; }
-  .container { max-width: 900px; margin: 0 auto; }
-  .section-title { font-size: 14px; color: #f0c040; letter-spacing: 1px; text-transform: uppercase; margin: 32px 0 14px; }
-  .diagram-box { background: #1a2d3d; border: 1px solid #243d52; border-radius: 8px; padding: 16px; }
-  svg text { font-family: 'Segoe UI', system-ui, sans-serif; }
-  table { width: 100%; border-collapse: collapse; margin-bottom: 20px; }
-  th { background: #1a2d3d; color: #f0c040; font-size: 12px; text-align: left; padding: 10px 14px; letter-spacing: 0.5px; }
-  td { font-size: 13px; color: #e8edf2; padding: 9px 14px; border-bottom: 1px solid #1a2d3d; vertical-align: top; }
-  tr:last-child td { border-bottom: none; }
   .ice-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 12px; }
   .ice-card { background: #1a2d3d; border: 1px solid #243d52; border-radius: 8px; padding: 14px; }
   .ice-card h3 { font-size: 14px; color: #f0c040; margin-bottom: 4px; letter-spacing: 0.5px; }
@@ -25,9 +14,7 @@
   .effects { display: grid; grid-template-columns: 1fr 1fr; gap: 10px; }
   .eff-card { background: #1a2d3d; border-left: 3px solid #e05050; padding: 10px 14px; font-size: 12px; color: #e8edf2; line-height: 1.5; }
   .eff-card strong { color: #e05050; }
-  .memory-hook { background: #1a2a1a; border: 1px solid #2d5a2d; border-radius: 8px; padding: 14px 18px; margin-top: 24px; font-size: 13px; line-height: 1.6; }
-  .memory-hook .badge { display: inline-block; background: #2d5a2d; color: #e8edf2; font-size: 10px; letter-spacing: 1px; padding: 2px 8px; border-radius: 3px; margin-bottom: 6px; }
-  @media (max-width: 640px) { body { padding: 16px; } .ice-grid { grid-template-columns: 1fr; } .effects { grid-template-columns: 1fr; } }
+  @media (max-width: 640px) { .ice-grid { grid-template-columns: 1fr; } .effects { grid-template-columns: 1fr; } }
 </style>
 </head>
 <body>

--- a/web-app/public/visuals/met011-turbulence.html
+++ b/web-app/public/visuals/met011-turbulence.html
@@ -4,13 +4,8 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>MET-011: Turbulence</title>
+<link rel="stylesheet" href="/visuals/_common.css">
 <style>
-  * { box-sizing: border-box; margin: 0; padding: 0; }
-  body { background: #0d1b2a; color: #e8edf2; font-family: 'Segoe UI', system-ui, sans-serif; padding: 32px; }
-  h1 { font-size: 22px; color: #f0c040; letter-spacing: 1px; margin-bottom: 6px; }
-  .subtitle { font-size: 13px; color: #7a9ab5; margin-bottom: 32px; letter-spacing: 0.5px; }
-  .container { max-width: 900px; margin: 0 auto; }
-  .section-title { font-size: 14px; color: #f0c040; letter-spacing: 1px; text-transform: uppercase; margin: 32px 0 14px; }
   .int-grid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 10px; }
   .int-card { background: #1a2d3d; border: 1px solid #243d52; border-radius: 8px; padding: 12px; }
   .int-card .h { font-size: 14px; color: #f0c040; font-weight: bold; letter-spacing: 0.5px; margin-bottom: 6px; }
@@ -24,13 +19,7 @@
   .type-card h3 { font-size: 14px; color: #f0c040; margin-bottom: 6px; letter-spacing: 0.5px; }
   .type-card .sub { font-size: 11px; color: #7a9ab5; margin-bottom: 8px; }
   .type-card ul { margin-left: 18px; font-size: 12px; color: #e8edf2; line-height: 1.6; }
-  table { width: 100%; border-collapse: collapse; margin-bottom: 20px; }
-  th { background: #1a2d3d; color: #f0c040; font-size: 12px; text-align: left; padding: 10px 14px; letter-spacing: 0.5px; }
-  td { font-size: 13px; color: #e8edf2; padding: 9px 14px; border-bottom: 1px solid #1a2d3d; vertical-align: top; }
-  tr:last-child td { border-bottom: none; }
-  .memory-hook { background: #1a2a1a; border: 1px solid #2d5a2d; border-radius: 8px; padding: 14px 18px; margin-top: 24px; font-size: 13px; line-height: 1.6; }
-  .memory-hook .badge { display: inline-block; background: #2d5a2d; color: #e8edf2; font-size: 10px; letter-spacing: 1px; padding: 2px 8px; border-radius: 3px; margin-bottom: 6px; }
-  @media (max-width: 640px) { body { padding: 16px; } .int-grid { grid-template-columns: repeat(2, 1fr); } .type-grid { grid-template-columns: 1fr; } }
+  @media (max-width: 640px) { .int-grid { grid-template-columns: repeat(2, 1fr); } .type-grid { grid-template-columns: 1fr; } }
 </style>
 </head>
 <body>

--- a/web-app/public/visuals/met012-wind-shear-microburst.html
+++ b/web-app/public/visuals/met012-wind-shear-microburst.html
@@ -4,26 +4,14 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>MET-012: Wind Shear & Microburst</title>
+<link rel="stylesheet" href="/visuals/_common.css">
 <style>
-  * { box-sizing: border-box; margin: 0; padding: 0; }
-  body { background: #0d1b2a; color: #e8edf2; font-family: 'Segoe UI', system-ui, sans-serif; padding: 32px; }
-  h1 { font-size: 22px; color: #f0c040; letter-spacing: 1px; margin-bottom: 6px; }
-  .subtitle { font-size: 13px; color: #7a9ab5; margin-bottom: 32px; letter-spacing: 0.5px; }
-  .container { max-width: 900px; margin: 0 auto; }
-  .section-title { font-size: 14px; color: #f0c040; letter-spacing: 1px; text-transform: uppercase; margin: 32px 0 14px; }
   .diagram-box { background: #1a2d3d; border: 1px solid #243d52; border-radius: 8px; padding: 16px; margin-bottom: 16px; }
-  svg text { font-family: 'Segoe UI', system-ui, sans-serif; }
-  table { width: 100%; border-collapse: collapse; margin-bottom: 20px; }
-  th { background: #1a2d3d; color: #f0c040; font-size: 12px; text-align: left; padding: 10px 14px; letter-spacing: 0.5px; }
-  td { font-size: 13px; color: #e8edf2; padding: 9px 14px; border-bottom: 1px solid #1a2d3d; vertical-align: top; }
-  tr:last-child td { border-bottom: none; }
-  .memory-hook { background: #1a2a1a; border: 1px solid #2d5a2d; border-radius: 8px; padding: 14px 18px; margin-top: 24px; font-size: 13px; line-height: 1.6; }
-  .memory-hook .badge { display: inline-block; background: #2d5a2d; color: #e8edf2; font-size: 10px; letter-spacing: 1px; padding: 2px 8px; border-radius: 3px; margin-bottom: 6px; }
   .caption { font-size: 11px; color: #7a9ab5; text-align: center; margin-top: 8px; }
   .stages { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 10px; }
   .stage-card { background: #1a2d3d; border-left: 3px solid #f0c040; padding: 10px 14px; font-size: 12px; color: #e8edf2; line-height: 1.5; }
   .stage-card .n { color: #f0c040; font-weight: bold; font-size: 13px; }
-  @media (max-width: 640px) { body { padding: 16px; } .stages { grid-template-columns: 1fr; } }
+  @media (max-width: 640px) { .stages { grid-template-columns: 1fr; } }
 </style>
 </head>
 <body>

--- a/web-app/public/visuals/met013-fronts.html
+++ b/web-app/public/visuals/met013-fronts.html
@@ -4,28 +4,15 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>MET-013: Fronts</title>
+<link rel="stylesheet" href="/visuals/_common.css">
 <style>
-  * { box-sizing: border-box; margin: 0; padding: 0; }
-  body { background: #0d1b2a; color: #e8edf2; font-family: 'Segoe UI', system-ui, sans-serif; padding: 32px; }
-  h1 { font-size: 22px; color: #f0c040; letter-spacing: 1px; margin-bottom: 6px; }
-  .subtitle { font-size: 13px; color: #7a9ab5; margin-bottom: 32px; letter-spacing: 0.5px; }
-  .container { max-width: 900px; margin: 0 auto; }
-  .section-title { font-size: 14px; color: #f0c040; letter-spacing: 1px; text-transform: uppercase; margin: 32px 0 14px; }
   .diagram-box { background: #1a2d3d; border: 1px solid #243d52; border-radius: 8px; padding: 16px; margin-bottom: 14px; }
-  svg text { font-family: 'Segoe UI', system-ui, sans-serif; }
-  table { width: 100%; border-collapse: collapse; margin-bottom: 20px; }
-  th { background: #1a2d3d; color: #f0c040; font-size: 12px; text-align: left; padding: 10px 14px; letter-spacing: 0.5px; }
-  td { font-size: 13px; color: #e8edf2; padding: 9px 14px; border-bottom: 1px solid #1a2d3d; vertical-align: top; }
-  tr:last-child td { border-bottom: none; }
   .mass-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 10px; margin-bottom: 14px; }
   .mass-card { background: #1a2d3d; border: 1px solid #243d52; border-radius: 8px; padding: 12px; text-align: center; }
   .mass-card .code { font-size: 18px; color: #f0c040; font-weight: bold; font-family: 'Consolas', monospace; }
   .mass-card .name { font-size: 11px; color: #e8edf2; margin-top: 4px; }
   .mass-card .note { font-size: 10px; color: #7a9ab5; margin-top: 4px; }
-  .memory-hook { background: #1a2a1a; border: 1px solid #2d5a2d; border-radius: 8px; padding: 14px 18px; margin-top: 24px; font-size: 13px; line-height: 1.6; }
-  .memory-hook .badge { display: inline-block; background: #2d5a2d; color: #e8edf2; font-size: 10px; letter-spacing: 1px; padding: 2px 8px; border-radius: 3px; margin-bottom: 6px; }
   .caption { font-size: 11px; color: #7a9ab5; text-align: center; margin-top: 8px; }
-  @media (max-width: 640px) { body { padding: 16px; } }
 </style>
 </head>
 <body>

--- a/web-app/public/visuals/met014-wx-decision-making.html
+++ b/web-app/public/visuals/met014-wx-decision-making.html
@@ -4,13 +4,8 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>MET-014: Weather Decision-Making</title>
+<link rel="stylesheet" href="/visuals/_common.css">
 <style>
-  * { box-sizing: border-box; margin: 0; padding: 0; }
-  body { background: #0d1b2a; color: #e8edf2; font-family: 'Segoe UI', system-ui, sans-serif; padding: 32px; }
-  h1 { font-size: 22px; color: #f0c040; letter-spacing: 1px; margin-bottom: 6px; }
-  .subtitle { font-size: 13px; color: #7a9ab5; margin-bottom: 32px; letter-spacing: 0.5px; }
-  .container { max-width: 900px; margin: 0 auto; }
-  .section-title { font-size: 14px; color: #f0c040; letter-spacing: 1px; text-transform: uppercase; margin: 32px 0 14px; }
   .flow { display: flex; flex-direction: column; gap: 10px; }
   .flow-row { background: #1a2d3d; border-left: 4px solid #f0c040; border-radius: 6px; padding: 14px 18px; }
   .flow-row h3 { font-size: 13px; color: #f0c040; margin-bottom: 6px; letter-spacing: 0.5px; }
@@ -18,10 +13,6 @@
   .flow-row.ok { border-left-color: #4caf7d; }
   .flow-row.warn { border-left-color: #f0c040; }
   .flow-row.stop { border-left-color: #e05050; }
-  table { width: 100%; border-collapse: collapse; margin-bottom: 20px; }
-  th { background: #1a2d3d; color: #f0c040; font-size: 12px; text-align: left; padding: 10px 14px; letter-spacing: 0.5px; }
-  td { font-size: 13px; color: #e8edf2; padding: 9px 14px; border-bottom: 1px solid #1a2d3d; vertical-align: top; }
-  tr:last-child td { border-bottom: none; }
   .imsafe { display: grid; grid-template-columns: repeat(auto-fit, minmax(130px, 1fr)); gap: 10px; }
   .im-card { background: #1a2d3d; border: 1px solid #243d52; border-radius: 8px; padding: 12px; text-align: center; }
   .im-letter { font-size: 20px; color: #f0c040; font-weight: bold; font-family: 'Consolas', monospace; }
@@ -33,9 +24,7 @@
   .r-cell.low { background: #1e3a28; }
   .r-cell.med { background: #4a3a1a; }
   .r-cell.high { background: #4a1a1a; }
-  .memory-hook { background: #1a2a1a; border: 1px solid #2d5a2d; border-radius: 8px; padding: 14px 18px; margin-top: 24px; font-size: 13px; line-height: 1.6; }
-  .memory-hook .badge { display: inline-block; background: #2d5a2d; color: #e8edf2; font-size: 10px; letter-spacing: 1px; padding: 2px 8px; border-radius: 3px; margin-bottom: 6px; }
-  @media (max-width: 640px) { body { padding: 16px; } .risk-matrix { grid-template-columns: 80px repeat(3, 1fr); } }
+  @media (max-width: 640px) { .risk-matrix { grid-template-columns: 80px repeat(3, 1fr); } }
 </style>
 </head>
 <body>


### PR DESCRIPTION
## Summary

- Creates `web-app/public/visuals/_common.css` with shared dark-aviation tokens: palette, reset, typography, table, memory-hook, grid-paper backdrop (DESIGN-SYSTEM.md §4.4), and `diagram-box` card surface
- Migrates all 14 `met*.html` visuals to `<link rel="stylesheet" href="/visuals/_common.css">` and removes duplicate inline rules
- File-specific styles (SVG positioning, bespoke components, colour-coded segments, responsive overrides) kept inline; back-link button (#179) preserved in all files
- `npm run build` passes

## Files changed

- **Created:** `web-app/public/visuals/_common.css`
- **Modified:** `web-app/public/visuals/met001` – `met014` (14 files)

## Test plan

- [ ] Open each migrated visual at `/visuals/met*.html` — layout and colours match pre-migration appearance
- [ ] Back-link button visible top-left in each visual
- [ ] `npm run build` passes ✓ (verified locally)
- [ ] No changes to al\*, nav\*, gk\* visuals or app source

Closes #215

🤖 Generated with [Claude Code](https://claude.com/claude-code)