### PR TITLE
[PPL-203] Add user playlist CRUD feature

### DIFF
--- a/web-app/src/App.tsx
+++ b/web-app/src/App.tsx
@@ -16,6 +16,8 @@ import PSTARExam from './pages/PSTARExam';
 import Plan from './pages/Plan';
 import Playlist from './pages/Playlist';
 import SmartPlaylist from './pages/SmartPlaylist';
+import PlaylistEditor from './pages/PlaylistEditor';
+import UserPlaylistPage from './pages/UserPlaylistPage';
 import PSTARPath from './pages/PSTARPath';
 
 const RAIL_EXPANDED = 240;
@@ -110,6 +112,9 @@ export default function App() {
               <Route path="/playlist" element={<Playlist />} />
               <Route path="/playlist/smart/:kind" element={<SmartPlaylist />} />
               <Route path="/playlist/:topic" element={<Playlist />} />
+              <Route path="/playlist/new" element={<PlaylistEditor />} />
+              <Route path="/playlist/user/:id" element={<UserPlaylistPage />} />
+              <Route path="/playlist/user/:id/edit" element={<PlaylistEditor />} />
               <Route path="/pstar" element={<PSTARPath />} />
             </Routes>
           </Box>

--- a/web-app/src/lib/user-playlists.ts
+++ b/web-app/src/lib/user-playlists.ts
@@ -1,10 +1,74 @@
+const LS_KEY = 'ppl.playlists.user';
+
 export interface UserPlaylist {
   id: string;
   name: string;
   lessonIds: string[];
   createdAt: string;
+  updatedAt: string;
+}
+
+function load(): UserPlaylist[] {
+  try {
+    const raw = localStorage.getItem(LS_KEY);
+    if (!raw) return [];
+    return JSON.parse(raw) as UserPlaylist[];
+  } catch {
+    return [];
+  }
+}
+
+function save(playlists: UserPlaylist[]): void {
+  localStorage.setItem(LS_KEY, JSON.stringify(playlists));
+}
+
+export function listPlaylists(): UserPlaylist[] {
+  return load();
 }
 
 export function getUserPlaylists(): UserPlaylist[] {
-  return [];
+  return load();
+}
+
+export function getPlaylist(id: string): UserPlaylist | undefined {
+  return load().find((p) => p.id === id);
+}
+
+export function createPlaylist(name: string, lessonIds: string[] = []): UserPlaylist {
+  const now = new Date().toISOString();
+  const playlist: UserPlaylist = {
+    id: crypto.randomUUID(),
+    name,
+    lessonIds,
+    createdAt: now,
+    updatedAt: now,
+  };
+  const all = load();
+  save([...all, playlist]);
+  return playlist;
+}
+
+export function updatePlaylist(
+  id: string,
+  partial: Partial<Pick<UserPlaylist, 'name' | 'lessonIds'>>,
+): UserPlaylist | undefined {
+  const all = load();
+  const idx = all.findIndex((p) => p.id === id);
+  if (idx === -1) return undefined;
+  const updated: UserPlaylist = {
+    ...all[idx],
+    ...partial,
+    updatedAt: new Date().toISOString(),
+  };
+  all[idx] = updated;
+  save(all);
+  return updated;
+}
+
+export function deletePlaylist(id: string): void {
+  save(load().filter((p) => p.id !== id));
+}
+
+export function reorderLessons(id: string, lessonIds: string[]): UserPlaylist | undefined {
+  return updatePlaylist(id, { lessonIds });
 }

--- a/web-app/src/pages/PlaylistEditor.tsx
+++ b/web-app/src/pages/PlaylistEditor.tsx
@@ -1,0 +1,208 @@
+import { useState, useMemo } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Checkbox from '@mui/material/Checkbox';
+import Container from '@mui/material/Container';
+import Divider from '@mui/material/Divider';
+import IconButton from '@mui/material/IconButton';
+import List from '@mui/material/List';
+import ListItem from '@mui/material/ListItem';
+import ListItemIcon from '@mui/material/ListItemIcon';
+import ListItemText from '@mui/material/ListItemText';
+import TextField from '@mui/material/TextField';
+import Typography from '@mui/material/Typography';
+import ArrowDownwardIcon from '@mui/icons-material/ArrowDownward';
+import ArrowUpwardIcon from '@mui/icons-material/ArrowUpward';
+
+import { TOPICS, TOPIC_LABELS } from '../lib/curriculum';
+import { getAllLessons } from '../lib/lesson-loader';
+import {
+  createPlaylist,
+  getPlaylist,
+  updatePlaylist,
+} from '../lib/user-playlists';
+
+export default function PlaylistEditor() {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+  const isNew = !id;
+
+  const existing = useMemo(() => (id ? getPlaylist(id) : undefined), [id]);
+
+  const allLessons = useMemo(
+    () => getAllLessons().filter((l) => l.status !== 'planning' && l.audio !== null),
+    [],
+  );
+
+  const [name, setName] = useState(existing?.name ?? '');
+  const [selectedIds, setSelectedIds] = useState<string[]>(existing?.lessonIds ?? []);
+
+  const lessonById = useMemo(
+    () => new Map(allLessons.map((l) => [l.id, l])),
+    [allLessons],
+  );
+
+  function toggleLesson(lessonId: string) {
+    setSelectedIds((prev) =>
+      prev.includes(lessonId) ? prev.filter((id) => id !== lessonId) : [...prev, lessonId],
+    );
+  }
+
+  function moveUp(index: number) {
+    if (index === 0) return;
+    setSelectedIds((prev) => {
+      const next = [...prev];
+      [next[index - 1], next[index]] = [next[index], next[index - 1]];
+      return next;
+    });
+  }
+
+  function moveDown(index: number) {
+    setSelectedIds((prev) => {
+      if (index >= prev.length - 1) return prev;
+      const next = [...prev];
+      [next[index], next[index + 1]] = [next[index + 1], next[index]];
+      return next;
+    });
+  }
+
+  function handleSave() {
+    const trimmed = name.trim();
+    if (!trimmed) return;
+    if (isNew) {
+      const playlist = createPlaylist(trimmed, selectedIds);
+      navigate(`/playlist/user/${playlist.id}`, { replace: true });
+    } else {
+      updatePlaylist(id!, { name: trimmed, lessonIds: selectedIds });
+      navigate(`/playlist/user/${id}`, { replace: true });
+    }
+  }
+
+  return (
+    <Container id="main-content" tabIndex={-1} maxWidth="md" sx={{ py: 4 }}>
+      <Typography variant="h4" gutterBottom>
+        {isNew ? 'New Playlist' : 'Edit Playlist'}
+      </Typography>
+
+      <TextField
+        label="Playlist name"
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+        fullWidth
+        sx={{ mb: 4 }}
+        inputProps={{ maxLength: 80 }}
+      />
+
+      {/* Selected order */}
+      {selectedIds.length > 0 && (
+        <Box sx={{ mb: 4 }}>
+          <Typography variant="h6" gutterBottom>
+            Selected Lessons ({selectedIds.length})
+          </Typography>
+          <Divider sx={{ mb: 1 }} />
+          <List dense disablePadding>
+            {selectedIds.map((lessonId, index) => {
+              const lesson = lessonById.get(lessonId);
+              if (!lesson) return null;
+              return (
+                <ListItem
+                  key={lessonId}
+                  disablePadding
+                  sx={{ py: 0.25 }}
+                  secondaryAction={
+                    <Box sx={{ display: 'flex', gap: 0 }}>
+                      <IconButton
+                        size="small"
+                        onClick={() => moveUp(index)}
+                        disabled={index === 0}
+                        aria-label="Move up"
+                      >
+                        <ArrowUpwardIcon fontSize="small" />
+                      </IconButton>
+                      <IconButton
+                        size="small"
+                        onClick={() => moveDown(index)}
+                        disabled={index === selectedIds.length - 1}
+                        aria-label="Move down"
+                      >
+                        <ArrowDownwardIcon fontSize="small" />
+                      </IconButton>
+                    </Box>
+                  }
+                >
+                  <ListItemIcon sx={{ minWidth: 32 }}>
+                    <Typography variant="caption" color="text.secondary">
+                      {index + 1}
+                    </Typography>
+                  </ListItemIcon>
+                  <ListItemText
+                    primary={lesson.title}
+                    secondary={TOPIC_LABELS[lesson.topic] ?? lesson.topic}
+                    primaryTypographyProps={{ variant: 'body2' }}
+                    secondaryTypographyProps={{ variant: 'caption' }}
+                  />
+                </ListItem>
+              );
+            })}
+          </List>
+        </Box>
+      )}
+
+      {/* Lesson picker grouped by topic */}
+      <Typography variant="h6" gutterBottom>
+        Add Lessons
+      </Typography>
+      {TOPICS.map((topic) => {
+        const topicLessons = allLessons.filter((l) => l.topic === topic);
+        if (topicLessons.length === 0) return null;
+        return (
+          <Box key={topic} sx={{ mb: 3 }}>
+            <Typography variant="subtitle2" color="text.secondary" sx={{ mb: 0.5 }}>
+              {TOPIC_LABELS[topic]}
+            </Typography>
+            <Divider sx={{ mb: 1 }} />
+            <List dense disablePadding>
+              {topicLessons.map((lesson) => {
+                const checked = selectedIds.includes(lesson.id);
+                return (
+                  <ListItem key={lesson.id} disablePadding sx={{ py: 0.25 }}>
+                    <ListItemIcon sx={{ minWidth: 36 }}>
+                      <Checkbox
+                        edge="start"
+                        size="small"
+                        checked={checked}
+                        onChange={() => toggleLesson(lesson.id)}
+                        sx={{ p: 0.5 }}
+                      />
+                    </ListItemIcon>
+                    <ListItemText
+                      primary={lesson.title}
+                      primaryTypographyProps={{
+                        variant: 'body2',
+                        color: checked ? 'text.secondary' : 'text.primary',
+                      }}
+                    />
+                  </ListItem>
+                );
+              })}
+            </List>
+          </Box>
+        );
+      })}
+
+      <Box sx={{ display: 'flex', gap: 2, mt: 2 }}>
+        <Button
+          variant="contained"
+          onClick={handleSave}
+          disabled={!name.trim() || selectedIds.length === 0}
+        >
+          Save Playlist
+        </Button>
+        <Button variant="outlined" onClick={() => navigate(-1)}>
+          Cancel
+        </Button>
+      </Box>
+    </Container>
+  );
+}

--- a/web-app/src/pages/UserPlaylistPage.tsx
+++ b/web-app/src/pages/UserPlaylistPage.tsx
@@ -1,0 +1,62 @@
+import { useMemo } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Container from '@mui/material/Container';
+import Typography from '@mui/material/Typography';
+import PlaylistPlayer from '../components/PlaylistPlayer';
+import { getAllLessons } from '../lib/lesson-loader';
+import { getPlaylist } from '../lib/user-playlists';
+
+export default function UserPlaylistPage() {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+
+  const playlist = useMemo(() => (id ? getPlaylist(id) : undefined), [id]);
+
+  const lessons = useMemo(() => {
+    if (!playlist) return [];
+    const all = getAllLessons();
+    const byId = new Map(all.map((l) => [l.id, l]));
+    return playlist.lessonIds
+      .map((lid) => byId.get(lid))
+      .filter((l): l is NonNullable<typeof l> => l !== undefined && l.audio !== null);
+  }, [playlist]);
+
+  if (!playlist) {
+    return (
+      <Container maxWidth="md" sx={{ py: 4 }}>
+        <Typography variant="h5" gutterBottom>
+          Playlist not found
+        </Typography>
+        <Button variant="outlined" onClick={() => navigate('/playlist')}>
+          Back to Playlists
+        </Button>
+      </Container>
+    );
+  }
+
+  return (
+    <Container maxWidth="md" sx={{ py: 4 }}>
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, mb: 3, flexWrap: 'wrap' }}>
+        <Typography variant="h4" sx={{ flex: 1 }}>
+          {playlist.name}
+        </Typography>
+        <Button
+          variant="outlined"
+          size="small"
+          onClick={() => navigate(`/playlist/user/${playlist.id}/edit`)}
+        >
+          Edit
+        </Button>
+      </Box>
+      {lessons.length === 0 ? (
+        <Typography color="text.secondary">
+          No audio lessons available in this playlist yet.
+        </Typography>
+      ) : (
+        <PlaylistPlayer lessons={lessons} />
+      )}
+    </Container>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds `user-playlists.ts` with localStorage-backed CRUD helpers (`list`, `create`, `update`, `delete`, `reorderLessons`) using `crypto.randomUUID` for IDs, stored under key `ppl.playlists.user`
- Adds `PlaylistEditor.tsx` page handling both `/playlist/new` and `/playlist/user/:id/edit` — name input, multi-select lessons grouped by topic, up/down reorder buttons, save
- Adds `UserPlaylistPage.tsx` for `/playlist/user/:id` — renders existing `PlaylistPlayer` with lessons resolved from the stored lesson IDs
- Updates `App.tsx` with three new routes: `/playlist/new`, `/playlist/user/:id`, `/playlist/user/:id/edit`

## Test plan
- [ ] Navigate to `/playlist/new`, enter a name, select lessons, reorder, save — confirm redirect to `/playlist/user/:id`
- [ ] Playlist player loads with selected lessons in correct order
- [ ] Edit button from player page opens editor with pre-populated fields
- [ ] Saving edits updates the playlist and redirects back to player
- [ ] localStorage key `ppl.playlists.user` holds correct JSON shape after create/edit

Closes #203

🤖 Generated with [Claude Code](https://claude.com/claude-code)