### PR TITLE
[PPL-213] Migrate al*.html visuals to _common.css

### DIFF
--- a/web-app/public/visuals/_common.css
+++ b/web-app/public/visuals/_common.css
@@ -1,27 +1,55 @@
-/* Shared design tokens for PPL Study GK visuals.
-   Link this file from gk*.html; do not link from other topic visuals. */
+/* PPL Study — Shared Visual Styles (dark · Variant A Cockpit Briefing) */
 
 * { box-sizing: border-box; margin: 0; padding: 0; }
-body { background: #0d1b2a; color: #e8edf2; font-family: 'Segoe UI', system-ui, sans-serif; padding: 32px; }
+
+body {
+  background: #0d1b2a;
+  color: #e8edf2;
+  font-family: 'Segoe UI', system-ui, sans-serif;
+  font-size: 13px;
+  line-height: 1.6;
+  padding: 32px;
+  max-width: 900px;
+  margin: auto;
+}
+
 h1 { font-size: 22px; color: #f0c040; letter-spacing: 1px; margin-bottom: 6px; }
 .subtitle { font-size: 13px; color: #7a9ab5; margin-bottom: 32px; letter-spacing: 0.5px; }
-.container { max-width: 900px; margin: 0 auto; }
+
+/* GK section header */
 .section-title { font-size: 14px; color: #f0c040; letter-spacing: 1px; text-transform: uppercase; margin-bottom: 14px; margin-top: 32px; }
+/* AL section header */
+.section-label { font-size: 11px; color: #7a9ab5; letter-spacing: 1px; text-transform: uppercase; margin-bottom: 8px; font-weight: 600; }
+
+.container { max-width: 900px; margin: 0 auto; }
 
 svg text { font-family: 'Segoe UI', system-ui, sans-serif; }
 
+/* Tables */
 table { width: 100%; border-collapse: collapse; margin-bottom: 20px; }
 th { background: #1a2d3d; color: #f0c040; font-size: 12px; text-align: left; padding: 10px 14px; letter-spacing: 0.5px; }
 td { font-size: 13px; color: #e8edf2; padding: 9px 14px; border-bottom: 1px solid #1a2d3d; vertical-align: top; }
 tr:last-child td { border-bottom: none; }
 
-/* Card backdrop used by most GK diagrams */
+/* Status indicators (al visuals) */
+.yes { color: #80e080; font-weight: 700; }
+.no  { color: #ff8080; font-weight: 700; }
+
+/* GK diagram components */
 .diagram-box { background: #1a2d3d; border: 1px solid #243d52; border-radius: 8px; padding: 16px; }
-
-/* Note / exam-tip callout (amber border by default; override border-left for other colours) */
 .note-box { background: #1a2d3d; border-left: 3px solid #f0c040; border-radius: 4px; padding: 14px 18px; margin-top: 20px; font-size: 13px; color: #e8edf2; line-height: 1.6; }
-
-/* Memory-hook card (gk002 and future files) */
 .memory-box { background: #1a2d3d; border: 1px solid #f0c040; border-radius: 8px; padding: 20px; margin-top: 24px; }
 .memory-title { color: #f0c040; font-size: 13px; font-weight: bold; letter-spacing: 0.5px; margin-bottom: 10px; }
 .memory-item { font-size: 13px; color: #e8edf2; margin-bottom: 6px; padding-left: 12px; }
+
+/* AL hook card */
+.hook-box { background: #1a2a1a; border: 1.5px solid #2d5a2d; border-radius: 10px; padding: 18px 22px; }
+.hook-box h2 { font-size: 12px; color: #80c880; text-transform: uppercase; letter-spacing: 1px; margin-bottom: 12px; }
+.hook-row { display: flex; gap: 10px; margin-bottom: 8px; align-items: flex-start; }
+.hook-badge { background: #2d5a2d; color: #80c880; font-size: 10px; font-weight: 800; padding: 2px 8px; border-radius: 10px; white-space: nowrap; flex-shrink: 0; margin-top: 2px; }
+.hook-text { font-size: 13px; color: #c8d8c8; line-height: 1.5; }
+.hook-text strong { color: #f0c040; }
+
+@media (max-width: 640px) {
+  body { padding: 16px; }
+}

--- a/web-app/public/visuals/al001-airspace-classifications.html
+++ b/web-app/public/visuals/al001-airspace-classifications.html
@@ -3,13 +3,9 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
+<link rel="stylesheet" href="/visuals/_common.css">
 <title>AL-001: Canadian Airspace Classifications</title>
 <style>
-  * { box-sizing: border-box; margin: 0; padding: 0; }
-  body { background: #0d1b2a; color: #e8edf2; font-family: 'Segoe UI', system-ui, sans-serif; padding: 32px; }
-  h1 { font-size: 22px; color: #f0c040; letter-spacing: 1px; margin-bottom: 6px; }
-  .subtitle { font-size: 13px; color: #7a9ab5; margin-bottom: 32px; letter-spacing: 0.5px; }
-
   .stack { display: flex; gap: 0; flex-direction: column; margin-bottom: 36px; border-radius: 10px; overflow: hidden; border: 1.5px solid #1a2d3d; }
   .layer { display: grid; grid-template-columns: 120px 80px 1fr 1fr; align-items: center; padding: 12px 16px; gap: 12px; border-bottom: 1px solid rgba(255,255,255,0.05); }
   .layer:last-child { border-bottom: none; }
@@ -30,20 +26,7 @@
   .f  { background: #1a1a05; } .badge-f  { background: #827717; color:#fff; }
   .g  { background: #0a200a; } .badge-g  { background: #2e7d32; color:#fff; }
 
-  .section-label { font-size: 11px; color: #7a9ab5; letter-spacing: 1px; text-transform: uppercase; margin-bottom: 8px; font-weight: 600; }
-  table { width: 100%; border-collapse: collapse; font-size: 12px; margin-bottom: 28px; }
-  th { background: #1a2d3d; color: #7a9ab5; padding: 8px 10px; text-align: left; font-size: 11px; text-transform: uppercase; letter-spacing: 0.5px; }
-  td { padding: 9px 10px; border-bottom: 1px solid #1a2d3d; }
-  .yes { color: #80e080; font-weight: 700; }
-  .no  { color: #ff8080; font-weight: 700; }
   .req-col { color: #f0c040; font-weight: 600; }
-
-  .hook-box { background: #1a2a1a; border: 1.5px solid #2d5a2d; border-radius: 10px; padding: 18px 22px; }
-  .hook-box h2 { font-size: 12px; color: #80c880; text-transform: uppercase; letter-spacing: 1px; margin-bottom: 12px; }
-  .hook-row { display: flex; gap: 10px; margin-bottom: 8px; align-items: flex-start; }
-  .hook-badge { background: #2d5a2d; color: #80c880; font-size: 10px; font-weight: 800; padding: 2px 8px; border-radius: 10px; white-space: nowrap; flex-shrink: 0; margin-top: 2px; }
-  .hook-text { font-size: 13px; color: #c8d8c8; line-height: 1.5; }
-  .hook-text strong { color: #f0c040; }
 </style>
 </head>
 <body>

--- a/web-app/public/visuals/al002-controlled-vs-uncontrolled.html
+++ b/web-app/public/visuals/al002-controlled-vs-uncontrolled.html
@@ -3,13 +3,9 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
+<link rel="stylesheet" href="/visuals/_common.css">
 <title>AL-002: Controlled vs Uncontrolled Airspace</title>
 <style>
-  * { box-sizing: border-box; margin: 0; padding: 0; }
-  body { background: #0d1b2a; color: #e8edf2; font-family: 'Segoe UI', system-ui, sans-serif; padding: 32px; }
-  h1 { font-size: 22px; color: #f0c040; letter-spacing: 1px; margin-bottom: 6px; }
-  .subtitle { font-size: 13px; color: #7a9ab5; margin-bottom: 32px; letter-spacing: 0.5px; }
-
   .two-col { display: grid; grid-template-columns: 1fr 1fr; gap: 20px; margin-bottom: 32px; }
   .zone { border-radius: 10px; padding: 20px; }
   .ctrl-zone { background: #0a1a35; border: 1.5px solid #1565c0; }
@@ -27,12 +23,8 @@
   .dot-uctrl { background: #80e080; }
   .point-text { font-size: 13px; color: #c8d8e8; line-height: 1.5; }
 
-  table { width: 100%; border-collapse: collapse; font-size: 12px; margin-bottom: 28px; }
   th { background: #1a2d3d; color: #7a9ab5; padding: 8px 12px; text-align: left; font-size: 11px; text-transform: uppercase; letter-spacing: 0.5px; }
   td { padding: 9px 12px; border-bottom: 1px solid #1a2d3d; vertical-align: middle; }
-  tr:last-child td { border-bottom: none; }
-  .yes { color: #80e080; font-weight: 700; }
-  .no  { color: #ff8080; font-weight: 700; }
   .partial { color: #f0c040; font-weight: 600; }
   .ctrl-row { background: rgba(20,60,120,0.2); }
   .uctrl-row { background: rgba(20,80,20,0.2); }

--- a/web-app/public/visuals/al003-vfr-weather-minimums.html
+++ b/web-app/public/visuals/al003-vfr-weather-minimums.html
@@ -3,13 +3,9 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
+<link rel="stylesheet" href="/visuals/_common.css">
 <title>AL-003: VFR Weather Minimums</title>
 <style>
-  * { box-sizing: border-box; margin: 0; padding: 0; }
-  body { background: #0d1b2a; color: #e8edf2; font-family: 'Segoe UI', system-ui, sans-serif; padding: 32px; }
-  h1 { font-size: 22px; color: #f0c040; letter-spacing: 1px; margin-bottom: 6px; }
-  .subtitle { font-size: 13px; color: #7a9ab5; margin-bottom: 32px; letter-spacing: 0.5px; }
-
   /* Airspace diagram */
   .diagram { display: flex; gap: 16px; margin-bottom: 36px; align-items: stretch; }
   .airspace-col { flex: 1; }
@@ -64,7 +60,6 @@
   table { width: 100%; border-collapse: collapse; font-size: 13px; }
   th { background: #1a2d3d; color: #7a9ab5; padding: 10px 12px; text-align: left; font-weight: 600; letter-spacing: 0.5px; font-size: 11px; text-transform: uppercase; }
   td { padding: 10px 12px; border-bottom: 1px solid #1a2d3d; vertical-align: middle; }
-  tr:last-child td { border-bottom: none; }
   .vis { color: #f0c040; font-weight: 700; }
   .cloud { color: #7ec8e3; font-weight: 600; }
   .ctrl { background: rgba(20,60,100,0.3); }

--- a/web-app/public/visuals/al004-altimeter-settings.html
+++ b/web-app/public/visuals/al004-altimeter-settings.html
@@ -3,13 +3,9 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
+<link rel="stylesheet" href="/visuals/_common.css">
 <title>AL-004: Altimeter Settings</title>
 <style>
-  * { box-sizing: border-box; margin: 0; padding: 0; }
-  body { background: #0d1b2a; color: #e8edf2; font-family: 'Segoe UI', system-ui, sans-serif; padding: 32px; max-width: 900px; margin: auto; }
-  h1 { font-size: 22px; color: #f0c040; letter-spacing: 1px; margin-bottom: 6px; }
-  .subtitle { font-size: 13px; color: #7a9ab5; margin-bottom: 32px; letter-spacing: 0.5px; }
-  .section-label { font-size: 11px; color: #7a9ab5; letter-spacing: 1px; text-transform: uppercase; margin-bottom: 8px; font-weight: 600; }
   table { width: 100%; border-collapse: collapse; font-size: 13px; margin-bottom: 28px; }
   th { background: #1a2d3d; color: #7a9ab5; padding: 9px 12px; text-align: left; font-size: 11px; text-transform: uppercase; letter-spacing: 0.5px; }
   td { padding: 10px 12px; border-bottom: 1px solid #1a2d3d; vertical-align: top; }
@@ -29,13 +25,6 @@
   .qne-badge { background: rgba(240,192,64,0.15); color: #f0c040; border: 1px solid rgba(240,192,64,0.4); }
   .qnh-badge { background: rgba(80,160,255,0.12); color: #80b8ff; border: 1px solid rgba(80,160,255,0.3); }
   .alt-content p { font-size: 12px; color: #c8d8e8; margin-top: 4px; }
-
-  .hook-box { background: #1a2a1a; border: 1.5px solid #2d5a2d; border-radius: 10px; padding: 18px 22px; }
-  .hook-box h2 { font-size: 12px; color: #80c880; text-transform: uppercase; letter-spacing: 1px; margin-bottom: 12px; }
-  .hook-row { display: flex; gap: 10px; margin-bottom: 8px; align-items: flex-start; }
-  .hook-badge { background: #2d5a2d; color: #80c880; font-size: 10px; font-weight: 800; padding: 2px 8px; border-radius: 10px; white-space: nowrap; flex-shrink: 0; margin-top: 2px; }
-  .hook-text { font-size: 13px; color: #c8d8c8; line-height: 1.5; }
-  .hook-text strong { color: #f0c040; }
 </style>
 </head>
 <body>

--- a/web-app/public/visuals/al005-right-of-way-rules.html
+++ b/web-app/public/visuals/al005-right-of-way-rules.html
@@ -3,14 +3,9 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
+<link rel="stylesheet" href="/visuals/_common.css">
 <title>AL-005: Right-of-Way Rules</title>
 <style>
-  * { box-sizing: border-box; margin: 0; padding: 0; }
-  body { background: #0d1b2a; color: #e8edf2; font-family: 'Segoe UI', system-ui, sans-serif; padding: 32px; max-width: 900px; margin: auto; }
-  h1 { font-size: 22px; color: #f0c040; letter-spacing: 1px; margin-bottom: 6px; }
-  .subtitle { font-size: 13px; color: #7a9ab5; margin-bottom: 32px; letter-spacing: 0.5px; }
-  .section-label { font-size: 11px; color: #7a9ab5; letter-spacing: 1px; text-transform: uppercase; margin-bottom: 8px; font-weight: 600; }
-
   /* Hierarchy pyramid */
   .hierarchy { display: flex; flex-direction: column; gap: 4px; margin-bottom: 28px; }
   .hier-row { display: flex; align-items: center; gap: 12px; padding: 10px 16px; border-radius: 6px; }
@@ -34,13 +29,6 @@
   .scenario-col { font-weight: 600; color: #e8edf2; }
   .gives-way-col { color: #ff9090; font-weight: 700; }
   .rule-col { font-size: 12px; color: #7a9ab5; }
-
-  .hook-box { background: #1a2a1a; border: 1.5px solid #2d5a2d; border-radius: 10px; padding: 18px 22px; }
-  .hook-box h2 { font-size: 12px; color: #80c880; text-transform: uppercase; letter-spacing: 1px; margin-bottom: 12px; }
-  .hook-row { display: flex; gap: 10px; margin-bottom: 8px; align-items: flex-start; }
-  .hook-badge { background: #2d5a2d; color: #80c880; font-size: 10px; font-weight: 800; padding: 2px 8px; border-radius: 10px; white-space: nowrap; flex-shrink: 0; margin-top: 2px; }
-  .hook-text { font-size: 13px; color: #c8d8c8; line-height: 1.5; }
-  .hook-text strong { color: #f0c040; }
 </style>
 </head>
 <body>

--- a/web-app/public/visuals/al006-aerodrome-traffic-circuit.html
+++ b/web-app/public/visuals/al006-aerodrome-traffic-circuit.html
@@ -3,14 +3,9 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
+<link rel="stylesheet" href="/visuals/_common.css">
 <title>AL-006: Aerodrome Traffic Circuit</title>
 <style>
-  * { box-sizing: border-box; margin: 0; padding: 0; }
-  body { background: #0d1b2a; color: #e8edf2; font-family: 'Segoe UI', system-ui, sans-serif; padding: 32px; max-width: 900px; margin: auto; }
-  h1 { font-size: 22px; color: #f0c040; letter-spacing: 1px; margin-bottom: 6px; }
-  .subtitle { font-size: 13px; color: #7a9ab5; margin-bottom: 32px; letter-spacing: 0.5px; }
-  .section-label { font-size: 11px; color: #7a9ab5; letter-spacing: 1px; text-transform: uppercase; margin-bottom: 8px; font-weight: 600; }
-
   /* Circuit diagram using CSS grid */
   .circuit-container { background: #0a1520; border: 1.5px solid #1a2d3d; border-radius: 10px; padding: 24px; margin-bottom: 28px; }
   .circuit-diagram { display: grid; grid-template-columns: 1fr 180px 1fr; grid-template-rows: auto auto auto auto auto; gap: 0; max-width: 600px; margin: 0 auto; }
@@ -61,13 +56,6 @@
   .std-card h3 { font-size: 11px; color: #7a9ab5; text-transform: uppercase; letter-spacing: 0.5px; margin-bottom: 8px; }
   .std-value { font-size: 16px; font-weight: 800; color: #f0c040; }
   .std-note { font-size: 11px; color: #7a9ab5; margin-top: 4px; }
-
-  .hook-box { background: #1a2a1a; border: 1.5px solid #2d5a2d; border-radius: 10px; padding: 18px 22px; }
-  .hook-box h2 { font-size: 12px; color: #80c880; text-transform: uppercase; letter-spacing: 1px; margin-bottom: 12px; }
-  .hook-row { display: flex; gap: 10px; margin-bottom: 8px; align-items: flex-start; }
-  .hook-badge { background: #2d5a2d; color: #80c880; font-size: 10px; font-weight: 800; padding: 2px 8px; border-radius: 10px; white-space: nowrap; flex-shrink: 0; margin-top: 2px; }
-  .hook-text { font-size: 13px; color: #c8d8c8; line-height: 1.5; }
-  .hook-text strong { color: #f0c040; }
 
   @media (max-width: 600px) { .standards-grid { grid-template-columns: 1fr; } }
 </style>

--- a/web-app/public/visuals/al007-radio-communications.html
+++ b/web-app/public/visuals/al007-radio-communications.html
@@ -3,14 +3,9 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
+<link rel="stylesheet" href="/visuals/_common.css">
 <title>AL-007: Radio Communications</title>
 <style>
-  * { box-sizing: border-box; margin: 0; padding: 0; }
-  body { background: #0d1b2a; color: #e8edf2; font-family: 'Segoe UI', system-ui, sans-serif; padding: 32px; max-width: 900px; margin: auto; }
-  h1 { font-size: 22px; color: #f0c040; letter-spacing: 1px; margin-bottom: 6px; }
-  .subtitle { font-size: 13px; color: #7a9ab5; margin-bottom: 32px; letter-spacing: 0.5px; }
-  .section-label { font-size: 11px; color: #7a9ab5; letter-spacing: 1px; text-transform: uppercase; margin-bottom: 8px; font-weight: 600; }
-
   /* Phonetic alphabet — two-column grid */
   .alphabet-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 3px; margin-bottom: 28px; border-radius: 8px; overflow: hidden; border: 1.5px solid #1a2d3d; }
   .alpha-row { display: grid; grid-template-columns: 36px 1fr; align-items: center; padding: 7px 12px; background: #0d1b2a; border-bottom: 1px solid rgba(255,255,255,0.04); }
@@ -32,13 +27,6 @@
   .gun-red { color: #ff9090; }
   .gun-white { color: #e8edf2; }
   .gun-alt { color: #f0c040; }
-
-  .hook-box { background: #1a2a1a; border: 1.5px solid #2d5a2d; border-radius: 10px; padding: 18px 22px; }
-  .hook-box h2 { font-size: 12px; color: #80c880; text-transform: uppercase; letter-spacing: 1px; margin-bottom: 12px; }
-  .hook-row { display: flex; gap: 10px; margin-bottom: 8px; align-items: flex-start; }
-  .hook-badge { background: #2d5a2d; color: #80c880; font-size: 10px; font-weight: 800; padding: 2px 8px; border-radius: 10px; white-space: nowrap; flex-shrink: 0; margin-top: 2px; }
-  .hook-text { font-size: 13px; color: #c8d8c8; line-height: 1.5; }
-  .hook-text strong { color: #f0c040; }
 
   @media (max-width: 500px) { .alphabet-grid { grid-template-columns: 1fr; } }
 </style>

--- a/web-app/public/visuals/al008-atc-services-clearances.html
+++ b/web-app/public/visuals/al008-atc-services-clearances.html
@@ -3,14 +3,9 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
+<link rel="stylesheet" href="/visuals/_common.css">
 <title>AL-008: ATC Services and Clearances</title>
 <style>
-  * { box-sizing: border-box; margin: 0; padding: 0; }
-  body { background: #0d1b2a; color: #e8edf2; font-family: 'Segoe UI', system-ui, sans-serif; padding: 32px; max-width: 900px; margin: auto; }
-  h1 { font-size: 22px; color: #f0c040; letter-spacing: 1px; margin-bottom: 6px; }
-  .subtitle { font-size: 13px; color: #7a9ab5; margin-bottom: 32px; letter-spacing: 0.5px; }
-  .section-label { font-size: 11px; color: #7a9ab5; letter-spacing: 1px; text-transform: uppercase; margin-bottom: 8px; font-weight: 600; }
-
   /* ATC units cards */
   .units-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; margin-bottom: 28px; }
   .unit-card { background: #1a2d3d; border-radius: 8px; padding: 16px; border-left: 4px solid #1a2d3d; }
@@ -52,13 +47,6 @@
   .craft-letter { font-size: 20px; font-weight: 800; color: #f0c040; width: 36px; }
   .craft-word { font-weight: 700; color: #e8edf2; }
   .craft-desc { font-size: 12px; color: #7a9ab5; margin-top: 3px; }
-
-  .hook-box { background: #1a2a1a; border: 1.5px solid #2d5a2d; border-radius: 10px; padding: 18px 22px; }
-  .hook-box h2 { font-size: 12px; color: #80c880; text-transform: uppercase; letter-spacing: 1px; margin-bottom: 12px; }
-  .hook-row { display: flex; gap: 10px; margin-bottom: 8px; align-items: flex-start; }
-  .hook-badge { background: #2d5a2d; color: #80c880; font-size: 10px; font-weight: 800; padding: 2px 8px; border-radius: 10px; white-space: nowrap; flex-shrink: 0; margin-top: 2px; }
-  .hook-text { font-size: 13px; color: #c8d8c8; line-height: 1.5; }
-  .hook-text strong { color: #f0c040; }
 
   @media (max-width: 550px) { .units-grid { grid-template-columns: 1fr; } }
 </style>

--- a/web-app/public/visuals/al014-emergency-procedures-law.html
+++ b/web-app/public/visuals/al014-emergency-procedures-law.html
@@ -3,14 +3,9 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
+<link rel="stylesheet" href="/visuals/_common.css">
 <title>AL-014: Emergency Procedures — Distress and Urgency</title>
 <style>
-  * { box-sizing: border-box; margin: 0; padding: 0; }
-  body { background: #0d1b2a; color: #e8edf2; font-family: 'Segoe UI', system-ui, sans-serif; padding: 32px; max-width: 900px; margin: 0 auto; }
-  h1 { font-size: 22px; color: #f0c040; letter-spacing: 1px; margin-bottom: 6px; }
-  .subtitle { font-size: 13px; color: #7a9ab5; margin-bottom: 32px; letter-spacing: 0.5px; }
-  .section-label { font-size: 11px; color: #7a9ab5; letter-spacing: 1px; text-transform: uppercase; margin-bottom: 8px; font-weight: 600; }
-
   .cards { display: grid; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); gap: 16px; margin-bottom: 36px; }
   .card { background: #1a2d3d; border-radius: 10px; border: 1.5px solid #1a2d3d; padding: 20px; }
   .card-header { display: flex; align-items: center; gap: 12px; margin-bottom: 12px; }
@@ -23,10 +18,6 @@
   .card p:last-child { margin-bottom: 0; }
   .highlight { color: #f0c040; font-weight: 700; }
 
-  table { width: 100%; border-collapse: collapse; font-size: 12px; margin-bottom: 28px; }
-  th { background: #1a2d3d; color: #7a9ab5; padding: 8px 10px; text-align: left; font-size: 11px; text-transform: uppercase; letter-spacing: 0.5px; }
-  td { padding: 9px 10px; border-bottom: 1px solid #1a2d3d; vertical-align: top; }
-  tr:last-child td { border-bottom: none; }
   .col-signal { color: #f0c040; font-weight: 700; }
   .col-distress { color: #ff7070; font-weight: 600; }
   .col-urgency { color: #f0c040; font-weight: 600; }

--- a/web-app/public/visuals/al015-transponder-codes.html
+++ b/web-app/public/visuals/al015-transponder-codes.html
@@ -3,19 +3,9 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
+<link rel="stylesheet" href="/visuals/_common.css">
 <title>AL-015: Transponder Codes and Mode C Requirements</title>
 <style>
-  * { box-sizing: border-box; margin: 0; padding: 0; }
-  body { background: #0d1b2a; color: #e8edf2; font-family: 'Segoe UI', system-ui, sans-serif; padding: 32px; max-width: 900px; margin: 0 auto; }
-  h1 { font-size: 22px; color: #f0c040; letter-spacing: 1px; margin-bottom: 6px; }
-  .subtitle { font-size: 13px; color: #7a9ab5; margin-bottom: 32px; letter-spacing: 0.5px; }
-  .section-label { font-size: 11px; color: #7a9ab5; letter-spacing: 1px; text-transform: uppercase; margin-bottom: 8px; font-weight: 600; }
-
-  table { width: 100%; border-collapse: collapse; font-size: 12px; margin-bottom: 28px; }
-  th { background: #1a2d3d; color: #7a9ab5; padding: 8px 10px; text-align: left; font-size: 11px; text-transform: uppercase; letter-spacing: 0.5px; }
-  td { padding: 9px 10px; border-bottom: 1px solid #1a2d3d; vertical-align: top; }
-  tr:last-child td { border-bottom: none; }
-
   .modes-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(240px, 1fr)); gap: 16px; margin-bottom: 28px; }
   .mode-card { background: #1a2d3d; border-radius: 10px; padding: 16px 18px; border: 1.5px solid #1a2d3d; }
   .mode-label { font-size: 20px; font-weight: 900; color: #f0c040; margin-bottom: 6px; letter-spacing: 1px; }
@@ -34,15 +24,6 @@
   .code-label { font-size: 12px; font-weight: 700; color: #e8edf2; margin-bottom: 4px; }
   .code-desc { font-size: 11px; color: #7a9ab5; line-height: 1.4; }
 
-  .hook-box { background: #1a2a1a; border: 1.5px solid #2d5a2d; border-radius: 10px; padding: 18px 22px; margin-bottom: 0; }
-  .hook-box h2 { font-size: 12px; color: #80c880; text-transform: uppercase; letter-spacing: 1px; margin-bottom: 12px; }
-  .hook-row { display: flex; gap: 10px; margin-bottom: 8px; align-items: flex-start; }
-  .hook-badge { background: #2d5a2d; color: #80c880; font-size: 10px; font-weight: 800; padding: 2px 8px; border-radius: 10px; white-space: nowrap; flex-shrink: 0; margin-top: 2px; }
-  .hook-text { font-size: 13px; color: #c8d8c8; line-height: 1.5; }
-  .hook-text strong { color: #f0c040; }
-
-  .yes { color: #80e080; font-weight: 700; }
-  .no  { color: #ff8080; font-weight: 700; }
   .req { color: #f0c040; font-weight: 600; }
 </style>
 </head>

--- a/web-app/public/visuals/al016-wake-turbulence.html
+++ b/web-app/public/visuals/al016-wake-turbulence.html
@@ -3,18 +3,9 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
+<link rel="stylesheet" href="/visuals/_common.css">
 <title>AL-016: Wake Turbulence — Categories, Avoidance, Timing</title>
 <style>
-  * { box-sizing: border-box; margin: 0; padding: 0; }
-  body { background: #0d1b2a; color: #e8edf2; font-family: 'Segoe UI', system-ui, sans-serif; padding: 32px; max-width: 900px; margin: 0 auto; }
-  h1 { font-size: 22px; color: #f0c040; letter-spacing: 1px; margin-bottom: 6px; }
-  .subtitle { font-size: 13px; color: #7a9ab5; margin-bottom: 32px; letter-spacing: 0.5px; }
-  .section-label { font-size: 11px; color: #7a9ab5; letter-spacing: 1px; text-transform: uppercase; margin-bottom: 8px; font-weight: 600; }
-
-  table { width: 100%; border-collapse: collapse; font-size: 12px; margin-bottom: 28px; }
-  th { background: #1a2d3d; color: #7a9ab5; padding: 8px 10px; text-align: left; font-size: 11px; text-transform: uppercase; letter-spacing: 0.5px; }
-  td { padding: 9px 10px; border-bottom: 1px solid #1a2d3d; vertical-align: top; }
-  tr:last-child td { border-bottom: none; }
   .cat-heavy { color: #ff7070; font-weight: 700; }
   .cat-medium { color: #f0c040; font-weight: 700; }
   .cat-light { color: #80e080; font-weight: 700; }
@@ -35,13 +26,6 @@
   .avoid-icon { font-size: 16px; flex-shrink: 0; }
   .avoid-text { font-size: 13px; color: #c8d8e8; line-height: 1.5; }
   .avoid-text strong { color: #f0c040; }
-
-  .hook-box { background: #1a2a1a; border: 1.5px solid #2d5a2d; border-radius: 10px; padding: 18px 22px; }
-  .hook-box h2 { font-size: 12px; color: #80c880; text-transform: uppercase; letter-spacing: 1px; margin-bottom: 12px; }
-  .hook-row { display: flex; gap: 10px; margin-bottom: 8px; align-items: flex-start; }
-  .hook-badge { background: #2d5a2d; color: #80c880; font-size: 10px; font-weight: 800; padding: 2px 8px; border-radius: 10px; white-space: nowrap; flex-shrink: 0; margin-top: 2px; }
-  .hook-text { font-size: 13px; color: #c8d8c8; line-height: 1.5; }
-  .hook-text strong { color: #f0c040; }
 </style>
 </head>
 <body>

--- a/web-app/public/visuals/al017-low-level-flight-rules.html
+++ b/web-app/public/visuals/al017-low-level-flight-rules.html
@@ -3,18 +3,9 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
+<link rel="stylesheet" href="/visuals/_common.css">
 <title>AL-017: Low-Level Flight Rules — 500 ft, Congested Areas, Noise Abatement</title>
 <style>
-  * { box-sizing: border-box; margin: 0; padding: 0; }
-  body { background: #0d1b2a; color: #e8edf2; font-family: 'Segoe UI', system-ui, sans-serif; padding: 32px; max-width: 900px; margin: 0 auto; }
-  h1 { font-size: 22px; color: #f0c040; letter-spacing: 1px; margin-bottom: 6px; }
-  .subtitle { font-size: 13px; color: #7a9ab5; margin-bottom: 32px; letter-spacing: 0.5px; }
-  .section-label { font-size: 11px; color: #7a9ab5; letter-spacing: 1px; text-transform: uppercase; margin-bottom: 8px; font-weight: 600; }
-
-  table { width: 100%; border-collapse: collapse; font-size: 12px; margin-bottom: 28px; }
-  th { background: #1a2d3d; color: #7a9ab5; padding: 8px 10px; text-align: left; font-size: 11px; text-transform: uppercase; letter-spacing: 0.5px; }
-  td { padding: 9px 10px; border-bottom: 1px solid #1a2d3d; vertical-align: top; }
-  tr:last-child td { border-bottom: none; }
   .rule-ref { color: #7a9ab5; font-size: 11px; }
   .alt-value { color: #f0c040; font-weight: 700; }
   .dist-value { color: #80c880; font-weight: 600; }
@@ -29,13 +20,6 @@
   .card-rule { font-size: 11px; color: #7a9ab5; margin-bottom: 8px; }
   .card-body { font-size: 13px; color: #c8d8e8; line-height: 1.6; }
   .card-body strong { color: #e8edf2; }
-
-  .hook-box { background: #1a2a1a; border: 1.5px solid #2d5a2d; border-radius: 10px; padding: 18px 22px; }
-  .hook-box h2 { font-size: 12px; color: #80c880; text-transform: uppercase; letter-spacing: 1px; margin-bottom: 12px; }
-  .hook-row { display: flex; gap: 10px; margin-bottom: 8px; align-items: flex-start; }
-  .hook-badge { background: #2d5a2d; color: #80c880; font-size: 10px; font-weight: 800; padding: 2px 8px; border-radius: 10px; white-space: nowrap; flex-shrink: 0; margin-top: 2px; }
-  .hook-text { font-size: 13px; color: #c8d8c8; line-height: 1.5; }
-  .hook-text strong { color: #f0c040; }
 </style>
 </head>
 <body>

--- a/web-app/public/visuals/al018-special-use-airspace.html
+++ b/web-app/public/visuals/al018-special-use-airspace.html
@@ -3,14 +3,9 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
+<link rel="stylesheet" href="/visuals/_common.css">
 <title>AL-018: Special Use Airspace — Class F(R), MOAs, ADIZs</title>
 <style>
-  * { box-sizing: border-box; margin: 0; padding: 0; }
-  body { background: #0d1b2a; color: #e8edf2; font-family: 'Segoe UI', system-ui, sans-serif; padding: 32px; max-width: 900px; margin: 0 auto; }
-  h1 { font-size: 22px; color: #f0c040; letter-spacing: 1px; margin-bottom: 6px; }
-  .subtitle { font-size: 13px; color: #7a9ab5; margin-bottom: 32px; letter-spacing: 0.5px; }
-  .section-label { font-size: 11px; color: #7a9ab5; letter-spacing: 1px; text-transform: uppercase; margin-bottom: 8px; font-weight: 600; }
-
   .type-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); gap: 14px; margin-bottom: 28px; }
   .type-card { border-radius: 10px; padding: 18px; border: 1.5px solid; }
   .card-fr { background: rgba(255,80,80,0.06); border-color: rgba(255,80,80,0.3); }
@@ -31,12 +26,6 @@
   .rule-restricted-moa { background: rgba(100,160,255,0.15); color: #64a0ff; }
   .rule-adiz { background: rgba(130,100,255,0.15); color: #a080ff; }
 
-  table { width: 100%; border-collapse: collapse; font-size: 12px; margin-bottom: 28px; }
-  th { background: #1a2d3d; color: #7a9ab5; padding: 8px 10px; text-align: left; font-size: 11px; text-transform: uppercase; letter-spacing: 0.5px; }
-  td { padding: 9px 10px; border-bottom: 1px solid #1a2d3d; vertical-align: top; }
-  tr:last-child td { border-bottom: none; }
-  .yes { color: #80e080; font-weight: 700; }
-  .no  { color: #ff8080; font-weight: 700; }
   .cond { color: #f0c040; font-weight: 600; }
 
   .adiz-box { background: rgba(130,100,255,0.06); border: 1.5px solid rgba(130,100,255,0.25); border-radius: 10px; padding: 18px 20px; margin-bottom: 28px; }
@@ -45,13 +34,6 @@
   .adiz-num { background: rgba(130,100,255,0.2); color: #a080ff; font-size: 10px; font-weight: 800; width: 22px; height: 22px; border-radius: 50%; display: flex; align-items: center; justify-content: center; flex-shrink: 0; margin-top: 1px; }
   .adiz-text { font-size: 13px; color: #c8d8e8; line-height: 1.5; }
   .adiz-text strong { color: #f0c040; }
-
-  .hook-box { background: #1a2a1a; border: 1.5px solid #2d5a2d; border-radius: 10px; padding: 18px 22px; }
-  .hook-box h2 { font-size: 12px; color: #80c880; text-transform: uppercase; letter-spacing: 1px; margin-bottom: 12px; }
-  .hook-row { display: flex; gap: 10px; margin-bottom: 8px; align-items: flex-start; }
-  .hook-badge { background: #2d5a2d; color: #80c880; font-size: 10px; font-weight: 800; padding: 2px 8px; border-radius: 10px; white-space: nowrap; flex-shrink: 0; margin-top: 2px; }
-  .hook-text { font-size: 13px; color: #c8d8c8; line-height: 1.5; }
-  .hook-text strong { color: #f0c040; }
 </style>
 </head>
 <body>


### PR DESCRIPTION
## Summary

- Create `web-app/public/visuals/_common.css` with shared Variant A dark-aviation styles: CSS reset, body, h1, subtitle, section-label, table/th/td, `.yes`/`.no` status indicators, `.hook-box` component, and responsive media query
- Add `<link rel="stylesheet" href="/visuals/_common.css">` to all 13 `al*.html` files
- Remove inline duplicates of shared tokens from each file; retain file-specific SVG layouts, diagram positioning, and bespoke component styles
- Preserve back-link button and all visual content verbatim in every file

## Test plan

- [ ] `npm run build` passes (verified locally — exit 0)
- [ ] All 13 `al*.html` files link `_common.css` and render correctly with dark Variant A palette
- [ ] Back-link button present in every file
- [ ] No visual content removed — palette/CSS refactor only
- [ ] Non-al topic visuals (`nav*`, `met*`, `gk*`) are unchanged

Closes #213

🤖 Generated with [Claude Code](https://claude.com/claude-code)