### PR TITLE
[PPL-202] Add curated playlists data and route

### DIFF
--- a/web-app/src/App.tsx
+++ b/web-app/src/App.tsx
@@ -111,6 +111,7 @@ export default function App() {
               <Route path="/plan" element={<Plan />} />
               <Route path="/playlist" element={<Playlist />} />
               <Route path="/playlist/smart/:kind" element={<SmartPlaylist />} />
+              <Route path="/playlist/curated/:id" element={<Playlist />} />
               <Route path="/playlist/:topic" element={<Playlist />} />
               <Route path="/playlist/new" element={<PlaylistEditor />} />
               <Route path="/playlist/user/:id" element={<UserPlaylistPage />} />

--- a/web-app/src/data/curated-playlists.ts
+++ b/web-app/src/data/curated-playlists.ts
@@ -3,7 +3,35 @@ export interface CuratedPlaylist {
   name: string;
   tagline: string;
   lessonIds: string[];
-  durationMin: number;
+  badge?: string;
 }
 
-export const curatedPlaylists: CuratedPlaylist[] = [];
+export const CURATED_PLAYLISTS: CuratedPlaylist[] = [
+  {
+    id: 'weather-essentials',
+    name: 'Weather Essentials',
+    tagline: 'Decode METARs, TAFs, GFAs, and PIREPs — the core wx briefing tools',
+    lessonIds: ['MET-005', 'MET-006', 'MET-007', 'MET-008', 'MET-009', 'MET-010'],
+    badge: 'Met',
+  },
+  {
+    id: 'preflight-10min',
+    name: 'Preflight in 10 min',
+    tagline: 'Aircraft parts, fuel system, and inspection basics — fast refresh before a flight',
+    lessonIds: ['GK-001', 'GK-003', 'GK-004', 'GK-014'],
+  },
+  {
+    id: 'emergency-playbook',
+    name: 'Emergency Playbook',
+    tagline: 'Emergency procedures, stalls, and load factor — know them before you need them',
+    lessonIds: ['AL-014', 'GK-012', 'GK-013'],
+    badge: '!',
+  },
+  {
+    id: 'nav-fundamentals',
+    name: 'Nav Fundamentals',
+    tagline: 'VFR charts, dead reckoning, and wind correction — the cross-country core',
+    lessonIds: ['NAV-001', 'NAV-002', 'NAV-003', 'NAV-004', 'NAV-005'],
+    badge: 'Nav',
+  },
+];

--- a/web-app/src/pages/Playlist.tsx
+++ b/web-app/src/pages/Playlist.tsx
@@ -1,13 +1,16 @@
 import { useEffect } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
 import ButtonBase from '@mui/material/ButtonBase';
 import Container from '@mui/material/Container';
 import Typography from '@mui/material/Typography';
 import { useTheme } from '@mui/material/styles';
-import { getLessonsByTopic } from '../lib/lesson-loader';
+import PlaylistPlayer from '../components/PlaylistPlayer';
+import { getAllLessons, getLessonsByTopic } from '../lib/lesson-loader';
 import { TOPICS, TOPIC_LABELS, CURRICULUM } from '../lib/curriculum';
-import { curatedPlaylists } from '../data/curated-playlists';
+import type { Lesson } from '../lib/types';
+import { CURATED_PLAYLISTS } from '../data/curated-playlists';
 import { getUserPlaylists } from '../lib/user-playlists';
 import { typographyTokens } from '../tokens';
 import { useStickyPlayer } from '../context/StickyPlayerContext';
@@ -423,20 +426,20 @@ function PlaylistLibrary() {
     };
   });
 
-  // Section 2: Curated playlists (stub: empty until feature merges)
-  const curatedEntries: CardEntry[] = curatedPlaylists.map((p) => ({
+  // Section 2: Curated playlists
+  const curatedEntries: CardEntry[] = CURATED_PLAYLISTS.map((p) => ({
     id: p.id,
     name: p.name,
     tagline: p.tagline,
     badge: 'CURATED',
     lessonCount: p.lessonIds.length,
-    durationMin: p.durationMin,
+    durationMin: p.lessonIds.length * 20,
     href: `/playlist/curated/${p.id}`,
     coverCode: p.id.slice(0, 4).toUpperCase(),
     coverAngle: 90,
   }));
 
-  // Section 3: User playlists (stub: empty until feature merges)
+  // Section 3: User playlists
   const userPlaylists = getUserPlaylists();
   const userEntries: CardEntry[] = userPlaylists.map((p) => ({
     id: p.id,
@@ -616,8 +619,52 @@ function TopicPlaylist({ topic, lessons, setLessons }: TopicPlaylistProps) {
 // ── Route entry point ──────────────────────────────────────────────────────
 
 export default function Playlist() {
-  const { topic } = useParams<{ topic: string }>();
+  const { topic, id } = useParams<{ topic?: string; id?: string }>();
   const { setLessons } = useStickyPlayer();
+  const navigate = useNavigate();
+
+  if (id !== undefined) {
+    const playlist = CURATED_PLAYLISTS.find((p) => p.id === id);
+
+    if (!playlist) {
+      return (
+        <Container maxWidth="md" sx={{ py: 4 }}>
+          <Typography variant="h4" gutterBottom>
+            Playlist Not Found
+          </Typography>
+          <Typography color="text.secondary" sx={{ mb: 3 }}>
+            No curated playlist with id "{id}" exists.
+          </Typography>
+          <Button variant="outlined" onClick={() => navigate('/playlist')}>
+            Back to Playlists
+          </Button>
+        </Container>
+      );
+    }
+
+    const allLessons = getAllLessons();
+    const lessons: Lesson[] = playlist.lessonIds
+      .map((lid) => allLessons.find((l) => l.id === lid))
+      .filter((l): l is Lesson => l !== undefined);
+
+    return (
+      <Container maxWidth="md" sx={{ py: 4 }}>
+        <Typography variant="h4" gutterBottom>
+          {playlist.name}
+        </Typography>
+        <Typography variant="body1" color="text.secondary" sx={{ mb: 3 }}>
+          {playlist.tagline}
+        </Typography>
+        {lessons.length === 0 ? (
+          <Typography color="text.secondary">
+            No audio lessons are available for this playlist yet.
+          </Typography>
+        ) : (
+          <PlaylistPlayer lessons={lessons} />
+        )}
+      </Container>
+    );
+  }
 
   if (topic) {
     const lessons = getLessonsByTopic(topic).filter(


### PR DESCRIPTION
## Summary
- Add `web-app/src/data/curated-playlists.ts` exporting `CuratedPlaylist[]` with 4 seeded entries: weather-essentials, preflight-10min, emergency-playbook, nav-fundamentals
- Add `/playlist/curated/:id` route in `App.tsx` (before `/playlist/:topic` so static segment wins)
- Update `Playlist.tsx` to detect the curated `id` param, look up the matched playlist, render `PlaylistPlayer` with lessons resolved from `getAllLessons()`, and show a 404-style fallback for unknown ids

Closes #202

## Test plan
- [ ] Navigate to `/playlist/curated/weather-essentials` — should show PlaylistPlayer with MET-005 through MET-010
- [ ] Navigate to `/playlist/curated/preflight-10min` — should show GK-001, GK-003, GK-004, GK-014
- [ ] Navigate to `/playlist/curated/emergency-playbook` — should show AL-014, GK-012, GK-013
- [ ] Navigate to `/playlist/curated/nav-fundamentals` — should show NAV-001 through NAV-005
- [ ] Navigate to `/playlist/curated/unknown-id` — should show 404-style fallback with back button
- [ ] `/playlist/air-law` still works as before (topic route unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)