### PR TITLE
[PPL-212] Add _common.css shared design tokens for lesson visuals

### DIFF
--- a/docs/design/examples/visual-template.html
+++ b/docs/design/examples/visual-template.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>XXX-000: Lesson Title</title>
+<link rel="stylesheet" href="/visuals/_common.css">
+<style>
+  /* Visual-specific styles only — tokens and shared components come from _common.css */
+</style>
+</head>
+<body>
+  <button
+    data-backlink="true"
+    onclick="if(window.history.length<=1){window.close();}else{window.history.back();}"
+    style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:#f0c040;border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);"
+    aria-label="Back to lesson"
+  >&#8592; Back to lesson</button>
+  <style>.container{padding-top:56px!important;}@media(max-width:480px){.container{padding-top:60px!important;}}</style>
+
+<div class="container">
+  <h1>XXX-000 — Lesson Title</h1>
+  <p class="subtitle">Transport Canada · TP 12880E Ch. X · Source</p>
+
+  <!-- Example: section heading -->
+  <div class="section-title">Section Name</div>
+
+  <!-- Example: table -->
+  <table>
+    <thead>
+      <tr><th>Column A</th><th>Column B</th><th>Column C</th></tr>
+    </thead>
+    <tbody>
+      <tr><td>Value</td><td>Value</td><td>Value</td></tr>
+    </tbody>
+  </table>
+
+  <!-- Example: fact cards -->
+  <div class="fact-card">
+    <div class="fact-label">Metric Label</div>
+    <div class="fact-value">Numeric Value</div>
+    <div class="fact-note">Supporting detail sentence.</div>
+  </div>
+
+  <!-- Example: memory hook -->
+  <div class="memory-hook">
+    <span class="badge">EXAM HOOK</span><br>
+    <strong>Key point to remember.</strong> Elaboration and exam context.
+  </div>
+</div>
+</body>
+</html>

--- a/docs/visuals-standards.md
+++ b/docs/visuals-standards.md
@@ -14,13 +14,27 @@ page.
 All new visuals must match the look and structure of this file. Read it before
 authoring a new one.
 
+## Scheme
+
+**Variant A · Cockpit Briefing — dark scheme (canonical).** All visuals use the
+dark scheme by default. Light-scheme variants are not produced for visuals.
+
 ## Format
 
-**Standalone dark-aviation HTML** — a complete `<!DOCTYPE html>` document with all
-CSS inlined in a `<style>` block inside `<head>`. No external stylesheets, no
-JavaScript frameworks, no `<link>` or `<script src>` tags pointing outside the
-document. The file must render correctly when opened directly from the filesystem
-(`file://`) without a server.
+**Dark-aviation HTML** — a complete `<!DOCTYPE html>` document served via Firebase
+Hosting. Every visual **must** link the shared token stylesheet in `<head>`:
+
+```html
+<link rel="stylesheet" href="/visuals/_common.css">
+```
+
+`/visuals/_common.css` provides `:root` color tokens, body defaults, the
+grid-paper backdrop, and shared component classes (`.fact-card`, `.memory-hook`,
+`table`/`th`/`td`, `.status-bar`). Visual-specific layout rules go in a `<style>`
+block below the `<link>`. Do not re-declare tokens or shared component styles
+inline — override only what is unique to this visual.
+
+No JavaScript frameworks, no `<script src>` tags pointing outside the document.
 
 ## Viewport and dimensions
 
@@ -36,18 +50,29 @@ document. The file must render correctly when opened directly from the filesyste
 
 ## Colour palette
 
-| Role | Hex | Usage |
-|------|-----|-------|
-| Background | `#0d1b2a` | `body` background; darkest layer |
-| Primary text | `#e8edf2` | Body copy |
-| Amber accent | `#f0c040` | Headings, key values, callout labels |
-| Blue-grey secondary | `#7a9ab5` | Subtitles, labels, table headers |
-| Panel surface | `#1a2d3d` | Card/table header backgrounds |
-| Border | `#1a2d3d` | Table and card borders |
+Color tokens are defined in `docs/design/DESIGN-SYSTEM.md §2.1` (dark scheme)
+and exposed as CSS custom properties by `/visuals/_common.css`. Use `var(--...)`
+references in visual-specific styles; do not hard-code hex values.
 
-Do not introduce colours outside this palette without a documented reason. Tints
-and alpha variants (e.g. `rgba(255,80,80,0.15)` for danger tags) are acceptable
-as long as they stay within the dark-aviation aesthetic.
+| Role | CSS variable | Dark value |
+|------|-------------|------------|
+| Page background | `--bg2` | `#0d1b2a` |
+| Surface (card, panel) | `--surface` | `#0f1f33` |
+| Raised surface | `--surface2` | `#142a40` |
+| Border | `--border` | `#1a3550` |
+| Border, emphasized | `--border-hi` | `#2a4a70` |
+| Amber accent | `--accent` | `#f0c040` |
+| Text primary | `--text` | `#e4ecf5` |
+| Text muted | `--text-muted` | `#7a9ab5` |
+| Success / correct | `--success` | `#4caf7d` |
+| Danger / wrong | `--danger` | `#e05050` |
+
+Full token table (including `--bg`, `--accent-dim`, `--warning`, `--info`) is in
+`docs/design/DESIGN-SYSTEM.md §2.1` — that document is the single source of
+truth. Do not introduce colors outside the token set without first amending
+DESIGN-SYSTEM.md. Alpha tints of existing tokens (e.g.
+`rgba(76,175,125,0.10)` for memory-hook background) are acceptable as long as
+they stay within the dark-aviation aesthetic.
 
 ## File naming
 
@@ -204,7 +229,8 @@ bash scripts/add-visual-backlink.sh
 - **No stock filler.** Do not embed stock photos, clip art, or decorative imagery
   that does not directly support the lesson content.
 - **No external resources.** No `<img src="https://...">`, no Google Fonts `@import`,
-  no CDN-hosted scripts or stylesheets. Everything the page needs must be inlined.
+  no CDN-hosted scripts or stylesheets. The only permitted external stylesheet is
+  `/visuals/_common.css` served from the same Firebase Hosting origin.
 - **No copyright-protected charts.** Do not reproduce VNC/VTA chart extracts or
   other Transport Canada map products verbatim. Diagrams must be original
   illustrations inspired by the content, not reproductions of licensed materials.

--- a/web-app/public/visuals/_common.css
+++ b/web-app/public/visuals/_common.css
@@ -1,0 +1,194 @@
+/* _common.css — shared tokens and component styles for PPL Study lesson visuals
+ * Variant A · Cockpit Briefing · dark scheme (default)
+ * Source of truth: docs/design/DESIGN-SYSTEM.md
+ * Do not add colors outside these tokens.
+ */
+
+/* ── Color tokens — verbatim from DESIGN-SYSTEM.md §2.1 ───────────────── */
+:root {
+  --bg:         #071020;
+  --bg2:        #0d1b2a;
+  --surface:    #0f1f33;
+  --surface2:   #142a40;
+  --border:     #1a3550;
+  --border-hi:  #2a4a70;
+  --accent:     #f0c040;
+  --accent-dim: #8b6f24;
+  --text:       #e4ecf5;
+  --text-muted: #7a9ab5;
+  --success:    #4caf7d;
+  --warning:    #f0c040;
+  --danger:     #e05050;
+  --info:       #5b9bd5;
+  /* Grid-paper line — DESIGN-SYSTEM.md §4.4, dark value */
+  --grid-line:  rgba(26,53,80,0.15);
+}
+
+/* ── Reset ─────────────────────────────────────────────────────────────── */
+* { box-sizing: border-box; margin: 0; padding: 0; }
+
+/* ── Body defaults ─────────────────────────────────────────────────────── */
+body {
+  background: var(--bg2);
+  color: var(--text);
+  font-family: 'Segoe UI', system-ui, sans-serif;
+  padding: 32px;
+  position: relative;
+}
+
+/* ── Grid-paper backdrop — DESIGN-SYSTEM.md §4.4 ──────────────────────── */
+body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  z-index: 0;
+  background-image:
+    linear-gradient(var(--grid-line) 1px, transparent 1px),
+    linear-gradient(90deg, var(--grid-line) 1px, transparent 1px);
+  background-size: 40px 40px;
+}
+
+/* ── Container ─────────────────────────────────────────────────────────── */
+.container {
+  max-width: 900px;
+  margin: 0 auto;
+  position: relative;
+  z-index: 1;
+}
+
+/* ── Typography ────────────────────────────────────────────────────────── */
+h1 {
+  font-size: 22px;
+  color: var(--accent);
+  letter-spacing: 1px;
+  margin-bottom: 6px;
+}
+
+.subtitle {
+  font-size: 13px;
+  color: var(--text-muted);
+  margin-bottom: 32px;
+  letter-spacing: 0.5px;
+}
+
+.section-title {
+  font-size: 14px;
+  color: var(--accent);
+  letter-spacing: 1px;
+  text-transform: uppercase;
+  margin: 32px 0 14px;
+}
+
+/* ── Status bar — DESIGN-SYSTEM.md §5.1 ───────────────────────────────── */
+.status-bar {
+  border-top: 1px solid var(--border);
+  border-bottom: 1px solid var(--border);
+  padding: 6px 0;
+  font-size: 11px;
+  font-family: 'SF Mono', 'JetBrains Mono', Consolas, monospace;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 24px;
+}
+
+.status-bar .status-dot {
+  display: inline-block;
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--success);
+  box-shadow: 0 0 4px var(--success);
+  margin-right: 6px;
+}
+
+.status-bar .status-key {
+  color: var(--accent);
+}
+
+/* ── Tables ────────────────────────────────────────────────────────────── */
+table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-bottom: 20px;
+}
+
+th {
+  background: var(--surface);
+  color: var(--accent);
+  font-size: 12px;
+  text-align: left;
+  padding: 10px 14px;
+  letter-spacing: 0.5px;
+}
+
+td {
+  font-size: 13px;
+  color: var(--text);
+  padding: 9px 14px;
+  border-bottom: 1px solid var(--surface);
+  vertical-align: top;
+}
+
+tr:last-child td { border-bottom: none; }
+
+/* ── Cards ─────────────────────────────────────────────────────────────── */
+.fact-card {
+  background: var(--surface);
+  border: 1px solid var(--border-hi);
+  border-radius: 4px;
+  padding: 14px 16px;
+  margin-bottom: 12px;
+}
+
+.fact-label {
+  font-size: 11px;
+  color: var(--text-muted);
+  letter-spacing: 0.5px;
+  text-transform: uppercase;
+  margin-bottom: 4px;
+}
+
+.fact-value {
+  font-size: 18px;
+  color: var(--accent);
+  font-weight: bold;
+}
+
+.fact-note {
+  font-size: 12px;
+  color: var(--text);
+  margin-top: 4px;
+}
+
+/* ── Memory hook ───────────────────────────────────────────────────────── */
+.memory-hook {
+  background: rgba(76, 175, 125, 0.10);
+  border: 1px solid rgba(76, 175, 125, 0.35);
+  border-radius: 4px;
+  padding: 14px 18px;
+  margin-top: 24px;
+  font-size: 13px;
+  line-height: 1.6;
+}
+
+.memory-hook .badge {
+  display: inline-block;
+  background: rgba(76, 175, 125, 0.22);
+  color: var(--text);
+  font-size: 10px;
+  letter-spacing: 1px;
+  padding: 2px 8px;
+  border-radius: 3px;
+  margin-bottom: 6px;
+}
+
+/* ── Mobile ────────────────────────────────────────────────────────────── */
+@media (max-width: 640px) {
+  body { padding: 16px; }
+}

--- a/web-app/public/visuals/met001-atmosphere-structure.html
+++ b/web-app/public/visuals/met001-atmosphere-structure.html
@@ -4,28 +4,13 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>MET-001: Atmosphere Structure</title>
+<link rel="stylesheet" href="/visuals/_common.css">
 <style>
-  * { box-sizing: border-box; margin: 0; padding: 0; }
-  body { background: #0d1b2a; color: #e8edf2; font-family: 'Segoe UI', system-ui, sans-serif; padding: 32px; }
-  h1 { font-size: 22px; color: #f0c040; letter-spacing: 1px; margin-bottom: 6px; }
-  .subtitle { font-size: 13px; color: #7a9ab5; margin-bottom: 32px; letter-spacing: 0.5px; }
-  .container { max-width: 900px; margin: 0 auto; }
-  .section-title { font-size: 14px; color: #f0c040; letter-spacing: 1px; text-transform: uppercase; margin: 32px 0 14px; }
+  /* Visual-specific layout */
   .layout { display: grid; grid-template-columns: 1.1fr 1fr; gap: 24px; align-items: start; }
-  .diagram-box { background: #1a2d3d; border: 1px solid #243d52; border-radius: 8px; padding: 16px; }
+  .diagram-box { background: var(--surface); border: 1px solid var(--border-hi); border-radius: 8px; padding: 16px; }
   svg text { font-family: 'Segoe UI', system-ui, sans-serif; }
-  table { width: 100%; border-collapse: collapse; margin-bottom: 20px; }
-  th { background: #1a2d3d; color: #f0c040; font-size: 12px; text-align: left; padding: 10px 14px; letter-spacing: 0.5px; }
-  td { font-size: 13px; color: #e8edf2; padding: 9px 14px; border-bottom: 1px solid #1a2d3d; vertical-align: top; }
-  tr:last-child td { border-bottom: none; }
-  .fact-card { background: #1a2d3d; border: 1px solid #243d52; border-radius: 8px; padding: 14px 16px; margin-bottom: 12px; }
-  .fact-label { font-size: 11px; color: #7a9ab5; letter-spacing: 0.5px; text-transform: uppercase; margin-bottom: 4px; }
-  .fact-value { font-size: 18px; color: #f0c040; font-weight: bold; }
-  .fact-note { font-size: 12px; color: #e8edf2; margin-top: 4px; }
-  .memory-hook { background: #1a2a1a; border: 1px solid #2d5a2d; border-radius: 8px; padding: 14px 18px; margin-top: 24px; font-size: 13px; line-height: 1.6; }
-  .memory-hook .badge { display: inline-block; background: #2d5a2d; color: #e8edf2; font-size: 10px; letter-spacing: 1px; padding: 2px 8px; border-radius: 3px; margin-bottom: 6px; }
   @media (max-width: 640px) {
-    body { padding: 16px; }
     .layout { grid-template-columns: 1fr; }
   }
 </style>


### PR DESCRIPTION
## Summary

- **Creates `web-app/public/visuals/_common.css`** — shared token stylesheet for all lesson visuals. Contains `:root` color tokens copied verbatim from `DESIGN-SYSTEM.md §2.1` (dark scheme), the 40×40 grid-paper backdrop (§4.4), body defaults, and reusable component classes: `.container`, `.status-bar`, `table`/`th`/`td`, `.fact-card`/`.fact-label`/`.fact-value`/`.fact-note`, `.memory-hook`/`.badge`.
- **Creates `docs/design/examples/visual-template.html`** — minimal canonical template for new visuals that links `_common.css` instead of duplicating shared styles.
- **Updates `docs/visuals-standards.md`** — removes the inline palette table, points to `DESIGN-SYSTEM.md §2.1` as source of truth, requires `/visuals/_common.css`, states Variant A dark-scheme is canonical, updates "no external resources" rule to permit the same-origin `_common.css`.
- **Pilot-migrates `met001-atmosphere-structure.html`** — strips duplicated shared styles (reset, body, h1, .subtitle, .section-title, table, .fact-card, .memory-hook), adds `<link rel="stylesheet" href="/visuals/_common.css">`. Visual-specific layout (`.layout`, `.diagram-box`, SVG) stays inline. Other 59 visuals are untouched.

## Test plan

- [ ] `npm run build` passes (verified locally — ✓ built in 3.08s)
- [ ] `met001-atmosphere-structure.html` renders correctly via Firebase Hosting preview — layout, SVG diagram, fact cards, table, memory hook all visible
- [ ] Back-link button present and functional
- [ ] No other visuals modified (confirm with `git diff --name-only`)
- [ ] `docs/visuals-standards.md` no longer contains the inline hex palette table

Adheres to `docs/design/DESIGN-SYSTEM.md`

Closes #212

🤖 Generated with [Claude Code](https://claude.com/claude-code)