### PR TITLE
[PPL-212] adopt DESIGN-SYSTEM tokens via shared _common.css + pilot MET-001

### DIFF
--- a/docs/design/examples/visual-template.html
+++ b/docs/design/examples/visual-template.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>XXX-000: Lesson Title</title>
+<!-- Shared tokens, body defaults, and component classes.
+     See docs/design/DESIGN-SYSTEM.md §2.1 and docs/visuals-standards.md. -->
+<link rel="stylesheet" href="/visuals/_common.css">
+<style>
+  /* Visual-specific layout only — do not redeclare shared component styles */
+</style>
+</head>
+<body>
+  <!-- Back-link button — required on every visual (docs/visuals-standards.md §Back-link required) -->
+  <button
+    data-backlink="true"
+    onclick="if(window.history.length<=1){window.close();}else{window.history.back();}"
+    style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:#f0c040;border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);"
+    aria-label="Back to lesson"
+  >&#8592; Back to lesson</button>
+  <style>.container{padding-top:56px!important;}@media(max-width:480px){.container{padding-top:60px!important;}}</style>
+
+<div class="container">
+  <h1>XXX-000 — Lesson Title</h1>
+  <p class="subtitle">Transport Canada · TP XXXXX Ch. X · Source Reference</p>
+
+  <!-- ── Section heading ──────────────────────────────────────────────── -->
+  <div class="section-title">Section Name</div>
+
+  <!-- ── Table (reference data) ───────────────────────────────────────── -->
+  <table>
+    <thead>
+      <tr><th>Column A</th><th>Column B</th><th>Column C</th></tr>
+    </thead>
+    <tbody>
+      <tr><td>Value</td><td>Value</td><td>Description</td></tr>
+    </tbody>
+  </table>
+
+  <!-- ── Fact cards ───────────────────────────────────────────────────── -->
+  <div class="fact-card">
+    <div class="fact-label">Metric Label</div>
+    <div class="fact-value">Numeric Value</div>
+    <div class="fact-note">Supporting detail sentence.</div>
+  </div>
+
+  <!-- ── NOTAM / note callout ─────────────────────────────────────────── -->
+  <div class="note-box">
+    Left-accented callout for important notes or warnings.
+  </div>
+
+  <!-- ── Memory hook ──────────────────────────────────────────────────── -->
+  <div class="memory-hook">
+    <span class="badge">EXAM HOOK</span><br>
+    <strong>Key point to remember.</strong> Elaboration and exam context in
+    plain language.
+  </div>
+</div>
+</body>
+</html>

--- a/docs/visuals-standards.md
+++ b/docs/visuals-standards.md
@@ -14,27 +14,37 @@ page.
 All new visuals must match the look and structure of this file. Read it before
 authoring a new one.
 
+## Template
+
+`docs/design/examples/visual-template.html` is the starting point for every new
+visual. It already links `_common.css` and includes the back-link element.
+
+## Scheme
+
+**Variant A · Cockpit Briefing — dark scheme (canonical).** All visuals use the
+dark scheme. Light-scheme variants are deferred and not produced at this time.
+
 ## Format
 
-**Standalone dark-aviation HTML** — a complete `<!DOCTYPE html>` document.
-JavaScript frameworks and `<script src>` tags pointing outside the document are
-prohibited.
+**Dark-aviation HTML** — a complete `<!DOCTYPE html>` document served via Firebase
+Hosting. JavaScript frameworks and `<script src>` tags pointing outside the
+document are prohibited.
 
-**CSS:** New topic visuals (al, met, nav) must inline all CSS in a `<style>` block
-in `<head>`. **GK visuals** (`gk*.html`) are the sole exception — they link the
-shared token sheet and keep only file-specific rules inline:
+**Every visual must link the shared token stylesheet in `<head>`:**
 
 ```html
-<link rel="stylesheet" href="_common.css">
-<style>
-  /* file-specific rules only */
-</style>
+<link rel="stylesheet" href="/visuals/_common.css">
 ```
 
-`_common.css` lives in the same `web-app/public/visuals/` directory, so it loads
-correctly from Firebase Hosting. GK files will not render correctly when opened via
-`file://` without a local server — this is an acceptable trade-off for the dedup
-benefit. All other topic visuals remain fully self-contained.
+`/visuals/_common.css` lives in `web-app/public/visuals/` and is served by
+Firebase Hosting at the `/visuals/` path. It provides the design-system color
+tokens (`:root`), body defaults, the 40 × 40 px grid-paper backdrop, and shared
+component classes (`.diagram-box`, `.note-box`, `.memory-box`, `.fact-card`,
+`.memory-hook`, `.hook-box`, `table`/`th`/`td`, `.yes`/`.no`, etc.).
+
+Visual-specific layout rules go in a `<style>` block below the `<link>`. Do not
+re-declare tokens or shared component styles inline — override only what is
+unique to this visual.
 
 ## Viewport and dimensions
 
@@ -50,18 +60,27 @@ benefit. All other topic visuals remain fully self-contained.
 
 ## Colour palette
 
-| Role | Hex | Usage |
-|------|-----|-------|
-| Background | `#0d1b2a` | `body` background; darkest layer |
-| Primary text | `#e8edf2` | Body copy |
-| Amber accent | `#f0c040` | Headings, key values, callout labels |
-| Blue-grey secondary | `#7a9ab5` | Subtitles, labels, table headers |
-| Panel surface | `#1a2d3d` | Card/table header backgrounds |
-| Border | `#1a2d3d` | Table and card borders |
+The canonical color token set is defined in **`docs/design/DESIGN-SYSTEM.md §2.1`**
+(dark scheme) and exposed as CSS custom properties (`--bg`, `--accent`,
+`--text-muted`, etc.) by `/visuals/_common.css`.
 
-Do not introduce colours outside this palette without a documented reason. Tints
-and alpha variants (e.g. `rgba(255,80,80,0.15)` for danger tags) are acceptable
-as long as they stay within the dark-aviation aesthetic.
+Do not introduce colors outside the token set without first amending
+`DESIGN-SYSTEM.md`. Alpha tints of existing palette colors (e.g.
+`rgba(255,80,80,0.15)` for danger tags) are acceptable as long as they stay
+within the dark-aviation aesthetic.
+
+For reference, the most commonly used visual palette values:
+
+| Role | Hex | CSS variable |
+|------|-----|--------------|
+| Background | `#0d1b2a` | `--bg2` |
+| Primary text | `#e8edf2` | (body default) |
+| Amber accent | `#f0c040` | `--accent` |
+| Blue-grey secondary | `#7a9ab5` | `--text-muted` |
+| Panel surface | `#1a2d3d` | (visual palette) |
+
+See `docs/design/DESIGN-SYSTEM.md §2.1` for the full token table including
+`--surface`, `--border`, `--success`, `--danger`, and `--info`.
 
 ## File naming
 
@@ -117,7 +136,7 @@ regardless of how the file was produced.
 
 ## Accessibility requirements
 
-- Every `<img>` tag must have a descriptive `alt` attribute. Do not use `alt=""` 
+- Every `<img>` tag must have a descriptive `alt` attribute. Do not use `alt=""`
   unless the image is purely decorative and adjacent text already conveys the
   information.
 - Use semantic HTML where appropriate: `<table>` for tabular data, `<h1>`/`<h2>`
@@ -218,7 +237,8 @@ bash scripts/add-visual-backlink.sh
 - **No stock filler.** Do not embed stock photos, clip art, or decorative imagery
   that does not directly support the lesson content.
 - **No external resources.** No `<img src="https://...">`, no Google Fonts `@import`,
-  no CDN-hosted scripts or stylesheets. Everything the page needs must be inlined.
+  no CDN-hosted scripts or stylesheets. The only permitted external stylesheet is
+  `/visuals/_common.css` served from the same Firebase Hosting origin.
 - **No copyright-protected charts.** Do not reproduce VNC/VTA chart extracts or
   other Transport Canada map products verbatim. Diagrams must be original
   illustrations inspired by the content, not reproductions of licensed materials.

--- a/web-app/public/visuals/_common.css
+++ b/web-app/public/visuals/_common.css
@@ -1,4 +1,27 @@
-/* PPL Study — Shared Visual Styles (dark · Variant A Cockpit Briefing) */
+/* PPL Study — Shared Visual Styles (dark · Variant A Cockpit Briefing)
+ * Color tokens: docs/design/DESIGN-SYSTEM.md §2.1 (dark scheme)
+ * Do not add colors outside the token set or the visual palette.
+ */
+
+/* ── Color tokens — verbatim from DESIGN-SYSTEM.md §2.1 dark scheme ──── */
+:root {
+  --bg:         #071020;
+  --bg2:        #0d1b2a;
+  --surface:    #0f1f33;
+  --surface2:   #142a40;
+  --border:     #1a3550;
+  --border-hi:  #2a4a70;
+  --accent:     #f0c040;
+  --accent-dim: #8b6f24;
+  --text:       #e4ecf5;
+  --text-muted: #7a9ab5;
+  --success:    #4caf7d;
+  --warning:    #f0c040;
+  --danger:     #e05050;
+  --info:       #5b9bd5;
+  /* Grid-paper backdrop line — DESIGN-SYSTEM.md §4.4, dark value */
+  --grid-line:  rgba(26,53,80,0.15);
+}
 
 * { box-sizing: border-box; margin: 0; padding: 0; }
 
@@ -13,6 +36,19 @@ body {
   margin: auto;
 }
 
+/* ── Grid-paper backdrop — DESIGN-SYSTEM.md §4.4 ─────────────────────── */
+body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  z-index: 0;
+  background-image:
+    linear-gradient(var(--grid-line) 1px, transparent 1px),
+    linear-gradient(90deg, var(--grid-line) 1px, transparent 1px);
+  background-size: 40px 40px;
+}
+
 h1 { font-size: 22px; color: #f0c040; letter-spacing: 1px; margin-bottom: 6px; }
 .subtitle { font-size: 13px; color: #7a9ab5; margin-bottom: 32px; letter-spacing: 0.5px; }
 
@@ -21,7 +57,8 @@ h1 { font-size: 22px; color: #f0c040; letter-spacing: 1px; margin-bottom: 6px; }
 /* AL section header */
 .section-label { font-size: 11px; color: #7a9ab5; letter-spacing: 1px; text-transform: uppercase; margin-bottom: 8px; font-weight: 600; }
 
-.container { max-width: 900px; margin: 0 auto; }
+/* Sits above the grid-paper backdrop */
+.container { max-width: 900px; margin: 0 auto; position: relative; z-index: 1; }
 
 svg text { font-family: 'Segoe UI', system-ui, sans-serif; }
 
@@ -49,6 +86,16 @@ tr:last-child td { border-bottom: none; }
 .hook-badge { background: #2d5a2d; color: #80c880; font-size: 10px; font-weight: 800; padding: 2px 8px; border-radius: 10px; white-space: nowrap; flex-shrink: 0; margin-top: 2px; }
 .hook-text { font-size: 13px; color: #c8d8c8; line-height: 1.5; }
 .hook-text strong { color: #f0c040; }
+
+/* Fact cards (MET visuals) */
+.fact-card { background: #1a2d3d; border: 1px solid #243d52; border-radius: 8px; padding: 14px 16px; margin-bottom: 12px; }
+.fact-label { font-size: 11px; color: #7a9ab5; letter-spacing: 0.5px; text-transform: uppercase; margin-bottom: 4px; }
+.fact-value { font-size: 18px; color: #f0c040; font-weight: bold; }
+.fact-note { font-size: 12px; color: #e8edf2; margin-top: 4px; }
+
+/* Memory hook (MET visuals) */
+.memory-hook { background: #1a2a1a; border: 1px solid #2d5a2d; border-radius: 8px; padding: 14px 18px; margin-top: 24px; font-size: 13px; line-height: 1.6; }
+.memory-hook .badge { display: inline-block; background: #2d5a2d; color: #e8edf2; font-size: 10px; letter-spacing: 1px; padding: 2px 8px; border-radius: 3px; margin-bottom: 6px; }
 
 @media (max-width: 640px) {
   body { padding: 16px; }

--- a/web-app/public/visuals/met001-atmosphere-structure.html
+++ b/web-app/public/visuals/met001-atmosphere-structure.html
@@ -4,28 +4,11 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>MET-001: Atmosphere Structure</title>
+<link rel="stylesheet" href="/visuals/_common.css">
 <style>
-  * { box-sizing: border-box; margin: 0; padding: 0; }
-  body { background: #0d1b2a; color: #e8edf2; font-family: 'Segoe UI', system-ui, sans-serif; padding: 32px; }
-  h1 { font-size: 22px; color: #f0c040; letter-spacing: 1px; margin-bottom: 6px; }
-  .subtitle { font-size: 13px; color: #7a9ab5; margin-bottom: 32px; letter-spacing: 0.5px; }
-  .container { max-width: 900px; margin: 0 auto; }
-  .section-title { font-size: 14px; color: #f0c040; letter-spacing: 1px; text-transform: uppercase; margin: 32px 0 14px; }
+  /* Visual-specific layout */
   .layout { display: grid; grid-template-columns: 1.1fr 1fr; gap: 24px; align-items: start; }
-  .diagram-box { background: #1a2d3d; border: 1px solid #243d52; border-radius: 8px; padding: 16px; }
-  svg text { font-family: 'Segoe UI', system-ui, sans-serif; }
-  table { width: 100%; border-collapse: collapse; margin-bottom: 20px; }
-  th { background: #1a2d3d; color: #f0c040; font-size: 12px; text-align: left; padding: 10px 14px; letter-spacing: 0.5px; }
-  td { font-size: 13px; color: #e8edf2; padding: 9px 14px; border-bottom: 1px solid #1a2d3d; vertical-align: top; }
-  tr:last-child td { border-bottom: none; }
-  .fact-card { background: #1a2d3d; border: 1px solid #243d52; border-radius: 8px; padding: 14px 16px; margin-bottom: 12px; }
-  .fact-label { font-size: 11px; color: #7a9ab5; letter-spacing: 0.5px; text-transform: uppercase; margin-bottom: 4px; }
-  .fact-value { font-size: 18px; color: #f0c040; font-weight: bold; }
-  .fact-note { font-size: 12px; color: #e8edf2; margin-top: 4px; }
-  .memory-hook { background: #1a2a1a; border: 1px solid #2d5a2d; border-radius: 8px; padding: 14px 18px; margin-top: 24px; font-size: 13px; line-height: 1.6; }
-  .memory-hook .badge { display: inline-block; background: #2d5a2d; color: #e8edf2; font-size: 10px; letter-spacing: 1px; padding: 2px 8px; border-radius: 3px; margin-bottom: 6px; }
   @media (max-width: 640px) {
-    body { padding: 16px; }
     .layout { grid-template-columns: 1fr; }
   }
 </style>


### PR DESCRIPTION
Closes #212

## Changes

### `web-app/public/visuals/_common.css`
- Prepends `:root` color token block — values verbatim from `DESIGN-SYSTEM.md §2.1` dark scheme (`--bg`, `--bg2`, `--surface`, `--surface2`, `--border`, `--border-hi`, `--accent`, `--accent-dim`, `--text`, `--text-muted`, `--success`, `--warning`, `--danger`, `--info`, `--grid-line`).
- Adds `body::before` 40 × 40 px grid-paper backdrop (§4.4).
- Updates `.container` to `position: relative; z-index: 1` so content sits above backdrop.
- Adds `.fact-card` / `.fact-label` / `.fact-value` / `.fact-note` (MET visual fact card pattern).
- Adds `.memory-hook` / `.memory-hook .badge` (MET visual exam-hook pattern).
- All existing classes preserved unchanged (no regression to the 59 already-migrated visuals).

### `web-app/public/visuals/met001-atmosphere-structure.html` (pilot migration)
- Removes all styles now provided by `_common.css` (reset, body, h1, .subtitle, .section-title, .container, svg text, table/th/td, .diagram-box, .fact-card, .memory-hook, media body padding).
- Adds `<link rel="stylesheet" href="/visuals/_common.css">`.
- Retains only the two visual-specific rules: `.layout` grid and its 640 px responsive collapse.
- Back-link button unchanged.

### `docs/visuals-standards.md`
- Removes inline colour palette table.
- Points to `DESIGN-SYSTEM.md §2.1` as colour source of truth.
- States all new visuals must link `/visuals/_common.css`; clarifies "no external resources" permits this same-origin sheet.
- States Variant A dark is canonical; light deferred.
- References `docs/design/examples/visual-template.html`.
- Back-link section (#179) preserved in full.

### `docs/design/examples/visual-template.html` (new file)
- Canonical starting point for new visuals.
- Links `_common.css`, includes back-link element, demonstrates section-title / table / fact-card / note-box / memory-hook components.

## Test plan

- [ ] `npm run build` passes — verified locally (✓ built in 2.29s, no errors)
- [ ] `met001-atmosphere-structure.html` renders correctly via Firebase Hosting — all sections visible, layout/diagram/table/cards/memory-hook unchanged in appearance
- [ ] Back-link button present and functional on met001
- [ ] No other visual HTML files modified (`git diff --name-only` shows only 4 files)
- [ ] `docs/visuals-standards.md` no longer contains inline hex palette table

Adheres to `docs/design/DESIGN-SYSTEM.md`