### PR TITLE
[PPL-211] LessonDetail: top prev/next nav

### DIFF
--- a/web-app/src/components/LessonPrevNext.tsx
+++ b/web-app/src/components/LessonPrevNext.tsx
@@ -1,0 +1,220 @@
+import { useNavigate } from 'react-router-dom';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import ArrowBackIcon from '@mui/icons-material/ArrowBack';
+import ArrowForwardIcon from '@mui/icons-material/ArrowForward';
+import type { Lesson } from '../lib/types';
+
+interface LessonPrevNextProps {
+  prev: Lesson | null;
+  next: Lesson | null;
+  variant: 'compact' | 'full';
+}
+
+export default function LessonPrevNext({ prev, next, variant }: LessonPrevNextProps) {
+  const navigate = useNavigate();
+
+  if (variant === 'compact') {
+    return (
+      <Box
+        sx={{
+          display: 'flex',
+          gap: 1,
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          mb: 2,
+        }}
+      >
+        {prev ? (
+          <Button
+            variant="outlined"
+            size="small"
+            startIcon={<ArrowBackIcon fontSize="small" />}
+            onClick={() => navigate(`/lessons/${prev.topic}/${prev.slug}`)}
+            title={prev.title}
+            aria-label={`Previous lesson: ${prev.title}`}
+            sx={{
+              minHeight: 48,
+              minWidth: 48,
+              px: 1.5,
+              borderRadius: '3px',
+              fontFamily: "'SF Mono', 'JetBrains Mono', Consolas, monospace",
+              fontSize: '0.6875rem',
+              fontWeight: 500,
+              letterSpacing: '0.08em',
+              textTransform: 'uppercase',
+              justifyContent: 'flex-start',
+              flexShrink: 0,
+              maxWidth: { xs: '50%', md: 'none' },
+              overflow: 'hidden',
+              '& .MuiButton-startIcon': { flexShrink: 0 },
+            }}
+          >
+            <Box
+              component="span"
+              sx={{
+                display: 'inline-flex',
+                alignItems: 'center',
+                gap: 1,
+                overflow: 'hidden',
+              }}
+            >
+              <Box component="span" sx={{ flexShrink: 0 }}>
+                {prev.id}
+              </Box>
+              <Box
+                component="span"
+                sx={{
+                  display: { xs: 'none', md: 'inline' },
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                  whiteSpace: 'nowrap',
+                  fontFamily: "'Inter', system-ui, sans-serif",
+                  textTransform: 'none',
+                  letterSpacing: 'normal',
+                  fontSize: '0.75rem',
+                  color: 'text.secondary',
+                }}
+              >
+                {prev.title}
+              </Box>
+            </Box>
+          </Button>
+        ) : (
+          <Box sx={{ minWidth: 48, minHeight: 48 }} />
+        )}
+
+        {next ? (
+          <Button
+            variant="outlined"
+            size="small"
+            endIcon={<ArrowForwardIcon fontSize="small" />}
+            onClick={() => navigate(`/lessons/${next.topic}/${next.slug}`)}
+            title={next.title}
+            aria-label={`Next lesson: ${next.title}`}
+            sx={{
+              minHeight: 48,
+              minWidth: 48,
+              px: 1.5,
+              borderRadius: '3px',
+              fontFamily: "'SF Mono', 'JetBrains Mono', Consolas, monospace",
+              fontSize: '0.6875rem',
+              fontWeight: 500,
+              letterSpacing: '0.08em',
+              textTransform: 'uppercase',
+              justifyContent: 'flex-end',
+              flexShrink: 0,
+              maxWidth: { xs: '50%', md: 'none' },
+              overflow: 'hidden',
+              '& .MuiButton-endIcon': { flexShrink: 0 },
+            }}
+          >
+            <Box
+              component="span"
+              sx={{
+                display: 'inline-flex',
+                alignItems: 'center',
+                gap: 1,
+                overflow: 'hidden',
+              }}
+            >
+              <Box
+                component="span"
+                sx={{
+                  display: { xs: 'none', md: 'inline' },
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                  whiteSpace: 'nowrap',
+                  fontFamily: "'Inter', system-ui, sans-serif",
+                  textTransform: 'none',
+                  letterSpacing: 'normal',
+                  fontSize: '0.75rem',
+                  color: 'text.secondary',
+                }}
+              >
+                {next.title}
+              </Box>
+              <Box component="span" sx={{ flexShrink: 0 }}>
+                {next.id}
+              </Box>
+            </Box>
+          </Button>
+        ) : (
+          <Box sx={{ minWidth: 48, minHeight: 48 }} />
+        )}
+      </Box>
+    );
+  }
+
+  // full variant — the existing bottom row
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        gap: 1,
+        justifyContent: 'space-between',
+        alignItems: 'stretch',
+      }}
+    >
+      {prev ? (
+        <Button
+          variant="outlined"
+          startIcon={<ArrowBackIcon />}
+          onClick={() => navigate(`/lessons/${prev.topic}/${prev.slug}`)}
+          title={prev.title}
+          aria-label={`Previous lesson: ${prev.title}`}
+          sx={{
+            minHeight: 48,
+            flex: '1 1 0',
+            minWidth: 0,
+            justifyContent: 'flex-start',
+            overflow: 'hidden',
+            '& .MuiButton-startIcon': { flexShrink: 0 },
+          }}
+        >
+          <Box
+            sx={{
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+            }}
+          >
+            {prev.title}
+          </Box>
+        </Button>
+      ) : (
+        <Box sx={{ flex: '1 1 0' }} />
+      )}
+
+      {next ? (
+        <Button
+          variant="outlined"
+          endIcon={<ArrowForwardIcon />}
+          onClick={() => navigate(`/lessons/${next.topic}/${next.slug}`)}
+          title={next.title}
+          aria-label={`Next lesson: ${next.title}`}
+          sx={{
+            minHeight: 48,
+            flex: '1 1 0',
+            minWidth: 0,
+            justifyContent: 'flex-end',
+            overflow: 'hidden',
+            '& .MuiButton-endIcon': { flexShrink: 0 },
+          }}
+        >
+          <Box
+            sx={{
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+            }}
+          >
+            {next.title}
+          </Box>
+        </Button>
+      ) : (
+        <Box sx={{ flex: '1 1 0' }} />
+      )}
+    </Box>
+  );
+}

--- a/web-app/src/pages/LessonDetail.tsx
+++ b/web-app/src/pages/LessonDetail.tsx
@@ -7,10 +7,9 @@ import Chip from '@mui/material/Chip';
 import Container from '@mui/material/Container';
 import Divider from '@mui/material/Divider';
 import Typography from '@mui/material/Typography';
-import ArrowBackIcon from '@mui/icons-material/ArrowBack';
-import ArrowForwardIcon from '@mui/icons-material/ArrowForward';
 import { useState, useEffect, type ReactNode } from 'react';
 import AudioPlayer from '../components/AudioPlayer';
+import LessonPrevNext from '../components/LessonPrevNext';
 import SourceList from '../components/SourceList';
 import { getLessonBySlug, getAdjacentLessons } from '../lib/lesson-loader';
 import { useProgress } from '../lib/progress';
@@ -127,6 +126,8 @@ export default function LessonDetail() {
 
   return (
     <Container id="main-content" tabIndex={-1} maxWidth={false} sx={{ maxWidth: 700, mx: 'auto', px: { xs: 2, sm: 3 }, py: 4 }}>
+      <LessonPrevNext prev={prev} next={next} variant="compact" />
+
       <Box sx={{ mb: 1, display: 'flex', gap: 1, flexWrap: 'wrap', alignItems: 'center' }}>
         <Chip
           label={lesson.topic.replace(/-/g, ' ')}
@@ -198,74 +199,7 @@ export default function LessonDetail() {
 
       <Divider sx={{ mt: 3, mb: 2 }} />
 
-      <Box
-        sx={{
-          display: 'flex',
-          gap: 1,
-          justifyContent: 'space-between',
-          alignItems: 'stretch',
-        }}
-      >
-        {prev ? (
-          <Button
-            variant="outlined"
-            startIcon={<ArrowBackIcon />}
-            onClick={() => navigate(`/lessons/${prev.topic}/${prev.slug}`)}
-            title={prev.title}
-            aria-label={`Previous lesson: ${prev.title}`}
-            sx={{
-              minHeight: 48,
-              flex: '1 1 0',
-              minWidth: 0,
-              justifyContent: 'flex-start',
-              overflow: 'hidden',
-              '& .MuiButton-startIcon': { flexShrink: 0 },
-            }}
-          >
-            <Box
-              sx={{
-                overflow: 'hidden',
-                textOverflow: 'ellipsis',
-                whiteSpace: 'nowrap',
-              }}
-            >
-              {prev.title}
-            </Box>
-          </Button>
-        ) : (
-          <Box sx={{ flex: '1 1 0' }} />
-        )}
-
-        {next ? (
-          <Button
-            variant="outlined"
-            endIcon={<ArrowForwardIcon />}
-            onClick={() => navigate(`/lessons/${next.topic}/${next.slug}`)}
-            title={next.title}
-            aria-label={`Next lesson: ${next.title}`}
-            sx={{
-              minHeight: 48,
-              flex: '1 1 0',
-              minWidth: 0,
-              justifyContent: 'flex-end',
-              overflow: 'hidden',
-              '& .MuiButton-endIcon': { flexShrink: 0 },
-            }}
-          >
-            <Box
-              sx={{
-                overflow: 'hidden',
-                textOverflow: 'ellipsis',
-                whiteSpace: 'nowrap',
-              }}
-            >
-              {next.title}
-            </Box>
-          </Button>
-        ) : (
-          <Box sx={{ flex: '1 1 0' }} />
-        )}
-      </Box>
+      <LessonPrevNext prev={prev} next={next} variant="full" />
     </Container>
   );
 }


### PR DESCRIPTION
## Summary

- Extracts inline bottom prev/next nav into `web-app/src/components/LessonPrevNext.tsx` with `variant: 'compact' | 'full'` prop
- Adds compact nav row just above the lesson title — shows `← AL-013` / `AL-015 →` (chevron + monospace lesson ID); at `md+` breakpoint also shows adjacent lesson title
- Tap targets ≥ 48×48 px; truncates to code-only under 360 px width
- Prev hidden on first lesson in topic; Next hidden on last lesson
- Bottom full-variant nav and ← / → keyboard shortcuts preserved unchanged
- Uses DESIGN-SYSTEM.md tokens: monospace for IDs, 3 px radius, theme palette paths, dark+light parity

Closes #211

Adheres to docs/design/DESIGN-SYSTEM.md

## Test plan

- [ ] Middle-of-topic lesson: compact pills above title, full row at bottom
- [ ] First lesson in topic: Prev pill absent (spacer), Next shown
- [ ] Last lesson in topic: Next pill absent (spacer), Prev shown
- [ ] At 360 px: only chevron + lesson code visible in compact row
- [ ] At desktop (md+): adjacent title appears after code
- [ ] Keyboard ← / → navigate correctly
- [ ] Dark mode and light mode render correctly with no hardcoded hex

🤖 Generated with [Claude Code](https://claude.com/claude-code)