### PR TITLE
[PPL-182] Generate and publish audio for navigation lessons NAV-003..NAV-014

### DIFF
--- a/lessons/navigation/003-true-magnetic-compass.md
+++ b/lessons/navigation/003-true-magnetic-compass.md
@@ -6,7 +6,7 @@ slug: true-magnetic-compass
 title: "True vs Magnetic vs Compass Heading"
 duration_min: 20
 status: complete
-audio: null
+audio: https://media.suprun.workers.dev/ppl/lessons/navigation/003-true-magnetic-compass.m4a
 visual: /visuals/nav003-true-magnetic-compass.html
 sources:
   - TP 12880E

--- a/lessons/navigation/004-dead-reckoning-basics.md
+++ b/lessons/navigation/004-dead-reckoning-basics.md
@@ -6,7 +6,7 @@ slug: dead-reckoning-basics
 title: "Dead Reckoning"
 duration_min: 20
 status: complete
-audio: null
+audio: https://media.suprun.workers.dev/ppl/lessons/navigation/004-dead-reckoning-basics.m4a
 visual: /visuals/nav004-dead-reckoning-basics.html
 sources:
   - TP 12880E

--- a/lessons/navigation/005-wind-correction-angle.md
+++ b/lessons/navigation/005-wind-correction-angle.md
@@ -6,7 +6,7 @@ slug: wind-correction-angle
 title: "Wind Correction Angle and Ground Speed"
 duration_min: 20
 status: complete
-audio: null
+audio: https://media.suprun.workers.dev/ppl/lessons/navigation/005-wind-correction-angle.m4a
 visual: /visuals/nav005-wind-correction-angle.html
 sources:
   - TP 12880E

--- a/lessons/navigation/006-time-speed-distance.md
+++ b/lessons/navigation/006-time-speed-distance.md
@@ -6,7 +6,7 @@ slug: time-speed-distance
 title: "Time-Speed-Distance Calculations"
 duration_min: 20
 status: complete
-audio: null
+audio: https://media.suprun.workers.dev/ppl/lessons/navigation/006-time-speed-distance.m4a
 visual: /visuals/nav006-time-speed-distance.html
 sources:
   - TP 12880E

--- a/lessons/navigation/007-fuel-planning.md
+++ b/lessons/navigation/007-fuel-planning.md
@@ -6,7 +6,7 @@ slug: fuel-planning
 title: "Fuel Planning"
 duration_min: 20
 status: complete
-audio: null
+audio: https://media.suprun.workers.dev/ppl/lessons/navigation/007-fuel-planning.m4a
 visual: /visuals/nav007-fuel-planning.html
 sources:
   - TP 12880E

--- a/lessons/navigation/008-cross-country-planning.md
+++ b/lessons/navigation/008-cross-country-planning.md
@@ -6,7 +6,7 @@ slug: cross-country-planning
 title: "Cross-Country Planning"
 duration_min: 20
 status: complete
-audio: null
+audio: https://media.suprun.workers.dev/ppl/lessons/navigation/008-cross-country-planning.m4a
 visual: /visuals/nav008-cross-country-planning.html
 sources:
   - TP 12880E

--- a/lessons/navigation/009-pilotage.md
+++ b/lessons/navigation/009-pilotage.md
@@ -6,7 +6,7 @@ slug: pilotage
 title: "Pilotage — Navigating by Ground Reference"
 duration_min: 20
 status: complete
-audio: null
+audio: https://media.suprun.workers.dev/ppl/lessons/navigation/009-pilotage.m4a
 visual: /visuals/nav009-pilotage.html
 sources:
   - TP 12880E

--- a/lessons/navigation/010-vor-navigation.md
+++ b/lessons/navigation/010-vor-navigation.md
@@ -6,7 +6,7 @@ slug: vor-navigation
 title: "VOR Navigation"
 duration_min: 20
 status: complete
-audio: null
+audio: https://media.suprun.workers.dev/ppl/lessons/navigation/010-vor-navigation.m4a
 visual: /visuals/nav010-vor-navigation.html
 sources:
   - TP 12880E

--- a/lessons/navigation/011-gps-basics.md
+++ b/lessons/navigation/011-gps-basics.md
@@ -6,7 +6,7 @@ slug: gps-basics
 title: "GPS Basics"
 duration_min: 20
 status: complete
-audio: null
+audio: https://media.suprun.workers.dev/ppl/lessons/navigation/011-gps-basics.m4a
 visual: /visuals/nav011-gps-basics.html
 sources:
   - TP 12880E

--- a/lessons/navigation/012-altitude-types.md
+++ b/lessons/navigation/012-altitude-types.md
@@ -6,7 +6,7 @@ slug: altitude-types
 title: "Altitude Types"
 duration_min: 20
 status: complete
-audio: null
+audio: https://media.suprun.workers.dev/ppl/lessons/navigation/012-altitude-types.m4a
 visual: /visuals/nav012-altitude-types.html
 sources:
   - TP 12880E

--- a/lessons/navigation/013-density-altitude.md
+++ b/lessons/navigation/013-density-altitude.md
@@ -6,7 +6,7 @@ slug: density-altitude
 title: "Density Altitude"
 duration_min: 20
 status: complete
-audio: null
+audio: https://media.suprun.workers.dev/ppl/lessons/navigation/013-density-altitude.m4a
 visual: /visuals/nav013-density-altitude.html
 sources:
   - TP 12880E

--- a/lessons/navigation/014-lost-procedure.md
+++ b/lessons/navigation/014-lost-procedure.md
@@ -6,7 +6,7 @@ slug: lost-procedure
 title: "Lost Procedure and Diversion"
 duration_min: 20
 status: complete
-audio: null
+audio: https://media.suprun.workers.dev/ppl/lessons/navigation/014-lost-procedure.m4a
 visual: /visuals/nav014-lost-procedure.html
 sources:
   - TP 12880E


### PR DESCRIPTION
## Summary

- Generated narration audio for 12 navigation lessons (NAV-003 through NAV-014) using Kokoro TTS (`mlx-community/Kokoro-82M-bf16`, voice `am_echo`, speed 1.1, AAC/M4A 64kbps)
- All audio extracted from `## Narration Script` sections per `docs/audio-standards.md`
- Files uploaded to Cloudflare R2 bucket `suprun-media` under `ppl/lessons/navigation/`
- Updated `audio:` frontmatter field in each of the 12 lesson files — only frontmatter `audio:` lines changed, no body edits

Closes #182

## Lessons Updated

| Lesson | URL |
|---|---|
| NAV-003 | `ppl/lessons/navigation/003-true-magnetic-compass.m4a` |
| NAV-004 | `ppl/lessons/navigation/004-dead-reckoning-basics.m4a` |
| NAV-005 | `ppl/lessons/navigation/005-wind-correction-angle.m4a` |
| NAV-006 | `ppl/lessons/navigation/006-time-speed-distance.m4a` |
| NAV-007 | `ppl/lessons/navigation/007-fuel-planning.m4a` |
| NAV-008 | `ppl/lessons/navigation/008-cross-country-planning.m4a` |
| NAV-009 | `ppl/lessons/navigation/009-pilotage.m4a` |
| NAV-010 | `ppl/lessons/navigation/010-vor-navigation.m4a` |
| NAV-011 | `ppl/lessons/navigation/011-gps-basics.m4a` |
| NAV-012 | `ppl/lessons/navigation/012-altitude-types.m4a` |
| NAV-013 | `ppl/lessons/navigation/013-density-altitude.m4a` |
| NAV-014 | `ppl/lessons/navigation/014-lost-procedure.m4a` |

## Spot-check

NAV-003 spot-checked: `https://media.suprun.workers.dev/ppl/lessons/navigation/003-true-magnetic-compass.m4a` — HTTP 200, `audio/mp4`, 431s duration, correct `am_echo` voice and content (begins "Welcome to Lesson NAV-003...").

## Test plan

- [ ] `npm run build` passes (verified locally in `web-app/`)
- [ ] All 12 `audio:` fields updated with correct R2 URLs
- [ ] No body edits, no other frontmatter fields, no other topics modified
- [ ] Spot-check a lesson URL in browser to confirm playback

🤖 Generated with [Claude Code](https://claude.com/claude-code)