### PR TITLE
[PPL-183] Add audio narration for MET-001..MET-014

### DIFF
--- a/lessons/meteorology/001-atmosphere-structure.md
+++ b/lessons/meteorology/001-atmosphere-structure.md
@@ -6,7 +6,7 @@ slug: atmosphere-structure
 title: "Atmosphere Structure"
 duration_min: 20
 status: complete
-audio: null
+audio: https://media.suprun.workers.dev/ppl/lessons/meteorology/001-atmosphere-structure.m4a
 visual: /visuals/met001-atmosphere-structure.html
 sources:
   - TP 12880E Chapter 8

--- a/lessons/meteorology/002-temp-pressure-humidity.md
+++ b/lessons/meteorology/002-temp-pressure-humidity.md
@@ -6,7 +6,7 @@ slug: temp-pressure-humidity
 title: "Temperature, Pressure, Humidity"
 duration_min: 20
 status: complete
-audio: null
+audio: https://media.suprun.workers.dev/ppl/lessons/meteorology/002-temp-pressure-humidity.m4a
 visual: /visuals/met002-temp-pressure-humidity.html
 sources:
   - TP 12880E Chapter 8

--- a/lessons/meteorology/003-clouds-types.md
+++ b/lessons/meteorology/003-clouds-types.md
@@ -6,7 +6,7 @@ slug: clouds-types
 title: "Cloud Types and Formation"
 duration_min: 20
 status: complete
-audio: null
+audio: https://media.suprun.workers.dev/ppl/lessons/meteorology/003-clouds-types.m4a
 visual: /visuals/met003-clouds-types.html
 sources:
   - TP 12880E Chapter 8

--- a/lessons/meteorology/004-fog-types.md
+++ b/lessons/meteorology/004-fog-types.md
@@ -6,7 +6,7 @@ slug: fog-types
 title: "Fog Formation and Types"
 duration_min: 20
 status: complete
-audio: null
+audio: https://media.suprun.workers.dev/ppl/lessons/meteorology/004-fog-types.m4a
 visual: /visuals/met004-fog-types.html
 sources:
   - TP 12880E Chapter 8

--- a/lessons/meteorology/005-metar-decoding.md
+++ b/lessons/meteorology/005-metar-decoding.md
@@ -6,7 +6,7 @@ slug: metar-decoding
 title: "METAR Decoding"
 duration_min: 20
 status: complete
-audio: null
+audio: https://media.suprun.workers.dev/ppl/lessons/meteorology/005-metar-decoding.m4a
 visual: /visuals/met005-metar-decoding.html
 sources:
   - TP 12880E Chapter 8

--- a/lessons/meteorology/006-taf-decoding.md
+++ b/lessons/meteorology/006-taf-decoding.md
@@ -6,7 +6,7 @@ slug: taf-decoding
 title: "TAF Decoding"
 duration_min: 20
 status: complete
-audio: null
+audio: https://media.suprun.workers.dev/ppl/lessons/meteorology/006-taf-decoding.m4a
 visual: /visuals/met006-taf-decoding.html
 sources:
   - TP 12880E Chapter 8

--- a/lessons/meteorology/007-gfa.md
+++ b/lessons/meteorology/007-gfa.md
@@ -6,7 +6,7 @@ slug: gfa
 title: "GFA — Graphical Forecast for Aviation"
 duration_min: 20
 status: complete
-audio: null
+audio: https://media.suprun.workers.dev/ppl/lessons/meteorology/007-gfa.m4a
 visual: /visuals/met007-gfa.html
 sources:
   - TP 12880E Chapter 8

--- a/lessons/meteorology/008-pireps.md
+++ b/lessons/meteorology/008-pireps.md
@@ -6,7 +6,7 @@ slug: pireps
 title: "PIREPs"
 duration_min: 20
 status: complete
-audio: null
+audio: https://media.suprun.workers.dev/ppl/lessons/meteorology/008-pireps.m4a
 visual: /visuals/met008-pireps.html
 sources:
   - TP 12880E Chapter 8

--- a/lessons/meteorology/009-thunderstorms.md
+++ b/lessons/meteorology/009-thunderstorms.md
@@ -6,7 +6,7 @@ slug: thunderstorms
 title: "Thunderstorms"
 duration_min: 20
 status: complete
-audio: null
+audio: https://media.suprun.workers.dev/ppl/lessons/meteorology/009-thunderstorms.m4a
 visual: /visuals/met009-thunderstorms.html
 sources:
   - TP 12880E Chapter 8

--- a/lessons/meteorology/010-icing.md
+++ b/lessons/meteorology/010-icing.md
@@ -6,7 +6,7 @@ slug: icing
 title: "Icing"
 duration_min: 20
 status: complete
-audio: null
+audio: https://media.suprun.workers.dev/ppl/lessons/meteorology/010-icing.m4a
 visual: /visuals/met010-icing.html
 sources:
   - TP 12880E Chapter 8

--- a/lessons/meteorology/011-turbulence.md
+++ b/lessons/meteorology/011-turbulence.md
@@ -6,7 +6,7 @@ slug: turbulence
 title: "Turbulence"
 duration_min: 20
 status: complete
-audio: null
+audio: https://media.suprun.workers.dev/ppl/lessons/meteorology/011-turbulence.m4a
 visual: /visuals/met011-turbulence.html
 sources:
   - TP 12880E Chapter 8

--- a/lessons/meteorology/012-wind-shear-microburst.md
+++ b/lessons/meteorology/012-wind-shear-microburst.md
@@ -6,7 +6,7 @@ slug: wind-shear-microburst
 title: "Wind Shear and Microburst"
 duration_min: 20
 status: complete
-audio: null
+audio: https://media.suprun.workers.dev/ppl/lessons/meteorology/012-wind-shear-microburst.m4a
 visual: /visuals/met012-wind-shear-microburst.html
 sources:
   - TP 12880E Chapter 8

--- a/lessons/meteorology/013-fronts.md
+++ b/lessons/meteorology/013-fronts.md
@@ -6,7 +6,7 @@ slug: fronts
 title: "Fronts"
 duration_min: 20
 status: complete
-audio: null
+audio: https://media.suprun.workers.dev/ppl/lessons/meteorology/013-fronts.m4a
 visual: /visuals/met013-fronts.html
 sources:
   - TP 12880E Chapter 8

--- a/lessons/meteorology/014-wx-decision-making.md
+++ b/lessons/meteorology/014-wx-decision-making.md
@@ -6,7 +6,7 @@ slug: wx-decision-making
 title: "Weather Decision-Making"
 duration_min: 20
 status: complete
-audio: null
+audio: https://media.suprun.workers.dev/ppl/lessons/meteorology/014-wx-decision-making.m4a
 visual: /visuals/met014-wx-decision-making.html
 sources:
   - TP 12880E Chapter 8


### PR DESCRIPTION
## Summary

- Generated Kokoro TTS audio (voice `am_echo`, speed 1.1, AAC 64 kbps) for all 14 meteorology lessons (MET-001 through MET-014)
- Uploaded `.m4a` files to Cloudflare R2 `suprun-media` bucket at `ppl/lessons/meteorology/{NNN}-{slug}.m4a`
- Updated `audio:` frontmatter field in each of the 14 lesson `.md` files with the public CDN URL

Closes #183

## Test plan

- [x] All 14 lessons have `## Narration Script` sections — confirmed before generation
- [x] Each lesson's `audio:` frontmatter updated to `https://media.suprun.workers.dev/ppl/lessons/meteorology/{NNN}-{slug}.m4a`
- [x] Only `audio:` frontmatter line modified — no body edits, no other frontmatter fields touched
- [x] `npm run build` passes in `web-app/`
- [x] Audio parameters match `docs/audio-standards.md`: model `mlx-community/Kokoro-82M-bf16`, voice `am_echo`, speed 1.1, AAC 64 kbps

🤖 Generated with [Claude Code](https://claude.com/claude-code)