### PR TITLE
[PPL-234] Fix audio not updating on lesson transition

### DIFF
--- a/web-app/src/pages/LessonDetail.tsx
+++ b/web-app/src/pages/LessonDetail.tsx
@@ -154,6 +154,7 @@ export default function LessonDetail() {
       </Typography>
 
       <AudioPlayer
+        key={lesson.id}
         src={lesson.audio}
         title={lesson.title}
         topic={TOPIC_LABELS[lesson.topic] ?? lesson.topic}


### PR DESCRIPTION
## Summary
- Adds `key={lesson.id}` to `<AudioPlayer>` in `LessonDetail.tsx`
- Forces a full component remount when navigating between lessons
- Ensures the browser loads the new audio source instead of keeping the stale element

## Root Cause
React reused the same `AudioPlayer` component instance across lesson navigations, only updating props. The `<source src>` inside the `<audio>` element changed, but without `audio.load()` being called (or a remount), the browser ignored the new source and continued with the old audio.

## Fix
Using `key={lesson.id}` is the canonical React pattern for this: it guarantees a clean remount per lesson, resetting the audio element state entirely. Playback speed is already persisted in localStorage so it survives the remount.

Closes #234

## Test Plan
- [ ] Navigate from one lesson to another — audio player should load and display the new lesson's audio
- [ ] Playback speed setting persists across lesson navigation (read from localStorage on mount)
- [ ] Saved playback position restores correctly for each lesson
- [ ] Playlist player and sticky player (which use index-based `audio.load()`) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)