### PR TITLE
[PPL-244] Migrate GK visuals gk001–gk005 to CSS custom properties

### DIFF
--- a/web-app/public/visuals/gk001-aircraft-parts-controls.html
+++ b/web-app/public/visuals/gk001-aircraft-parts-controls.html
@@ -13,13 +13,14 @@
   .tag-secondary { display: inline-block; background: #2a1a0d; color: #f0a040; font-size: 11px; padding: 2px 8px; border-radius: 3px; border: 1px solid #f0a040; }
   .tables-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 24px; }
   @media (max-width: 480px) {
+    body { font-size: 14px; }
     .diagrams { grid-template-columns: 1fr; }
     .tables-grid { grid-template-columns: 1fr; }
   }
 </style>
 </head>
 <body>
-  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:#f0c040;border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
+  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:var(--accent);border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
   <style>.container{padding-top:56px!important;}@media(max-width:480px){.container{padding-top:60px!important;}}</style>
 <div class="container">
   <h1>GK-001 — Aircraft Parts &amp; Controls</h1>

--- a/web-app/public/visuals/gk001-aircraft-parts-controls.html
+++ b/web-app/public/visuals/gk001-aircraft-parts-controls.html
@@ -8,10 +8,14 @@
 <style>
   .diagrams { display: grid; grid-template-columns: 1fr 1fr; gap: 24px; margin-bottom: 32px; }
   .diagram-box { border-color: #1a2d3d; }
-  .diagram-label { font-size: 12px; color: #7a9ab5; text-align: center; margin-bottom: 10px; letter-spacing: 0.5px; }
-  .tag-primary { display: inline-block; background: #0d2a1a; color: #4caf7d; font-size: 11px; padding: 2px 8px; border-radius: 3px; border: 1px solid #4caf7d; }
+  .diagram-label { font-size: 12px; color: var(--text-muted); text-align: center; margin-bottom: 10px; letter-spacing: 0.5px; }
+  .tag-primary { display: inline-block; background: #0d2a1a; color: var(--success); font-size: 11px; padding: 2px 8px; border-radius: 3px; border: 1px solid var(--success); }
   .tag-secondary { display: inline-block; background: #2a1a0d; color: #f0a040; font-size: 11px; padding: 2px 8px; border-radius: 3px; border: 1px solid #f0a040; }
   .tables-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 24px; }
+  @media (max-width: 480px) {
+    .diagrams { grid-template-columns: 1fr; }
+    .tables-grid { grid-template-columns: 1fr; }
+  }
 </style>
 </head>
 <body>

--- a/web-app/public/visuals/gk001-aircraft-parts-controls.html
+++ b/web-app/public/visuals/gk001-aircraft-parts-controls.html
@@ -7,7 +7,7 @@
 <link rel="stylesheet" href="_common.css">
 <style>
   .diagrams { display: grid; grid-template-columns: 1fr 1fr; gap: 24px; margin-bottom: 32px; }
-  .diagram-box { border-color: #1a2d3d; }
+  .diagram-box { border-color: var(--border); }
   .diagram-label { font-size: 12px; color: var(--text-muted); text-align: center; margin-bottom: 10px; letter-spacing: 0.5px; }
   .tag-primary { display: inline-block; background: #0d2a1a; color: var(--success); font-size: 11px; padding: 2px 8px; border-radius: 3px; border: 1px solid var(--success); }
   .tag-secondary { display: inline-block; background: #2a1a0d; color: #f0a040; font-size: 11px; padding: 2px 8px; border-radius: 3px; border: 1px solid #f0a040; }

--- a/web-app/public/visuals/gk002-four-forces.html
+++ b/web-app/public/visuals/gk002-four-forces.html
@@ -7,10 +7,13 @@
 <link rel="stylesheet" href="_common.css">
 <style>
   .layout { display: grid; grid-template-columns: 1fr 1fr; gap: 24px; align-items: start; }
-  .force-amber { color: #f0c040; font-weight: bold; }
+  .force-amber { color: var(--accent); font-weight: bold; }
   .force-blue { color: #5b9bd5; font-weight: bold; }
-  .force-green { color: #4caf7d; font-weight: bold; }
-  .force-red { color: #e05050; font-weight: bold; }
+  .force-green { color: var(--success); font-weight: bold; }
+  .force-red { color: var(--danger); font-weight: bold; }
+  @media (max-width: 480px) {
+    .layout { grid-template-columns: 1fr; }
+  }
 </style>
 </head>
 <body>

--- a/web-app/public/visuals/gk002-four-forces.html
+++ b/web-app/public/visuals/gk002-four-forces.html
@@ -12,12 +12,13 @@
   .force-green { color: var(--success); font-weight: bold; }
   .force-red { color: var(--danger); font-weight: bold; }
   @media (max-width: 480px) {
+    body { font-size: 14px; }
     .layout { grid-template-columns: 1fr; }
   }
 </style>
 </head>
 <body>
-  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:#f0c040;border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
+  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:var(--accent);border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
   <style>.container{padding-top:56px!important;}@media(max-width:480px){.container{padding-top:60px!important;}}</style>
 <div class="container">
   <h1>GK-002 — Four Forces of Flight</h1>

--- a/web-app/public/visuals/gk003-piston-engines.html
+++ b/web-app/public/visuals/gk003-piston-engines.html
@@ -7,10 +7,10 @@
 <link rel="stylesheet" href="_common.css">
 <style>
   .strokes-grid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 16px; margin-bottom: 32px; }
-  .stroke-card { background: #1a2d3d; border: 1px solid #243d52; border-radius: 8px; padding: 14px; text-align: center; }
+  .stroke-card { background: var(--surface); border: 1px solid var(--border); border-radius: 8px; padding: 14px; text-align: center; }
   .stroke-number { font-size: 11px; color: var(--text-muted); letter-spacing: 1px; text-transform: uppercase; margin-bottom: 6px; }
   .stroke-name { font-size: 15px; color: var(--accent); font-weight: bold; margin-bottom: 10px; }
-  .stroke-desc { font-size: 12px; color: #e8edf2; line-height: 1.5; margin-bottom: 10px; min-height: 48px; }
+  .stroke-desc { font-size: 12px; color: var(--text); line-height: 1.5; margin-bottom: 10px; min-height: 48px; }
   .valve-state { font-size: 11px; padding: 4px 8px; border-radius: 4px; margin: 2px 0; }
   .valve-open { background: #0d2a1a; color: var(--success); border: 1px solid var(--success); }
   .valve-closed { background: #2a1a1a; color: var(--danger); border: 1px solid var(--danger); }

--- a/web-app/public/visuals/gk003-piston-engines.html
+++ b/web-app/public/visuals/gk003-piston-engines.html
@@ -15,6 +15,7 @@
   .valve-open { background: #0d2a1a; color: var(--success); border: 1px solid var(--success); }
   .valve-closed { background: #2a1a1a; color: var(--danger); border: 1px solid var(--danger); }
   @media (max-width: 480px) {
+    body { font-size: 14px; }
     .strokes-grid { grid-template-columns: 1fr 1fr; }
     .stroke-name { font-size: 13px; }
     .stroke-card { padding: 10px; }
@@ -22,7 +23,7 @@
 </style>
 </head>
 <body>
-  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:#f0c040;border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
+  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:var(--accent);border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
   <style>.container{padding-top:56px!important;}@media(max-width:480px){.container{padding-top:60px!important;}}</style>
 <div class="container">
   <h1>GK-003 — Piston Engine: Four-Stroke Cycle</h1>

--- a/web-app/public/visuals/gk003-piston-engines.html
+++ b/web-app/public/visuals/gk003-piston-engines.html
@@ -8,12 +8,17 @@
 <style>
   .strokes-grid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 16px; margin-bottom: 32px; }
   .stroke-card { background: #1a2d3d; border: 1px solid #243d52; border-radius: 8px; padding: 14px; text-align: center; }
-  .stroke-number { font-size: 11px; color: #7a9ab5; letter-spacing: 1px; text-transform: uppercase; margin-bottom: 6px; }
-  .stroke-name { font-size: 15px; color: #f0c040; font-weight: bold; margin-bottom: 10px; }
+  .stroke-number { font-size: 11px; color: var(--text-muted); letter-spacing: 1px; text-transform: uppercase; margin-bottom: 6px; }
+  .stroke-name { font-size: 15px; color: var(--accent); font-weight: bold; margin-bottom: 10px; }
   .stroke-desc { font-size: 12px; color: #e8edf2; line-height: 1.5; margin-bottom: 10px; min-height: 48px; }
   .valve-state { font-size: 11px; padding: 4px 8px; border-radius: 4px; margin: 2px 0; }
-  .valve-open { background: #0d2a1a; color: #4caf7d; border: 1px solid #4caf7d; }
-  .valve-closed { background: #2a1a1a; color: #e05050; border: 1px solid #e05050; }
+  .valve-open { background: #0d2a1a; color: var(--success); border: 1px solid var(--success); }
+  .valve-closed { background: #2a1a1a; color: var(--danger); border: 1px solid var(--danger); }
+  @media (max-width: 480px) {
+    .strokes-grid { grid-template-columns: 1fr 1fr; }
+    .stroke-name { font-size: 13px; }
+    .stroke-card { padding: 10px; }
+  }
 </style>
 </head>
 <body>

--- a/web-app/public/visuals/gk004-fuel-system.html
+++ b/web-app/public/visuals/gk004-fuel-system.html
@@ -15,12 +15,13 @@
   /* design-exception: Clear/Straw Jet-A fuel colour (#d0c040 straw-yellow on dark olive); no CSS-var equivalent in token set */
   .badge-straw { background: #2a2a0d; color: #d0c040; border: 1px solid #d0c040; }
   @media (max-width: 480px) {
+    body { font-size: 14px; }
     .layout { grid-template-columns: 1fr; }
   }
 </style>
 </head>
 <body>
-  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:#f0c040;border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
+  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:var(--accent);border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
   <style>.container{padding-top:56px!important;}@media(max-width:480px){.container{padding-top:60px!important;}}</style>
 <div class="container">
   <h1>GK-004 — Fuel System</h1>

--- a/web-app/public/visuals/gk004-fuel-system.html
+++ b/web-app/public/visuals/gk004-fuel-system.html
@@ -9,9 +9,12 @@
   .layout { display: grid; grid-template-columns: 1fr 1fr; gap: 24px; align-items: start; }
   .badge { display: inline-block; font-size: 11px; font-weight: bold; padding: 2px 10px; border-radius: 12px; }
   .badge-blue { background: #0d1a3a; color: #5b9bd5; border: 1px solid #5b9bd5; }
-  .badge-red { background: #2a0d0d; color: #e05050; border: 1px solid #e05050; }
-  .badge-green { background: #0d2a1a; color: #4caf7d; border: 1px solid #4caf7d; }
-  .warning-box { background: #1a2d3d; border-left: 3px solid #e05050; border-radius: 4px; padding: 14px 18px; margin-top: 20px; font-size: 13px; color: #e8edf2; line-height: 1.6; }
+  .badge-red { background: #2a0d0d; color: var(--danger); border: 1px solid var(--danger); }
+  .badge-green { background: #0d2a1a; color: var(--success); border: 1px solid var(--success); }
+  .warning-box { background: #1a2d3d; border-left: 3px solid var(--danger); border-radius: 4px; padding: 14px 18px; margin-top: 20px; font-size: 13px; color: #e8edf2; line-height: 1.6; }
+  @media (max-width: 480px) {
+    .layout { grid-template-columns: 1fr; }
+  }
 </style>
 </head>
 <body>

--- a/web-app/public/visuals/gk004-fuel-system.html
+++ b/web-app/public/visuals/gk004-fuel-system.html
@@ -11,7 +11,9 @@
   .badge-blue { background: #0d1a3a; color: #5b9bd5; border: 1px solid #5b9bd5; }
   .badge-red { background: #2a0d0d; color: var(--danger); border: 1px solid var(--danger); }
   .badge-green { background: #0d2a1a; color: var(--success); border: 1px solid var(--success); }
-  .warning-box { background: #1a2d3d; border-left: 3px solid var(--danger); border-radius: 4px; padding: 14px 18px; margin-top: 20px; font-size: 13px; color: #e8edf2; line-height: 1.6; }
+  .warning-box { background: var(--surface); border-left: 3px solid var(--danger); border-radius: 4px; padding: 14px 18px; margin-top: 20px; font-size: 13px; color: var(--text); line-height: 1.6; }
+  /* design-exception: Clear/Straw Jet-A fuel colour (#d0c040 straw-yellow on dark olive); no CSS-var equivalent in token set */
+  .badge-straw { background: #2a2a0d; color: #d0c040; border: 1px solid #d0c040; }
   @media (max-width: 480px) {
     .layout { grid-template-columns: 1fr; }
   }
@@ -103,7 +105,7 @@
           </tr>
           <tr>
             <td><strong>Jet-A / Jet B</strong></td>
-            <td><span class="badge" style="background:#2a2a0d;color:#d0c040;border:1px solid #d0c040;">Clear/Straw</span></td>
+            <td><span class="badge badge-straw">Clear/Straw</span></td>
             <td>Turbine (jet/turboprop) fuel ONLY. <strong>Fatal if used in piston engine.</strong></td>
           </tr>
         </tbody>

--- a/web-app/public/visuals/gk005-electrical-system.html
+++ b/web-app/public/visuals/gk005-electrical-system.html
@@ -8,6 +8,9 @@
 <style>
   .diagram-box { margin-bottom: 24px; }
   .layout { display: grid; grid-template-columns: 1fr 1fr; gap: 24px; align-items: start; }
+  @media (max-width: 480px) {
+    .layout { grid-template-columns: 1fr; }
+  }
 </style>
 </head>
 <body>

--- a/web-app/public/visuals/gk005-electrical-system.html
+++ b/web-app/public/visuals/gk005-electrical-system.html
@@ -9,12 +9,13 @@
   .diagram-box { margin-bottom: 24px; }
   .layout { display: grid; grid-template-columns: 1fr 1fr; gap: 24px; align-items: start; }
   @media (max-width: 480px) {
+    body { font-size: 14px; }
     .layout { grid-template-columns: 1fr; }
   }
 </style>
 </head>
 <body>
-  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:#f0c040;border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
+  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:var(--accent);border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
   <style>.container{padding-top:56px!important;}@media(max-width:480px){.container{padding-top:60px!important;}}</style>
 <div class="container">
   <h1>GK-005 — Electrical System</h1>


### PR DESCRIPTION
## Summary

- Replaced hardcoded hex values in the inline `<style>` blocks of gk001–gk005 with `_common.css` CSS custom properties (`--accent`, `--success`, `--danger`, `--text-muted`)
- Preserved SVG element colors (fill/stroke) unchanged
- Preserved domain-specific tint backgrounds (`#0d2a1a`, `#2a1a0d`, `#2a1a1a`, `#0d1a3a`, `#2a0d0d`) and constrained state colors (`#5b9bd5`, `#f0a040`) as hardcoded
- Added `@media (max-width: 480px)` blocks to each file collapsing multi-column grids to 1-column (gk001 diagrams+tables, gk002/gk004/gk005 layouts) and 2-column (gk003 strokes-grid), eliminating horizontal scroll at 375 px

## Test plan

- [x] `npm run build` from `web-app/` passes with no errors
- [ ] Verify 375 px viewport has no horizontal scroll in each visual
- [ ] Confirm token substitutions resolve correctly against `_common.css` `:root` variables

Closes #244

🤖 Generated with [Claude Code](https://claude.com/claude-code)