### PR TITLE
[PPL-249] Migrate MET-011–014 visuals to _common.css tokens

### DIFF
--- a/web-app/public/visuals/met011-turbulence.html
+++ b/web-app/public/visuals/met011-turbulence.html
@@ -7,19 +7,23 @@
 <link rel="stylesheet" href="/visuals/_common.css">
 <style>
   .int-grid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 10px; }
-  .int-card { background: #1a2d3d; border: 1px solid #243d52; border-radius: 8px; padding: 12px; }
-  .int-card .h { font-size: 14px; color: #f0c040; font-weight: bold; letter-spacing: 0.5px; margin-bottom: 6px; }
-  .int-card .body { font-size: 11px; color: #e8edf2; line-height: 1.5; }
-  .int-card.lgt { border-left: 3px solid #4caf7d; }
-  .int-card.mod { border-left: 3px solid #f0c040; }
-  .int-card.sev { border-left: 3px solid #e05050; }
-  .int-card.ext { border-left: 3px solid #b030b0; }
+  .int-card { background: var(--surface); border: 1px solid var(--border-hi); border-radius: 8px; padding: 12px; }
+  .int-card .h { font-size: 14px; color: var(--accent); font-weight: bold; letter-spacing: 0.5px; margin-bottom: 6px; }
+  .int-card .body { font-size: 11px; color: var(--text); line-height: 1.5; }
+  .int-card.lgt { border-left: 3px solid var(--success); }
+  .int-card.mod { border-left: 3px solid var(--accent); }
+  .int-card.sev { border-left: 3px solid var(--danger); }
+  .int-card.ext { border-left: 3px solid #b030b0; /* design-exception: extreme turbulence accent, no token */ }
   .type-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 14px; }
-  .type-card { background: #1a2d3d; border: 1px solid #243d52; border-radius: 8px; padding: 14px; }
-  .type-card h3 { font-size: 14px; color: #f0c040; margin-bottom: 6px; letter-spacing: 0.5px; }
-  .type-card .sub { font-size: 11px; color: #7a9ab5; margin-bottom: 8px; }
-  .type-card ul { margin-left: 18px; font-size: 12px; color: #e8edf2; line-height: 1.6; }
-  @media (max-width: 640px) { .int-grid { grid-template-columns: repeat(2, 1fr); } .type-grid { grid-template-columns: 1fr; } }
+  .type-card { background: var(--surface); border: 1px solid var(--border-hi); border-radius: 8px; padding: 14px; }
+  .type-card h3 { font-size: 14px; color: var(--accent); margin-bottom: 6px; letter-spacing: 0.5px; }
+  .type-card .sub { font-size: 11px; color: var(--text-muted); margin-bottom: 8px; }
+  .type-card ul { margin-left: 18px; font-size: 12px; color: var(--text); line-height: 1.6; }
+  @media (max-width: 480px) {
+    body { padding: 16px; font-size: 14px; }
+    .int-grid { grid-template-columns: repeat(2, 1fr); }
+    .type-grid { grid-template-columns: 1fr; }
+  }
 </style>
 </head>
 <body>

--- a/web-app/public/visuals/met012-wind-shear-microburst.html
+++ b/web-app/public/visuals/met012-wind-shear-microburst.html
@@ -6,12 +6,15 @@
 <title>MET-012: Wind Shear & Microburst</title>
 <link rel="stylesheet" href="/visuals/_common.css">
 <style>
-  .diagram-box { background: #1a2d3d; border: 1px solid #243d52; border-radius: 8px; padding: 16px; margin-bottom: 16px; }
-  .caption { font-size: 11px; color: #7a9ab5; text-align: center; margin-top: 8px; }
+  .diagram-box { background: var(--surface); border: 1px solid var(--border-hi); border-radius: 8px; padding: 16px; margin-bottom: 16px; }
+  .caption { font-size: 11px; color: var(--text-muted); text-align: center; margin-top: 8px; }
   .stages { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 10px; }
-  .stage-card { background: #1a2d3d; border-left: 3px solid #f0c040; padding: 10px 14px; font-size: 12px; color: #e8edf2; line-height: 1.5; }
-  .stage-card .n { color: #f0c040; font-weight: bold; font-size: 13px; }
-  @media (max-width: 640px) { .stages { grid-template-columns: 1fr; } }
+  .stage-card { background: var(--surface); border-left: 3px solid var(--accent); padding: 10px 14px; font-size: 12px; color: var(--text); line-height: 1.5; }
+  .stage-card .n { color: var(--accent); font-weight: bold; font-size: 13px; }
+  @media (max-width: 480px) {
+    body { padding: 16px; font-size: 14px; }
+    .stages { grid-template-columns: 1fr; }
+  }
 </style>
 </head>
 <body>

--- a/web-app/public/visuals/met013-fronts.html
+++ b/web-app/public/visuals/met013-fronts.html
@@ -6,13 +6,17 @@
 <title>MET-013: Fronts</title>
 <link rel="stylesheet" href="/visuals/_common.css">
 <style>
-  .diagram-box { background: #1a2d3d; border: 1px solid #243d52; border-radius: 8px; padding: 16px; margin-bottom: 14px; }
+  .diagram-box { background: var(--surface); border: 1px solid var(--border-hi); border-radius: 8px; padding: 16px; margin-bottom: 14px; }
   .mass-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 10px; margin-bottom: 14px; }
-  .mass-card { background: #1a2d3d; border: 1px solid #243d52; border-radius: 8px; padding: 12px; text-align: center; }
-  .mass-card .code { font-size: 18px; color: #f0c040; font-weight: bold; font-family: 'Consolas', monospace; }
-  .mass-card .name { font-size: 11px; color: #e8edf2; margin-top: 4px; }
-  .mass-card .note { font-size: 10px; color: #7a9ab5; margin-top: 4px; }
-  .caption { font-size: 11px; color: #7a9ab5; text-align: center; margin-top: 8px; }
+  .mass-card { background: var(--surface); border: 1px solid var(--border-hi); border-radius: 8px; padding: 12px; text-align: center; }
+  .mass-card .code { font-size: 18px; color: var(--accent); font-weight: bold; font-family: 'Consolas', monospace; }
+  .mass-card .name { font-size: 11px; color: var(--text); margin-top: 4px; }
+  .mass-card .note { font-size: 10px; color: var(--text-muted); margin-top: 4px; }
+  .caption { font-size: 11px; color: var(--text-muted); text-align: center; margin-top: 8px; }
+  @media (max-width: 480px) {
+    body { padding: 16px; font-size: 14px; }
+    .mass-grid { grid-template-columns: 1fr; }
+  }
 </style>
 </head>
 <body>

--- a/web-app/public/visuals/met014-wx-decision-making.html
+++ b/web-app/public/visuals/met014-wx-decision-making.html
@@ -7,24 +7,28 @@
 <link rel="stylesheet" href="/visuals/_common.css">
 <style>
   .flow { display: flex; flex-direction: column; gap: 10px; }
-  .flow-row { background: #1a2d3d; border-left: 4px solid #f0c040; border-radius: 6px; padding: 14px 18px; }
-  .flow-row h3 { font-size: 13px; color: #f0c040; margin-bottom: 6px; letter-spacing: 0.5px; }
-  .flow-row p { font-size: 12px; color: #e8edf2; line-height: 1.55; }
-  .flow-row.ok { border-left-color: #4caf7d; }
-  .flow-row.warn { border-left-color: #f0c040; }
-  .flow-row.stop { border-left-color: #e05050; }
+  .flow-row { background: var(--surface); border-left: 4px solid var(--accent); border-radius: 6px; padding: 14px 18px; }
+  .flow-row h3 { font-size: 13px; color: var(--accent); margin-bottom: 6px; letter-spacing: 0.5px; }
+  .flow-row p { font-size: 12px; color: var(--text); line-height: 1.55; }
+  .flow-row.ok { border-left-color: var(--success); }
+  .flow-row.warn { border-left-color: var(--accent); }
+  .flow-row.stop { border-left-color: var(--danger); }
   .imsafe { display: grid; grid-template-columns: repeat(auto-fit, minmax(130px, 1fr)); gap: 10px; }
-  .im-card { background: #1a2d3d; border: 1px solid #243d52; border-radius: 8px; padding: 12px; text-align: center; }
-  .im-letter { font-size: 20px; color: #f0c040; font-weight: bold; font-family: 'Consolas', monospace; }
-  .im-word { font-size: 12px; color: #e8edf2; margin-top: 4px; font-weight: bold; }
-  .im-sub { font-size: 10px; color: #7a9ab5; margin-top: 3px; line-height: 1.4; }
-  .risk-matrix { display: grid; grid-template-columns: 120px repeat(3, 1fr); gap: 1px; background: #243d52; border: 1px solid #243d52; border-radius: 8px; overflow: hidden; }
-  .r-cell { background: #1a2d3d; padding: 10px 12px; font-size: 12px; text-align: center; color: #e8edf2; }
-  .r-cell.hdr { background: #243d52; color: #f0c040; font-weight: bold; letter-spacing: 0.5px; font-size: 11px; }
-  .r-cell.low { background: #1e3a28; }
-  .r-cell.med { background: #4a3a1a; }
-  .r-cell.high { background: #4a1a1a; }
-  @media (max-width: 640px) { .risk-matrix { grid-template-columns: 80px repeat(3, 1fr); } }
+  .im-card { background: var(--surface); border: 1px solid var(--border-hi); border-radius: 8px; padding: 12px; text-align: center; }
+  .im-letter { font-size: 20px; color: var(--accent); font-weight: bold; font-family: 'Consolas', monospace; }
+  .im-word { font-size: 12px; color: var(--text); margin-top: 4px; font-weight: bold; }
+  .im-sub { font-size: 10px; color: var(--text-muted); margin-top: 3px; line-height: 1.4; }
+  .risk-matrix { display: grid; grid-template-columns: 120px repeat(3, 1fr); gap: 1px; background: var(--border-hi); border: 1px solid var(--border-hi); border-radius: 8px; overflow: hidden; }
+  .r-cell { background: var(--surface); padding: 10px 12px; font-size: 12px; text-align: center; color: var(--text); }
+  .r-cell.hdr { background: var(--border-hi); color: var(--accent); font-weight: bold; letter-spacing: 0.5px; font-size: 11px; }
+  .r-cell.low { background: #1e3a28; /* design-exception: risk-low tint, no token */ }
+  .r-cell.med { background: #4a3a1a; /* design-exception: risk-medium tint, no token */ }
+  .r-cell.high { background: #4a1a1a; /* design-exception: risk-high tint, no token */ }
+  @media (max-width: 480px) {
+    body { padding: 16px; font-size: 14px; }
+    .imsafe { grid-template-columns: 1fr; }
+    .risk-matrix { grid-template-columns: 80px repeat(3, 1fr); }
+  }
 </style>
 </head>
 <body>


### PR DESCRIPTION
## Summary

- Replace all hardcoded hex/rgb color values in `met011`–`met014` per-file `<style>` blocks with `var(--…)` design-system tokens from `_common.css`
- Change `@media (max-width: 640px)` breakpoints to `480px` in met011, met012, met014; add missing mobile breakpoint to met013
- Each 480px query ensures `body { padding: 16px; font-size: 14px }` and multi-column grids collapse to `1fr`
- `#b030b0` (extreme turbulence) and risk-matrix tints kept with `/* design-exception */` comments
- No text, label, or diagram content changed
- `npm run build` passes ✓

Closes #249

## Token mapping applied
| Hex | Token |
|-----|-------|
| `#1a2d3d` | `var(--surface)` |
| `#243d52` | `var(--border-hi)` |
| `#f0c040` | `var(--accent)` |
| `#e8edf2` | `var(--text)` |
| `#7a9ab5` | `var(--text-muted)` |
| `#4caf7d` | `var(--success)` |
| `#e05050` | `var(--danger)` |

## Test plan
- [ ] Open each visual at desktop (1280px) — no visible change from before
- [ ] Open each visual at 360px mobile — grids collapse to 1 column, font ≥ 14px, back button accessible
- [ ] Verify build output is clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)