### PR TITLE
[PPL-252] Migrate NAV-011–014 visuals to CSS vars + mobile responsive

### DIFF
--- a/web-app/public/visuals/nav011-gps-basics.html
+++ b/web-app/public/visuals/nav011-gps-basics.html
@@ -6,13 +6,17 @@
 <link rel="stylesheet" href="/visuals/_common.css">
 <title>NAV-011 — GPS Basics</title>
 <style>
-.note-box { background: #1a1a0a; border: 1.5px solid #c8a040; border-radius: 10px; padding: 16px 20px; margin-top: 16px; }
-  .note-box .badge { display: inline-block; background: #3a2d00; color: #f0c040; font-size: 11px; font-weight: 700; text-transform: uppercase; letter-spacing: 1px; padding: 3px 10px; border-radius: 4px; margin-bottom: 10px; }
-  .note-box p, .note-box li { color: #c8d8e8; font-size: 12px; line-height: 1.7; }
+  .note-box .badge { display: inline-block; background: var(--bg2); color: var(--accent); font-size: 11px; font-weight: 700; text-transform: uppercase; letter-spacing: 1px; padding: 3px 10px; border-radius: 4px; margin-bottom: 10px; }
+  .note-box p, .note-box li { color: var(--text); font-size: 12px; line-height: 1.7; }
+
+  @media (max-width: 480px) {
+    body { font-size: 14px; overflow-x: hidden; }
+    .two-col, .three-col { grid-template-columns: 1fr; }
+  }
 </style>
 </head>
 <body>
-  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:#f0c040;border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
+  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:color-mix(in srgb,var(--bg2) 90%,transparent);color:var(--accent);border:1.5px solid color-mix(in srgb,var(--accent) 40%,transparent);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
   <style>
 .container{padding-top:56px!important;}@media(max-width:480px){.container{padding-top:60px!important;}}
 </style>
@@ -135,8 +139,8 @@
       <ul>
         <li>Satellites transmit precise time signals from known orbital positions</li>
         <li>Receiver measures time delay = distance (ranging)</li>
-        <li><strong style="color:#f0c040">Minimum 3 satellites</strong> for 2D fix (lat/lon only)</li>
-        <li><strong style="color:#f0c040">4+ satellites</strong> required for 3D fix (lat/lon + altitude)</li>
+        <li><strong style="color:var(--accent)">Minimum 3 satellites</strong> for 2D fix (lat/lon only)</li>
+        <li><strong style="color:var(--accent)">4+ satellites</strong> required for 3D fix (lat/lon + altitude)</li>
         <li>Accuracy: civilian GPS ~15 m horizontal (WAAS can improve to ~3 m)</li>
         <li>HDOP (Horizontal Dilution of Precision) indicates geometric accuracy — lower is better</li>
       </ul>
@@ -144,9 +148,9 @@
     <div class="card">
       <h3>GPS Limitations</h3>
       <ul>
-        <li><strong style="color:#f0c040">Signal shadowing:</strong> Deep valleys, canyons, urban canyons can block satellites</li>
-        <li><strong style="color:#f0c040">Jamming/spoofing:</strong> Military or civilian interference can degrade accuracy</li>
-        <li><strong style="color:#f0c040">True north by default:</strong> GPS measures true track — magnetic variation is applied by the unit's database (may be outdated)</li>
+        <li><strong style="color:var(--accent)">Signal shadowing:</strong> Deep valleys, canyons, urban canyons can block satellites</li>
+        <li><strong style="color:var(--accent)">Jamming/spoofing:</strong> Military or civilian interference can degrade accuracy</li>
+        <li><strong style="color:var(--accent)">True north by default:</strong> GPS measures true track — magnetic variation is applied by the unit's database (may be outdated)</li>
         <li>Database currency: waypoints and airways must be current for IFR; VFR use still needs current VNC</li>
         <li>No terrain warning unless TAWS/EGPWS installed separately</li>
         <li>Selective Availability (SA) discontinued 2000 — no longer an issue</li>
@@ -175,17 +179,17 @@
 
   <div class="note-box">
     <div class="badge">Important — VFR GPS Use</div>
-    <p>GPS is <strong style="color:#f0c040">supplemental navigation for VFR</strong> — always carry current paper charts (VNC/VTA) and know how to navigate without GPS. GPS heading is <strong style="color:#f0c040">TRUE</strong> unless the unit applies magnetic variation from its database. Verify the unit's variation matches your VNC chart. Never use GPS as sole-means for VFR flight planning.</p>
+    <p>GPS is <strong style="color:var(--accent)">supplemental navigation for VFR</strong> — always carry current paper charts (VNC/VTA) and know how to navigate without GPS. GPS heading is <strong style="color:var(--accent)">TRUE</strong> unless the unit applies magnetic variation from its database. Verify the unit's variation matches your VNC chart. Never use GPS as sole-means for VFR flight planning.</p>
   </div>
 
   <div class="section-label">Memory Hook</div>
   <div class="memory-hook">
     <div class="badge">Memory Hook</div>
     <ul>
-      <li><strong style="color:#80c880">GPS = True north by default.</strong> When ATC gives you a heading, it is magnetic. GPS track is true. Know the difference — add or subtract variation (~15°W in southern Canada).</li>
-      <li><strong style="color:#80c880">4 satellites = 3D fix:</strong> Need 3 for position, 4th for altitude. If only 3 in view, altitude is unreliable.</li>
-      <li><strong style="color:#80c880">Never sole-means for VFR:</strong> GPS can fail, jam, or go out of date. Charts and pilotage are your backup.</li>
-      <li><strong style="color:#80c880">XTK vs DTK:</strong> DTK is where you should go; XTK is how far off you are. Use XTK like a CDI needle.</li>
+      <li><strong style="color:var(--success)">GPS = True north by default.</strong> When ATC gives you a heading, it is magnetic. GPS track is true. Know the difference — add or subtract variation (~15°W in southern Canada).</li>
+      <li><strong style="color:var(--success)">4 satellites = 3D fix:</strong> Need 3 for position, 4th for altitude. If only 3 in view, altitude is unreliable.</li>
+      <li><strong style="color:var(--success)">Never sole-means for VFR:</strong> GPS can fail, jam, or go out of date. Charts and pilotage are your backup.</li>
+      <li><strong style="color:var(--success)">XTK vs DTK:</strong> DTK is where you should go; XTK is how far off you are. Use XTK like a CDI needle.</li>
     </ul>
   </div>
 </div>

--- a/web-app/public/visuals/nav012-altitude-types.html
+++ b/web-app/public/visuals/nav012-altitude-types.html
@@ -5,10 +5,15 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <link rel="stylesheet" href="/visuals/_common.css">
 <title>NAV-012 — Altitude Types</title>
-
+<style>
+  @media (max-width: 480px) {
+    body { font-size: 14px; overflow-x: hidden; }
+    .two-col, .three-col { grid-template-columns: 1fr; }
+  }
+</style>
 </head>
 <body>
-  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:#f0c040;border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
+  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:color-mix(in srgb,var(--bg2) 90%,transparent);color:var(--accent);border:1.5px solid color-mix(in srgb,var(--accent) 40%,transparent);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
   <style>
 .container{padding-top:56px!important;}@media(max-width:480px){.container{padding-top:60px!important;}}
 </style>
@@ -171,10 +176,10 @@
   <div class="memory-hook">
     <div class="badge">Memory Hook</div>
     <ul>
-      <li><strong style="color:#80c880">"Indicated for ATC, Pressure for Performance, Density for Departures"</strong> — the three Ps of altitude</li>
-      <li><strong style="color:#80c880">Cold = lower than indicated:</strong> On a cold day, true altitude is LOWER than indicated — you are closer to terrain than the altimeter suggests. "From high to low, look out below."</li>
-      <li><strong style="color:#80c880">QNH vs QNE:</strong> QNH = local pressure (use for normal flight below FL180); QNE = 29.92 standard (use for flight levels and performance charts)</li>
-      <li><strong style="color:#80c880">Density altitude = aircraft performance:</strong> High DA = longer takeoff roll, slower climb, reduced engine power — even if indicated altitude looks fine.</li>
+      <li><strong style="color:var(--success)">"Indicated for ATC, Pressure for Performance, Density for Departures"</strong> — the three Ps of altitude</li>
+      <li><strong style="color:var(--success)">Cold = lower than indicated:</strong> On a cold day, true altitude is LOWER than indicated — you are closer to terrain than the altimeter suggests. "From high to low, look out below."</li>
+      <li><strong style="color:var(--success)">QNH vs QNE:</strong> QNH = local pressure (use for normal flight below FL180); QNE = 29.92 standard (use for flight levels and performance charts)</li>
+      <li><strong style="color:var(--success)">Density altitude = aircraft performance:</strong> High DA = longer takeoff roll, slower climb, reduced engine power — even if indicated altitude looks fine.</li>
     </ul>
   </div>
 </div>

--- a/web-app/public/visuals/nav013-density-altitude.html
+++ b/web-app/public/visuals/nav013-density-altitude.html
@@ -6,11 +6,16 @@
 <link rel="stylesheet" href="/visuals/_common.css">
 <title>NAV-013 — Density Altitude</title>
 <style>
-.formula { background: #0d1b2a; border: 1.5px solid #1a3a5a; border-radius: 8px; padding: 14px 18px; margin: 12px 0; color: #f0c040; font-weight: 700; font-size: 15px; text-align: center; letter-spacing: 0.5px; }
+  .formula { background: var(--bg2); border: 1.5px solid var(--border); border-radius: 8px; padding: 14px 18px; margin: 12px 0; color: var(--accent); font-weight: 700; font-size: 15px; text-align: center; letter-spacing: 0.5px; }
+
+  @media (max-width: 480px) {
+    body { font-size: 14px; overflow-x: hidden; }
+    .two-col, .three-col { grid-template-columns: 1fr; }
+  }
 </style>
 </head>
 <body>
-  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:#f0c040;border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
+  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:color-mix(in srgb,var(--bg2) 90%,transparent);color:var(--accent);border:1.5px solid color-mix(in srgb,var(--accent) 40%,transparent);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
   <style>
 .container{padding-top:56px!important;}@media(max-width:480px){.container{padding-top:60px!important;}}
 </style>
@@ -196,7 +201,7 @@
     <div class="card">
       <h3>What is Density Altitude?</h3>
       <ul>
-        <li><strong style="color:#f0c040">Pressure altitude corrected for non-standard temperature</strong></li>
+        <li><strong style="color:var(--accent)">Pressure altitude corrected for non-standard temperature</strong></li>
         <li>Represents the air density — how "thick" the air actually is</li>
         <li>High temperature = lower air density = higher density altitude</li>
         <li>High elevation = lower pressure = higher density altitude</li>
@@ -207,9 +212,9 @@
     <div class="card">
       <h3>Why Density Altitude Matters</h3>
       <ul>
-        <li><strong style="color:#f0c040">Engine produces less power</strong> — less oxygen per intake stroke</li>
-        <li><strong style="color:#f0c040">Wings produce less lift</strong> — thinner air, less molecules over airfoil</li>
-        <li><strong style="color:#f0c040">Longer takeoff roll</strong> — both effects combined, plus higher groundspeed at rotation</li>
+        <li><strong style="color:var(--accent)">Engine produces less power</strong> — less oxygen per intake stroke</li>
+        <li><strong style="color:var(--accent)">Wings produce less lift</strong> — thinner air, less molecules over airfoil</li>
+        <li><strong style="color:var(--accent)">Longer takeoff roll</strong> — both effects combined, plus higher groundspeed at rotation</li>
         <li>Slower initial climb rate — critical near terrain</li>
         <li>Propeller less efficient — reduced thrust</li>
         <li>Never skip DA calculation at high-elevation or hot-day airports</li>
@@ -238,10 +243,10 @@
     <h3>Worked Example</h3>
     <ul>
       <li>Airport elevation = 3,500 ft → Pressure Altitude ≈ 3,500 ft (assuming QNH near standard)</li>
-      <li>ISA temperature at 3,500 ft = 15 − (2 × 3.5) = <strong style="color:#f0c040">8°C</strong></li>
-      <li>Actual OAT = <strong style="color:#f0c040">+30°C</strong></li>
-      <li>Temperature excess above ISA = 30 − 8 = <strong style="color:#f0c040">22°C above ISA</strong></li>
-      <li>DA ≈ 3,500 + (22 × 120) = 3,500 + 2,640 = <strong style="color:#e07070">~6,140 ft</strong></li>
+      <li>ISA temperature at 3,500 ft = 15 − (2 × 3.5) = <strong style="color:var(--accent)">8°C</strong></li>
+      <li>Actual OAT = <strong style="color:var(--accent)">+30°C</strong></li>
+      <li>Temperature excess above ISA = 30 − 8 = <strong style="color:var(--accent)">22°C above ISA</strong></li>
+      <li>DA ≈ 3,500 + (22 × 120) = 3,500 + 2,640 = <strong style="color:var(--danger)">~6,140 ft</strong></li>
       <li>Aircraft performs as if at 6,140 ft on a standard day — significantly degraded</li>
     </ul>
   </div>
@@ -265,10 +270,10 @@
   <div class="memory-hook">
     <div class="badge">Memory Hook</div>
     <ul>
-      <li><strong style="color:#80c880">Hot + High = High DA = Hazard:</strong> Both high temperature and high elevation push DA up. Together they can double the apparent altitude.</li>
-      <li><strong style="color:#80c880">ISA lapse rate = 2°C per 1,000 ft:</strong> At 3,000 ft, ISA = 15 − 6 = 9°C. Memorize this: start at 15°C at sea level, subtract 2°C for every 1,000 ft.</li>
-      <li><strong style="color:#80c880">120 ft per °C:</strong> Each 1°C above ISA adds 120 ft to your density altitude. On a 10°C-above-ISA day, add 1,200 ft.</li>
-      <li><strong style="color:#80c880">Check POH performance charts:</strong> Always calculate DA before takeoff and compare to your aircraft's POH climb/takeoff charts — especially on short runways or near terrain.</li>
+      <li><strong style="color:var(--success)">Hot + High = High DA = Hazard:</strong> Both high temperature and high elevation push DA up. Together they can double the apparent altitude.</li>
+      <li><strong style="color:var(--success)">ISA lapse rate = 2°C per 1,000 ft:</strong> At 3,000 ft, ISA = 15 − 6 = 9°C. Memorize this: start at 15°C at sea level, subtract 2°C for every 1,000 ft.</li>
+      <li><strong style="color:var(--success)">120 ft per °C:</strong> Each 1°C above ISA adds 120 ft to your density altitude. On a 10°C-above-ISA day, add 1,200 ft.</li>
+      <li><strong style="color:var(--success)">Check POH performance charts:</strong> Always calculate DA before takeoff and compare to your aircraft's POH climb/takeoff charts — especially on short runways or near terrain.</li>
     </ul>
   </div>
 </div>

--- a/web-app/public/visuals/nav014-lost-procedure.html
+++ b/web-app/public/visuals/nav014-lost-procedure.html
@@ -6,13 +6,19 @@
 <link rel="stylesheet" href="/visuals/_common.css">
 <title>NAV-014 — Lost Procedure and Diversion</title>
 <style>
-.squawk-7700 { color: #e07070; font-weight: 700; }
-  .squawk-7600 { color: #f0c040; font-weight: 700; }
+  .squawk-7700 { color: var(--danger); font-weight: 700; }
+  .squawk-7600 { color: var(--accent); font-weight: 700; }
+  /* design-exception: #c87040 (burnt-orange) distinguishes hijack from emergency/radio-fail; no equivalent token */
   .squawk-7500 { color: #c87040; font-weight: 700; }
+
+  @media (max-width: 480px) {
+    body { font-size: 14px; overflow-x: hidden; }
+    .two-col, .three-col { grid-template-columns: 1fr; }
+  }
 </style>
 </head>
 <body>
-  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:#f0c040;border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
+  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:color-mix(in srgb,var(--bg2) 90%,transparent);color:var(--accent);border:1.5px solid color-mix(in srgb,var(--accent) 40%,transparent);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
   <style>
 .container{padding-top:56px!important;}@media(max-width:480px){.container{padding-top:60px!important;}}
 </style>
@@ -150,10 +156,10 @@
     <div class="card">
       <h3>MAYDAY — Distress Call</h3>
       <ul>
-        <li>Used when aircraft, crew, or passengers are in <strong style="color:#e07070">grave and imminent danger</strong></li>
+        <li>Used when aircraft, crew, or passengers are in <strong style="color:var(--danger)">grave and imminent danger</strong></li>
         <li>Repeated 3 times: "MAYDAY MAYDAY MAYDAY"</li>
         <li>Followed by: callsign, nature of emergency, position, altitude, intentions, POB, any other relevant info</li>
-        <li>Frequency: current ATC freq or <strong style="color:#f0c040">121.5 MHz</strong></li>
+        <li>Frequency: current ATC freq or <strong style="color:var(--accent)">121.5 MHz</strong></li>
         <li>Squawk: <span class="squawk-7700">7700</span></li>
         <li>Examples: engine failure, fire, incapacitation</li>
       </ul>
@@ -161,7 +167,7 @@
     <div class="card">
       <h3>PAN-PAN — Urgency Call</h3>
       <ul>
-        <li>Used when aircraft has a serious but <strong style="color:#f0c040">non-immediately life-threatening</strong> condition</li>
+        <li>Used when aircraft has a serious but <strong style="color:var(--accent)">non-immediately life-threatening</strong> condition</li>
         <li>Repeated 3 times: "PAN-PAN PAN-PAN PAN-PAN"</li>
         <li>Followed by: same information as Mayday</li>
         <li>Frequency: current ATC freq or 121.5 MHz</li>
@@ -228,11 +234,11 @@
   <div class="memory-hook">
     <div class="badge">Memory Hook</div>
     <ul>
-      <li><strong style="color:#80c880">4 Cs — Climb, Confess, Communicate, Comply:</strong> The standard lost procedure. In that order — climb first to give yourself more options, confess quickly, communicate with ATC, then comply with instructions.</li>
-      <li><strong style="color:#80c880">Squawk codes — "7700 is heaven, 7600 is mute, 7500 is hijacked":</strong> 7700 = emergency (worst), 7600 = radio out (silent), 7500 = hijack (severe).</li>
-      <li><strong style="color:#80c880">Mayday = grave danger, Pan-Pan = urgent but not immediately fatal.</strong> When in doubt, say Mayday — downgrading is easy, upgrading too late is not.</li>
-      <li><strong style="color:#80c880">121.5 MHz is always monitored:</strong> ATC, SAR, and other aircraft monitor the guard frequency. If on any other freq and no contact, try 121.5.</li>
-      <li><strong style="color:#80c880">Aviate · Navigate · Communicate — in that order.</strong> Never let radio work cause you to fly into terrain or lose control.</li>
+      <li><strong style="color:var(--success)">4 Cs — Climb, Confess, Communicate, Comply:</strong> The standard lost procedure. In that order — climb first to give yourself more options, confess quickly, communicate with ATC, then comply with instructions.</li>
+      <li><strong style="color:var(--success)">Squawk codes — "7700 is heaven, 7600 is mute, 7500 is hijacked":</strong> 7700 = emergency (worst), 7600 = radio out (silent), 7500 = hijack (severe).</li>
+      <li><strong style="color:var(--success)">Mayday = grave danger, Pan-Pan = urgent but not immediately fatal.</strong> When in doubt, say Mayday — downgrading is easy, upgrading too late is not.</li>
+      <li><strong style="color:var(--success)">121.5 MHz is always monitored:</strong> ATC, SAR, and other aircraft monitor the guard frequency. If on any other freq and no contact, try 121.5.</li>
+      <li><strong style="color:var(--success)">Aviate · Navigate · Communicate — in that order.</strong> Never let radio work cause you to fly into terrain or lose control.</li>
     </ul>
   </div>
 </div>


### PR DESCRIPTION
Closes #252

## Summary
- Migrated all hardcoded hex/rgb colors in `<style>` blocks and inline `style=` attributes (non-SVG) in `nav011`–`nav014` to `var(--…)` tokens from `_common.css`
- Removed duplicate `.note-box` rule from `nav011` (now inherited from `_common.css`); kept and migrated child selectors
- Migrated back-button `rgba()` values to `color-mix(in srgb, var(--bg2/--accent) …%, transparent)`
- Mapped `#80c880 → var(--success)`, `#f0c040 → var(--accent)`, `#e07070 → var(--danger)`, `#0d1b2a → var(--bg2)`, `#1a3a5a → var(--border)`
- Preserved `#c87040` in `nav014 .squawk-7500` with design-exception comment (burnt-orange distinguishes hijack squawk from emergency/radio-fail)
- Added `@media (max-width: 480px)` to each file: collapses `.two-col`/`.three-col` grids to `1fr`, sets `font-size: 14px`, `overflow-x: hidden`
- SVG `fill`/`stroke`/`stop-color` attributes left untouched
- `npm run build` passes ✓

## Test plan
- [ ] Open each visual in a browser at 375px viewport width — no horizontal scroll, grids stack to 1 column, body text ≥14px
- [ ] Back button remains ≥44×44px tap target and styled correctly
- [ ] `.squawk-7500` in NAV-014 renders in burnt-orange (#c87040), distinct from 7700 (danger red) and 7600 (accent gold)
- [ ] SVG diagrams unchanged in all four visuals

🤖 Generated with [Claude Code](https://claude.com/claude-code)