### PR TITLE
[PPL-241] Migrate hex→CSS vars in al006-008, add al009/al010 visuals

### DIFF
--- a/web-app/public/visuals/al006-aerodrome-traffic-circuit.html
+++ b/web-app/public/visuals/al006-aerodrome-traffic-circuit.html
@@ -12,14 +12,14 @@
 
   /* Runway */
   .runway-cell { grid-column: 2; grid-row: 3; display: flex; align-items: center; justify-content: center; }
-  .runway { background: #2a3a4a; border: 2px solid #f0c040; border-radius: 4px; padding: 8px 16px; text-align: center; font-size: 11px; font-weight: 800; color: #f0c040; letter-spacing: 2px; width: 100%; }
-  .runway-arrows { font-size: 14px; display: block; margin-top: 2px; color: #7a9ab5; }
+  .runway { background: #2a3a4a; border: 2px solid var(--accent); border-radius: 4px; padding: 8px 16px; text-align: center; font-size: 11px; font-weight: 800; color: var(--accent); letter-spacing: 2px; width: 100%; }
+  .runway-arrows { font-size: 14px; display: block; margin-top: 2px; color: var(--text-muted); }
 
   /* Leg labels */
   .leg-cell { display: flex; align-items: center; justify-content: center; padding: 8px; }
   .leg-label { text-align: center; }
-  .leg-name { font-size: 13px; font-weight: 700; color: #f0c040; display: block; }
-  .leg-detail { font-size: 11px; color: #7a9ab5; display: block; margin-top: 3px; line-height: 1.4; }
+  .leg-name { font-size: 13px; font-weight: 700; color: var(--accent); display: block; }
+  .leg-detail { font-size: 11px; color: var(--text-muted); display: block; margin-top: 3px; line-height: 1.4; }
   .leg-arrow { font-size: 20px; color: #80b8ff; display: block; margin-bottom: 4px; }
 
   /* Direction arrows along legs */
@@ -41,23 +41,33 @@
   .corner-tl { grid-column: 1; grid-row: 1; display: flex; align-items: flex-end; justify-content: flex-end; padding: 4px; color: #80b8ff; font-size: 16px; }
   .corner-bl { grid-column: 1; grid-row: 5; display: flex; align-items: flex-start; justify-content: flex-end; padding: 4px; color: #80b8ff; font-size: 16px; }
 
-  .diagram-note { text-align: center; font-size: 11px; color: #7a9ab5; margin-top: 12px; }
+  .diagram-note { text-align: center; font-size: 11px; color: var(--text-muted); margin-top: 12px; }
 
   /* Legs reference table */
   table { width: 100%; border-collapse: collapse; font-size: 13px; margin-bottom: 28px; }
-  th { background: #1a2d3d; color: #7a9ab5; padding: 9px 12px; text-align: left; font-size: 11px; text-transform: uppercase; letter-spacing: 0.5px; }
+  th { background: #1a2d3d; color: var(--text-muted); padding: 9px 12px; text-align: left; font-size: 11px; text-transform: uppercase; letter-spacing: 0.5px; }
   td { padding: 10px 12px; border-bottom: 1px solid #1a2d3d; vertical-align: top; }
-  .leg-name-col { font-weight: 700; color: #f0c040; }
-  .leg-order { display: inline-block; width: 20px; height: 20px; border-radius: 50%; background: #1a2d3d; color: #7a9ab5; font-size: 10px; font-weight: 800; text-align: center; line-height: 20px; margin-right: 6px; }
+  .leg-name-col { font-weight: 700; color: var(--accent); }
+  .leg-order { display: inline-block; width: 20px; height: 20px; border-radius: 50%; background: #1a2d3d; color: var(--text-muted); font-size: 10px; font-weight: 800; text-align: center; line-height: 20px; margin-right: 6px; }
 
   /* Standards panel */
   .standards-grid { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 12px; margin-bottom: 28px; }
   .std-card { background: #1a2d3d; border-radius: 8px; padding: 14px 16px; }
-  .std-card h3 { font-size: 11px; color: #7a9ab5; text-transform: uppercase; letter-spacing: 0.5px; margin-bottom: 8px; }
-  .std-value { font-size: 16px; font-weight: 800; color: #f0c040; }
-  .std-note { font-size: 11px; color: #7a9ab5; margin-top: 4px; }
+  .std-card h3 { font-size: 11px; color: var(--text-muted); text-transform: uppercase; letter-spacing: 0.5px; margin-bottom: 8px; }
+  .std-value { font-size: 16px; font-weight: 800; color: var(--accent); }
+  .std-note { font-size: 11px; color: var(--text-muted); margin-top: 4px; }
 
   @media (max-width: 600px) { .standards-grid { grid-template-columns: 1fr; } }
+
+  @media (max-width: 480px) {
+    body { font-size: 14px; }
+    .circuit-diagram { grid-template-columns: 1fr 120px 1fr; }
+    .leg-name { font-size: 11px; }
+    .leg-detail { font-size: 10px; }
+    td, td strong { font-size: 14px; }
+    th { font-size: 11px; }
+    .std-value { font-size: 15px; }
+  }
 </style>
 </head>
 <body>
@@ -154,34 +164,34 @@
   </thead>
   <tbody>
     <tr>
-      <td><span style="color:#f0c040;font-weight:800;">1</span></td>
+      <td><span style="color:var(--accent);font-weight:800;">1</span></td>
       <td class="leg-name-col">Upwind</td>
       <td>Departure, same direction as runway heading, climbing</td>
-      <td style="font-size:12px;color:#7a9ab5;">Initial climb-out, retract flaps</td>
+      <td style="font-size:12px;color:var(--text-muted);">Initial climb-out, retract flaps</td>
     </tr>
     <tr>
-      <td><span style="color:#f0c040;font-weight:800;">2</span></td>
+      <td><span style="color:var(--accent);font-weight:800;">2</span></td>
       <td class="leg-name-col">Crosswind</td>
       <td>Perpendicular to runway, away from aerodrome</td>
-      <td style="font-size:12px;color:#7a9ab5;">Continue climb to circuit altitude</td>
+      <td style="font-size:12px;color:var(--text-muted);">Continue climb to circuit altitude</td>
     </tr>
     <tr>
-      <td><span style="color:#f0c040;font-weight:800;">3</span></td>
+      <td><span style="color:var(--accent);font-weight:800;">3</span></td>
       <td class="leg-name-col">Downwind</td>
       <td>Parallel to runway, opposite direction to landing, at circuit altitude</td>
-      <td style="font-size:12px;color:#7a9ab5;">ATIS/altimeter, fuel, pre-landing checks</td>
+      <td style="font-size:12px;color:var(--text-muted);">ATIS/altimeter, fuel, pre-landing checks</td>
     </tr>
     <tr>
-      <td><span style="color:#f0c040;font-weight:800;">4</span></td>
+      <td><span style="color:var(--accent);font-weight:800;">4</span></td>
       <td class="leg-name-col">Base</td>
       <td>Perpendicular to runway, toward the runway</td>
-      <td style="font-size:12px;color:#7a9ab5;">Reduce speed, extend flaps, begin descent</td>
+      <td style="font-size:12px;color:var(--text-muted);">Reduce speed, extend flaps, begin descent</td>
     </tr>
     <tr>
-      <td><span style="color:#f0c040;font-weight:800;">5</span></td>
+      <td><span style="color:var(--accent);font-weight:800;">5</span></td>
       <td class="leg-name-col">Final</td>
       <td>Aligned with runway, into wind, descending to land</td>
-      <td style="font-size:12px;color:#7a9ab5;">Manage descent rate, airspeed, alignment</td>
+      <td style="font-size:12px;color:var(--text-muted);">Manage descent rate, airspeed, alignment</td>
     </tr>
   </tbody>
 </table>

--- a/web-app/public/visuals/al006-aerodrome-traffic-circuit.html
+++ b/web-app/public/visuals/al006-aerodrome-traffic-circuit.html
@@ -7,7 +7,7 @@
 <title>AL-006: Aerodrome Traffic Circuit</title>
 <style>
   /* Circuit diagram using CSS grid */
-  .circuit-container { background: #0a1520; border: 1.5px solid #1a2d3d; border-radius: 10px; padding: 24px; margin-bottom: 28px; }
+  .circuit-container { background: var(--bg); border: 1.5px solid var(--border); border-radius: 10px; padding: 24px; margin-bottom: 28px; }
   .circuit-diagram { display: grid; grid-template-columns: 1fr 180px 1fr; grid-template-rows: auto auto auto auto auto; gap: 0; max-width: 600px; margin: 0 auto; }
 
   /* Runway */
@@ -45,14 +45,14 @@
 
   /* Legs reference table */
   table { width: 100%; border-collapse: collapse; font-size: 13px; margin-bottom: 28px; }
-  th { background: #1a2d3d; color: var(--text-muted); padding: 9px 12px; text-align: left; font-size: 11px; text-transform: uppercase; letter-spacing: 0.5px; }
-  td { padding: 10px 12px; border-bottom: 1px solid #1a2d3d; vertical-align: top; }
+  th { background: var(--surface2); color: var(--text-muted); padding: 9px 12px; text-align: left; font-size: 11px; text-transform: uppercase; letter-spacing: 0.5px; }
+  td { padding: 10px 12px; border-bottom: 1px solid var(--border); vertical-align: top; }
   .leg-name-col { font-weight: 700; color: var(--accent); }
-  .leg-order { display: inline-block; width: 20px; height: 20px; border-radius: 50%; background: #1a2d3d; color: var(--text-muted); font-size: 10px; font-weight: 800; text-align: center; line-height: 20px; margin-right: 6px; }
+  .leg-order { display: inline-block; width: 20px; height: 20px; border-radius: 50%; background: var(--border); color: var(--text-muted); font-size: 10px; font-weight: 800; text-align: center; line-height: 20px; margin-right: 6px; }
 
   /* Standards panel */
   .standards-grid { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 12px; margin-bottom: 28px; }
-  .std-card { background: #1a2d3d; border-radius: 8px; padding: 14px 16px; }
+  .std-card { background: var(--surface2); border-radius: 8px; padding: 14px 16px; }
   .std-card h3 { font-size: 11px; color: var(--text-muted); text-transform: uppercase; letter-spacing: 0.5px; margin-bottom: 8px; }
   .std-value { font-size: 16px; font-weight: 800; color: var(--accent); }
   .std-note { font-size: 11px; color: var(--text-muted); margin-top: 4px; }

--- a/web-app/public/visuals/al006-aerodrome-traffic-circuit.html
+++ b/web-app/public/visuals/al006-aerodrome-traffic-circuit.html
@@ -71,7 +71,7 @@
 </style>
 </head>
 <body>
-  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:#f0c040;border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
+  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:var(--accent);border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
   <style>.container{padding-top:56px!important;}@media(max-width:480px){.container{padding-top:60px!important;}}</style>
 
 <h1>AL-006 — Aerodrome Traffic Circuit</h1>

--- a/web-app/public/visuals/al007-radio-communications.html
+++ b/web-app/public/visuals/al007-radio-communications.html
@@ -8,16 +8,16 @@
 <style>
   /* Phonetic alphabet — two-column grid */
   .alphabet-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 3px; margin-bottom: 28px; border-radius: 8px; overflow: hidden; border: 1.5px solid #1a2d3d; }
-  .alpha-row { display: grid; grid-template-columns: 36px 1fr; align-items: center; padding: 7px 12px; background: #0d1b2a; border-bottom: 1px solid rgba(255,255,255,0.04); }
+  .alpha-row { display: grid; grid-template-columns: 36px 1fr; align-items: center; padding: 7px 12px; background: var(--bg2); border-bottom: 1px solid rgba(255,255,255,0.04); }
   .alpha-row:nth-child(even) { background: #0a1520; }
-  .alpha-letter { font-size: 16px; font-weight: 800; color: #f0c040; }
+  .alpha-letter { font-size: 16px; font-weight: 800; color: var(--accent); }
   .alpha-word { font-size: 13px; color: #e8edf2; }
 
   /* Phraseology table */
   table { width: 100%; border-collapse: collapse; font-size: 13px; margin-bottom: 28px; }
-  th { background: #1a2d3d; color: #7a9ab5; padding: 9px 12px; text-align: left; font-size: 11px; text-transform: uppercase; letter-spacing: 0.5px; }
+  th { background: #1a2d3d; color: var(--text-muted); padding: 9px 12px; text-align: left; font-size: 11px; text-transform: uppercase; letter-spacing: 0.5px; }
   td { padding: 10px 12px; border-bottom: 1px solid #1a2d3d; vertical-align: top; }
-  .word-col { font-weight: 800; color: #f0c040; font-size: 14px; }
+  .word-col { font-weight: 800; color: var(--accent); font-size: 14px; }
   .meaning-col { color: #e8edf2; }
   .trap-col { font-size: 12px; color: #ff9090; }
 
@@ -26,9 +26,18 @@
   .gun-green { color: #80e080; }
   .gun-red { color: #ff9090; }
   .gun-white { color: #e8edf2; }
-  .gun-alt { color: #f0c040; }
+  .gun-alt { color: var(--accent); }
 
   @media (max-width: 500px) { .alphabet-grid { grid-template-columns: 1fr; } }
+
+  @media (max-width: 480px) {
+    body { font-size: 14px; }
+    td, .meaning-col { font-size: 14px; }
+    th { font-size: 11px; }
+    .word-col { font-size: 14px; }
+    .trap-col { font-size: 12px; }
+    .alpha-word { font-size: 14px; }
+  }
 </style>
 </head>
 <body>
@@ -123,7 +132,7 @@
   <tbody>
     <tr>
       <td style="font-weight:600;">Take-off / Landing / Crossing / Hold-short clearance</td>
-      <td><span style="color:#f0c040;font-weight:700;">Runway designation + Aircraft call sign</span> + any hold-short instruction</td>
+      <td><span style="color:var(--accent);font-weight:700;">Runway designation + Aircraft call sign</span> + any hold-short instruction</td>
     </tr>
     <tr>
       <td style="font-weight:600;">Taxi route including runway crossing</td>

--- a/web-app/public/visuals/al007-radio-communications.html
+++ b/web-app/public/visuals/al007-radio-communications.html
@@ -41,7 +41,7 @@
 </style>
 </head>
 <body>
-  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:#f0c040;border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
+  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:var(--accent);border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
   <style>.container{padding-top:56px!important;}@media(max-width:480px){.container{padding-top:60px!important;}}</style>
 
 <h1>AL-007 — Radio Communications</h1>

--- a/web-app/public/visuals/al007-radio-communications.html
+++ b/web-app/public/visuals/al007-radio-communications.html
@@ -7,25 +7,25 @@
 <title>AL-007: Radio Communications</title>
 <style>
   /* Phonetic alphabet — two-column grid */
-  .alphabet-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 3px; margin-bottom: 28px; border-radius: 8px; overflow: hidden; border: 1.5px solid #1a2d3d; }
+  .alphabet-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 3px; margin-bottom: 28px; border-radius: 8px; overflow: hidden; border: 1.5px solid var(--border); }
   .alpha-row { display: grid; grid-template-columns: 36px 1fr; align-items: center; padding: 7px 12px; background: var(--bg2); border-bottom: 1px solid rgba(255,255,255,0.04); }
-  .alpha-row:nth-child(even) { background: #0a1520; }
+  .alpha-row:nth-child(even) { background: var(--bg); }
   .alpha-letter { font-size: 16px; font-weight: 800; color: var(--accent); }
-  .alpha-word { font-size: 13px; color: #e8edf2; }
+  .alpha-word { font-size: 13px; color: var(--text); }
 
   /* Phraseology table */
   table { width: 100%; border-collapse: collapse; font-size: 13px; margin-bottom: 28px; }
-  th { background: #1a2d3d; color: var(--text-muted); padding: 9px 12px; text-align: left; font-size: 11px; text-transform: uppercase; letter-spacing: 0.5px; }
-  td { padding: 10px 12px; border-bottom: 1px solid #1a2d3d; vertical-align: top; }
+  th { background: var(--surface2); color: var(--text-muted); padding: 9px 12px; text-align: left; font-size: 11px; text-transform: uppercase; letter-spacing: 0.5px; }
+  td { padding: 10px 12px; border-bottom: 1px solid var(--border); vertical-align: top; }
   .word-col { font-weight: 800; color: var(--accent); font-size: 14px; }
-  .meaning-col { color: #e8edf2; }
+  .meaning-col { color: var(--text); }
   .trap-col { font-size: 12px; color: #ff9090; }
 
   /* Light gun table */
   .gun-table td:first-child { font-weight: 700; }
   .gun-green { color: #80e080; }
   .gun-red { color: #ff9090; }
-  .gun-white { color: #e8edf2; }
+  .gun-white { color: var(--text); }
   .gun-alt { color: var(--accent); }
 
   @media (max-width: 500px) { .alphabet-grid { grid-template-columns: 1fr; } }

--- a/web-app/public/visuals/al008-atc-services-clearances.html
+++ b/web-app/public/visuals/al008-atc-services-clearances.html
@@ -62,7 +62,7 @@
 </style>
 </head>
 <body>
-  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:#f0c040;border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
+  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:var(--accent);border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
   <style>.container{padding-top:56px!important;}@media(max-width:480px){.container{padding-top:60px!important;}}</style>
 
 <h1>AL-008 — ATC Services and Clearances</h1>

--- a/web-app/public/visuals/al008-atc-services-clearances.html
+++ b/web-app/public/visuals/al008-atc-services-clearances.html
@@ -9,27 +9,27 @@
   /* ATC units cards */
   .units-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; margin-bottom: 28px; }
   .unit-card { background: #1a2d3d; border-radius: 8px; padding: 16px; border-left: 4px solid #1a2d3d; }
-  .unit-card.twr { border-left-color: #f0c040; }
+  .unit-card.twr { border-left-color: var(--accent); }
   .unit-card.tcu { border-left-color: #80b8ff; }
   .unit-card.acc { border-left-color: #80e080; }
-  .unit-card.fss { border-left-color: #7a9ab5; }
+  .unit-card.fss { border-left-color: var(--text-muted); }
   .unit-abbr { font-size: 18px; font-weight: 800; margin-bottom: 2px; }
-  .twr .unit-abbr { color: #f0c040; }
+  .twr .unit-abbr { color: var(--accent); }
   .tcu .unit-abbr { color: #80b8ff; }
   .acc .unit-abbr { color: #80e080; }
-  .fss .unit-abbr { color: #7a9ab5; }
-  .unit-name { font-size: 12px; color: #7a9ab5; margin-bottom: 8px; }
+  .fss .unit-abbr { color: var(--text-muted); }
+  .unit-name { font-size: 12px; color: var(--text-muted); margin-bottom: 8px; }
   .unit-role { font-size: 13px; color: #e8edf2; line-height: 1.5; }
-  .unit-detail { font-size: 11px; color: #7a9ab5; margin-top: 6px; line-height: 1.4; }
+  .unit-detail { font-size: 11px; color: var(--text-muted); margin-top: 6px; line-height: 1.4; }
   .not-atc { display: inline-block; font-size: 10px; background: rgba(150,150,150,0.12); color: #aaa; border: 1px solid rgba(150,150,150,0.25); border-radius: 4px; padding: 1px 6px; margin-bottom: 4px; }
 
   /* Handoff sequence */
   .handoff { display: flex; flex-direction: column; gap: 0; margin-bottom: 28px; border-radius: 10px; overflow: hidden; border: 1.5px solid #1a2d3d; }
   .handoff-row { display: grid; grid-template-columns: 36px 160px 1fr; align-items: center; padding: 11px 16px; gap: 12px; border-bottom: 1px solid rgba(255,255,255,0.05); }
   .handoff-row:last-child { border-bottom: none; }
-  .step-num { font-size: 11px; font-weight: 800; color: #7a9ab5; text-align: center; }
+  .step-num { font-size: 11px; font-weight: 800; color: var(--text-muted); text-align: center; }
   .step-unit { font-weight: 700; font-size: 13px; }
-  .step-twr { color: #f0c040; }
+  .step-twr { color: var(--accent); }
   .step-tcu { color: #80b8ff; }
   .step-acc { color: #80e080; }
   .step-gnd { color: #c8b870; }
@@ -38,17 +38,27 @@
   .dep-row { background: #0a1a0a; }
   .arr-row { background: #0a0a1a; }
   .header-row { background: #1a2d3d; }
-  .header-row .step-desc { color: #7a9ab5; font-weight: 700; font-size: 11px; text-transform: uppercase; letter-spacing: 0.5px; }
+  .header-row .step-desc { color: var(--text-muted); font-weight: 700; font-size: 11px; text-transform: uppercase; letter-spacing: 0.5px; }
 
   /* CRAFT table */
   table { width: 100%; border-collapse: collapse; font-size: 13px; margin-bottom: 28px; }
-  th { background: #1a2d3d; color: #7a9ab5; padding: 9px 12px; text-align: left; font-size: 11px; text-transform: uppercase; letter-spacing: 0.5px; }
+  th { background: #1a2d3d; color: var(--text-muted); padding: 9px 12px; text-align: left; font-size: 11px; text-transform: uppercase; letter-spacing: 0.5px; }
   td { padding: 10px 12px; border-bottom: 1px solid #1a2d3d; vertical-align: top; }
-  .craft-letter { font-size: 20px; font-weight: 800; color: #f0c040; width: 36px; }
+  .craft-letter { font-size: 20px; font-weight: 800; color: var(--accent); width: 36px; }
   .craft-word { font-weight: 700; color: #e8edf2; }
-  .craft-desc { font-size: 12px; color: #7a9ab5; margin-top: 3px; }
+  .craft-desc { font-size: 12px; color: var(--text-muted); margin-top: 3px; }
 
   @media (max-width: 550px) { .units-grid { grid-template-columns: 1fr; } }
+
+  @media (max-width: 480px) {
+    body { font-size: 14px; }
+    .handoff-row { grid-template-columns: 28px 1fr; gap: 8px; }
+    .handoff-row > :nth-child(3) { grid-column: 1 / -1; padding-left: 36px; }
+    .unit-role, .step-desc { font-size: 13px; }
+    td { font-size: 14px; }
+    th { font-size: 11px; }
+    .craft-desc { font-size: 12px; }
+  }
 </style>
 </head>
 <body>
@@ -146,27 +156,27 @@
     <tr>
       <td class="craft-letter">C</td>
       <td><span class="craft-word">Clearance limit</span><div class="craft-desc">The point to which you are cleared (usually destination)</div></td>
-      <td style="font-size:12px;color:#7a9ab5;">…cleared to CYOW…</td>
+      <td style="font-size:12px;color:var(--text-muted);">…cleared to CYOW…</td>
     </tr>
     <tr>
       <td class="craft-letter">R</td>
       <td><span class="craft-word">Route</span><div class="craft-desc">Airways, waypoints, or direct routing</div></td>
-      <td style="font-size:12px;color:#7a9ab5;">…via V300 direct…</td>
+      <td style="font-size:12px;color:var(--text-muted);">…via V300 direct…</td>
     </tr>
     <tr>
       <td class="craft-letter">A</td>
       <td><span class="craft-word">Altitude</span><div class="craft-desc">Cleared altitude; expect altitude en route</div></td>
-      <td style="font-size:12px;color:#7a9ab5;">…maintain FL180, expect FL220…</td>
+      <td style="font-size:12px;color:var(--text-muted);">…maintain FL180, expect FL220…</td>
     </tr>
     <tr>
       <td class="craft-letter">F</td>
       <td><span class="craft-word">Frequency</span><div class="craft-desc">Departure frequency to contact after take-off</div></td>
-      <td style="font-size:12px;color:#7a9ab5;">…departure 132.4…</td>
+      <td style="font-size:12px;color:var(--text-muted);">…departure 132.4…</td>
     </tr>
     <tr>
       <td class="craft-letter">T</td>
       <td><span class="craft-word">Transponder</span><div class="craft-desc">Squawk code assigned by ATC</div></td>
-      <td style="font-size:12px;color:#7a9ab5;">…squawk 4521</td>
+      <td style="font-size:12px;color:var(--text-muted);">…squawk 4521</td>
     </tr>
   </tbody>
 </table>

--- a/web-app/public/visuals/al008-atc-services-clearances.html
+++ b/web-app/public/visuals/al008-atc-services-clearances.html
@@ -8,7 +8,7 @@
 <style>
   /* ATC units cards */
   .units-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; margin-bottom: 28px; }
-  .unit-card { background: #1a2d3d; border-radius: 8px; padding: 16px; border-left: 4px solid #1a2d3d; }
+  .unit-card { background: var(--surface2); border-radius: 8px; padding: 16px; border-left: 4px solid var(--border); }
   .unit-card.twr { border-left-color: var(--accent); }
   .unit-card.tcu { border-left-color: #80b8ff; }
   .unit-card.acc { border-left-color: #80e080; }
@@ -19,12 +19,12 @@
   .acc .unit-abbr { color: #80e080; }
   .fss .unit-abbr { color: var(--text-muted); }
   .unit-name { font-size: 12px; color: var(--text-muted); margin-bottom: 8px; }
-  .unit-role { font-size: 13px; color: #e8edf2; line-height: 1.5; }
+  .unit-role { font-size: 13px; color: var(--text); line-height: 1.5; }
   .unit-detail { font-size: 11px; color: var(--text-muted); margin-top: 6px; line-height: 1.4; }
   .not-atc { display: inline-block; font-size: 10px; background: rgba(150,150,150,0.12); color: #aaa; border: 1px solid rgba(150,150,150,0.25); border-radius: 4px; padding: 1px 6px; margin-bottom: 4px; }
 
   /* Handoff sequence */
-  .handoff { display: flex; flex-direction: column; gap: 0; margin-bottom: 28px; border-radius: 10px; overflow: hidden; border: 1.5px solid #1a2d3d; }
+  .handoff { display: flex; flex-direction: column; gap: 0; margin-bottom: 28px; border-radius: 10px; overflow: hidden; border: 1.5px solid var(--border); }
   .handoff-row { display: grid; grid-template-columns: 36px 160px 1fr; align-items: center; padding: 11px 16px; gap: 12px; border-bottom: 1px solid rgba(255,255,255,0.05); }
   .handoff-row:last-child { border-bottom: none; }
   .step-num { font-size: 11px; font-weight: 800; color: var(--text-muted); text-align: center; }
@@ -33,19 +33,19 @@
   .step-tcu { color: #80b8ff; }
   .step-acc { color: #80e080; }
   .step-gnd { color: #c8b870; }
-  .step-cd { color: #d0a050; }
-  .step-desc { font-size: 12px; color: #c8d8e8; }
+  .step-cd { color: #d0a050; } /* design-exception: Clearance Delivery amber, distinguishes from Ground (#c8b870) */
+  .step-desc { font-size: 12px; color: var(--text); }
   .dep-row { background: #0a1a0a; }
   .arr-row { background: #0a0a1a; }
-  .header-row { background: #1a2d3d; }
+  .header-row { background: var(--surface2); }
   .header-row .step-desc { color: var(--text-muted); font-weight: 700; font-size: 11px; text-transform: uppercase; letter-spacing: 0.5px; }
 
   /* CRAFT table */
   table { width: 100%; border-collapse: collapse; font-size: 13px; margin-bottom: 28px; }
-  th { background: #1a2d3d; color: var(--text-muted); padding: 9px 12px; text-align: left; font-size: 11px; text-transform: uppercase; letter-spacing: 0.5px; }
-  td { padding: 10px 12px; border-bottom: 1px solid #1a2d3d; vertical-align: top; }
+  th { background: var(--surface2); color: var(--text-muted); padding: 9px 12px; text-align: left; font-size: 11px; text-transform: uppercase; letter-spacing: 0.5px; }
+  td { padding: 10px 12px; border-bottom: 1px solid var(--border); vertical-align: top; }
   .craft-letter { font-size: 20px; font-weight: 800; color: var(--accent); width: 36px; }
-  .craft-word { font-weight: 700; color: #e8edf2; }
+  .craft-word { font-weight: 700; color: var(--text); }
   .craft-desc { font-size: 12px; color: var(--text-muted); margin-top: 3px; }
 
   @media (max-width: 550px) { .units-grid { grid-template-columns: 1fr; } }

--- a/web-app/public/visuals/al009-flight-plans-itineraries.html
+++ b/web-app/public/visuals/al009-flight-plans-itineraries.html
@@ -1,0 +1,157 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>AL-009: Flight Plans and Itineraries</title>
+<link rel="stylesheet" href="/visuals/_common.css">
+<style>
+  .compare-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 14px; margin-bottom: 28px; }
+  .compare-card { background: #0a1a35; border: 1.5px solid #1a3a5a; border-radius: 8px; padding: 18px 20px; }
+  .compare-card h3 { font-size: 13px; font-weight: 700; color: var(--accent); margin-bottom: 8px; }
+  .compare-card p, .compare-card li { font-size: 13px; color: #c8d8e8; line-height: 1.7; }
+  .compare-card ul { padding-left: 18px; margin-top: 6px; }
+  .card-tag { display: inline-block; font-size: 10px; font-weight: 700; text-transform: uppercase; letter-spacing: 1px; padding: 2px 8px; border-radius: 10px; margin-bottom: 8px; }
+  .tag-atc { background: rgba(91,155,213,0.15); color: var(--info); border: 1px solid rgba(91,155,213,0.3); }
+  .tag-resp { background: rgba(76,175,125,0.12); color: var(--success); border: 1px solid rgba(76,175,125,0.3); }
+
+  /* Requirement table */
+  table { width: 100%; border-collapse: collapse; font-size: 13px; margin-bottom: 28px; }
+  th { background: #1a2d3d; color: var(--text-muted); padding: 9px 12px; text-align: left; font-size: 11px; text-transform: uppercase; letter-spacing: 0.5px; }
+  td { padding: 10px 12px; border-bottom: 1px solid #1a2d3d; vertical-align: top; }
+  td strong { color: var(--accent); }
+
+  /* ICAO field list */
+  .field-list { display: grid; grid-template-columns: 40px 1fr; gap: 4px 12px; margin-bottom: 28px; }
+  .field-num { font-size: 13px; font-weight: 800; color: var(--accent); padding: 6px 0; }
+  .field-desc { font-size: 13px; color: #c8d8e8; padding: 6px 0; border-bottom: 1px solid rgba(255,255,255,0.04); }
+  .field-num + .field-desc { border-bottom: 1px solid rgba(255,255,255,0.04); }
+
+  /* SAR timing callout */
+  .sar-box { background: #1a2a1a; border: 1.5px solid #2d5a2d; border-radius: 8px; padding: 16px 20px; margin-bottom: 28px; }
+  .sar-box h3 { font-size: 12px; color: #80c880; text-transform: uppercase; letter-spacing: 1px; margin-bottom: 12px; }
+  .sar-row { display: flex; gap: 12px; align-items: flex-start; margin-bottom: 8px; }
+  .sar-label { font-size: 11px; font-weight: 800; color: #80c880; background: #2d5a2d; padding: 2px 8px; border-radius: 10px; white-space: nowrap; flex-shrink: 0; margin-top: 2px; }
+  .sar-text { font-size: 13px; color: #c8d8c8; line-height: 1.5; }
+  .sar-text strong { color: var(--accent); }
+
+  @media (max-width: 640px) {
+    .compare-grid { grid-template-columns: 1fr; }
+    .field-list { grid-template-columns: 32px 1fr; }
+  }
+
+  @media (max-width: 480px) {
+    body { font-size: 14px; }
+    td, .compare-card p, .compare-card li, .sar-text, .field-desc { font-size: 14px; }
+    th { font-size: 11px; }
+  }
+</style>
+</head>
+<body>
+  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:#f0c040;border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
+  <style>.container{padding-top:56px!important;}@media(max-width:480px){.container{padding-top:60px!important;}}</style>
+<div class="container">
+  <h1>AL-009 — Flight Plans &amp; Itineraries</h1>
+  <p class="subtitle">Transport Canada · CARs 602.73–602.78, TP 12880E, AIM RAC 3.6 · PPL Written Exam</p>
+
+  <div class="section-label">Flight Plan vs. Flight Itinerary</div>
+  <div class="compare-grid">
+    <div class="compare-card">
+      <span class="card-tag tag-atc">Flight Plan</span>
+      <h3>Filed with ATC / FSS</h3>
+      <ul>
+        <li>Submitted to an ATC unit or Flight Service Station</li>
+        <li>Activates SAR alerting if overdue on arrival</li>
+        <li><strong>Required</strong> for all IFR flights</li>
+        <li>Required for VFR flights entering Class B airspace</li>
+        <li>Recommended for any overwater or remote VFR flight</li>
+        <li>Must be closed — failure to close triggers a SAR response</li>
+      </ul>
+    </div>
+    <div class="compare-card">
+      <span class="card-tag tag-resp">Flight Itinerary</span>
+      <h3>Left with a Responsible Person</h3>
+      <ul>
+        <li>Provided to a person on the ground (friend, FBO, employer)</li>
+        <li>Responsible person notifies SAR if pilot is overdue</li>
+        <li>Required for flights over remote or uninhabited terrain where a flight plan is not filed</li>
+        <li>No formal closing procedure — notify the responsible person upon arrival</li>
+        <li>SAR not automatically alerted — depends on responsible person acting</li>
+      </ul>
+    </div>
+  </div>
+
+  <div class="section-label">When a Flight Plan is Required — CARs 602.73</div>
+  <table>
+    <thead>
+      <tr><th>Flight Type</th><th>Flight Plan Required?</th><th>Notes</th></tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><strong>IFR — any route</strong></td>
+        <td><span class="yes">Yes — always</span></td>
+        <td>No exceptions. Must be filed before departure.</td>
+      </tr>
+      <tr>
+        <td><strong>VFR — Class B airspace</strong></td>
+        <td><span class="yes">Yes</span></td>
+        <td>Class B requires a clearance, which requires a flight plan.</td>
+      </tr>
+      <tr>
+        <td><strong>VFR — Class C/D controlled</strong></td>
+        <td><span class="no">Not required</span></td>
+        <td>Clearance needed to enter, but no flight plan mandatory.</td>
+      </tr>
+      <tr>
+        <td><strong>VFR — remote / uninhabited terrain</strong></td>
+        <td>Flight plan <em>or</em> itinerary</td>
+        <td>CARs 602.73(2): must have one or the other over hostile terrain.</td>
+      </tr>
+      <tr>
+        <td><strong>VFR — local / non-remote</strong></td>
+        <td><span class="no">Not required</span></td>
+        <td>Recommended practice for any cross-country flight.</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <div class="section-label">ICAO Flight Plan — Key Fields (Form CA 3093)</div>
+  <div class="field-list">
+    <div class="field-num">7</div><div class="field-desc">Aircraft identification (call sign / registration)</div>
+    <div class="field-num">8</div><div class="field-desc">Flight rules (I=IFR, V=VFR, Y/Z=mixed) and type of flight</div>
+    <div class="field-num">9</div><div class="field-desc">Number and type of aircraft; wake turbulence category; equipment</div>
+    <div class="field-num">10</div><div class="field-desc">Radio/navigation equipment and capabilities (COM/NAV/SSR)</div>
+    <div class="field-num">13</div><div class="field-desc">Departure aerodrome (ICAO 4-letter code) and estimated off-block time (UTC)</div>
+    <div class="field-num">15</div><div class="field-desc">Cruising speed, level, and route (airways or DCT)</div>
+    <div class="field-num">16</div><div class="field-desc">Destination aerodrome, total estimated elapsed time, alternate(s)</div>
+    <div class="field-num">18</div><div class="field-desc">Other information (STS/, PBN/, DOF/, etc.)</div>
+    <div class="field-num">19</div><div class="field-desc">Emergency info: fuel endurance, persons on board, survival equipment, ELT</div>
+  </div>
+
+  <div class="section-label">SAR Notification Timelines</div>
+  <div class="sar-box">
+    <h3>When Search and Rescue is Alerted</h3>
+    <div class="sar-row">
+      <span class="sar-label">Flight Plan</span>
+      <span class="sar-text">Aircraft is considered overdue when it has not arrived within <strong>1 hour</strong> of the ETA and has not closed the flight plan. ATC/FSS initiates the overdue aircraft procedure (ALERFA/DETRESFA).</span>
+    </div>
+    <div class="sar-row">
+      <span class="sar-label">Itinerary</span>
+      <span class="sar-text">The responsible person must notify the nearest JRCC (Joint Rescue Coordination Centre) or ATC unit within <strong>24 hours</strong> of the aircraft being overdue, or at whatever time is specified in the itinerary.</span>
+    </div>
+    <div class="sar-row">
+      <span class="sar-label">Closing</span>
+      <span class="sar-text">A flight plan <strong>must be closed</strong> by radio, phone, or in person with ATC/FSS on arrival. Failure to close is an offence under CARs 602.77 and triggers an unnecessary SAR response.</span>
+    </div>
+  </div>
+
+  <div class="hook-box">
+    <h2>Key Facts for the Exam</h2>
+    <div class="hook-row"><span class="hook-badge">IFR = Plan</span><span class="hook-text">IFR flights always require a flight plan — no exceptions. VFR flights require a plan or itinerary only when over <strong>remote or uninhabited terrain</strong>.</span></div>
+    <div class="hook-row"><span class="hook-badge">Always Close</span><span class="hook-text">Failure to close a flight plan is a <strong>CARs offence</strong> and wastes SAR resources. Close by phone (1-800-WXBRIEF) or radio to FSS/ATC.</span></div>
+    <div class="hook-row"><span class="hook-badge">Itinerary ≠ Plan</span><span class="hook-text">An itinerary left with a responsible person does <strong>not</strong> automatically alert SAR — that person must take action. A flight plan does alert SAR automatically when overdue.</span></div>
+    <div class="hook-row"><span class="hook-badge">Field 19</span><span class="hook-text">Field 19 covers <strong>emergency and survival information</strong>: fuel endurance, persons on board, survival equipment, ELT type — know what goes here.</span></div>
+  </div>
+</div>
+</body>
+</html>

--- a/web-app/public/visuals/al009-flight-plans-itineraries.html
+++ b/web-app/public/visuals/al009-flight-plans-itineraries.html
@@ -48,7 +48,7 @@
 </style>
 </head>
 <body>
-  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:#f0c040;border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
+  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:var(--accent);border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
   <style>.container{padding-top:56px!important;}@media(max-width:480px){.container{padding-top:60px!important;}}</style>
 <div class="container">
   <h1>AL-009 — Flight Plans &amp; Itineraries</h1>

--- a/web-app/public/visuals/al009-flight-plans-itineraries.html
+++ b/web-app/public/visuals/al009-flight-plans-itineraries.html
@@ -7,9 +7,9 @@
 <link rel="stylesheet" href="/visuals/_common.css">
 <style>
   .compare-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 14px; margin-bottom: 28px; }
-  .compare-card { background: #0a1a35; border: 1.5px solid #1a3a5a; border-radius: 8px; padding: 18px 20px; }
+  .compare-card { background: var(--surface); border: 1.5px solid var(--border); border-radius: 8px; padding: 18px 20px; }
   .compare-card h3 { font-size: 13px; font-weight: 700; color: var(--accent); margin-bottom: 8px; }
-  .compare-card p, .compare-card li { font-size: 13px; color: #c8d8e8; line-height: 1.7; }
+  .compare-card p, .compare-card li { font-size: 13px; color: var(--text); line-height: 1.7; }
   .compare-card ul { padding-left: 18px; margin-top: 6px; }
   .card-tag { display: inline-block; font-size: 10px; font-weight: 700; text-transform: uppercase; letter-spacing: 1px; padding: 2px 8px; border-radius: 10px; margin-bottom: 8px; }
   .tag-atc { background: rgba(91,155,213,0.15); color: var(--info); border: 1px solid rgba(91,155,213,0.3); }
@@ -17,14 +17,14 @@
 
   /* Requirement table */
   table { width: 100%; border-collapse: collapse; font-size: 13px; margin-bottom: 28px; }
-  th { background: #1a2d3d; color: var(--text-muted); padding: 9px 12px; text-align: left; font-size: 11px; text-transform: uppercase; letter-spacing: 0.5px; }
-  td { padding: 10px 12px; border-bottom: 1px solid #1a2d3d; vertical-align: top; }
+  th { background: var(--surface2); color: var(--text-muted); padding: 9px 12px; text-align: left; font-size: 11px; text-transform: uppercase; letter-spacing: 0.5px; }
+  td { padding: 10px 12px; border-bottom: 1px solid var(--border); vertical-align: top; }
   td strong { color: var(--accent); }
 
   /* ICAO field list */
   .field-list { display: grid; grid-template-columns: 40px 1fr; gap: 4px 12px; margin-bottom: 28px; }
   .field-num { font-size: 13px; font-weight: 800; color: var(--accent); padding: 6px 0; }
-  .field-desc { font-size: 13px; color: #c8d8e8; padding: 6px 0; border-bottom: 1px solid rgba(255,255,255,0.04); }
+  .field-desc { font-size: 13px; color: var(--text); padding: 6px 0; border-bottom: 1px solid rgba(255,255,255,0.04); }
   .field-num + .field-desc { border-bottom: 1px solid rgba(255,255,255,0.04); }
 
   /* SAR timing callout */
@@ -32,7 +32,7 @@
   .sar-box h3 { font-size: 12px; color: #80c880; text-transform: uppercase; letter-spacing: 1px; margin-bottom: 12px; }
   .sar-row { display: flex; gap: 12px; align-items: flex-start; margin-bottom: 8px; }
   .sar-label { font-size: 11px; font-weight: 800; color: #80c880; background: #2d5a2d; padding: 2px 8px; border-radius: 10px; white-space: nowrap; flex-shrink: 0; margin-top: 2px; }
-  .sar-text { font-size: 13px; color: #c8d8c8; line-height: 1.5; }
+  .sar-text { font-size: 13px; color: #c8d8c8; line-height: 1.5; } /* design-exception: greenish SAR text, distinguishes from primary body text */
   .sar-text strong { color: var(--accent); }
 
   @media (max-width: 640px) {

--- a/web-app/public/visuals/al010-notams.html
+++ b/web-app/public/visuals/al010-notams.html
@@ -46,7 +46,7 @@
 </style>
 </head>
 <body>
-  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:#f0c040;border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
+  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:var(--accent);border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
   <style>.container{padding-top:56px!important;}@media(max-width:480px){.container{padding-top:60px!important;}}</style>
 <div class="container">
   <h1>AL-010 — NOTAMs</h1>

--- a/web-app/public/visuals/al010-notams.html
+++ b/web-app/public/visuals/al010-notams.html
@@ -1,0 +1,175 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>AL-010: NOTAMs</title>
+<link rel="stylesheet" href="/visuals/_common.css">
+<style>
+  /* Type cards */
+  .type-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; margin-bottom: 28px; }
+  .type-card { background: #0a1a35; border: 1.5px solid #1a3a5a; border-radius: 8px; padding: 16px 18px; }
+  .type-card h3 { font-size: 13px; font-weight: 700; color: var(--accent); margin-bottom: 6px; }
+  .type-card p { font-size: 13px; color: #c8d8e8; line-height: 1.6; }
+  .type-badge { display: inline-block; font-size: 10px; font-weight: 800; text-transform: uppercase; letter-spacing: 1px; padding: 2px 8px; border-radius: 10px; margin-bottom: 8px; background: #1a2d3d; color: var(--text-muted); }
+
+  /* NOTAM format breakdown */
+  .notam-sample { background: #071020; border: 1.5px solid #1a3550; border-radius: 8px; padding: 18px 20px; margin-bottom: 28px; font-family: 'Courier New', monospace; }
+  .notam-sample .line { font-size: 13px; color: #c8d8e8; margin-bottom: 4px; word-break: break-all; }
+  .notam-sample .line .hl-acc { color: var(--accent); font-weight: 700; }
+  .notam-sample .line .hl-info { color: #80b8ff; }
+  .notam-sample .line .hl-ok { color: #80e080; }
+  .notam-sample .line .hl-warn { color: #ff9090; }
+  .legend { display: grid; grid-template-columns: 1fr 1fr; gap: 6px 16px; margin-top: 14px; }
+  .legend-item { display: flex; align-items: center; gap: 8px; font-size: 12px; color: #c8d8e8; }
+  .legend-dot { width: 10px; height: 10px; border-radius: 50%; flex-shrink: 0; }
+
+  /* Table */
+  table { width: 100%; border-collapse: collapse; font-size: 13px; margin-bottom: 28px; }
+  th { background: #1a2d3d; color: var(--text-muted); padding: 9px 12px; text-align: left; font-size: 11px; text-transform: uppercase; letter-spacing: 0.5px; }
+  td { padding: 10px 12px; border-bottom: 1px solid #1a2d3d; vertical-align: top; }
+  td strong { color: var(--accent); }
+  td code { font-family: 'Courier New', monospace; font-size: 12px; background: #1a2d3d; padding: 1px 5px; border-radius: 3px; color: #80b8ff; }
+
+  @media (max-width: 640px) {
+    .type-grid { grid-template-columns: 1fr; }
+    .legend { grid-template-columns: 1fr; }
+  }
+
+  @media (max-width: 480px) {
+    body { font-size: 14px; }
+    .type-card p, td { font-size: 14px; }
+    th { font-size: 11px; }
+    .notam-sample .line { font-size: 12px; }
+    .legend-item { font-size: 12px; }
+  }
+</style>
+</head>
+<body>
+  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:#f0c040;border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
+  <style>.container{padding-top:56px!important;}@media(max-width:480px){.container{padding-top:60px!important;}}</style>
+<div class="container">
+  <h1>AL-010 — NOTAMs</h1>
+  <p class="subtitle">Transport Canada · CARs 602.72, AIP Canada GEN 3.3, AIM RAC 2.1 · PPL Written Exam</p>
+
+  <div class="section-label">What is a NOTAM?</div>
+  <p style="font-size:13px;color:#c8d8e8;line-height:1.7;margin-bottom:20px;">
+    A <strong style="color:var(--accent);">NOTAM</strong> (Notice to Air Missions) is a notice containing information essential to personnel concerned with flight operations that is not known sufficiently in advance to be publicised by other means. NOTAMs are mandatory pre-flight briefing material — a pilot-in-command must review all applicable NOTAMs before any flight (CARs 602.72).
+  </p>
+
+  <div class="section-label">NOTAM Types</div>
+  <div class="type-grid">
+    <div class="type-card">
+      <span class="type-badge">NOTAM (D)</span>
+      <h3>Distributed NOTAM</h3>
+      <p>Standard NOTAM distributed nationally via the NOTAMplus system. Covers aerodromes, navaids, airspace restrictions, obstacles, and procedures. Most NOTAMs encountered in pre-flight briefings are D NOTAMs.</p>
+    </div>
+    <div class="type-card">
+      <span class="type-badge">NOTAM (L)</span>
+      <h3>Local NOTAM</h3>
+      <p>Distributed only to the affected local area. Covers information too minor or local for national distribution — e.g., a taxiway light outage at a small aerodrome. Not always available on national databases.</p>
+    </div>
+    <div class="type-card">
+      <span class="type-badge">SNOWTAM</span>
+      <h3>Snow / Runway Condition</h3>
+      <p>Special NOTAM series reporting snow, ice, slush, and braking action on runways and taxiways. Critical for winter operations — provides runway condition codes (RCC) per the Global Reporting Format (GRF).</p>
+    </div>
+    <div class="type-card">
+      <span class="type-badge">ASHTAM</span>
+      <h3>Volcanic Ash</h3>
+      <p>Special NOTAM series warning of volcanic ash cloud activity. Issued when volcanic ash is a hazard to aviation — provides location, altitude, and forecast movement of ash cloud.</p>
+    </div>
+  </div>
+
+  <div class="section-label">Reading a NOTAM — Sample Format</div>
+  <div class="notam-sample">
+    <div class="line"><span class="hl-acc">A1234/25</span> NOTAMN</div>
+    <div class="line">Q) <span class="hl-ok">CZEG</span>/<span class="hl-info">QMXLC</span>/IV/NBO/A/000/999/<span class="hl-ok">5117N11433W005</span></div>
+    <div class="line">A) <span class="hl-acc">CYYC</span> B) <span class="hl-ok">2503010600</span> C) <span class="hl-warn">2503312359</span></div>
+    <div class="line">E) TWY B BTN TWY C AND TWY D CLSD</div>
+    <div class="legend">
+      <div class="legend-item"><div class="legend-dot" style="background:var(--accent);"></div>A1234/25 — NOTAM number / year</div>
+      <div class="legend-item"><div class="legend-dot" style="background:#80b8ff;"></div>QMXLC — Q-code: subject &amp; condition</div>
+      <div class="legend-item"><div class="legend-dot" style="background:#80e080;"></div>CZEG — FIR; CYYC — aerodrome ICAO</div>
+      <div class="legend-item"><div class="legend-dot" style="background:#ff9090;"></div>C) 2503312359 — expiry (UTC)</div>
+    </div>
+  </div>
+
+  <div class="section-label">NOTAM Q-Code Subject Subjects — Common Examples</div>
+  <table>
+    <thead>
+      <tr><th>Q-Code</th><th>Subject</th><th>Example meaning</th></tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><code>MX</code></td>
+        <td><strong>Taxiway</strong></td>
+        <td><code>QMXLC</code> — Taxiway closed (L=limited, C=closed)</td>
+      </tr>
+      <tr>
+        <td><code>MR</code></td>
+        <td><strong>Runway</strong></td>
+        <td><code>QMRLC</code> — Runway closed; <code>QMRXX</code> — runway unserviceable</td>
+      </tr>
+      <tr>
+        <td><code>LT</code></td>
+        <td><strong>Lighting</strong></td>
+        <td><code>QLTLC</code> — Runway lighting unserviceable</td>
+      </tr>
+      <tr>
+        <td><code>NV</code></td>
+        <td><strong>Navaid (VOR)</strong></td>
+        <td><code>QNVAS</code> — VOR unserviceable</td>
+      </tr>
+      <tr>
+        <td><code>RA</code></td>
+        <td><strong>Airspace restriction</strong></td>
+        <td>Temporary restricted area, danger area activation</td>
+      </tr>
+      <tr>
+        <td><code>OB</code></td>
+        <td><strong>Obstacle</strong></td>
+        <td>New crane, tower, or structure — height and coordinates given</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <div class="section-label">Where to Find NOTAMs</div>
+  <table>
+    <thead>
+      <tr><th>Source</th><th>Coverage</th><th>Notes</th></tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><strong>NOTAMplus</strong> (nav.canada.ca)</td>
+        <td>Canadian domestic NOTAMs</td>
+        <td>Official NAV CANADA briefing system — use for pre-flight planning.</td>
+      </tr>
+      <tr>
+        <td><strong>FSS Pre-flight Briefing</strong></td>
+        <td>All applicable NOTAMs for route</td>
+        <td>Call 1-800-WXBRIEF or use online. Briefer consolidates relevant NOTAMs.</td>
+      </tr>
+      <tr>
+        <td><strong>CFRS (Canadian NOTAM)</strong></td>
+        <td>Domestic + international</td>
+        <td>Canadian Flight Route Service — for international departures.</td>
+      </tr>
+      <tr>
+        <td><strong>EFB / Aviation Apps</strong></td>
+        <td>Varies</td>
+        <td>Convenience only — must verify currency. Not a substitute for official briefing.</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <div class="hook-box">
+    <h2>Key Facts for the Exam</h2>
+    <div class="hook-row"><span class="hook-badge">Mandatory</span><span class="hook-text">CARs 602.72 requires the pilot-in-command to review <strong>all applicable NOTAMs</strong> before flight — this is a legal requirement, not a suggestion.</span></div>
+    <div class="hook-row"><span class="hook-badge">SNOWTAM</span><span class="hook-text">A SNOWTAM is a <strong>special NOTAM series</strong> — not a weather product. It reports runway surface conditions using the Global Reporting Format (GRF) runway condition codes.</span></div>
+    <div class="hook-row"><span class="hook-badge">Time Format</span><span class="hook-text">All NOTAM times are in <strong>UTC (Zulu)</strong>. The format YYMMDDHHMM is used — e.g., 2503010600 = 2025 March 01 at 0600Z.</span></div>
+    <div class="hook-row"><span class="hook-badge">PERM vs. EST</span><span class="hook-text">If the expiry field shows <strong>PERM</strong>, the condition is permanent. <strong>EST</strong> means estimated — the actual end time may differ.</span></div>
+  </div>
+</div>
+</body>
+</html>

--- a/web-app/public/visuals/al010-notams.html
+++ b/web-app/public/visuals/al010-notams.html
@@ -8,28 +8,28 @@
 <style>
   /* Type cards */
   .type-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; margin-bottom: 28px; }
-  .type-card { background: #0a1a35; border: 1.5px solid #1a3a5a; border-radius: 8px; padding: 16px 18px; }
+  .type-card { background: var(--surface); border: 1.5px solid var(--border); border-radius: 8px; padding: 16px 18px; }
   .type-card h3 { font-size: 13px; font-weight: 700; color: var(--accent); margin-bottom: 6px; }
-  .type-card p { font-size: 13px; color: #c8d8e8; line-height: 1.6; }
-  .type-badge { display: inline-block; font-size: 10px; font-weight: 800; text-transform: uppercase; letter-spacing: 1px; padding: 2px 8px; border-radius: 10px; margin-bottom: 8px; background: #1a2d3d; color: var(--text-muted); }
+  .type-card p { font-size: 13px; color: var(--text); line-height: 1.6; }
+  .type-badge { display: inline-block; font-size: 10px; font-weight: 800; text-transform: uppercase; letter-spacing: 1px; padding: 2px 8px; border-radius: 10px; margin-bottom: 8px; background: var(--border); color: var(--text-muted); }
 
   /* NOTAM format breakdown */
-  .notam-sample { background: #071020; border: 1.5px solid #1a3550; border-radius: 8px; padding: 18px 20px; margin-bottom: 28px; font-family: 'Courier New', monospace; }
-  .notam-sample .line { font-size: 13px; color: #c8d8e8; margin-bottom: 4px; word-break: break-all; }
+  .notam-sample { background: var(--bg); border: 1.5px solid var(--border); border-radius: 8px; padding: 18px 20px; margin-bottom: 28px; font-family: 'Courier New', monospace; }
+  .notam-sample .line { font-size: 13px; color: var(--text); margin-bottom: 4px; word-break: break-all; }
   .notam-sample .line .hl-acc { color: var(--accent); font-weight: 700; }
   .notam-sample .line .hl-info { color: #80b8ff; }
   .notam-sample .line .hl-ok { color: #80e080; }
   .notam-sample .line .hl-warn { color: #ff9090; }
   .legend { display: grid; grid-template-columns: 1fr 1fr; gap: 6px 16px; margin-top: 14px; }
-  .legend-item { display: flex; align-items: center; gap: 8px; font-size: 12px; color: #c8d8e8; }
+  .legend-item { display: flex; align-items: center; gap: 8px; font-size: 12px; color: var(--text); }
   .legend-dot { width: 10px; height: 10px; border-radius: 50%; flex-shrink: 0; }
 
   /* Table */
   table { width: 100%; border-collapse: collapse; font-size: 13px; margin-bottom: 28px; }
-  th { background: #1a2d3d; color: var(--text-muted); padding: 9px 12px; text-align: left; font-size: 11px; text-transform: uppercase; letter-spacing: 0.5px; }
-  td { padding: 10px 12px; border-bottom: 1px solid #1a2d3d; vertical-align: top; }
+  th { background: var(--surface2); color: var(--text-muted); padding: 9px 12px; text-align: left; font-size: 11px; text-transform: uppercase; letter-spacing: 0.5px; }
+  td { padding: 10px 12px; border-bottom: 1px solid var(--border); vertical-align: top; }
   td strong { color: var(--accent); }
-  td code { font-family: 'Courier New', monospace; font-size: 12px; background: #1a2d3d; padding: 1px 5px; border-radius: 3px; color: #80b8ff; }
+  td code { font-family: 'Courier New', monospace; font-size: 12px; background: var(--surface2); padding: 1px 5px; border-radius: 3px; color: #80b8ff; }
 
   @media (max-width: 640px) {
     .type-grid { grid-template-columns: 1fr; }
@@ -53,7 +53,7 @@
   <p class="subtitle">Transport Canada · CARs 602.72, AIP Canada GEN 3.3, AIM RAC 2.1 · PPL Written Exam</p>
 
   <div class="section-label">What is a NOTAM?</div>
-  <p style="font-size:13px;color:#c8d8e8;line-height:1.7;margin-bottom:20px;">
+  <p style="font-size:13px;color:var(--text);line-height:1.7;margin-bottom:20px;">
     A <strong style="color:var(--accent);">NOTAM</strong> (Notice to Air Missions) is a notice containing information essential to personnel concerned with flight operations that is not known sufficiently in advance to be publicised by other means. NOTAMs are mandatory pre-flight briefing material — a pilot-in-command must review all applicable NOTAMs before any flight (CARs 602.72).
   </p>
 


### PR DESCRIPTION
## Summary

- **al006/al007/al008**: replace hardcoded hex colours with CSS vars (`--accent`, `--text-muted`, `--bg2`) in local `<style>` blocks and inline styles, preserving SVG attributes and the five data-encoding colours (`#80b8ff`, `#80e080`, `#80c880`, `#ff9090`, `#c8b870`)
- **al006/al007/al008**: add `@media (max-width: 480px)` blocks — `font-size: 14px` body minimum, collapse multi-column grids, prevent horizontal overflow at 375 px
- **al009-flight-plans-itineraries.html**: new visual covering flight plan vs itinerary, when a plan is required (CARs 602.73), ICAO flight plan fields, SAR notification timelines, and exam hooks
- **al010-notams.html**: new visual covering NOTAM types (D/L/SNOWTAM/ASHTAM), Q-code format with annotated sample, common subject codes, where to find NOTAMs, and exam hooks

Both new files follow the gk001/met001 pattern: `<div class="container">` wrapper, `/visuals/_common.css` link, back-to-lesson button with inline style, container padding offset block, dark-aviation theme.

## Test plan

- [ ] Verify 375 px viewport: no horizontal scrollbar in al006/al007/al008/al009/al010
- [ ] Verify back-to-lesson button tap target ≥ 44×44 px on mobile
- [ ] Verify body text renders ≥ 14 px at ≤ 480 px in all five files
- [ ] Confirm data-encoding colours (#80b8ff, #80e080, #80c880, #ff9090, #c8b870) still hardcoded
- [ ] Confirm SVG fill/stroke attributes unchanged in al006
- [ ] `npm run build` passes with exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)