### PR TITLE
[PPL-248] Migrate MET-006–010 visuals to CSS vars + mobile fixes

### DIFF
--- a/web-app/public/visuals/met006-taf-decoding.html
+++ b/web-app/public/visuals/met006-taf-decoding.html
@@ -6,27 +6,31 @@
 <title>MET-006: TAF Decoding</title>
 <link rel="stylesheet" href="/visuals/_common.css">
 <style>
-  .taf-sample { background: #1a2d3d; border: 1px solid #243d52; border-radius: 8px; padding: 18px 20px; font-family: 'Consolas', 'Menlo', monospace; font-size: 14px; line-height: 1.9; margin-bottom: 14px; word-break: break-word; }
+  .taf-sample { background: var(--surface); border: 1px solid var(--border); border-radius: 8px; padding: 18px 20px; font-family: 'Consolas', 'Menlo', monospace; font-size: 14px; line-height: 1.9; margin-bottom: 14px; word-break: break-word; }
   .seg { padding: 2px 6px; border-radius: 3px; margin: 0 2px; display: inline-block; }
-  .s-hdr  { background: #2d3e50; color: #e8edf2; }
-  .s-time { background: #4c5b8c; color: #e8edf2; }
-  .s-base { background: #3a7a70; color: #e8edf2; }
-  .s-bec  { background: #806030; color: #e8edf2; }
-  .s-tmp  { background: #903a3a; color: #e8edf2; }
-  .s-fm   { background: #5a7a3a; color: #e8edf2; }
-  .s-prob { background: #6a4a7a; color: #e8edf2; }
-  td code { font-family: 'Consolas', 'Menlo', monospace; background: #0d1b2a; color: #f0c040; padding: 1px 6px; border-radius: 3px; font-size: 12px; }
-  .timeline { background: #1a2d3d; border: 1px solid #243d52; border-radius: 8px; padding: 14px 16px; margin-bottom: 14px; }
-  .t-bar { display: flex; height: 46px; border-radius: 4px; overflow: hidden; border: 1px solid #243d52; }
-  .t-block { flex: 1; padding: 6px 4px; text-align: center; font-size: 11px; color: #e8edf2; border-right: 1px solid #0d1b2a; line-height: 1.2; }
+  .s-hdr  { background: #2d3e50; color: var(--text); }
+  .s-time { background: #4c5b8c; color: var(--text); }
+  .s-base { background: #3a7a70; color: var(--text); }
+  .s-bec  { background: #806030; color: var(--text); }
+  .s-tmp  { background: #903a3a; color: var(--text); }
+  .s-fm   { background: #5a7a3a; color: var(--text); }
+  .s-prob { background: #6a4a7a; color: var(--text); }
+  td code { font-family: 'Consolas', 'Menlo', monospace; background: var(--bg); color: var(--accent); padding: 1px 6px; border-radius: 3px; font-size: 12px; }
+  .timeline { background: var(--surface); border: 1px solid var(--border); border-radius: 8px; padding: 14px 16px; margin-bottom: 14px; }
+  .t-bar { display: flex; height: 46px; border-radius: 4px; overflow: hidden; border: 1px solid var(--border); }
+  .t-block { flex: 1; padding: 6px 4px; text-align: center; font-size: 11px; color: var(--text); border-right: 1px solid var(--bg); line-height: 1.2; }
   .t-block:last-child { border-right: none; }
-  .t-block .hh { display: block; font-size: 10px; color: #7a9ab5; margin-top: 3px; }
+  .t-block .hh { display: block; font-size: 10px; color: var(--text-muted); margin-top: 3px; }
   .t-block.base { background: #2a4a5a; }
   .t-block.bec  { background: #806030; }
   .t-block.tmp  { background: #903a3a; }
   .t-block.fm   { background: #5a7a3a; }
-  .t-legend { margin-top: 10px; font-size: 11px; color: #7a9ab5; display: flex; gap: 14px; flex-wrap: wrap; }
+  .t-legend { margin-top: 10px; font-size: 11px; color: var(--text-muted); display: flex; gap: 14px; flex-wrap: wrap; }
   .t-legend .sw { display: inline-block; width: 12px; height: 12px; border-radius: 2px; vertical-align: middle; margin-right: 4px; }
+  @media (max-width: 480px) {
+    body { font-size: 14px; }
+    .t-bar { overflow-x: auto; }
+  }
 </style>
 </head>
 <body>
@@ -71,9 +75,9 @@
   <table>
     <thead><tr><th>Group</th><th>Duration</th><th>Certainty</th><th>Effect on previous line</th></tr></thead>
     <tbody>
-      <tr><td><strong style="color:#4caf7d;">FM</strong></td><td>Rapid (&lt; 1 hr) &amp; permanent</td><td>Certain</td><td>Replaces it entirely.</td></tr>
+      <tr><td><strong style="color:var(--success);">FM</strong></td><td>Rapid (&lt; 1 hr) &amp; permanent</td><td>Certain</td><td>Replaces it entirely.</td></tr>
       <tr><td><strong style="color:#ffb040;">BECMG</strong></td><td>Gradual, within window</td><td>Certain</td><td>Replaces after window ends.</td></tr>
-      <tr><td><strong style="color:#e05050;">TEMPO</strong></td><td>&lt; 1 hr at a time, &lt; half window</td><td>Certain fluctuations</td><td>Overlays it temporarily.</td></tr>
+      <tr><td><strong style="color:var(--danger);">TEMPO</strong></td><td>&lt; 1 hr at a time, &lt; half window</td><td>Certain fluctuations</td><td>Overlays it temporarily.</td></tr>
       <tr><td><strong style="color:#b070c0;">PROB30 / PROB40</strong></td><td>Window stated</td><td>Likelihood only</td><td>Overlays as possibility.</td></tr>
     </tbody>
   </table>

--- a/web-app/public/visuals/met007-gfa.html
+++ b/web-app/public/visuals/met007-gfa.html
@@ -7,17 +7,18 @@
 <link rel="stylesheet" href="/visuals/_common.css">
 <style>
   .chart-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; }
-  .chart-card { background: #1a2d3d; border: 1px solid #243d52; border-radius: 8px; padding: 16px; }
-  .chart-card h3 { font-size: 14px; color: #f0c040; margin-bottom: 4px; letter-spacing: 0.5px; }
-  .chart-card .sub { font-size: 11px; color: #7a9ab5; margin-bottom: 12px; letter-spacing: 0.5px; }
-  .chart-card ul { margin-left: 18px; font-size: 12px; color: #e8edf2; line-height: 1.7; }
+  .chart-card { background: var(--surface); border: 1px solid var(--border); border-radius: 8px; padding: 16px; }
+  .chart-card h3 { font-size: 14px; color: var(--accent); margin-bottom: 4px; letter-spacing: 0.5px; }
+  .chart-card .sub { font-size: 11px; color: var(--text-muted); margin-bottom: 12px; letter-spacing: 0.5px; }
+  .chart-card ul { margin-left: 18px; font-size: 12px; color: var(--text); line-height: 1.7; }
   .timeline { display: grid; grid-template-columns: repeat(4, 1fr); gap: 8px; margin-bottom: 14px; }
-  .t-panel { background: #1a2d3d; border: 1px solid #243d52; border-radius: 8px; padding: 12px; text-align: center; }
-  .t-panel .t-label { font-size: 11px; color: #7a9ab5; letter-spacing: 0.5px; }
-  .t-panel .t-time  { font-size: 18px; color: #f0c040; font-weight: bold; margin: 4px 0 2px; }
-  .t-panel .t-use   { font-size: 11px; color: #e8edf2; }
-  .symbol { display: inline-block; min-width: 28px; text-align: center; font-weight: bold; color: #f0c040; font-family: 'Consolas', monospace; }
+  .t-panel { background: var(--surface); border: 1px solid var(--border); border-radius: 8px; padding: 12px; text-align: center; }
+  .t-panel .t-label { font-size: 11px; color: var(--text-muted); letter-spacing: 0.5px; }
+  .t-panel .t-time  { font-size: 18px; color: var(--accent); font-weight: bold; margin: 4px 0 2px; }
+  .t-panel .t-use   { font-size: 11px; color: var(--text); }
+  .symbol { display: inline-block; min-width: 28px; text-align: center; font-weight: bold; color: var(--accent); font-family: 'Consolas', monospace; }
   @media (max-width: 640px) { .chart-grid { grid-template-columns: 1fr; } .timeline { grid-template-columns: repeat(2, 1fr); } }
+  @media (max-width: 480px) { body { font-size: 14px; } }
 </style>
 </head>
 <body>
@@ -59,7 +60,7 @@
     <div class="t-panel"><div class="t-label">T+12</div><div class="t-time">+12 hr</div><div class="t-use">End-of-day planning</div></div>
     <div class="t-panel"><div class="t-label">IFO</div><div class="t-time">+24 hr</div><div class="t-use">Outlook only (text)</div></div>
   </div>
-  <p style="font-size:12px; color:#7a9ab5; margin-bottom:10px;">Issued four times daily: <strong>0000Z, 0600Z, 1200Z, 1800Z</strong> — new set available within ~30 min of issue time.</p>
+  <p style="font-size:12px; color:var(--text-muted); margin-bottom:10px;">Issued four times daily: <strong>0000Z, 0600Z, 1200Z, 1800Z</strong> — new set available within ~30 min of issue time.</p>
 
   <div class="section-title">Symbol Legend (Essentials)</div>
   <table>

--- a/web-app/public/visuals/met008-pireps.html
+++ b/web-app/public/visuals/met008-pireps.html
@@ -6,24 +6,25 @@
 <title>MET-008: PIREPs</title>
 <link rel="stylesheet" href="/visuals/_common.css">
 <style>
-  .pirep-sample { background: #1a2d3d; border: 1px solid #243d52; border-radius: 8px; padding: 18px 20px; font-family: 'Consolas', 'Menlo', monospace; font-size: 14px; line-height: 1.9; margin-bottom: 14px; word-break: break-word; }
+  .pirep-sample { background: var(--surface); border: 1px solid var(--border); border-radius: 8px; padding: 18px 20px; font-family: 'Consolas', 'Menlo', monospace; font-size: 14px; line-height: 1.9; margin-bottom: 14px; word-break: break-word; }
   .seg { padding: 2px 6px; border-radius: 3px; margin: 0 2px; display: inline-block; }
-  .sh { background: #3d5a80; color: #e8edf2; }
-  td code { font-family: 'Consolas', 'Menlo', monospace; background: #0d1b2a; color: #f0c040; padding: 1px 6px; border-radius: 3px; font-size: 12px; }
+  .sh { background: #3d5a80; color: var(--text); }
+  td code { font-family: 'Consolas', 'Menlo', monospace; background: var(--bg); color: var(--accent); padding: 1px 6px; border-radius: 3px; font-size: 12px; }
   .intensity-grid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 10px; }
-  .int-card { background: #1a2d3d; border: 1px solid #243d52; border-radius: 8px; padding: 12px; text-align: center; }
-  .int-code { font-size: 15px; color: #f0c040; font-weight: bold; font-family: 'Consolas', monospace; }
-  .int-name { font-size: 11px; color: #e8edf2; margin-top: 4px; font-weight: bold; }
-  .int-eff { font-size: 11px; color: #7a9ab5; margin-top: 4px; line-height: 1.4; }
-  .int-card.lgt { border-left: 3px solid #4caf7d; }
-  .int-card.mod { border-left: 3px solid #f0c040; }
-  .int-card.sev { border-left: 3px solid #e05050; }
+  .int-card { background: var(--surface); border: 1px solid var(--border); border-radius: 8px; padding: 12px; text-align: center; }
+  .int-code { font-size: 15px; color: var(--accent); font-weight: bold; font-family: 'Consolas', monospace; }
+  .int-name { font-size: 11px; color: var(--text); margin-top: 4px; font-weight: bold; }
+  .int-eff { font-size: 11px; color: var(--text-muted); margin-top: 4px; line-height: 1.4; }
+  .int-card.lgt { border-left: 3px solid var(--success); }
+  .int-card.mod { border-left: 3px solid var(--accent); }
+  .int-card.sev { border-left: 3px solid var(--danger); }
   .int-card.ext { border-left: 3px solid #b030b0; }
   .advisory-grid { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 12px; }
-  .adv-card { background: #1a2d3d; border: 1px solid #243d52; border-radius: 8px; padding: 14px; }
-  .adv-card h3 { font-size: 13px; color: #f0c040; margin-bottom: 6px; letter-spacing: 0.5px; }
-  .adv-card p { font-size: 11px; color: #e8edf2; line-height: 1.5; }
+  .adv-card { background: var(--surface); border: 1px solid var(--border); border-radius: 8px; padding: 14px; }
+  .adv-card h3 { font-size: 13px; color: var(--accent); margin-bottom: 6px; letter-spacing: 0.5px; }
+  .adv-card p { font-size: 11px; color: var(--text); line-height: 1.5; }
   @media (max-width: 640px) { .intensity-grid { grid-template-columns: repeat(2, 1fr); } .advisory-grid { grid-template-columns: 1fr; } }
+  @media (max-width: 480px) { body { font-size: 14px; } .intensity-grid { grid-template-columns: repeat(2, 1fr); } }
 </style>
 </head>
 <body>

--- a/web-app/public/visuals/met009-thunderstorms.html
+++ b/web-app/public/visuals/met009-thunderstorms.html
@@ -7,13 +7,14 @@
 <link rel="stylesheet" href="/visuals/_common.css">
 <style>
   .ingredients { display: grid; grid-template-columns: repeat(3, 1fr); gap: 12px; margin-bottom: 14px; }
-  .ing-card { background: #1a2d3d; border: 1px solid #243d52; border-radius: 8px; padding: 14px; text-align: center; }
-  .ing-card .n { font-size: 20px; color: #f0c040; font-weight: bold; }
-  .ing-card .l { font-size: 12px; color: #e8edf2; margin-top: 6px; line-height: 1.5; }
+  .ing-card { background: var(--surface); border: 1px solid var(--border); border-radius: 8px; padding: 14px; text-align: center; }
+  .ing-card .n { font-size: 20px; color: var(--accent); font-weight: bold; }
+  .ing-card .l { font-size: 12px; color: var(--text); margin-top: 6px; line-height: 1.5; }
   .hazards-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 10px; }
-  .haz-card { background: #1a2d3d; border-left: 3px solid #e05050; padding: 10px 14px; font-size: 12px; color: #e8edf2; line-height: 1.5; }
-  .haz-card strong { color: #e05050; }
+  .haz-card { background: var(--surface); border-left: 3px solid var(--danger); padding: 10px 14px; font-size: 12px; color: var(--text); line-height: 1.5; }
+  .haz-card strong { color: var(--danger); }
   @media (max-width: 640px) { .ingredients { grid-template-columns: 1fr; } .hazards-grid { grid-template-columns: 1fr; } }
+  @media (max-width: 480px) { body { font-size: 14px; } }
 </style>
 </head>
 <body>

--- a/web-app/public/visuals/met010-icing.html
+++ b/web-app/public/visuals/met010-icing.html
@@ -7,14 +7,15 @@
 <link rel="stylesheet" href="/visuals/_common.css">
 <style>
   .ice-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 12px; }
-  .ice-card { background: #1a2d3d; border: 1px solid #243d52; border-radius: 8px; padding: 14px; }
-  .ice-card h3 { font-size: 14px; color: #f0c040; margin-bottom: 4px; letter-spacing: 0.5px; }
-  .ice-card .temp { font-size: 11px; color: #7a9ab5; margin-bottom: 8px; }
-  .ice-card ul { margin-left: 18px; font-size: 11px; color: #e8edf2; line-height: 1.6; }
+  .ice-card { background: var(--surface); border: 1px solid var(--border); border-radius: 8px; padding: 14px; }
+  .ice-card h3 { font-size: 14px; color: var(--accent); margin-bottom: 4px; letter-spacing: 0.5px; }
+  .ice-card .temp { font-size: 11px; color: var(--text-muted); margin-bottom: 8px; }
+  .ice-card ul { margin-left: 18px; font-size: 11px; color: var(--text); line-height: 1.6; }
   .effects { display: grid; grid-template-columns: 1fr 1fr; gap: 10px; }
-  .eff-card { background: #1a2d3d; border-left: 3px solid #e05050; padding: 10px 14px; font-size: 12px; color: #e8edf2; line-height: 1.5; }
-  .eff-card strong { color: #e05050; }
+  .eff-card { background: var(--surface); border-left: 3px solid var(--danger); padding: 10px 14px; font-size: 12px; color: var(--text); line-height: 1.5; }
+  .eff-card strong { color: var(--danger); }
   @media (max-width: 640px) { .ice-grid { grid-template-columns: 1fr; } .effects { grid-template-columns: 1fr; } }
+  @media (max-width: 480px) { body { font-size: 14px; } }
 </style>
 </head>
 <body>


### PR DESCRIPTION
## Summary

- Migrated hardcoded hex values to CSS custom properties (`var(--surface)`, `var(--border)`, `var(--accent)`, `var(--text)`, `var(--text-muted)`, `var(--success)`, `var(--danger)`, `var(--bg)`) in all five MET-006–010 visual HTML files
- Preserved data-encoding segment colours in MET-006 (TAF change groups: `.s-hdr/.s-time/.s-base/.s-bec/.s-tmp/.s-fm/.s-prob` and `.t-block.base/.bec/.tmp/.fm`) and MET-008 (`.sh` PIREP header) per spec
- Preserved SVG element fill/stroke colours in MET-009 and MET-010 (diagram content, not theme)
- Added `@media (max-width: 480px)` fixes: `body { font-size: 14px }` in all files; `overflow-x: auto` on `.t-bar` in MET-006 to prevent horizontal scroll at 375px
- `npm run build` passes ✓

## Test plan

- [ ] Open each file in browser at 375px viewport — confirm no horizontal scrollbar
- [ ] Verify back button tap area ≥ 44px (already enforced via `min-width/min-height` in inline style)
- [ ] Confirm body text renders at ≥ 14px at ≤ 480px
- [ ] Spot-check TAF segment colours in MET-006 unchanged (data-encoding exempt)
- [ ] Spot-check SVG diagram colours in MET-009 and MET-010 unchanged

Closes #248

🤖 Generated with [Claude Code](https://claude.com/claude-code)