### PR TITLE
[PPL-243] Migrate AL-016–018 visuals to CSS vars + mobile fixes

### DIFF
--- a/web-app/public/visuals/al016-wake-turbulence.html
+++ b/web-app/public/visuals/al016-wake-turbulence.html
@@ -7,29 +7,35 @@
 <title>AL-016: Wake Turbulence — Categories, Avoidance, Timing</title>
 <style>
   .cat-heavy { color: #ff7070; font-weight: 700; }
-  .cat-medium { color: #f0c040; font-weight: 700; }
+  .cat-medium { color: var(--accent); font-weight: 700; }
   .cat-light { color: #80e080; font-weight: 700; }
 
-  .vortex-diagram { background: #1a2d3d; border-radius: 10px; padding: 20px; margin-bottom: 28px; }
-  .vortex-diagram h2 { font-size: 12px; color: #7a9ab5; text-transform: uppercase; letter-spacing: 1px; margin-bottom: 16px; font-weight: 600; }
+  .vortex-diagram { background: var(--surface); border-radius: 10px; padding: 20px; margin-bottom: 28px; }
+  .vortex-diagram h2 { font-size: 12px; color: var(--text-muted); text-transform: uppercase; letter-spacing: 1px; margin-bottom: 16px; font-weight: 600; }
   .runway-svg { width: 100%; height: auto; display: block; }
 
   .facts-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 14px; margin-bottom: 28px; }
-  .fact-card { background: #1a2d3d; border-radius: 8px; padding: 14px 16px; border-left: 3px solid #f0c040; }
-  .fact-title { font-size: 12px; color: #f0c040; font-weight: 700; text-transform: uppercase; letter-spacing: 0.5px; margin-bottom: 6px; }
-  .fact-value { font-size: 22px; font-weight: 900; color: #e8edf2; margin-bottom: 4px; }
-  .fact-unit { font-size: 11px; color: #7a9ab5; }
+  .fact-card { background: var(--surface); border-radius: 8px; padding: 14px 16px; border-left: 3px solid var(--accent); }
+  .fact-title { font-size: 12px; color: var(--accent); font-weight: 700; text-transform: uppercase; letter-spacing: 0.5px; margin-bottom: 6px; }
+  .fact-value { font-size: 22px; font-weight: 900; color: var(--text); margin-bottom: 4px; }
+  .fact-unit { font-size: 11px; color: var(--text-muted); }
 
-  .avoid-list { background: #1a2d3d; border-radius: 10px; padding: 18px; margin-bottom: 28px; }
+  .avoid-list { background: var(--surface); border-radius: 10px; padding: 18px; margin-bottom: 28px; }
   .avoid-item { display: flex; gap: 10px; padding: 8px 0; border-bottom: 1px solid rgba(255,255,255,0.05); align-items: flex-start; }
   .avoid-item:last-child { border-bottom: none; }
   .avoid-icon { font-size: 16px; flex-shrink: 0; }
-  .avoid-text { font-size: 13px; color: #c8d8e8; line-height: 1.5; }
-  .avoid-text strong { color: #f0c040; }
+  .avoid-text { font-size: 13px; color: var(--text); line-height: 1.5; }
+  .avoid-text strong { color: var(--accent); }
+
+  @media (max-width: 480px) {
+    body { font-size: 14px; }
+    .facts-grid { grid-template-columns: 1fr; }
+    table { display: block; overflow-x: auto; -webkit-overflow-scrolling: touch; }
+  }
 </style>
 </head>
 <body>
-  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:#f0c040;border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
+  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:var(--accent);border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
   <style>.container{padding-top:56px!important;}@media(max-width:480px){.container{padding-top:60px!important;}}</style>
 
 <h1>AL-016 — Wake Turbulence: Categories, Avoidance, Timing</h1>

--- a/web-app/public/visuals/al017-low-level-flight-rules.html
+++ b/web-app/public/visuals/al017-low-level-flight-rules.html
@@ -6,24 +6,30 @@
 <link rel="stylesheet" href="/visuals/_common.css">
 <title>AL-017: Low-Level Flight Rules — 500 ft, Congested Areas, Noise Abatement</title>
 <style>
-  .rule-ref { color: #7a9ab5; font-size: 11px; }
-  .alt-value { color: #f0c040; font-weight: 700; }
+  .rule-ref { color: var(--text-muted); font-size: 11px; }
+  .alt-value { color: var(--accent); font-weight: 700; }
   .dist-value { color: #80c880; font-weight: 600; }
 
-  .diagram-box { background: #1a2d3d; border-radius: 10px; padding: 20px; margin-bottom: 28px; }
-  .diagram-box h2 { font-size: 12px; color: #7a9ab5; text-transform: uppercase; letter-spacing: 1px; margin-bottom: 16px; font-weight: 600; }
+  .diagram-box { background: var(--surface); border-radius: 10px; padding: 20px; margin-bottom: 28px; }
+  .diagram-box h2 { font-size: 12px; color: var(--text-muted); text-transform: uppercase; letter-spacing: 1px; margin-bottom: 16px; font-weight: 600; }
   .alt-svg { width: 100%; height: auto; display: block; }
 
   .cards { display: grid; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); gap: 14px; margin-bottom: 28px; }
-  .card { background: #1a2d3d; border-radius: 10px; padding: 16px 18px; }
-  .card-title { font-size: 13px; font-weight: 700; color: #f0c040; margin-bottom: 6px; }
-  .card-rule { font-size: 11px; color: #7a9ab5; margin-bottom: 8px; }
-  .card-body { font-size: 13px; color: #c8d8e8; line-height: 1.6; }
-  .card-body strong { color: #e8edf2; }
+  .card { background: var(--surface); border-radius: 10px; padding: 16px 18px; }
+  .card-title { font-size: 13px; font-weight: 700; color: var(--accent); margin-bottom: 6px; }
+  .card-rule { font-size: 11px; color: var(--text-muted); margin-bottom: 8px; }
+  .card-body { font-size: 13px; color: var(--text); line-height: 1.6; }
+  .card-body strong { color: var(--text); }
+
+  @media (max-width: 480px) {
+    body { font-size: 14px; }
+    .cards { grid-template-columns: 1fr; }
+    table { display: block; overflow-x: auto; -webkit-overflow-scrolling: touch; }
+  }
 </style>
 </head>
 <body>
-  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:#f0c040;border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
+  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:var(--accent);border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
   <style>.container{padding-top:56px!important;}@media(max-width:480px){.container{padding-top:60px!important;}}</style>
 
 <h1>AL-017 — Low-Level Flight Rules: 500 ft Rule, Congested Areas, Noise Abatement</h1>

--- a/web-app/public/visuals/al018-special-use-airspace.html
+++ b/web-app/public/visuals/al018-special-use-airspace.html
@@ -17,27 +17,33 @@
   .label-fa { color: #f0c040; }
   .label-moa { color: #64a0ff; }
   .label-adiz { color: #a080ff; }
-  .type-name { font-size: 12px; color: #7a9ab5; margin-bottom: 10px; font-weight: 600; }
-  .type-body { font-size: 13px; color: #c8d8e8; line-height: 1.6; }
-  .type-body strong { color: #e8edf2; }
+  .type-name { font-size: 12px; color: var(--text-muted); margin-bottom: 10px; font-weight: 600; }
+  .type-body { font-size: 13px; color: var(--text); line-height: 1.6; }
+  .type-body strong { color: var(--text); }
   .entry-rule { font-size: 12px; font-weight: 700; margin-top: 8px; padding: 4px 8px; border-radius: 4px; display: inline-block; }
   .rule-restricted { background: rgba(255,80,80,0.15); color: #ff7070; }
   .rule-advisory { background: rgba(255,200,0,0.12); color: #f0c040; }
   .rule-restricted-moa { background: rgba(100,160,255,0.15); color: #64a0ff; }
   .rule-adiz { background: rgba(130,100,255,0.15); color: #a080ff; }
 
-  .cond { color: #f0c040; font-weight: 600; }
+  .cond { color: var(--accent); font-weight: 600; }
 
   .adiz-box { background: rgba(130,100,255,0.06); border: 1.5px solid rgba(130,100,255,0.25); border-radius: 10px; padding: 18px 20px; margin-bottom: 28px; }
   .adiz-box h2 { font-size: 12px; color: #a080ff; text-transform: uppercase; letter-spacing: 1px; margin-bottom: 12px; font-weight: 600; }
   .adiz-step { display: flex; gap: 10px; margin-bottom: 8px; align-items: flex-start; }
   .adiz-num { background: rgba(130,100,255,0.2); color: #a080ff; font-size: 10px; font-weight: 800; width: 22px; height: 22px; border-radius: 50%; display: flex; align-items: center; justify-content: center; flex-shrink: 0; margin-top: 1px; }
-  .adiz-text { font-size: 13px; color: #c8d8e8; line-height: 1.5; }
-  .adiz-text strong { color: #f0c040; }
+  .adiz-text { font-size: 13px; color: var(--text); line-height: 1.5; }
+  .adiz-text strong { color: var(--accent); }
+
+  @media (max-width: 480px) {
+    body { font-size: 14px; }
+    .type-grid { grid-template-columns: 1fr; }
+    table { display: block; overflow-x: auto; -webkit-overflow-scrolling: touch; }
+  }
 </style>
 </head>
 <body>
-  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:#f0c040;border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
+  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:var(--accent);border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
   <style>.container{padding-top:56px!important;}@media(max-width:480px){.container{padding-top:60px!important;}}</style>
 
 <h1>AL-018 — Special Use Airspace: Class F(R), MOAs, ADIZs</h1>


### PR DESCRIPTION
## Summary

- Replace hardcoded hex values in `<style>` blocks and inline `color:` attributes in AL-016, AL-017, and AL-018 visuals with `var(--accent)`, `var(--surface)`, `var(--text)`, `var(--text-muted)` CSS tokens from `_common.css`
- Preserved all domain data-encoding colors: `.cat-heavy`/`.cat-light` (#ff7070/#80e080) in AL-016; `.dist-value` (#80c880) in AL-017; F(R) #ff7070, MOA #64a0ff, ADIZ #a080ff, F(A) rgba(255,200,0,…) in AL-018; all SVG-internal colors untouched
- Added `@media (max-width: 480px)` blocks: `font-size: 14px`, single-column grid layout, `overflow-x: auto` on tables — ensures no horizontal scroll at 375 px, body text ≥ 14 px, tap targets already ≥ 44 px

Closes #243

## Test plan

- [ ] Open each visual in browser at 375 px width — no horizontal scroll
- [ ] Verify accent colour (#f0c040) renders on vortex diagram heading, fact card titles, hook badges in AL-016
- [ ] Verify domain colours unchanged: red Heavy/Light labels in AL-016, green dist-value in AL-017, red/blue/purple/yellow airspace labels in AL-018
- [ ] Verify SVG diagram colours unchanged in all three files
- [ ] `npm run build` from `web-app/` passes without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)