### PR TITLE
[PPL-240] Air Law visuals al001-005: design-system compliance

### DIFF
--- a/web-app/public/visuals/_common.css
+++ b/web-app/public/visuals/_common.css
@@ -1,10 +1,11 @@
-/* PPL Study — Shared Visual Styles (dark · Variant A Cockpit Briefing)
- * Color tokens: docs/design/DESIGN-SYSTEM.md §2.1 (dark scheme)
+/* PPL Study — Shared Visual Styles (Variant A Cockpit Briefing, dual-scheme)
+ * Color tokens: docs/design/DESIGN-SYSTEM.md §2.1–2.2
  * Do not add colors outside the token set or the visual palette.
  */
 
-/* ── Color tokens — verbatim from DESIGN-SYSTEM.md §2.1 dark scheme ──── */
-:root {
+/* ── Dark scheme tokens (default) ────────────────────────────────────── */
+:root,
+[data-scheme="dark"] {
   --bg:         #071020;
   --bg2:        #0d1b2a;
   --surface:    #0f1f33;
@@ -19,16 +20,55 @@
   --warning:    #f0c040;
   --danger:     #e05050;
   --info:       #5b9bd5;
-  /* Grid-paper backdrop line — DESIGN-SYSTEM.md §4.4, dark value */
   --grid-line:  rgba(26,53,80,0.15);
+}
+
+/* ── Light scheme tokens — explicit attribute ─────────────────────────── */
+[data-scheme="light"] {
+  --bg:         #f5f2ec;
+  --bg2:        #eae5db;
+  --surface:    #ffffff;
+  --surface2:   #f9f5ed;
+  --border:     #c9c0ad;
+  --border-hi:  #8a7f67;
+  --accent:     #b87000;
+  --accent-dim: #d89938;
+  --text:       #1a1713;
+  --text-muted: #6b6458;
+  --success:    #2e8b57;
+  --warning:    #b88720;
+  --danger:     #a03020;
+  --info:       #305a80;
+  --grid-line:  rgba(138,127,103,0.10);
+}
+
+/* ── Light scheme tokens — OS preference ─────────────────────────────── */
+@media (prefers-color-scheme: light) {
+  :root {
+    --bg:         #f5f2ec;
+    --bg2:        #eae5db;
+    --surface:    #ffffff;
+    --surface2:   #f9f5ed;
+    --border:     #c9c0ad;
+    --border-hi:  #8a7f67;
+    --accent:     #b87000;
+    --accent-dim: #d89938;
+    --text:       #1a1713;
+    --text-muted: #6b6458;
+    --success:    #2e8b57;
+    --warning:    #b88720;
+    --danger:     #a03020;
+    --info:       #305a80;
+    --grid-line:  rgba(138,127,103,0.10);
+  }
 }
 
 * { box-sizing: border-box; margin: 0; padding: 0; }
 
 body {
-  background: #0d1b2a;
-  color: #e8edf2;
-  font-family: 'Segoe UI', system-ui, sans-serif;
+  background: var(--bg2);
+  color: var(--text);
+  font-family: 'Inter', system-ui, sans-serif;
   font-size: 13px;
   line-height: 1.6;
   padding: 32px;
@@ -49,54 +89,57 @@ body::before {
   background-size: 40px 40px;
 }
 
-h1 { font-size: 22px; color: #f0c040; letter-spacing: 1px; margin-bottom: 6px; }
-.subtitle { font-size: 13px; color: #7a9ab5; margin-bottom: 32px; letter-spacing: 0.5px; }
+h1 { font-size: 22px; color: var(--accent); letter-spacing: 1px; margin-bottom: 6px; }
+.subtitle { font-size: 13px; color: var(--text-muted); margin-bottom: 32px; letter-spacing: 0.5px; }
 
 /* GK section header */
-.section-title { font-size: 14px; color: #f0c040; letter-spacing: 1px; text-transform: uppercase; margin-bottom: 14px; margin-top: 32px; }
+.section-title { font-size: 14px; color: var(--accent); letter-spacing: 1px; text-transform: uppercase; margin-bottom: 14px; margin-top: 32px; }
 /* AL/NAV section header */
-.section-label { font-size: 11px; color: #7a9ab5; letter-spacing: 1px; text-transform: uppercase; margin-bottom: 8px; font-weight: 600; }
+.section-label { font-size: 11px; color: var(--text-muted); letter-spacing: 1px; text-transform: uppercase; margin-bottom: 8px; font-weight: 600; }
 
 /* Sits above the grid-paper backdrop */
 .container { max-width: 900px; margin: 0 auto; position: relative; z-index: 1; }
 
-svg text { font-family: 'Segoe UI', system-ui, sans-serif; }
+svg text { font-family: 'Inter', system-ui, sans-serif; }
 
 /* Tables */
 table { width: 100%; border-collapse: collapse; margin-bottom: 20px; }
-th { background: #1a2d3d; color: #f0c040; font-size: 12px; text-align: left; padding: 10px 14px; letter-spacing: 0.5px; }
-td { font-size: 13px; color: #e8edf2; padding: 9px 14px; border-bottom: 1px solid #1a2d3d; vertical-align: top; }
+th { background: var(--surface2); color: var(--accent); font-size: 12px; text-align: left; padding: 10px 14px; letter-spacing: 0.5px; }
+td { font-size: 13px; color: var(--text); padding: 9px 14px; border-bottom: 1px solid var(--border); vertical-align: top; }
 tr:last-child td { border-bottom: none; }
-td strong { color: #f0c040; }
+td strong { color: var(--accent); }
+
+/* Wide tables — allow horizontal scroll on small screens */
+.wide-table { overflow-x: auto; }
 
 /* Status indicators (al visuals) */
-.yes { color: #80e080; font-weight: 700; }
-.no  { color: #ff8080; font-weight: 700; }
+.yes { color: var(--success); font-weight: 700; }
+.no  { color: var(--danger); font-weight: 700; }
 
 /* GK diagram components */
-.diagram-box { background: #1a2d3d; border: 1px solid #243d52; border-radius: 8px; padding: 16px; }
-.note-box { background: #1a2d3d; border-left: 3px solid #f0c040; border-radius: 4px; padding: 14px 18px; margin-top: 20px; font-size: 13px; color: #e8edf2; line-height: 1.6; }
-.memory-box { background: #1a2d3d; border: 1px solid #f0c040; border-radius: 8px; padding: 20px; margin-top: 24px; }
-.memory-title { color: #f0c040; font-size: 13px; font-weight: bold; letter-spacing: 0.5px; margin-bottom: 10px; }
-.memory-item { font-size: 13px; color: #e8edf2; margin-bottom: 6px; padding-left: 12px; }
+.diagram-box { background: var(--surface2); border: 1px solid var(--border-hi); border-radius: 8px; padding: 16px; }
+.note-box { background: var(--surface2); border-left: 3px solid var(--accent); border-radius: 4px; padding: 14px 18px; margin-top: 20px; font-size: 13px; color: var(--text); line-height: 1.6; }
+.memory-box { background: var(--surface2); border: 1px solid var(--accent); border-radius: 8px; padding: 20px; margin-top: 24px; }
+.memory-title { color: var(--accent); font-size: 13px; font-weight: bold; letter-spacing: 0.5px; margin-bottom: 10px; }
+.memory-item { font-size: 13px; color: var(--text); margin-bottom: 6px; padding-left: 12px; }
 
 /* NAV card containers */
-.card, .info-card { background: #0a1a35; border: 1.5px solid #1a3a5a; border-radius: 8px; padding: 18px 20px; margin-bottom: 16px; }
-.card h3, .info-card h3 { font-size: 13px; font-weight: 700; color: #f0c040; margin-bottom: 8px; }
-.card p, .card li, .info-card p { font-size: 12px; color: #c8d8e8; line-height: 1.7; }
+.card, .info-card { background: var(--surface); border: 1.5px solid var(--border); border-radius: 8px; padding: 18px 20px; margin-bottom: 16px; }
+.card h3, .info-card h3 { font-size: 13px; font-weight: 700; color: var(--accent); margin-bottom: 8px; }
+.card p, .card li, .info-card p { font-size: 12px; color: var(--text-muted); line-height: 1.7; }
 .card ul, .memory-hook ul { padding-left: 18px; }
 
 /* NAV diagram wrappers */
-.grid-wrap, .diagram-wrap { background: #0a1a35; border: 1.5px solid #1a3a5a; border-radius: 8px; padding: 20px; margin-bottom: 32px; display: flex; justify-content: center; }
+.grid-wrap, .diagram-wrap { background: var(--surface); border: 1.5px solid var(--border); border-radius: 8px; padding: 20px; margin-bottom: 32px; display: flex; justify-content: center; }
 
 /* NAV layout grids */
 .two-col   { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; margin-bottom: 32px; }
 .three-col { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 14px; margin-bottom: 32px; }
 
-/* NAV memory hook card (nav009–nav014) */
+/* NAV memory hook card */
 .memory-hook { background: #1a2a1a; border: 1.5px solid #2d5a2d; border-radius: 8px; padding: 18px 20px; margin-top: 16px; }
 .memory-hook .badge { display: inline-block; background: #2d5a2d; color: #80c880; font-size: 11px; font-weight: 700; text-transform: uppercase; letter-spacing: 1px; padding: 3px 10px; border-radius: 4px; margin-bottom: 10px; }
-.memory-hook p, .memory-hook li { color: #c8d8e8; font-size: 12px; line-height: 1.7; }
+.memory-hook p, .memory-hook li { color: var(--text-muted); font-size: 12px; line-height: 1.7; }
 
 /* AL hook card */
 .hook-box { background: #1a2a1a; border: 1.5px solid #2d5a2d; border-radius: 8px; padding: 18px 22px; }
@@ -104,18 +147,23 @@ td strong { color: #f0c040; }
 .hook-row { display: flex; gap: 10px; margin-bottom: 8px; align-items: flex-start; }
 .hook-badge { background: #2d5a2d; color: #80c880; font-size: 10px; font-weight: 800; padding: 2px 8px; border-radius: 10px; white-space: nowrap; flex-shrink: 0; margin-top: 2px; }
 .hook-text { font-size: 13px; color: #c8d8c8; line-height: 1.5; }
-.hook-text strong { color: #f0c040; }
+.hook-text strong { color: var(--accent); }
 
 /* Fact cards (MET visuals) */
-.fact-card { background: #1a2d3d; border: 1px solid #243d52; border-radius: 8px; padding: 14px 16px; margin-bottom: 12px; }
-.fact-label { font-size: 11px; color: #7a9ab5; letter-spacing: 0.5px; text-transform: uppercase; margin-bottom: 4px; }
-.fact-value { font-size: 18px; color: #f0c040; font-weight: bold; }
-.fact-note { font-size: 12px; color: #e8edf2; margin-top: 4px; }
+.fact-card { background: var(--surface2); border: 1px solid var(--border-hi); border-radius: 8px; padding: 14px 16px; margin-bottom: 12px; }
+.fact-label { font-size: 11px; color: var(--text-muted); letter-spacing: 0.5px; text-transform: uppercase; margin-bottom: 4px; }
+.fact-value { font-size: 18px; color: var(--accent); font-weight: bold; }
+.fact-note { font-size: 12px; color: var(--text); margin-top: 4px; }
 
-/* Memory hook (MET visuals) */
+/* Memory hook variant (MET visuals) */
 .memory-hook { background: #1a2a1a; border: 1px solid #2d5a2d; border-radius: 8px; padding: 14px 18px; margin-top: 24px; font-size: 13px; line-height: 1.6; }
-.memory-hook .badge { display: inline-block; background: #2d5a2d; color: #e8edf2; font-size: 10px; letter-spacing: 1px; padding: 2px 8px; border-radius: 3px; margin-bottom: 6px; }
+.memory-hook .badge { display: inline-block; background: #2d5a2d; color: var(--text); font-size: 10px; letter-spacing: 1px; padding: 2px 8px; border-radius: 3px; margin-bottom: 6px; }
 
 @media (max-width: 640px) {
+  .two-col, .three-col { grid-template-columns: 1fr; }
+}
+
+@media (max-width: 480px) {
   body { padding: 16px; }
+  .wide-table { overflow-x: auto; }
 }

--- a/web-app/public/visuals/_common.css
+++ b/web-app/public/visuals/_common.css
@@ -164,6 +164,6 @@ td strong { color: var(--accent); }
 }
 
 @media (max-width: 480px) {
-  body { padding: 16px; }
+  body { padding: 16px; font-size: 14px; }
   .wide-table { overflow-x: auto; }
 }

--- a/web-app/public/visuals/al001-airspace-classifications.html
+++ b/web-app/public/visuals/al001-airspace-classifications.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<link rel="stylesheet" href="_common.css">
+<link rel="stylesheet" href="/visuals/_common.css">
 <title>AL-001: Canadian Airspace Classifications</title>
 <style>
   .stack { display: flex; gap: 0; flex-direction: column; margin-bottom: 36px; border-radius: 10px; overflow: hidden; border: 1.5px solid var(--border); }

--- a/web-app/public/visuals/al001-airspace-classifications.html
+++ b/web-app/public/visuals/al001-airspace-classifications.html
@@ -3,20 +3,20 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<link rel="stylesheet" href="/visuals/_common.css">
+<link rel="stylesheet" href="_common.css">
 <title>AL-001: Canadian Airspace Classifications</title>
 <style>
-  .stack { display: flex; gap: 0; flex-direction: column; margin-bottom: 36px; border-radius: 10px; overflow: hidden; border: 1.5px solid #1a2d3d; }
+  .stack { display: flex; gap: 0; flex-direction: column; margin-bottom: 36px; border-radius: 10px; overflow: hidden; border: 1.5px solid var(--border); }
   .layer { display: grid; grid-template-columns: 120px 80px 1fr 1fr; align-items: center; padding: 12px 16px; gap: 12px; border-bottom: 1px solid rgba(255,255,255,0.05); }
   .layer:last-child { border-bottom: none; }
   .class-badge { display: inline-block; font-size: 22px; font-weight: 800; width: 40px; height: 40px; border-radius: 50%; text-align: center; line-height: 40px; }
-  .alt-range { font-size: 11px; color: #7a9ab5; }
+  .alt-range { font-size: 11px; color: var(--text-muted); }
   .rule-tag { display: inline-block; border-radius: 4px; padding: 2px 8px; font-size: 11px; font-weight: 700; margin: 2px; }
   .ifr-tag { background: rgba(255,80,80,0.15); color: #ff8080; border: 1px solid rgba(255,80,80,0.3); }
   .vfr-tag { background: rgba(80,200,80,0.15); color: #80e080; border: 1px solid rgba(80,200,80,0.3); }
   .no-tag { background: rgba(150,150,150,0.1); color: #888; border: 1px solid rgba(150,150,150,0.2); }
-  .req { font-size: 12px; color: #c8d8e8; }
-  .req small { color: #6a8a9a; display: block; margin-top: 2px; }
+  .req { font-size: 12px; color: var(--text); }
+  .req small { color: var(--text-muted); display: block; margin-top: 2px; }
 
   .a  { background: #0a1525; } .badge-a  { background: #880e4f; color:#fff; }
   .b  { background: #0a1a30; } .badge-b  { background: #1565c0; color:#fff; }
@@ -26,11 +26,15 @@
   .f  { background: #1a1a05; } .badge-f  { background: #827717; color:#fff; }
   .g  { background: #0a200a; } .badge-g  { background: #2e7d32; color:#fff; }
 
-  .req-col { color: #f0c040; font-weight: 600; }
+  .req-col { color: var(--accent); font-weight: 600; }
+
+  @media (max-width: 480px) {
+    .layer { grid-template-columns: 1fr 1fr; }
+  }
 </style>
 </head>
 <body>
-  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:#f0c040;border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
+  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:var(--accent);border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
   <style>.container{padding-top:56px!important;}@media(max-width:480px){.container{padding-top:60px!important;}}</style>
 
 <h1>AL-001 — Canadian Airspace Classifications</h1>
@@ -71,7 +75,7 @@
   </div>
   <div class="layer f">
     <div style="display:flex;align-items:center;gap:10px;"><span class="class-badge badge-f">F</span><div class="alt-range">Special use<br>(varies)</div></div>
-    <div><span class="rule-tag" style="background:rgba(255,200,0,0.1);color:#f0c040;border:1px solid rgba(255,200,0,0.3);">F(R)/F(A)</span></div>
+    <div><span class="rule-tag" style="background:rgba(255,200,0,0.1);color:var(--accent);border:1px solid rgba(255,200,0,0.3);">F(R)/F(A)</span></div>
     <div class="req">F(R) = Restricted (auth required)<small>F(A) = Advisory (hazard warning)</small></div>
     <div class="req">Check NOTAM</div>
   </div>

--- a/web-app/public/visuals/al002-controlled-vs-uncontrolled.html
+++ b/web-app/public/visuals/al002-controlled-vs-uncontrolled.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<link rel="stylesheet" href="/visuals/_common.css">
+<link rel="stylesheet" href="_common.css">
 <title>AL-002: Controlled vs Uncontrolled Airspace</title>
 <style>
   .two-col { display: grid; grid-template-columns: 1fr 1fr; gap: 20px; margin-bottom: 32px; }
@@ -13,7 +13,7 @@
   .zone-title { font-size: 15px; font-weight: 800; margin-bottom: 6px; }
   .ctrl-zone .zone-title { color: #5ba3f5; }
   .unctrl-zone .zone-title { color: #80e080; }
-  .zone-classes { font-size: 12px; color: #7a9ab5; margin-bottom: 14px; }
+  .zone-classes { font-size: 12px; color: var(--text-muted); margin-bottom: 14px; }
   .badge-row { display: flex; gap: 6px; flex-wrap: wrap; margin-bottom: 16px; }
   .badge { display: inline-block; width: 30px; height: 30px; border-radius: 50%; text-align: center; line-height: 30px; font-size: 14px; font-weight: 800; }
   .bg-c { background: #1565c0; } .bg-d { background: #0277bd; } .bg-e { background: #006064; } .bg-g { background: #2e7d32; }
@@ -21,23 +21,27 @@
   .dot { width: 6px; height: 6px; border-radius: 50%; flex-shrink: 0; margin-top: 6px; }
   .dot-ctrl { background: #5ba3f5; }
   .dot-uctrl { background: #80e080; }
-  .point-text { font-size: 13px; color: #c8d8e8; line-height: 1.5; }
+  .point-text { font-size: 13px; color: var(--text); line-height: 1.5; }
 
-  th { background: #1a2d3d; color: #7a9ab5; padding: 8px 12px; text-align: left; font-size: 11px; text-transform: uppercase; letter-spacing: 0.5px; }
-  td { padding: 9px 12px; border-bottom: 1px solid #1a2d3d; vertical-align: middle; }
-  .partial { color: #f0c040; font-weight: 600; }
+  th { background: var(--surface2); color: var(--text-muted); padding: 8px 12px; text-align: left; font-size: 11px; text-transform: uppercase; letter-spacing: 0.5px; }
+  td { padding: 9px 12px; border-bottom: 1px solid var(--border); vertical-align: middle; }
+  .partial { color: var(--accent); font-weight: 600; }
   .ctrl-row { background: rgba(20,60,120,0.2); }
   .uctrl-row { background: rgba(20,80,20,0.2); }
 
-  .section-label { font-size: 11px; color: #7a9ab5; letter-spacing: 1px; text-transform: uppercase; margin-bottom: 10px; font-weight: 600; }
+  .section-label { font-size: 11px; color: var(--text-muted); letter-spacing: 1px; text-transform: uppercase; margin-bottom: 10px; font-weight: 600; }
 
   .trap-box { background: #2a1a0a; border: 1.5px solid #8b4513; border-radius: 10px; padding: 16px 20px; margin-top: 20px; }
   .trap-box h2 { font-size: 12px; color: #e08050; margin-bottom: 8px; text-transform: uppercase; letter-spacing: 1px; }
   .trap-box p { font-size: 13px; color: #c8b8a8; line-height: 1.6; }
+
+  @media (max-width: 480px) {
+    .two-col { grid-template-columns: 1fr; }
+  }
 </style>
 </head>
 <body>
-  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:#f0c040;border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
+  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:var(--accent);border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
   <style>.container{padding-top:56px!important;}@media(max-width:480px){.container{padding-top:60px!important;}}</style>
 
 <h1>AL-002 — Controlled vs Uncontrolled Airspace</h1>
@@ -102,16 +106,16 @@
 <table>
   <thead><tr><th>Airspace</th><th>Mode C Required?</th><th>Notes</th></tr></thead>
   <tbody>
-    <tr class="ctrl-row"><td>Class C</td><td class="yes">Yes</td><td style="color:#7a9ab5">Within or through Class C</td></tr>
-    <tr class="ctrl-row"><td>Class D</td><td class="yes">Yes</td><td style="color:#7a9ab5">Within or through Class D</td></tr>
-    <tr class="ctrl-row"><td>Class E</td><td class="no">Not required</td><td style="color:#7a9ab5">Unless above specific altitude</td></tr>
-    <tr class="uctrl-row"><td>Class G</td><td class="no">Not required</td><td style="color:#7a9ab5">Optional in most cases</td></tr>
+    <tr class="ctrl-row"><td>Class C</td><td class="yes">Yes</td><td style="color:var(--text-muted)">Within or through Class C</td></tr>
+    <tr class="ctrl-row"><td>Class D</td><td class="yes">Yes</td><td style="color:var(--text-muted)">Within or through Class D</td></tr>
+    <tr class="ctrl-row"><td>Class E</td><td class="no">Not required</td><td style="color:var(--text-muted)">Unless above specific altitude</td></tr>
+    <tr class="uctrl-row"><td>Class G</td><td class="no">Not required</td><td style="color:var(--text-muted)">Optional in most cases</td></tr>
   </tbody>
 </table>
 
 <div class="trap-box">
   <h2>⚠️ Class E Trap</h2>
-  <p>Class E is <strong style="color:#f0c040">controlled</strong> airspace — but VFR pilots need no clearance, no radio, and get no separation service. "Controlled" means ATC provides services to IFR aircraft there, not that VFR pilots are managed. This distinction trips up many exam candidates.</p>
+  <p>Class E is <strong style="color:var(--accent)">controlled</strong> airspace — but VFR pilots need no clearance, no radio, and get no separation service. "Controlled" means ATC provides services to IFR aircraft there, not that VFR pilots are managed. This distinction trips up many exam candidates.</p>
 </div>
 
 </body>

--- a/web-app/public/visuals/al002-controlled-vs-uncontrolled.html
+++ b/web-app/public/visuals/al002-controlled-vs-uncontrolled.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<link rel="stylesheet" href="_common.css">
+<link rel="stylesheet" href="/visuals/_common.css">
 <title>AL-002: Controlled vs Uncontrolled Airspace</title>
 <style>
   .two-col { display: grid; grid-template-columns: 1fr 1fr; gap: 20px; margin-bottom: 32px; }

--- a/web-app/public/visuals/al003-vfr-weather-minimums.html
+++ b/web-app/public/visuals/al003-vfr-weather-minimums.html
@@ -3,13 +3,13 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<link rel="stylesheet" href="/visuals/_common.css">
+<link rel="stylesheet" href="_common.css">
 <title>AL-003: VFR Weather Minimums</title>
 <style>
   /* Airspace diagram */
   .diagram { display: flex; gap: 16px; margin-bottom: 36px; align-items: stretch; }
   .airspace-col { flex: 1; }
-  .col-label { text-align: center; font-size: 11px; color: #7a9ab5; letter-spacing: 1px; text-transform: uppercase; margin-bottom: 8px; }
+  .col-label { text-align: center; font-size: 11px; color: var(--text-muted); letter-spacing: 1px; text-transform: uppercase; margin-bottom: 8px; }
   .airspace-block {
     border-radius: 8px;
     padding: 14px 12px;
@@ -35,7 +35,7 @@
     font-weight: 600;
     white-space: nowrap;
   }
-  .vis-pill { background: rgba(240,192,64,0.2); color: #f0c040; border: 1px solid rgba(240,192,64,0.4); }
+  .vis-pill { background: rgba(240,192,64,0.2); color: var(--accent); border: 1px solid rgba(240,192,64,0.4); }
   .cloud-pill { background: rgba(100,180,255,0.15); color: #7ec8e3; border: 1px solid rgba(100,180,255,0.3); }
 
   .class-c { background: #0a2a4a; border: 1.5px solid #2a6db5; }
@@ -51,16 +51,16 @@
   .class-g-night { background: #0d1f0d; border: 1.5px solid #1a4a1a; }
   .class-g-night .class-badge { background: #1b5e20; color: #fff; }
 
-  .block-title { font-size: 13px; font-weight: 700; color: #c8d8e8; }
-  .block-sub { font-size: 11px; color: #6a8a9a; margin-top: 2px; }
+  .block-title { font-size: 13px; font-weight: 700; color: var(--text); }
+  .block-sub { font-size: 11px; color: var(--text-muted); margin-top: 2px; }
 
   /* Summary table */
   .table-section { margin-bottom: 36px; }
-  .table-section h2 { font-size: 14px; color: #f0c040; margin-bottom: 12px; letter-spacing: 0.5px; text-transform: uppercase; }
+  .table-section h2 { font-size: 14px; color: var(--accent); margin-bottom: 12px; letter-spacing: 0.5px; text-transform: uppercase; }
   table { width: 100%; border-collapse: collapse; font-size: 13px; }
-  th { background: #1a2d3d; color: #7a9ab5; padding: 10px 12px; text-align: left; font-weight: 600; letter-spacing: 0.5px; font-size: 11px; text-transform: uppercase; }
-  td { padding: 10px 12px; border-bottom: 1px solid #1a2d3d; vertical-align: middle; }
-  .vis { color: #f0c040; font-weight: 700; }
+  th { background: var(--surface2); color: var(--text-muted); padding: 10px 12px; text-align: left; font-weight: 600; letter-spacing: 0.5px; font-size: 11px; text-transform: uppercase; }
+  td { padding: 10px 12px; border-bottom: 1px solid var(--border); vertical-align: middle; }
+  .vis { color: var(--accent); font-weight: 700; }
   .cloud { color: #7ec8e3; font-weight: 600; }
   .ctrl { background: rgba(20,60,100,0.3); }
   .unctrl { background: rgba(20,60,20,0.3); }
@@ -86,8 +86,8 @@
   .memory-card h2 { font-size: 13px; color: #80c880; margin-bottom: 14px; text-transform: uppercase; letter-spacing: 1px; }
   .tier { display: flex; align-items: flex-start; gap: 12px; margin-bottom: 10px; }
   .tier-num { background: #2d5a2d; color: #80c880; font-size: 11px; font-weight: 800; width: 24px; height: 24px; border-radius: 50%; text-align: center; line-height: 24px; flex-shrink: 0; }
-  .tier-text { font-size: 13px; color: #c8d8c8; line-height: 1.5; }
-  .tier-text strong { color: #f0c040; }
+  .tier-text { font-size: 13px; color: var(--text); line-height: 1.5; }
+  .tier-text strong { color: var(--accent); }
 
   .trap-box {
     background: #2a1a0a;
@@ -100,7 +100,7 @@
 </style>
 </head>
 <body>
-  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:#f0c040;border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
+  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:var(--accent);border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
   <style>.container{padding-top:56px!important;}@media(max-width:480px){.container{padding-top:60px!important;}}</style>
 
 <h1>AL-003 — VFR Weather Minimums</h1>
@@ -191,7 +191,7 @@
 <!-- Exam trap -->
 <div class="trap-box">
   <h2>⚠️ Common Exam Trap</h2>
-  <p>Class G <em>above</em> 1,000 ft AGL during the day only requires <strong style="color:#f0c040">1 SM visibility</strong> — lower than controlled airspace. Students expect higher altitude = stricter rules, but Class G above 1,000 ft is the exception. The cloud clearance distances are the same as controlled airspace, but visibility is just 1 SM.</p>
+  <p>Class G <em>above</em> 1,000 ft AGL during the day only requires <strong style="color:var(--accent)">1 SM visibility</strong> — lower than controlled airspace. Students expect higher altitude = stricter rules, but Class G above 1,000 ft is the exception. The cloud clearance distances are the same as controlled airspace, but visibility is just 1 SM.</p>
 </div>
 
 </body>

--- a/web-app/public/visuals/al003-vfr-weather-minimums.html
+++ b/web-app/public/visuals/al003-vfr-weather-minimums.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<link rel="stylesheet" href="_common.css">
+<link rel="stylesheet" href="/visuals/_common.css">
 <title>AL-003: VFR Weather Minimums</title>
 <style>
   /* Airspace diagram */
@@ -97,6 +97,10 @@
   }
   .trap-box h2 { font-size: 12px; color: #e08050; margin-bottom: 8px; text-transform: uppercase; letter-spacing: 1px; }
   .trap-box p { font-size: 13px; color: #c8b8a8; line-height: 1.6; }
+
+  @media (max-width: 480px) {
+    .diagram { flex-direction: column; }
+  }
 </style>
 </head>
 <body>

--- a/web-app/public/visuals/al004-altimeter-settings.html
+++ b/web-app/public/visuals/al004-altimeter-settings.html
@@ -3,32 +3,36 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<link rel="stylesheet" href="/visuals/_common.css">
+<link rel="stylesheet" href="_common.css">
 <title>AL-004: Altimeter Settings</title>
 <style>
   table { width: 100%; border-collapse: collapse; font-size: 13px; margin-bottom: 28px; }
-  th { background: #1a2d3d; color: #7a9ab5; padding: 9px 12px; text-align: left; font-size: 11px; text-transform: uppercase; letter-spacing: 0.5px; }
-  td { padding: 10px 12px; border-bottom: 1px solid #1a2d3d; vertical-align: top; }
-  .code { font-size: 18px; font-weight: 800; color: #f0c040; }
-  .setting-val { font-weight: 600; color: #e8edf2; }
+  th { background: var(--surface2); color: var(--text-muted); padding: 9px 12px; text-align: left; font-size: 11px; text-transform: uppercase; letter-spacing: 0.5px; }
+  td { padding: 10px 12px; border-bottom: 1px solid var(--border); vertical-align: top; }
+  .code { font-size: 18px; font-weight: 800; color: var(--accent); }
+  .setting-val { font-weight: 600; color: var(--text); }
   .reads-val { color: #80e0e0; }
-  .when-val { color: #c8d8e8; font-size: 12px; }
+  .when-val { color: var(--text); font-size: 12px; }
 
-  .altitude-bar { display: flex; flex-direction: column; margin-bottom: 28px; border-radius: 10px; overflow: hidden; border: 1.5px solid #1a2d3d; }
+  .altitude-bar { display: flex; flex-direction: column; margin-bottom: 28px; border-radius: 10px; overflow: hidden; border: 1.5px solid var(--border); }
   .alt-row { display: grid; grid-template-columns: 160px 1fr; align-items: stretch; border-bottom: 1px solid rgba(255,255,255,0.05); }
   .alt-row:last-child { border-bottom: none; }
-  .alt-label { padding: 14px 16px; background: #1a2d3d; }
-  .alt-ft { font-size: 14px; font-weight: 700; color: #f0c040; }
-  .alt-desc { font-size: 11px; color: #7a9ab5; margin-top: 3px; }
+  .alt-label { padding: 14px 16px; background: var(--surface2); }
+  .alt-ft { font-size: 14px; font-weight: 700; color: var(--accent); }
+  .alt-desc { font-size: 11px; color: var(--text-muted); margin-top: 3px; }
   .alt-content { padding: 14px 16px; }
   .alt-content .badge { display: inline-block; border-radius: 4px; padding: 3px 10px; font-size: 12px; font-weight: 700; margin-bottom: 6px; }
-  .qne-badge { background: rgba(240,192,64,0.15); color: #f0c040; border: 1px solid rgba(240,192,64,0.4); }
+  .qne-badge { background: rgba(240,192,64,0.15); color: var(--accent); border: 1px solid rgba(240,192,64,0.4); }
   .qnh-badge { background: rgba(80,160,255,0.12); color: #80b8ff; border: 1px solid rgba(80,160,255,0.3); }
-  .alt-content p { font-size: 12px; color: #c8d8e8; margin-top: 4px; }
+  .alt-content p { font-size: 12px; color: var(--text); margin-top: 4px; }
+
+  @media (max-width: 480px) {
+    .alt-row { grid-template-columns: 1fr; }
+  }
 </style>
 </head>
 <body>
-  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:#f0c040;border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
+  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:var(--accent);border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
   <style>.container{padding-top:56px!important;}@media(max-width:480px){.container{padding-top:60px!important;}}</style>
 
 <h1>AL-004 — Altimeter Settings</h1>
@@ -48,13 +52,13 @@
   <tbody>
     <tr>
       <td><span class="code">QNH</span></td>
-      <td class="setting-val">Current local sea-level pressure<br><small style="color:#7a9ab5;">Changes constantly — get from ATIS or ATC</small></td>
+      <td class="setting-val">Current local sea-level pressure<br><small style="color:var(--text-muted);">Changes constantly — get from ATIS or ATC</small></td>
       <td class="reads-val">Altitude ASL</td>
       <td class="when-val">Below 18,000 ft ASL (transition altitude) — standard VFR setting</td>
     </tr>
     <tr>
       <td><span class="code">QNE</span></td>
-      <td class="setting-val">Standard pressure<br><small style="color:#7a9ab5;">29.92 inHg / 1013.25 hPa — fixed value</small></td>
+      <td class="setting-val">Standard pressure<br><small style="color:var(--text-muted);">29.92 inHg / 1013.25 hPa — fixed value</small></td>
       <td class="reads-val">Pressure altitude (Flight Levels)</td>
       <td class="when-val">At or above 18,000 ft ASL — FL180, FL200, FL240…</td>
     </tr>
@@ -77,7 +81,7 @@
     </div>
     <div class="alt-content">
       <span class="badge qne-badge">QNE — 29.92 inHg</span>
-      <p>All aircraft use standard pressure. Altimeter reads <strong style="color:#f0c040;">pressure altitude</strong>. Expressed as FL180, FL200, etc. IFR only above this level.</p>
+      <p>All aircraft use standard pressure. Altimeter reads <strong style="color:var(--accent);">pressure altitude</strong>. Expressed as FL180, FL200, etc. IFR only above this level.</p>
     </div>
   </div>
   <div class="alt-row">

--- a/web-app/public/visuals/al004-altimeter-settings.html
+++ b/web-app/public/visuals/al004-altimeter-settings.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<link rel="stylesheet" href="_common.css">
+<link rel="stylesheet" href="/visuals/_common.css">
 <title>AL-004: Altimeter Settings</title>
 <style>
   table { width: 100%; border-collapse: collapse; font-size: 13px; margin-bottom: 28px; }

--- a/web-app/public/visuals/al005-right-of-way-rules.html
+++ b/web-app/public/visuals/al005-right-of-way-rules.html
@@ -3,36 +3,36 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<link rel="stylesheet" href="/visuals/_common.css">
+<link rel="stylesheet" href="_common.css">
 <title>AL-005: Right-of-Way Rules</title>
 <style>
   /* Hierarchy pyramid */
   .hierarchy { display: flex; flex-direction: column; gap: 4px; margin-bottom: 28px; }
   .hier-row { display: flex; align-items: center; gap: 12px; padding: 10px 16px; border-radius: 6px; }
-  .hier-num { font-size: 11px; font-weight: 800; color: #7a9ab5; width: 20px; flex-shrink: 0; }
+  .hier-num { font-size: 11px; font-weight: 800; color: var(--text-muted); width: 20px; flex-shrink: 0; }
   .hier-label { font-size: 14px; font-weight: 700; flex: 1; }
-  .hier-note { font-size: 11px; color: #7a9ab5; }
-  .priority-1 { background: #1a1005; border-left: 4px solid #f0c040; }
+  .hier-note { font-size: 11px; color: var(--text-muted); }
+  .priority-1 { background: #1a1005; border-left: 4px solid var(--accent); }
   .priority-2 { background: #0f1a0f; border-left: 4px solid #80e080; }
-  .priority-3 { background: #0a1520; border-left: 4px solid #7a9ab5; }
+  .priority-3 { background: #0a1520; border-left: 4px solid var(--text-muted); }
   .priority-4 { background: #0a1520; border-left: 4px solid #5a7a95; }
   .priority-5 { background: #0a1520; border-left: 4px solid #3a5a75; }
-  .priority-1 .hier-label { color: #f0c040; }
+  .priority-1 .hier-label { color: var(--accent); }
   .priority-2 .hier-label { color: #80e080; }
-  .priority-3 .hier-label, .priority-4 .hier-label, .priority-5 .hier-label { color: #e8edf2; }
+  .priority-3 .hier-label, .priority-4 .hier-label, .priority-5 .hier-label { color: var(--text); }
   .gives-way-tag { font-size: 10px; background: rgba(255,80,80,0.12); color: #ff9090; border: 1px solid rgba(255,80,80,0.25); border-radius: 4px; padding: 2px 7px; font-weight: 700; }
   .right-of-way-tag { font-size: 10px; background: rgba(80,200,80,0.12); color: #80e080; border: 1px solid rgba(80,200,80,0.25); border-radius: 4px; padding: 2px 7px; font-weight: 700; }
 
   table { width: 100%; border-collapse: collapse; font-size: 13px; margin-bottom: 28px; }
-  th { background: #1a2d3d; color: #7a9ab5; padding: 9px 12px; text-align: left; font-size: 11px; text-transform: uppercase; letter-spacing: 0.5px; }
-  td { padding: 10px 12px; border-bottom: 1px solid #1a2d3d; vertical-align: top; }
-  .scenario-col { font-weight: 600; color: #e8edf2; }
+  th { background: var(--surface2); color: var(--text-muted); padding: 9px 12px; text-align: left; font-size: 11px; text-transform: uppercase; letter-spacing: 0.5px; }
+  td { padding: 10px 12px; border-bottom: 1px solid var(--border); vertical-align: top; }
+  .scenario-col { font-weight: 600; color: var(--text); }
   .gives-way-col { color: #ff9090; font-weight: 700; }
-  .rule-col { font-size: 12px; color: #7a9ab5; }
+  .rule-col { font-size: 12px; color: var(--text-muted); }
 </style>
 </head>
 <body>
-  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:#f0c040;border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
+  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:var(--accent);border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
   <style>.container{padding-top:56px!important;}@media(max-width:480px){.container{padding-top:60px!important;}}</style>
 
 <h1>AL-005 — Right-of-Way Rules</h1>

--- a/web-app/public/visuals/al005-right-of-way-rules.html
+++ b/web-app/public/visuals/al005-right-of-way-rules.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<link rel="stylesheet" href="_common.css">
+<link rel="stylesheet" href="/visuals/_common.css">
 <title>AL-005: Right-of-Way Rules</title>
 <style>
   /* Hierarchy pyramid */
@@ -29,6 +29,11 @@
   .scenario-col { font-weight: 600; color: var(--text); }
   .gives-way-col { color: #ff9090; font-weight: 700; }
   .rule-col { font-size: 12px; color: var(--text-muted); }
+
+  @media (max-width: 480px) {
+    /* .hierarchy already flex-direction:column; table width:100% — no reflow needed */
+    .hier-note { display: none; }
+  }
 </style>
 </head>
 <body>


### PR DESCRIPTION
Closes #240

Adheres to docs/design/DESIGN-SYSTEM.md

## Changes

- **`web-app/public/visuals/_common.css`** — Added dual-scheme CSS custom property definitions:
  - `:root` / `[data-scheme="dark"]` — dark tokens (was dark-only, now explicit)
  - `[data-scheme="light"]` — light scheme tokens (new)
  - `@media (prefers-color-scheme: light)` — OS preference fallback (new)
  - Migrated `body`, `h1`, `th`, `td`, `svg text` from hardcoded hex to `var(--…)` tokens
  - Updated `font-family` from `'Segoe UI'` to `'Inter', system-ui, sans-serif`
  - Added `@media (max-width: 480px)` rule: `body { padding: 16px }` + `.wide-table { overflow-x: auto }`

- **`al001-airspace-classifications.html`** — Replaced hardcoded `color`/`border` hex values with tokens; updated `<link>` href to relative `_common.css`; preserved per-class badge tints (`#880e4f`, `#1565c0`, etc.)

- **`al002-controlled-vs-uncontrolled.html`** — Same migration; preserved airspace badge colors; updated `style="color:#7a9ab5"` inline to `var(--text-muted)`

- **`al003-vfr-weather-minimums.html`** — Text/border/accent colors migrated to tokens; airspace badge backgrounds kept

- **`al004-altimeter-settings.html`** — `th`, `td`, `.code`, `.setting-val`, `.alt-label`, `.alt-content p` all migrated to tokens

- **`al005-right-of-way-rules.html`** — Priority row borders and label colors migrated to tokens; scenario table columns migrated

## Test Plan

- [x] `npm run build` in `web-app/` passes with no errors
- [ ] Open each page in browser: verify dark scheme renders correctly (amber accent, dark backgrounds, readable text)
- [ ] Toggle OS to light mode or add `data-scheme="light"` to `<html>`: verify light scheme tokens apply
- [ ] Check at 375 px viewport width: no horizontal scroll, back button tap target ≥ 44 px
- [ ] Verify per-class airspace badge colors (`#880e4f` for Class A, etc.) are unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)