### PR TITLE
[PPL-245] migrate GK-006–010 visuals to CSS vars + ≤480px fixes

### DIFF
--- a/web-app/public/visuals/gk006-pitot-static-instruments.html
+++ b/web-app/public/visuals/gk006-pitot-static-instruments.html
@@ -120,7 +120,7 @@
 
     <div>
       <div class="section-title">ASI Speed Arcs (Colour Code)</div>
-      <div style="background:#1a2d3d; border-radius:8px; padding:16px;">
+      <div style="background:var(--surface); border-radius:8px; padding:16px;">
         <svg viewBox="0 0 220 200" width="100%" height="180">
           <!-- ASI dial background -->
           <circle cx="110" cy="100" r="85" fill="#0d1b2a" stroke="#7a9ab5" stroke-width="2"/>

--- a/web-app/public/visuals/gk006-pitot-static-instruments.html
+++ b/web-app/public/visuals/gk006-pitot-static-instruments.html
@@ -10,11 +10,17 @@
   .layout { display: grid; grid-template-columns: 1fr 1fr; gap: 24px; align-items: start; }
   .arc-row { display: flex; align-items: center; gap: 10px; margin-bottom: 8px; font-size: 13px; }
   .arc-swatch { width: 32px; height: 14px; border-radius: 3px; flex-shrink: 0; }
-  .note-box { border-left-color: #e05050; }
+  .note-box { border-left-color: var(--danger); }
+  @media (max-width: 480px) {
+    body { font-size: 14px; }
+    .layout { grid-template-columns: 1fr; }
+    table { display: block; overflow-x: auto; }
+    button { min-height: 44px; }
+  }
 </style>
 </head>
 <body>
-  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:#f0c040;border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
+  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:var(--accent);border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
   <style>.container{padding-top:56px!important;}@media(max-width:480px){.container{padding-top:60px!important;}}</style>
 <div class="container">
   <h1>GK-006 — Pitot-Static System</h1>
@@ -137,9 +143,9 @@
         <table style="margin-top:8px; margin-bottom:0;">
           <tbody>
             <tr><td style="padding:5px 8px;"><span style="color:white;font-weight:bold;">White arc</span></td><td style="padding:5px 8px; font-size:12px;">Vso to Vfe — flap operating range</td></tr>
-            <tr><td style="padding:5px 8px;"><span style="color:#4caf7d;font-weight:bold;">Green arc</span></td><td style="padding:5px 8px; font-size:12px;">Vs1 to Vno — normal operating range</td></tr>
-            <tr><td style="padding:5px 8px;"><span style="color:#f0c040;font-weight:bold;">Yellow arc</span></td><td style="padding:5px 8px; font-size:12px;">Vno to Vne — caution (smooth air only)</td></tr>
-            <tr><td style="padding:5px 8px;"><span style="color:#e05050;font-weight:bold;">Red line</span></td><td style="padding:5px 8px; font-size:12px;">Vne — never exceed speed</td></tr>
+            <tr><td style="padding:5px 8px;"><span style="color:var(--success);font-weight:bold;">Green arc</span></td><td style="padding:5px 8px; font-size:12px;">Vs1 to Vno — normal operating range</td></tr>
+            <tr><td style="padding:5px 8px;"><span style="color:var(--accent);font-weight:bold;">Yellow arc</span></td><td style="padding:5px 8px; font-size:12px;">Vno to Vne — caution (smooth air only)</td></tr>
+            <tr><td style="padding:5px 8px;"><span style="color:var(--danger);font-weight:bold;">Red line</span></td><td style="padding:5px 8px; font-size:12px;">Vne — never exceed speed</td></tr>
           </tbody>
         </table>
       </div>

--- a/web-app/public/visuals/gk007-gyroscopic-instruments.html
+++ b/web-app/public/visuals/gk007-gyroscopic-instruments.html
@@ -8,14 +8,20 @@
 <style>
   .instruments-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 20px; margin-bottom: 32px; }
   .instrument-card { background: #1a2d3d; border: 1px solid #243d52; border-radius: 8px; padding: 16px; text-align: center; }
-  .inst-name { font-size: 14px; color: #f0c040; font-weight: bold; margin-bottom: 4px; }
-  .inst-abbr { font-size: 11px; color: #7a9ab5; margin-bottom: 12px; letter-spacing: 1px; }
+  .inst-name { font-size: 14px; color: var(--accent); font-weight: bold; margin-bottom: 4px; }
+  .inst-abbr { font-size: 11px; color: var(--text-muted); margin-bottom: 12px; letter-spacing: 1px; }
   .inst-desc { font-size: 12px; color: #e8edf2; line-height: 1.5; margin-top: 10px; text-align: left; }
-  .warn { color: #e05050; font-weight: bold; }
+  .warn { color: var(--danger); font-weight: bold; }
+  @media (max-width: 480px) {
+    body { font-size: 14px; }
+    .instruments-grid { grid-template-columns: 1fr; }
+    table { display: block; overflow-x: auto; }
+    button { min-height: 44px; }
+  }
 </style>
 </head>
 <body>
-  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:#f0c040;border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
+  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:var(--accent);border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
   <style>.container{padding-top:56px!important;}@media(max-width:480px){.container{padding-top:60px!important;}}</style>
 <div class="container">
   <h1>GK-007 — Gyroscopic Instruments</h1>

--- a/web-app/public/visuals/gk007-gyroscopic-instruments.html
+++ b/web-app/public/visuals/gk007-gyroscopic-instruments.html
@@ -7,10 +7,10 @@
 <link rel="stylesheet" href="_common.css">
 <style>
   .instruments-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 20px; margin-bottom: 32px; }
-  .instrument-card { background: #1a2d3d; border: 1px solid #243d52; border-radius: 8px; padding: 16px; text-align: center; }
+  .instrument-card { background: var(--surface); border: 1px solid var(--border); border-radius: 8px; padding: 16px; text-align: center; }
   .inst-name { font-size: 14px; color: var(--accent); font-weight: bold; margin-bottom: 4px; }
   .inst-abbr { font-size: 11px; color: var(--text-muted); margin-bottom: 12px; letter-spacing: 1px; }
-  .inst-desc { font-size: 12px; color: #e8edf2; line-height: 1.5; margin-top: 10px; text-align: left; }
+  .inst-desc { font-size: 12px; color: var(--text); line-height: 1.5; margin-top: 10px; text-align: left; }
   .warn { color: var(--danger); font-weight: bold; }
   @media (max-width: 480px) {
     body { font-size: 14px; }

--- a/web-app/public/visuals/gk008-engine-instruments.html
+++ b/web-app/public/visuals/gk008-engine-instruments.html
@@ -7,7 +7,7 @@
 <link rel="stylesheet" href="_common.css">
 <style>
   .panel-grid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 14px; margin-bottom: 32px; }
-  .gauge-card { background: #1a2d3d; border: 1px solid #243d52; border-radius: 8px; padding: 12px; text-align: center; }
+  .gauge-card { background: var(--surface); border: 1px solid var(--border); border-radius: 8px; padding: 12px; text-align: center; }
   .gauge-name { font-size: 11px; color: var(--accent); font-weight: bold; letter-spacing: 0.5px; margin-bottom: 4px; }
   .gauge-abbr { font-size: 10px; color: var(--text-muted); margin-bottom: 8px; }
   .arc-green { color: var(--success); font-weight: bold; }

--- a/web-app/public/visuals/gk008-engine-instruments.html
+++ b/web-app/public/visuals/gk008-engine-instruments.html
@@ -8,16 +8,22 @@
 <style>
   .panel-grid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 14px; margin-bottom: 32px; }
   .gauge-card { background: #1a2d3d; border: 1px solid #243d52; border-radius: 8px; padding: 12px; text-align: center; }
-  .gauge-name { font-size: 11px; color: #f0c040; font-weight: bold; letter-spacing: 0.5px; margin-bottom: 4px; }
-  .gauge-abbr { font-size: 10px; color: #7a9ab5; margin-bottom: 8px; }
-  .arc-green { color: #4caf7d; font-weight: bold; }
-  .arc-yellow { color: #f0c040; font-weight: bold; }
-  .arc-red { color: #e05050; font-weight: bold; }
-  .note-box { border-left-color: #e05050; }
+  .gauge-name { font-size: 11px; color: var(--accent); font-weight: bold; letter-spacing: 0.5px; margin-bottom: 4px; }
+  .gauge-abbr { font-size: 10px; color: var(--text-muted); margin-bottom: 8px; }
+  .arc-green { color: var(--success); font-weight: bold; }
+  .arc-yellow { color: var(--accent); font-weight: bold; }
+  .arc-red { color: var(--danger); font-weight: bold; }
+  .note-box { border-left-color: var(--danger); }
+  @media (max-width: 480px) {
+    body { font-size: 14px; }
+    .panel-grid { grid-template-columns: repeat(2, 1fr); }
+    table { display: block; overflow-x: auto; }
+    button { min-height: 44px; }
+  }
 </style>
 </head>
 <body>
-  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:#f0c040;border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
+  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:var(--accent);border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
   <style>.container{padding-top:56px!important;}@media(max-width:480px){.container{padding-top:60px!important;}}</style>
 <div class="container">
   <h1>GK-008 — Engine Instruments Panel</h1>

--- a/web-app/public/visuals/gk009-weight-and-balance.html
+++ b/web-app/public/visuals/gk009-weight-and-balance.html
@@ -9,15 +9,21 @@
   .layout { display: grid; grid-template-columns: 1fr 1fr; gap: 24px; align-items: start; }
   td { text-align: right; }
   td:first-child { text-align: left; }
-  .formula-box { background: #1a2d3d; border: 1px solid #f0c040; border-radius: 8px; padding: 18px; margin-bottom: 20px; text-align: center; }
-  .formula { font-size: 18px; color: #f0c040; font-weight: bold; letter-spacing: 1px; margin-bottom: 6px; }
-  .formula-sub { font-size: 12px; color: #7a9ab5; }
-  .total-row td { background: #243d52; color: #f0c040; font-weight: bold; }
-  .warning { color: #e05050; font-weight: bold; }
+  .formula-box { background: #1a2d3d; border: 1px solid var(--accent); border-radius: 8px; padding: 18px; margin-bottom: 20px; text-align: center; }
+  .formula { font-size: 18px; color: var(--accent); font-weight: bold; letter-spacing: 1px; margin-bottom: 6px; }
+  .formula-sub { font-size: 12px; color: var(--text-muted); }
+  .total-row td { background: #243d52; color: var(--accent); font-weight: bold; }
+  .warning { color: var(--danger); font-weight: bold; }
+  @media (max-width: 480px) {
+    body { font-size: 14px; }
+    .layout { grid-template-columns: 1fr; }
+    table { display: block; overflow-x: auto; }
+    button { min-height: 44px; }
+  }
 </style>
 </head>
 <body>
-  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:#f0c040;border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
+  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:var(--accent);border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
   <style>.container{padding-top:56px!important;}@media(max-width:480px){.container{padding-top:60px!important;}}</style>
 <div class="container">
   <h1>GK-009 — Weight &amp; Balance</h1>
@@ -148,7 +154,7 @@
         </tbody>
       </table>
       <div class="formula-box" style="margin-top:0;">
-        <div class="formula">CG = 165,528 ÷ 1,870 = <span style="color:#4caf7d;">88.5 inches</span></div>
+        <div class="formula">CG = 165,528 ÷ 1,870 = <span style="color:var(--success);">88.5 inches</span></div>
         <div class="formula-sub">CG is aft of datum by 88.5 inches — check against envelope limits</div>
       </div>
     </div>

--- a/web-app/public/visuals/gk009-weight-and-balance.html
+++ b/web-app/public/visuals/gk009-weight-and-balance.html
@@ -9,10 +9,10 @@
   .layout { display: grid; grid-template-columns: 1fr 1fr; gap: 24px; align-items: start; }
   td { text-align: right; }
   td:first-child { text-align: left; }
-  .formula-box { background: #1a2d3d; border: 1px solid var(--accent); border-radius: 8px; padding: 18px; margin-bottom: 20px; text-align: center; }
+  .formula-box { background: var(--surface); border: 1px solid var(--accent); border-radius: 8px; padding: 18px; margin-bottom: 20px; text-align: center; }
   .formula { font-size: 18px; color: var(--accent); font-weight: bold; letter-spacing: 1px; margin-bottom: 6px; }
   .formula-sub { font-size: 12px; color: var(--text-muted); }
-  .total-row td { background: #243d52; color: var(--accent); font-weight: bold; }
+  .total-row td { background: var(--border); color: var(--accent); font-weight: bold; }
   .warning { color: var(--danger); font-weight: bold; }
   @media (max-width: 480px) {
     body { font-size: 14px; }

--- a/web-app/public/visuals/gk010-performance-charts.html
+++ b/web-app/public/visuals/gk010-performance-charts.html
@@ -11,7 +11,7 @@
   td { font-size: 12px; padding: 8px 12px; }
   .grid-2 { display: grid; grid-template-columns: 1fr 1fr; gap: 24px; margin-bottom: 24px; }
   .grid-4 { display: grid; grid-template-columns: repeat(4, 1fr); gap: 16px; margin-bottom: 24px; }
-  .card { background: #1a2d3d; border: 1px solid #243d52; border-radius: 8px; padding: 16px; }
+  .card { background: var(--surface); border: 1px solid var(--border); border-radius: 8px; padding: 16px; }
   .card-title { font-size: 12px; color: var(--accent); font-weight: bold; letter-spacing: 0.5px; margin-bottom: 10px; text-transform: uppercase; }
   .isa-box { background: #0d2040; border: 2px solid #5b9bd5; border-radius: 8px; padding: 18px; text-align: center; margin-bottom: 24px; }
   .isa-main { font-size: 18px; color: #5b9bd5; font-weight: bold; margin-bottom: 4px; }
@@ -19,7 +19,7 @@
   .better { color: var(--success); font-weight: bold; }
   .worse { color: var(--danger); font-weight: bold; }
   .neutral { color: var(--text-muted); }
-  .da-diagram { background: #1a2d3d; border: 1px solid #243d52; border-radius: 8px; padding: 16px; }
+  .da-diagram { background: var(--surface); border: 1px solid var(--border); border-radius: 8px; padding: 16px; }
   @media (max-width: 480px) {
     body { font-size: 14px; }
     .grid-2, .grid-4 { grid-template-columns: 1fr; }
@@ -100,19 +100,19 @@
   <div class="grid-4">
     <div class="card">
       <div class="card-title">Takeoff Distance</div>
-      <div style="font-size:12px; color:#e8edf2; line-height:1.6;">Ground roll distance + distance to clear 50 ft obstacle. Variables: pressure altitude, temp, weight, wind, runway surface</div>
+      <div style="font-size:12px; color:var(--text); line-height:1.6;">Ground roll distance + distance to clear 50 ft obstacle. Variables: pressure altitude, temp, weight, wind, runway surface</div>
     </div>
     <div class="card">
       <div class="card-title">Climb Performance</div>
-      <div style="font-size:12px; color:#e8edf2; line-height:1.6;">Best rate (Vy) and best angle (Vx) climb speeds and rates vs. pressure altitude and temperature</div>
+      <div style="font-size:12px; color:var(--text); line-height:1.6;">Best rate (Vy) and best angle (Vx) climb speeds and rates vs. pressure altitude and temperature</div>
     </div>
     <div class="card">
       <div class="card-title">Cruise Performance</div>
-      <div style="font-size:12px; color:#e8edf2; line-height:1.6;">TAS, fuel flow at various power settings, altitudes, temps. Used for flight planning and range/endurance</div>
+      <div style="font-size:12px; color:var(--text); line-height:1.6;">TAS, fuel flow at various power settings, altitudes, temps. Used for flight planning and range/endurance</div>
     </div>
     <div class="card">
       <div class="card-title">Landing Distance</div>
-      <div style="font-size:12px; color:#e8edf2; line-height:1.6;">Ground roll + distance from 50 ft obstacle to stop. Variables: same as takeoff. Generally shorter than TO distances</div>
+      <div style="font-size:12px; color:var(--text); line-height:1.6;">Ground roll + distance from 50 ft obstacle to stop. Variables: same as takeoff. Generally shorter than TO distances</div>
     </div>
   </div>
 

--- a/web-app/public/visuals/gk010-performance-charts.html
+++ b/web-app/public/visuals/gk010-performance-charts.html
@@ -12,18 +12,24 @@
   .grid-2 { display: grid; grid-template-columns: 1fr 1fr; gap: 24px; margin-bottom: 24px; }
   .grid-4 { display: grid; grid-template-columns: repeat(4, 1fr); gap: 16px; margin-bottom: 24px; }
   .card { background: #1a2d3d; border: 1px solid #243d52; border-radius: 8px; padding: 16px; }
-  .card-title { font-size: 12px; color: #f0c040; font-weight: bold; letter-spacing: 0.5px; margin-bottom: 10px; text-transform: uppercase; }
+  .card-title { font-size: 12px; color: var(--accent); font-weight: bold; letter-spacing: 0.5px; margin-bottom: 10px; text-transform: uppercase; }
   .isa-box { background: #0d2040; border: 2px solid #5b9bd5; border-radius: 8px; padding: 18px; text-align: center; margin-bottom: 24px; }
   .isa-main { font-size: 18px; color: #5b9bd5; font-weight: bold; margin-bottom: 4px; }
-  .isa-sub { font-size: 12px; color: #7a9ab5; line-height: 1.6; }
-  .better { color: #4caf7d; font-weight: bold; }
-  .worse { color: #e05050; font-weight: bold; }
-  .neutral { color: #7a9ab5; }
+  .isa-sub { font-size: 12px; color: var(--text-muted); line-height: 1.6; }
+  .better { color: var(--success); font-weight: bold; }
+  .worse { color: var(--danger); font-weight: bold; }
+  .neutral { color: var(--text-muted); }
   .da-diagram { background: #1a2d3d; border: 1px solid #243d52; border-radius: 8px; padding: 16px; }
+  @media (max-width: 480px) {
+    body { font-size: 14px; }
+    .grid-2, .grid-4 { grid-template-columns: 1fr; }
+    table { display: block; overflow-x: auto; }
+    button { min-height: 44px; }
+  }
 </style>
 </head>
 <body>
-  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:#f0c040;border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
+  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:var(--accent);border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
   <style>.container{padding-top:56px!important;}@media(max-width:480px){.container{padding-top:60px!important;}}</style>
 <div class="container">
   <h1>GK-010 — Performance Charts Reference</h1>


### PR DESCRIPTION
Closes #245

## Changes

- **GK-006 through GK-010**: Replaced all 9 hardcoded hex colours in `<style>` blocks and inline `style` attributes with the standard CSS custom properties:
  - `#f0c040` → `var(--accent)`
  - `#7a9ab5` → `var(--text-muted)`
  - `#4caf7d` → `var(--success)`
  - `#e05050` → `var(--danger)`
  - (other token mappings: `--bg`, `--bg2`, `--surface`, `--border`, `--text` — none of those specific hex values appeared outside SVGs in these files)
- SVG internals (`fill`, `stroke`, `stop-color`, linearGradient stops) are untouched
- Tag-overlay tints `#0d2a1a` and `#2a1a0d` preserved as-is
- Existing `≤640px` media query in `_common.css` untouched
- Added `@media (max-width: 480px)` block to each file:
  - `body { font-size: 14px }` — meets ≥14px requirement
  - Multi-column grids collapse to 1 column (or 2 for gk008 panel grid) — prevents horizontal overflow at 375px
  - `table { display: block; overflow-x: auto }` — fixes wide tables at 375px
  - `button { min-height: 44px }` — enforces ≥44px touch target (back button already had this inline)

## Test Plan

- [ ] Open each visual in a browser at 375px viewport width; verify `document.documentElement.scrollWidth === document.documentElement.clientWidth` (no horizontal overflow)
- [ ] Verify body text renders at ≥14px at 375px
- [ ] Verify colour tokens resolve correctly in both dark and any light override context
- [ ] Confirm SVG shapes, colours, and diagram content are visually unchanged
- [ ] `npm run build` from `web-app/` passes ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)