### PR TITLE
[PPL-250] migrate NAV-001–005 visuals to CSS vars + mobile fixes

### DIFF
--- a/web-app/public/visuals/nav001-vfr-charts.html
+++ b/web-app/public/visuals/nav001-vfr-charts.html
@@ -73,6 +73,7 @@ body { max-width: 860px; margin: auto; }
   /* ── Mobile ≤480px ───────────────────────────────────────────────── */
   @media (max-width: 480px) {
     body { font-size: 14px; }
+    .two-col { grid-template-columns: 1fr; }
     .symbol-grid { grid-template-columns: 1fr 1fr; }
     .obs-grid, .nav-grid { grid-template-columns: 1fr; }
     .notation-row { flex-direction: column; }


### PR DESCRIPTION
## Summary

- All five nav visual files (nav001–nav005) migrated from hardcoded hex to CSS custom properties per token mapping in issue #250
- SVG `fill`/`stroke` attributes left hardcoded (SVG exception)
- `#3a6a9a` `.scale-seg-light` left hardcoded (diagram-visualization exception)
- Aviation chart line colors (`#3a7ad5`, `#c050c0`, `#9050d0`) left hardcoded — not in token mapping table, represent chart-specific colors
- This PR adds the one missing mobile fix from PR #253: nav001 `.two-col` collapse to `1fr` in the ≤480px query so scale cards stack on narrow (375px) viewports

## Token mapping applied

| Hex | Variable |
|-----|----------|
| `#0a1a35`, `#0d2040` | `var(--surface)` |
| `#1a3a5a`, `#1a3550` | `var(--border)` |
| `#0d1b2a` | `var(--bg2)` |
| `#f0c040` | `var(--accent)` |
| `#c8d8e8`, `#e8edf2` | `var(--text)` |
| `#7a9ab5` | `var(--text-muted)` |

## Mobile fixes (all 5 files)
- `body { font-size: 14px }` at ≤480px ✓
- Back button `min-height: 44px; min-width: 44px` ✓
- `.two-col`, `.three-col` → `1fr` at ≤480px (nav001 fix in this PR)
- `table { overflow-x: auto }` at ≤480px ✓
- SVGs have `max-width: 100%; height: auto` ✓

## Verification
- `npm run build` passes ✓
- Zero tokens from mapping table remain hardcoded outside SVG elements ✓

Closes #250