### PR TITLE
[PPL-246] migrate GK-011–014 visuals to CSS vars + mobile fixes

### DIFF
--- a/web-app/public/visuals/gk011-takeoff-landing-perf.html
+++ b/web-app/public/visuals/gk011-takeoff-landing-perf.html
@@ -9,14 +9,20 @@
   .layout { display: grid; grid-template-columns: 1fr 1fr; gap: 24px; align-items: start; }
   .diagram-box { margin-bottom: 24px; }
   .speeds-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 14px; margin-bottom: 24px; }
-  .speed-card { background: #1a2d3d; border: 1px solid #243d52; border-radius: 8px; padding: 14px; text-align: center; }
-  .speed-label { font-size: 22px; color: #f0c040; font-weight: bold; margin-bottom: 4px; }
-  .speed-name { font-size: 11px; color: #7a9ab5; margin-bottom: 8px; letter-spacing: 0.5px; }
-  .speed-desc { font-size: 12px; color: #e8edf2; line-height: 1.5; }
+  .speed-card { background: var(--surface); border: 1px solid var(--border); border-radius: 8px; padding: 14px; text-align: center; }
+  .speed-label { font-size: 22px; color: var(--accent); font-weight: bold; margin-bottom: 4px; }
+  .speed-name { font-size: 11px; color: var(--text-muted); margin-bottom: 8px; letter-spacing: 0.5px; }
+  .speed-desc { font-size: 12px; color: var(--text); line-height: 1.5; }
+  @media (max-width: 480px) {
+    body { font-size: 14px; overflow-x: hidden; }
+    .layout { grid-template-columns: 1fr; }
+    .speeds-grid { grid-template-columns: 1fr; }
+    .speed-card { min-height: 44px; }
+  }
 </style>
 </head>
 <body>
-  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:#f0c040;border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
+  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:var(--accent);border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
   <style>.container{padding-top:56px!important;}@media(max-width:480px){.container{padding-top:60px!important;}}</style>
 <div class="container">
   <h1>GK-011 — Takeoff &amp; Landing Performance</h1>

--- a/web-app/public/visuals/gk012-stalls-spins.html
+++ b/web-app/public/visuals/gk012-stalls-spins.html
@@ -7,21 +7,26 @@
 <link rel="stylesheet" href="_common.css">
 <style>
   .layout { display: grid; grid-template-columns: 1fr 1fr; gap: 24px; align-items: start; }
-  .recovery-steps { background: #1a2d3d; border: 1px solid #243d52; border-radius: 8px; padding: 16px; }
+  .recovery-steps { background: var(--surface); border: 1px solid var(--border); border-radius: 8px; padding: 16px; }
   .step { display: flex; gap: 12px; margin-bottom: 12px; align-items: flex-start; }
   .step:last-child { margin-bottom: 0; }
-  .step-num { background: #f0c040; color: #0d1b2a; font-weight: bold; font-size: 12px; width: 24px; height: 24px; border-radius: 50%; display: flex; align-items: center; justify-content: center; flex-shrink: 0; }
-  .step-text { font-size: 13px; color: #e8edf2; line-height: 1.5; }
-  .step-label { color: #f0c040; font-weight: bold; }
-  .pare-box { background: #0d2040; border: 2px solid #f0c040; border-radius: 8px; padding: 16px; margin-top: 16px; }
-  .pare-title { font-size: 13px; color: #f0c040; font-weight: bold; margin-bottom: 10px; letter-spacing: 1px; }
+  .step-num { background: var(--accent); color: var(--bg2); font-weight: bold; font-size: 12px; width: 24px; height: 24px; border-radius: 50%; display: flex; align-items: center; justify-content: center; flex-shrink: 0; }
+  .step-text { font-size: 13px; color: var(--text); line-height: 1.5; }
+  .step-label { color: var(--accent); font-weight: bold; }
+  .pare-box { background: var(--bg2); border: 2px solid var(--accent); border-radius: 8px; padding: 16px; margin-top: 16px; }
+  .pare-title { font-size: 13px; color: var(--accent); font-weight: bold; margin-bottom: 10px; letter-spacing: 1px; }
   .pare-row { display: flex; gap: 10px; align-items: center; margin-bottom: 8px; font-size: 13px; }
-  .pare-letter { font-size: 22px; color: #f0c040; font-weight: bold; width: 28px; flex-shrink: 0; }
-  .note-box { border-left-color: #e05050; }
+  .pare-letter { font-size: 22px; color: var(--accent); font-weight: bold; width: 28px; flex-shrink: 0; }
+  .note-box { border-left-color: var(--danger); }
+  @media (max-width: 480px) {
+    body { font-size: 14px; overflow-x: hidden; }
+    .layout { grid-template-columns: 1fr; }
+    .recovery-steps { min-height: 44px; }
+  }
 </style>
 </head>
 <body>
-  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:#f0c040;border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
+  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:var(--accent);border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
   <style>.container{padding-top:56px!important;}@media(max-width:480px){.container{padding-top:60px!important;}}</style>
 <div class="container">
   <h1>GK-012 — Stalls &amp; Spins</h1>

--- a/web-app/public/visuals/gk013-load-factor.html
+++ b/web-app/public/visuals/gk013-load-factor.html
@@ -8,18 +8,24 @@
 <style>
   .layout { display: grid; grid-template-columns: 1fr 1fr; gap: 24px; align-items: start; }
   .bank-grid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 12px; margin-bottom: 24px; }
-  .bank-card { background: #1a2d3d; border: 1px solid #243d52; border-radius: 8px; padding: 14px; text-align: center; }
-  .bank-angle { font-size: 20px; color: #f0c040; font-weight: bold; margin-bottom: 2px; }
-  .bank-bank { font-size: 11px; color: #7a9ab5; margin-bottom: 8px; }
-  .bank-g { font-size: 16px; color: #4caf7d; font-weight: bold; }
-  .bank-g-label { font-size: 10px; color: #7a9ab5; }
-  .limit-normal { color: #4caf7d; font-weight: bold; }
-  .limit-utility { color: #f0c040; font-weight: bold; }
-  .limit-acro { color: #e05050; font-weight: bold; }
+  .bank-card { background: var(--surface); border: 1px solid var(--border); border-radius: 8px; padding: 14px; text-align: center; }
+  .bank-angle { font-size: 20px; color: var(--accent); font-weight: bold; margin-bottom: 2px; }
+  .bank-bank { font-size: 11px; color: var(--text-muted); margin-bottom: 8px; }
+  .bank-g { font-size: 16px; color: var(--success); font-weight: bold; }
+  .bank-g-label { font-size: 10px; color: var(--text-muted); }
+  .limit-normal { color: var(--success); font-weight: bold; }
+  .limit-utility { color: var(--accent); font-weight: bold; }
+  .limit-acro { color: var(--danger); font-weight: bold; }
+  @media (max-width: 480px) {
+    body { font-size: 14px; overflow-x: hidden; }
+    .layout { grid-template-columns: 1fr; }
+    .bank-grid { grid-template-columns: repeat(2, 1fr); }
+    .bank-card { min-height: 44px; }
+  }
 </style>
 </head>
 <body>
-  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:#f0c040;border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
+  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:var(--accent);border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
   <style>.container{padding-top:56px!important;}@media(max-width:480px){.container{padding-top:60px!important;}}</style>
 <div class="container">
   <h1>GK-013 — Load Factor &amp; Maneuvering Speed</h1>
@@ -134,7 +140,7 @@
         <div class="bank-card">
           <div class="bank-angle">60°</div>
           <div class="bank-bank">Steep bank</div>
-          <div class="bank-g" style="color:#f0c040;">2.00g</div>
+          <div class="bank-g" style="color:var(--accent);">2.00g</div>
           <div class="bank-g-label">Double weight!</div>
         </div>
       </div>
@@ -157,9 +163,9 @@
           <tr><th>Speed</th><th>Name</th><th>Significance</th></tr>
         </thead>
         <tbody>
-          <tr><td><strong style="color:#4caf7d;">Va</strong></td><td>Design Maneuvering Speed</td><td>At or below Va, full control inputs won't overstress the aircraft — it will stall first</td></tr>
-          <tr><td><strong style="color:#f0c040;">Vno</strong></td><td>Max Structural Cruise Speed</td><td>Top of green arc — do not exceed in rough/turbulent air</td></tr>
-          <tr><td><strong style="color:#e05050;">Vne</strong></td><td>Never Exceed Speed</td><td>Red line on ASI — structural failure risk above this</td></tr>
+          <tr><td><strong style="color:var(--success);">Va</strong></td><td>Design Maneuvering Speed</td><td>At or below Va, full control inputs won't overstress the aircraft — it will stall first</td></tr>
+          <tr><td><strong style="color:var(--accent);">Vno</strong></td><td>Max Structural Cruise Speed</td><td>Top of green arc — do not exceed in rough/turbulent air</td></tr>
+          <tr><td><strong style="color:var(--danger);">Vne</strong></td><td>Never Exceed Speed</td><td>Red line on ASI — structural failure risk above this</td></tr>
         </tbody>
       </table>
     </div>

--- a/web-app/public/visuals/gk014-preflight-inspection.html
+++ b/web-app/public/visuals/gk014-preflight-inspection.html
@@ -8,20 +8,25 @@
 <style>
   .layout { display: grid; grid-template-columns: 1fr 1fr; gap: 24px; align-items: start; }
   td { font-size: 12px; padding: 8px 12px; }
-  .zone-num { display: inline-flex; align-items: center; justify-content: center; width: 22px; height: 22px; background: #f0c040; color: #0d1b2a; border-radius: 50%; font-size: 11px; font-weight: bold; margin-right: 6px; flex-shrink: 0; }
-  .zone-title { display: flex; align-items: center; font-size: 13px; color: #f0c040; font-weight: bold; margin-bottom: 6px; }
-  .checklist-item { font-size: 12px; color: #e8edf2; padding: 3px 0 3px 28px; display: flex; align-items: flex-start; gap: 6px; }
-  .check-box { width: 12px; height: 12px; border: 1px solid #7a9ab5; border-radius: 2px; flex-shrink: 0; margin-top: 1px; }
-  .zone-card { background: #1a2d3d; border: 1px solid #243d52; border-radius: 8px; padding: 14px; margin-bottom: 14px; }
-  .arrow-box { background: #0d2040; border: 2px solid #f0c040; border-radius: 8px; padding: 16px; margin-top: 16px; }
-  .arrow-title { font-size: 13px; color: #f0c040; font-weight: bold; letter-spacing: 1px; margin-bottom: 10px; }
+  .zone-num { display: inline-flex; align-items: center; justify-content: center; width: 22px; height: 22px; background: var(--accent); color: var(--bg2); border-radius: 50%; font-size: 11px; font-weight: bold; margin-right: 6px; flex-shrink: 0; }
+  .zone-title { display: flex; align-items: center; font-size: 13px; color: var(--accent); font-weight: bold; margin-bottom: 6px; }
+  .checklist-item { font-size: 12px; color: var(--text); padding: 3px 0 3px 28px; display: flex; align-items: flex-start; gap: 6px; }
+  .check-box { width: 12px; height: 12px; border: 1px solid var(--text-muted); border-radius: 2px; flex-shrink: 0; margin-top: 1px; }
+  .zone-card { background: var(--surface); border: 1px solid var(--border); border-radius: 8px; padding: 14px; margin-bottom: 14px; }
+  .arrow-box { background: var(--bg2); border: 2px solid var(--accent); border-radius: 8px; padding: 16px; margin-top: 16px; }
+  .arrow-title { font-size: 13px; color: var(--accent); font-weight: bold; letter-spacing: 1px; margin-bottom: 10px; }
   .arrow-row { display: flex; gap: 10px; align-items: center; margin-bottom: 8px; font-size: 13px; }
-  .arrow-letter { font-size: 22px; color: #f0c040; font-weight: bold; width: 28px; flex-shrink: 0; }
-  .note-box { border-left-color: #4caf7d; }
+  .arrow-letter { font-size: 22px; color: var(--accent); font-weight: bold; width: 28px; flex-shrink: 0; }
+  .note-box { border-left-color: var(--success); }
+  @media (max-width: 480px) {
+    body { font-size: 14px; overflow-x: hidden; }
+    .layout { grid-template-columns: 1fr; }
+    .zone-card { min-height: 44px; }
+  }
 </style>
 </head>
 <body>
-  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:#f0c040;border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
+  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:var(--accent);border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
   <style>.container{padding-top:56px!important;}@media(max-width:480px){.container{padding-top:60px!important;}}</style>
 <div class="container">
   <h1>GK-014 — Preflight Inspection Walkaround</h1>


### PR DESCRIPTION
## Summary
- Replaced all hardcoded hex values outside `<svg>` elements with `_common.css` CSS variables (`--bg2`, `--surface`, `--border`, `--accent`, `--text`, `--text-muted`, `--success`, `--danger`) across gk011–gk014
- Added `≤480px` media query block (separate from existing `≤640px`) in each file: `font-size: 14px` on body, single-column layouts, `min-height: 44px` on key cards, `overflow-x: hidden`
- SVG element colors (fill/stroke/stop-color) left untouched
- `npm run build` passes cleanly

## Files Changed
- `web-app/public/visuals/gk011-takeoff-landing-perf.html`
- `web-app/public/visuals/gk012-stalls-spins.html`
- `web-app/public/visuals/gk013-load-factor.html`
- `web-app/public/visuals/gk014-preflight-inspection.html`

## Test plan
- [ ] Open each visual at 375px viewport — verify no horizontal scroll
- [ ] Check card backgrounds and text colors render using CSS tokens
- [ ] Back button tap target ≥44px on mobile
- [ ] Existing ≤640px media query still applies (body padding: 16px)

Closes #246

🤖 Generated with [Claude Code](https://claude.com/claude-code)