### PR TITLE
[PPL-247] Migrate MET-001–005 to _common.css vars + mobile fixes

### DIFF
--- a/web-app/public/visuals/met001-atmosphere-structure.html
+++ b/web-app/public/visuals/met001-atmosphere-structure.html
@@ -11,6 +11,10 @@
   @media (max-width: 640px) {
     .layout { grid-template-columns: 1fr; }
   }
+  @media (max-width: 480px) {
+    body { font-size: 14px; padding: 16px; }
+    .layout { grid-template-columns: 1fr; }
+  }
 </style>
 </head>
 <body>

--- a/web-app/public/visuals/met002-temp-pressure-humidity.html
+++ b/web-app/public/visuals/met002-temp-pressure-humidity.html
@@ -7,8 +7,12 @@
 <link rel="stylesheet" href="/visuals/_common.css">
 <style>
   .layout { display: grid; grid-template-columns: 1fr 1fr; gap: 24px; align-items: start; }
-  .caption { font-size: 12px; color: #7a9ab5; text-align: center; margin-top: 8px; }
+  .caption { font-size: 12px; color: var(--text-muted); text-align: center; margin-top: 8px; }
   @media (max-width: 640px) {
+    .layout { grid-template-columns: 1fr; }
+  }
+  @media (max-width: 480px) {
+    body { font-size: 14px; padding: 16px; }
     .layout { grid-template-columns: 1fr; }
   }
 </style>
@@ -106,7 +110,7 @@
     <thead><tr><th>Formula</th><th>Example</th></tr></thead>
     <tbody>
       <tr>
-        <td><strong style="color:#f0c040;">Base AGL = (T − Td) × 400 ft</strong></td>
+        <td><strong style="color:var(--accent);">Base AGL = (T − Td) × 400 ft</strong></td>
         <td>T = 18 °C, Td = 12 °C → spread 6 °C → cumulus base ≈ 2,400 ft AGL</td>
       </tr>
     </tbody>

--- a/web-app/public/visuals/met003-clouds-types.html
+++ b/web-app/public/visuals/met003-clouds-types.html
@@ -7,21 +7,27 @@
 <link rel="stylesheet" href="/visuals/_common.css">
 <style>
   .tier { display: grid; grid-template-columns: 160px 1fr; gap: 16px; align-items: stretch; margin-bottom: 10px; }
-  .tier-label { background: #1a2d3d; border: 1px solid #243d52; border-radius: 8px; padding: 14px; }
-  .tier-label .alt { font-size: 11px; color: #7a9ab5; letter-spacing: 0.5px; text-transform: uppercase; }
-  .tier-label .name { font-size: 16px; color: #f0c040; font-weight: bold; margin-top: 4px; }
-  .tier-label .range { font-size: 12px; color: #e8edf2; margin-top: 4px; }
+  .tier-label { background: var(--border); border: 1px solid var(--border); border-radius: 8px; padding: 14px; }
+  .tier-label .alt { font-size: 11px; color: var(--text-muted); letter-spacing: 0.5px; text-transform: uppercase; }
+  .tier-label .name { font-size: 16px; color: var(--accent); font-weight: bold; margin-top: 4px; }
+  .tier-label .range { font-size: 12px; color: var(--text); margin-top: 4px; }
   .tier-clouds { display: grid; grid-template-columns: repeat(auto-fit, minmax(140px, 1fr)); gap: 10px; }
-  .cloud-card { background: #1a2d3d; border: 1px solid #243d52; border-radius: 8px; padding: 12px; }
-  .cloud-card .cname { font-size: 13px; color: #f0c040; font-weight: bold; margin-bottom: 4px; }
-  .cloud-card .cabbr { font-size: 10px; color: #7a9ab5; letter-spacing: 1px; }
-  .cloud-card .cnote { font-size: 11px; color: #e8edf2; margin-top: 6px; line-height: 1.45; }
+  .cloud-card { background: var(--border); border: 1px solid var(--border); border-radius: 8px; padding: 12px; }
+  .cloud-card .cname { font-size: 13px; color: var(--accent); font-weight: bold; margin-bottom: 4px; }
+  .cloud-card .cabbr { font-size: 10px; color: var(--text-muted); letter-spacing: 1px; }
+  .cloud-card .cnote { font-size: 11px; color: var(--text); margin-top: 6px; line-height: 1.45; }
   .stability-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; }
-  .stab-card { background: #1a2d3d; border: 1px solid #243d52; border-radius: 8px; padding: 14px; }
-  .stab-card h3 { font-size: 13px; color: #f0c040; margin-bottom: 8px; letter-spacing: 0.5px; }
-  .stab-card ul { margin-left: 18px; color: #e8edf2; font-size: 12px; line-height: 1.7; }
+  .stab-card { background: var(--border); border: 1px solid var(--border); border-radius: 8px; padding: 14px; }
+  .stab-card h3 { font-size: 13px; color: var(--accent); margin-bottom: 8px; letter-spacing: 0.5px; }
+  .stab-card ul { margin-left: 18px; color: var(--text); font-size: 12px; line-height: 1.7; }
   @media (max-width: 640px) {
     .tier { grid-template-columns: 1fr; }
+    .stability-grid { grid-template-columns: 1fr; }
+  }
+  @media (max-width: 480px) {
+    body { font-size: 14px; padding: 16px; }
+    .tier { grid-template-columns: 1fr; }
+    .tier-clouds { grid-template-columns: repeat(auto-fit, minmax(120px, 1fr)); }
     .stability-grid { grid-template-columns: 1fr; }
   }
 </style>
@@ -40,7 +46,7 @@
       <div class="alt">High</div>
       <div class="name">Cirro-</div>
       <div class="range">&gt; 20,000 ft</div>
-      <div class="range" style="color:#7a9ab5;">Ice crystals</div>
+      <div class="range" style="color:var(--text-muted);">Ice crystals</div>
     </div>
     <div class="tier-clouds">
       <div class="cloud-card"><div class="cname">Cirrus</div><div class="cabbr">CI</div><div class="cnote">Wispy streaks — fair weather, but may signal approaching warm front 24–48 h out.</div></div>
@@ -54,7 +60,7 @@
       <div class="alt">Middle</div>
       <div class="name">Alto-</div>
       <div class="range">6,500 – 20,000 ft</div>
-      <div class="range" style="color:#7a9ab5;">Water + ice</div>
+      <div class="range" style="color:var(--text-muted);">Water + ice</div>
     </div>
     <div class="tier-clouds">
       <div class="cloud-card"><div class="cname">Altostratus</div><div class="cabbr">AS</div><div class="cnote">Grey/blue sheet — sun appears as through frosted glass. Steady rain/snow approaching.</div></div>
@@ -68,7 +74,7 @@
       <div class="alt">Low</div>
       <div class="name">Strato- / Cumulo-</div>
       <div class="range">Surface – 6,500 ft</div>
-      <div class="range" style="color:#7a9ab5;">Mostly water</div>
+      <div class="range" style="color:var(--text-muted);">Mostly water</div>
     </div>
     <div class="tier-clouds">
       <div class="cloud-card"><div class="cname">Stratus</div><div class="cabbr">ST</div><div class="cnote">Uniform low layer — drizzle/mist, poor VFR.</div></div>
@@ -107,7 +113,7 @@
     <thead><tr><th>Formula</th><th>Worked Example</th></tr></thead>
     <tbody>
       <tr>
-        <td><strong style="color:#f0c040;">Base AGL ≈ (T − Td) × 400 ft</strong></td>
+        <td><strong style="color:var(--accent);">Base AGL ≈ (T − Td) × 400 ft</strong></td>
         <td>Surface T 22 °C, Td 14 °C → spread 8 °C → base ≈ 3,200 ft AGL</td>
       </tr>
     </tbody>

--- a/web-app/public/visuals/met004-fog-types.html
+++ b/web-app/public/visuals/met004-fog-types.html
@@ -7,11 +7,15 @@
 <link rel="stylesheet" href="/visuals/_common.css">
 <style>
   .grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); gap: 14px; }
-  .card { background: #1a2d3d; border: 1px solid #243d52; border-radius: 8px; padding: 16px; }
-  .card h3 { font-size: 14px; color: #f0c040; margin-bottom: 6px; letter-spacing: 0.5px; }
-  .card .tag { display: inline-block; font-size: 10px; background: #243d52; color: #e8edf2; padding: 2px 7px; border-radius: 3px; letter-spacing: 0.5px; margin-bottom: 8px; }
-  .card .row { font-size: 12px; color: #e8edf2; margin-bottom: 4px; line-height: 1.5; }
-  .card .row .label { color: #7a9ab5; font-size: 10px; letter-spacing: 0.5px; text-transform: uppercase; display: block; margin-top: 6px; }
+  .card { background: var(--border); border: 1px solid var(--border); border-radius: 8px; padding: 16px; }
+  .card h3 { font-size: 14px; color: var(--accent); margin-bottom: 6px; letter-spacing: 0.5px; }
+  .card .tag { display: inline-block; font-size: 10px; background: var(--border); color: var(--text); padding: 2px 7px; border-radius: 3px; letter-spacing: 0.5px; margin-bottom: 8px; }
+  .card .row { font-size: 12px; color: var(--text); margin-bottom: 4px; line-height: 1.5; }
+  .card .row .label { color: var(--text-muted); font-size: 10px; letter-spacing: 0.5px; text-transform: uppercase; display: block; margin-top: 6px; }
+  @media (max-width: 480px) {
+    body { font-size: 14px; padding: 16px; }
+    .grid { grid-template-columns: 1fr; }
+  }
 </style>
 </head>
 <body>

--- a/web-app/public/visuals/met005-metar-decoding.html
+++ b/web-app/public/visuals/met005-metar-decoding.html
@@ -6,8 +6,9 @@
 <title>MET-005: METAR Decoding</title>
 <link rel="stylesheet" href="/visuals/_common.css">
 <style>
-  .metar-sample { background: #1a2d3d; border: 1px solid #243d52; border-radius: 8px; padding: 18px 20px; font-family: 'Consolas', 'Menlo', monospace; font-size: 15px; line-height: 1.9; margin-bottom: 14px; word-break: break-word; }
+  .metar-sample { background: var(--border); border: 1px solid var(--border); border-radius: 8px; padding: 18px 20px; font-family: 'Consolas', 'Menlo', monospace; font-size: 15px; line-height: 1.9; margin-bottom: 14px; word-break: break-word; }
   .seg { padding: 2px 6px; border-radius: 3px; margin: 0 2px; display: inline-block; }
+  /* data-encoding: METAR field segment colours — exempt from CSS var migration */
   .s-type { background: #2d3e50; color: #e8edf2; }
   .s-icao { background: #3d5a80; color: #e8edf2; }
   .s-time { background: #4c5b8c; color: #e8edf2; }
@@ -18,13 +19,18 @@
   .s-temp { background: #3a5a7a; color: #e8edf2; }
   .s-alt  { background: #6a4a7a; color: #e8edf2; }
   .s-rmk  { background: #3d3d3d; color: #e8edf2; }
-  td code { font-family: 'Consolas', 'Menlo', monospace; background: #0d1b2a; color: #f0c040; padding: 1px 6px; border-radius: 3px; font-size: 12px; }
+  td code { font-family: 'Consolas', 'Menlo', monospace; background: var(--bg); color: var(--accent); padding: 1px 6px; border-radius: 3px; font-size: 12px; }
   .sky-grid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 10px; }
-  .sky-card { background: #1a2d3d; border: 1px solid #243d52; border-radius: 8px; padding: 12px; text-align: center; }
-  .sky-code { font-size: 18px; color: #f0c040; font-weight: bold; font-family: 'Consolas', monospace; }
-  .sky-name { font-size: 11px; color: #e8edf2; margin-top: 4px; }
-  .sky-oktas { font-size: 10px; color: #7a9ab5; margin-top: 2px; }
+  .sky-card { background: var(--border); border: 1px solid var(--border); border-radius: 8px; padding: 12px; text-align: center; }
+  .sky-code { font-size: 18px; color: var(--accent); font-weight: bold; font-family: 'Consolas', monospace; }
+  .sky-name { font-size: 11px; color: var(--text); margin-top: 4px; }
+  .sky-oktas { font-size: 10px; color: var(--text-muted); margin-top: 2px; }
   @media (max-width: 640px) { .sky-grid { grid-template-columns: repeat(2, 1fr); } }
+  @media (max-width: 480px) {
+    body { font-size: 14px; padding: 16px; }
+    .metar-sample { font-size: 13px; padding: 12px 14px; }
+    .sky-grid { grid-template-columns: repeat(2, 1fr); }
+  }
 </style>
 </head>
 <body>
@@ -77,12 +83,12 @@
       <div class="sky-oktas">3 – 4 oktas</div>
     </div>
     <div class="sky-card">
-      <div class="sky-code" style="color:#ffb040;">BKN</div>
+      <div class="sky-code" style="color:#ffb040;">BKN</div><!-- design-exception: ceiling-warning amber, no token -->
       <div class="sky-name">Broken</div>
       <div class="sky-oktas">5 – 7 oktas — <strong>ceiling!</strong></div>
     </div>
     <div class="sky-card">
-      <div class="sky-code" style="color:#e05050;">OVC</div>
+      <div class="sky-code" style="color:var(--danger);">OVC</div>
       <div class="sky-name">Overcast</div>
       <div class="sky-oktas">8 oktas — <strong>ceiling!</strong></div>
     </div>


### PR DESCRIPTION
## Summary

- Replace all hardcoded hex values in `<style>` blocks and non-exempt inline attributes across MET-001–005 visuals with `_common.css` CSS custom properties per the token mapping in #247
- Add `@media (max-width: 480px)` fixes in all five files: `font-size: 14px`, `padding: 16px`, single-column layouts — eliminates horizontal scroll at 375px
- SVG element colours (MET-001 atmosphere gradients), MET-002 pressure data colours (`#5b9bd5`/`#e05050`), and MET-005 METAR segment classes (`.s-*`) remain hardcoded per spec
- `#ffb040` (BKN sky-code amber) kept as a design exception — no equivalent token; annotated with a comment matching the MET-011 `#b030b0` precedent

## Test plan

- [ ] `npm run build` passes ✓ (verified locally)
- [ ] Visual inspection: no text, shape, or diagram content changes across all 5 files
- [ ] 375px viewport: single-column layouts, no horizontal scroll
- [ ] Tap targets: back button retains `min-width/min-height: 44px`
- [ ] Body text: `font-size: 14px` applied at ≤480px in all files

Closes #247

🤖 Generated with [Claude Code](https://claude.com/claude-code)