### PR TITLE
[PPL-251] migrate NAV-006–010 visuals to CSS vars + mobile fixes

### DIFF
--- a/web-app/public/visuals/nav006-time-speed-distance.html
+++ b/web-app/public/visuals/nav006-time-speed-distance.html
@@ -7,30 +7,22 @@
 <title>NAV-006: Time-Speed-Distance Calculations</title>
 <style>
 body { max-width: 860px; margin: auto; }
-  
-  
-  
 
-  
+  .info-card .big { font-size: 26px; font-weight: 800; color: var(--accent); text-align: center; padding: 8px 0; letter-spacing: 1px; }
+  .info-card .sub { font-size: 11px; color: var(--text-muted); text-align: center; margin-top: 2px; }
 
-  
-  
-  
-  
-  
-  .info-card .big { font-size: 26px; font-weight: 800; color: #f0c040; text-align: center; padding: 8px 0; letter-spacing: 1px; }
-  .info-card .sub { font-size: 11px; color: #7a9ab5; text-align: center; margin-top: 2px; }
-
-  
-  
-  
-  
-  
   td.solve { color: #80c880; font-weight: 700; }
+
+  @media (max-width: 480px) {
+    body { font-size: 14px; overflow-x: hidden; }
+    .three-col, .two-col { grid-template-columns: 1fr; }
+    table { display: block; overflow-x: auto; }
+    .grid-wrap svg { width: 100%; height: auto; }
+  }
 </style>
 </head>
 <body>
-  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:#f0c040;border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
+  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:var(--accent);border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
   <style>
 .container{padding-top:56px!important;}@media(max-width:480px){.container{padding-top:60px!important;}}
 </style>

--- a/web-app/public/visuals/nav007-fuel-planning.html
+++ b/web-app/public/visuals/nav007-fuel-planning.html
@@ -7,30 +7,22 @@
 <title>NAV-007: Fuel Planning</title>
 <style>
 body { max-width: 860px; margin: auto; }
-  
-  
-  
 
-  
+  .info-card .big { font-size: 22px; font-weight: 800; color: var(--accent); text-align: center; padding: 8px 0; letter-spacing: 1px; }
+  .info-card .sub { font-size: 11px; color: var(--text-muted); text-align: center; margin-top: 2px; }
 
-  
-  
-  
-  
-  
-  .info-card .big { font-size: 22px; font-weight: 800; color: #f0c040; text-align: center; padding: 8px 0; letter-spacing: 1px; }
-  .info-card .sub { font-size: 11px; color: #7a9ab5; text-align: center; margin-top: 2px; }
+  td.total-row { background: var(--surface); color: var(--accent); font-weight: 700; }
 
-  
-  
-  
-  
-  
-  td.total-row { background: #1a2d3d; color: #f0c040; font-weight: 700; }
+  @media (max-width: 480px) {
+    body { font-size: 14px; overflow-x: hidden; }
+    .two-col { grid-template-columns: 1fr; }
+    table { display: block; overflow-x: auto; }
+    .grid-wrap svg { width: 100%; height: auto; }
+  }
 </style>
 </head>
 <body>
-  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:#f0c040;border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
+  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:var(--accent);border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
   <style>
 .container{padding-top:56px!important;}@media(max-width:480px){.container{padding-top:60px!important;}}
 </style>

--- a/web-app/public/visuals/nav008-cross-country-planning.html
+++ b/web-app/public/visuals/nav008-cross-country-planning.html
@@ -7,30 +7,22 @@
 <title>NAV-008: Cross-Country Planning</title>
 <style>
 body { max-width: 860px; margin: auto; }
-  
-  
-  
 
-  
+  .info-card .big { font-size: 20px; font-weight: 800; color: var(--accent); text-align: center; padding: 8px 0; letter-spacing: 0.5px; }
+  .info-card .sub { font-size: 11px; color: var(--text-muted); text-align: center; margin-top: 2px; }
 
-  
-  
-  
-  
-  
-  .info-card .big { font-size: 20px; font-weight: 800; color: #f0c040; text-align: center; padding: 8px 0; letter-spacing: 0.5px; }
-  .info-card .sub { font-size: 11px; color: #7a9ab5; text-align: center; margin-top: 2px; }
+  tr.sample-row td { background: var(--bg2); color: #80c880; }
 
-  
-  
-  
-  
-  
-  tr.sample-row td { background: #0d2035; color: #80c880; }
+  @media (max-width: 480px) {
+    body { font-size: 14px; overflow-x: hidden; }
+    .two-col { grid-template-columns: 1fr; }
+    table { display: block; overflow-x: auto; }
+    .grid-wrap svg { width: 100%; height: auto; }
+  }
 </style>
 </head>
 <body>
-  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:#f0c040;border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
+  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:var(--accent);border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
   <style>
 .container{padding-top:56px!important;}@media(max-width:480px){.container{padding-top:60px!important;}}
 </style>
@@ -144,7 +136,7 @@ body { max-width: 860px; margin: auto; }
   </thead>
   <tbody>
     <tr>
-      <td colspan="14" style="color:#7a9ab5; font-style:italic; font-size:10px; padding:6px 8px;">Column definitions: TT=True Track, TAS=True Airspeed, WCA=Wind Correction Angle, TH=True Heading, VAR=Magnetic Variation, MH=Magnetic Heading, DEV=Compass Deviation, CH=Compass Heading, GS=Ground Speed, ETE=Estimated Time En Route, ETA=Estimated Time of Arrival</td>
+      <td colspan="14" style="color:var(--text-muted); font-style:italic; font-size:10px; padding:6px 8px;">Column definitions: TT=True Track, TAS=True Airspeed, WCA=Wind Correction Angle, TH=True Heading, VAR=Magnetic Variation, MH=Magnetic Heading, DEV=Compass Deviation, CH=Compass Heading, GS=Ground Speed, ETE=Estimated Time En Route, ETA=Estimated Time of Arrival</td>
     </tr>
     <tr class="sample-row">
       <td><strong>A → B</strong></td>

--- a/web-app/public/visuals/nav009-pilotage.html
+++ b/web-app/public/visuals/nav009-pilotage.html
@@ -6,14 +6,20 @@
 <link rel="stylesheet" href="/visuals/_common.css">
 <title>NAV-009 — Pilotage — Navigating by Ground Reference</title>
 <style>
-.good { color: #80c880; }
+  .good { color: #80c880; }
   .poor { color: #e07070; }
   td.good { color: #80c880; }
   td.poor { color: #e07070; }
+
+  @media (max-width: 480px) {
+    body { font-size: 14px; overflow-x: hidden; }
+    .two-col { grid-template-columns: 1fr; }
+    .card table { display: block; overflow-x: auto; }
+  }
 </style>
 </head>
 <body>
-  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:#f0c040;border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
+  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:var(--accent);border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
   <style>
 .container{padding-top:56px!important;}@media(max-width:480px){.container{padding-top:60px!important;}}
 </style>
@@ -96,7 +102,7 @@
     <div class="card">
       <h3>What is Pilotage?</h3>
       <ul>
-        <li>Navigation by identifying <strong style="color:#f0c040">visual ground references</strong> and matching them to chart features</li>
+        <li>Navigation by identifying <strong style="color:var(--accent)">visual ground references</strong> and matching them to chart features</li>
         <li>Primary VFR nav method — no instruments required beyond chart and compass</li>
         <li>Pilot compares what they see out the window to the sectional/VNC chart</li>
         <li>Most reliable when planned checkpoints are used systematically</li>
@@ -106,10 +112,10 @@
     <div class="card">
       <h3>Checkpoint Selection Criteria</h3>
       <ul>
-        <li><strong style="color:#f0c040">Prominent</strong> — easily visible from altitude</li>
-        <li><strong style="color:#f0c040">Unique</strong> — not easily confused with similar features</li>
-        <li><strong style="color:#f0c040">Distinct shape</strong> on the chart (large lake, highway X)</li>
-        <li><strong style="color:#f0c040">Spacing:</strong> 20–30 NM apart (about every 15–20 min)</li>
+        <li><strong style="color:var(--accent)">Prominent</strong> — easily visible from altitude</li>
+        <li><strong style="color:var(--accent)">Unique</strong> — not easily confused with similar features</li>
+        <li><strong style="color:var(--accent)">Distinct shape</strong> on the chart (large lake, highway X)</li>
+        <li><strong style="color:var(--accent)">Spacing:</strong> 20–30 NM apart (about every 15–20 min)</li>
         <li>Visible from well ahead — no sudden recognition required</li>
         <li>Avoid features that change seasonally (e.g. dry riverbeds)</li>
       </ul>

--- a/web-app/public/visuals/nav010-vor-navigation.html
+++ b/web-app/public/visuals/nav010-vor-navigation.html
@@ -5,10 +5,16 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <link rel="stylesheet" href="/visuals/_common.css">
 <title>NAV-010 — VOR Navigation</title>
-
+<style>
+  @media (max-width: 480px) {
+    body { font-size: 14px; overflow-x: hidden; }
+    .two-col { grid-template-columns: 1fr; }
+    .card table { display: block; overflow-x: auto; }
+  }
+</style>
 </head>
 <body>
-  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:#f0c040;border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
+  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:var(--accent);border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
   <style>
 .container{padding-top:56px!important;}@media(max-width:480px){.container{padding-top:60px!important;}}
 </style>
@@ -179,7 +185,7 @@
       <h3>Tracking a Radial</h3>
       <ul>
         <li>Establish a wind correction angle (WCA) — try 10° initially</li>
-        <li>If CDI drifts, <strong style="color:#f0c040">bracket and halve</strong>: double the correction, then halve when back on course</li>
+        <li>If CDI drifts, <strong style="color:var(--accent)">bracket and halve</strong>: double the correction, then halve when back on course</li>
         <li>Keep corrections small — max 20° WCA in light winds</li>
         <li>OBS setting does NOT change — only aircraft heading changes</li>
         <li>Recheck station ident every 10–15 min en route</li>


### PR DESCRIPTION
Closes #251

## Changes

- **nav006-time-speed-distance.html** — replaced `#f0c040` → `var(--accent)`, `#7a9ab5` → `var(--text-muted)` in style block and back button; added ≤480px media query
- **nav007-fuel-planning.html** — replaced `#f0c040` → `var(--accent)`, `#7a9ab5` → `var(--text-muted)`, `#1a2d3d` → `var(--surface)` in style block and back button; added ≤480px media query
- **nav008-cross-country-planning.html** — replaced `#f0c040` → `var(--accent)`, `#7a9ab5` → `var(--text-muted)`, `#0d2035` → `var(--bg2)` in style block; migrated inline `color:#7a9ab5` on column-definition `<td>`; added ≤480px media query
- **nav009-pilotage.html** — migrated back button and all `color:#f0c040` inline `<strong>` tags to `var(--accent)`; kept `#80c880`/`#e07070` domain colors; added ≤480px media query
- **nav010-vor-navigation.html** — migrated back button and all `color:#f0c040` inline `<strong>` tags to `var(--accent)`; kept `#80c880`/`#e07070` domain colors; added new `<style>` block with ≤480px media query

All changes respect the constraints:
- No hex values migrated inside `<svg>` elements
- `#80c880` and `#e07070` kept hardcoded (domain-encoding colours)
- `rgba()` values in back button kept as-is (not hex)

## Test Plan

- [x] `npm run build` from `web-app/` passes (✓ built in 2.46s)
- [ ] Verify each page renders correctly at 375px width (no horizontal scroll)
- [ ] Verify back button hit area ≥ 44×44px (already `min-width:44px;min-height:44px` in all files)
- [ ] Verify body text ≥ 14px at ≤480px (enforced by `body { font-size: 14px }` in media query)
- [ ] Confirm `.two-col` / `.three-col` collapse to single column on mobile
- [ ] Confirm tables scroll horizontally rather than causing overflow