### PR TITLE
[PPL-184] Generate audio for GK-001–GK-014

### DIFF
--- a/lessons/general-knowledge/001-aircraft-parts-controls.md
+++ b/lessons/general-knowledge/001-aircraft-parts-controls.md
@@ -6,7 +6,7 @@ slug: aircraft-parts-controls
 title: "Aircraft Parts and Controls"
 duration_min: 20
 status: complete
-audio: null
+audio: https://media.suprun.workers.dev/ppl/lessons/general-knowledge/001-aircraft-parts-controls.m4a
 visual: /visuals/gk001-aircraft-parts-controls.html
 sources:
   - TP 12880E Chapter 1

--- a/lessons/general-knowledge/002-four-forces.md
+++ b/lessons/general-knowledge/002-four-forces.md
@@ -6,7 +6,7 @@ slug: four-forces
 title: "Four Forces of Flight"
 duration_min: 20
 status: complete
-audio: null
+audio: https://media.suprun.workers.dev/ppl/lessons/general-knowledge/002-four-forces.m4a
 visual: /visuals/gk002-four-forces.html
 sources:
   - TP 12880E Chapter 3

--- a/lessons/general-knowledge/003-piston-engines.md
+++ b/lessons/general-knowledge/003-piston-engines.md
@@ -6,7 +6,7 @@ slug: piston-engines
 title: "Piston Engines"
 duration_min: 20
 status: complete
-audio: null
+audio: https://media.suprun.workers.dev/ppl/lessons/general-knowledge/003-piston-engines.m4a
 visual: /visuals/gk003-piston-engines.html
 sources:
   - TP 12880E Chapter 5

--- a/lessons/general-knowledge/004-fuel-system.md
+++ b/lessons/general-knowledge/004-fuel-system.md
@@ -6,7 +6,7 @@ slug: fuel-system
 title: "Fuel System"
 duration_min: 20
 status: complete
-audio: null
+audio: https://media.suprun.workers.dev/ppl/lessons/general-knowledge/004-fuel-system.m4a
 visual: /visuals/gk004-fuel-system.html
 sources:
   - TP 12880E Chapter 5

--- a/lessons/general-knowledge/005-electrical-system.md
+++ b/lessons/general-knowledge/005-electrical-system.md
@@ -6,7 +6,7 @@ slug: electrical-system
 title: "Electrical System"
 duration_min: 20
 status: complete
-audio: null
+audio: https://media.suprun.workers.dev/ppl/lessons/general-knowledge/005-electrical-system.m4a
 visual: /visuals/gk005-electrical-system.html
 sources:
   - TP 12880E Chapter 5

--- a/lessons/general-knowledge/006-pitot-static-instruments.md
+++ b/lessons/general-knowledge/006-pitot-static-instruments.md
@@ -6,7 +6,7 @@ slug: pitot-static-instruments
 title: "Pitot-Static System"
 duration_min: 20
 status: complete
-audio: null
+audio: https://media.suprun.workers.dev/ppl/lessons/general-knowledge/006-pitot-static-instruments.m4a
 visual: /visuals/gk006-pitot-static-instruments.html
 sources:
   - TP 12880E Chapter 8

--- a/lessons/general-knowledge/007-gyroscopic-instruments.md
+++ b/lessons/general-knowledge/007-gyroscopic-instruments.md
@@ -6,7 +6,7 @@ slug: gyroscopic-instruments
 title: "Gyroscopic Instruments"
 duration_min: 20
 status: complete
-audio: null
+audio: https://media.suprun.workers.dev/ppl/lessons/general-knowledge/007-gyroscopic-instruments.m4a
 visual: /visuals/gk007-gyroscopic-instruments.html
 sources:
   - TP 12880E Chapter 8

--- a/lessons/general-knowledge/008-engine-instruments.md
+++ b/lessons/general-knowledge/008-engine-instruments.md
@@ -6,7 +6,7 @@ slug: engine-instruments
 title: "Engine Instruments"
 duration_min: 20
 status: complete
-audio: null
+audio: https://media.suprun.workers.dev/ppl/lessons/general-knowledge/008-engine-instruments.m4a
 visual: /visuals/gk008-engine-instruments.html
 sources:
   - TP 12880E Chapter 5

--- a/lessons/general-knowledge/009-weight-and-balance.md
+++ b/lessons/general-knowledge/009-weight-and-balance.md
@@ -6,7 +6,7 @@ slug: weight-and-balance
 title: "Weight and Balance"
 duration_min: 20
 status: complete
-audio: null
+audio: https://media.suprun.workers.dev/ppl/lessons/general-knowledge/009-weight-and-balance.m4a
 visual: /visuals/gk009-weight-and-balance.html
 sources:
   - TP 12880E Chapter 10

--- a/lessons/general-knowledge/010-performance-charts.md
+++ b/lessons/general-knowledge/010-performance-charts.md
@@ -6,7 +6,7 @@ slug: performance-charts
 title: "Performance Charts"
 duration_min: 20
 status: complete
-audio: null
+audio: https://media.suprun.workers.dev/ppl/lessons/general-knowledge/010-performance-charts.m4a
 visual: /visuals/gk010-performance-charts.html
 sources:
   - TP 12880E Chapter 11

--- a/lessons/general-knowledge/011-takeoff-landing-perf.md
+++ b/lessons/general-knowledge/011-takeoff-landing-perf.md
@@ -6,7 +6,7 @@ slug: takeoff-landing-perf
 title: "Takeoff and Landing Performance"
 duration_min: 20
 status: complete
-audio: null
+audio: https://media.suprun.workers.dev/ppl/lessons/general-knowledge/011-takeoff-landing-perf.m4a
 visual: /visuals/gk011-takeoff-landing-perf.html
 sources:
   - TP 12880E Chapter 11

--- a/lessons/general-knowledge/012-stalls-spins.md
+++ b/lessons/general-knowledge/012-stalls-spins.md
@@ -6,7 +6,7 @@ slug: stalls-spins
 title: "Stalls and Spins"
 duration_min: 20
 status: complete
-audio: null
+audio: https://media.suprun.workers.dev/ppl/lessons/general-knowledge/012-stalls-spins.m4a
 visual: /visuals/gk012-stalls-spins.html
 sources:
   - TP 12880E Chapter 3

--- a/lessons/general-knowledge/013-load-factor.md
+++ b/lessons/general-knowledge/013-load-factor.md
@@ -6,7 +6,7 @@ slug: load-factor
 title: "Load Factor and Maneuvering Speed"
 duration_min: 20
 status: complete
-audio: null
+audio: https://media.suprun.workers.dev/ppl/lessons/general-knowledge/013-load-factor.m4a
 visual: /visuals/gk013-load-factor.html
 sources:
   - TP 12880E Chapter 3

--- a/lessons/general-knowledge/014-preflight-inspection.md
+++ b/lessons/general-knowledge/014-preflight-inspection.md
@@ -6,7 +6,7 @@ slug: preflight-inspection
 title: "Pre-Flight Inspection and Maintenance"
 duration_min: 20
 status: complete
-audio: null
+audio: https://media.suprun.workers.dev/ppl/lessons/general-knowledge/014-preflight-inspection.m4a
 visual: /visuals/gk014-preflight-inspection.html
 sources:
   - CARs Part V (Airworthiness)


### PR DESCRIPTION
## Summary

- Generates narration audio for all 14 General Knowledge lessons (GK-001 through GK-014)
- Audio produced with Kokoro TTS (model `mlx-community/Kokoro-82M-bf16`, voice `am_echo`, speed 1.1) from each lesson's `## Narration Script` section
- Files encoded to AAC/M4A at 64 kbps and uploaded to Cloudflare R2 (`suprun-media` bucket) under `ppl/lessons/general-knowledge/`
- Updates `audio:` frontmatter field in all 14 lesson files from `null` to the public CDN URL
- Only the `audio:` frontmatter line changed in each file — no body edits

## Files Changed

`lessons/general-knowledge/001-aircraft-parts-controls.md` through `014-preflight-inspection.md` — `audio: null` → `audio: https://media.suprun.workers.dev/ppl/lessons/general-knowledge/{NNN}-{slug}.m4a`

## Test plan

- [x] All 14 lessons have `## Narration Script` section (verified before generation)
- [x] All 14 `.m4a` files uploaded to R2 successfully
- [x] `audio:` frontmatter set to correct CDN URL in all 14 lesson files
- [x] `npm run build` passes with no schema errors

Closes #184

🤖 Generated with [Claude Code](https://claude.com/claude-code)