### PR TITLE
[PPL-272] Add LessonCompleteScreen component

### DIFF
--- a/web-app/src/components/LessonCompleteScreen.tsx
+++ b/web-app/src/components/LessonCompleteScreen.tsx
@@ -1,0 +1,126 @@
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Container from '@mui/material/Container';
+import Divider from '@mui/material/Divider';
+import Typography from '@mui/material/Typography';
+import { useTheme } from '@mui/material/styles';
+import { typographyTokens } from '../tokens';
+
+export interface LessonScore {
+  correct: number;
+  total: number;
+}
+
+interface Props {
+  lessonTitle: string;
+  score: LessonScore | null;
+  hasNext: boolean;
+  onNextLesson: () => void;
+  onReviewLesson: () => void;
+  onBackToTopics: () => void;
+}
+
+export default function LessonCompleteScreen({
+  lessonTitle,
+  score,
+  hasNext,
+  onNextLesson,
+  onReviewLesson,
+  onBackToTopics,
+}: Props) {
+  const theme = useTheme();
+
+  const passed = score !== null && score.total > 0 && score.correct / score.total >= 0.7;
+  const scoreColor =
+    score !== null
+      ? passed
+        ? theme.palette.success.main
+        : theme.palette.error.main
+      : theme.palette.text.secondary;
+
+  const encouragement =
+    score === null
+      ? 'Lesson marked complete.'
+      : passed
+      ? 'Cleared for next. Proceed when ready.'
+      : 'Below threshold. Review material and retake before continuing.';
+
+  return (
+    <Container
+      id="main-content"
+      tabIndex={-1}
+      maxWidth={false}
+      sx={{ maxWidth: 700, mx: 'auto', px: { xs: 2, sm: 3 }, py: 4 }}
+    >
+      <Typography variant="overline" color="text.secondary" sx={{ display: 'block', mb: 2 }}>
+        ◆ LESSON COMPLETE
+      </Typography>
+
+      <Typography variant="h3" gutterBottom>
+        {lessonTitle}
+      </Typography>
+
+      {score !== null && (
+        <Box sx={{ mb: 2 }}>
+          <Typography
+            component="div"
+            sx={{
+              fontFamily: typographyTokens.fontFamily.mono,
+              fontSize: '2.5rem',
+              fontWeight: typographyTokens.weight.bold,
+              lineHeight: 1.1,
+              color: scoreColor,
+            }}
+          >
+            {score.correct}/{score.total}
+          </Typography>
+          <Typography
+            variant="overline"
+            sx={{ color: scoreColor, display: 'block', mt: 0.5 }}
+          >
+            {Math.round((score.correct / score.total) * 100)}%
+            {' · '}
+            {passed ? 'PASS' : 'BELOW 70%'}
+            {' · 70% REQUIRED'}
+          </Typography>
+        </Box>
+      )}
+
+      <Typography variant="body1" sx={{ mt: 1, mb: 3, color: score !== null ? scoreColor : 'text.primary' }}>
+        {encouragement}
+      </Typography>
+
+      <Divider sx={{ mb: 3 }} />
+
+      <Box
+        sx={{
+          display: 'flex',
+          flexDirection: { xs: 'column', sm: 'row' },
+          gap: 2,
+        }}
+      >
+        <Button
+          variant="contained"
+          onClick={onNextLesson}
+          sx={{ minHeight: 48, flex: { sm: 1 } }}
+        >
+          {hasNext ? 'Next Lesson ▸' : 'All Lessons ▸'}
+        </Button>
+        <Button
+          variant="outlined"
+          onClick={onReviewLesson}
+          sx={{ minHeight: 48, flex: { sm: 1 } }}
+        >
+          Review Lesson
+        </Button>
+        <Button
+          variant="outlined"
+          onClick={onBackToTopics}
+          sx={{ minHeight: 48, flex: { sm: 1 } }}
+        >
+          Back to Topics
+        </Button>
+      </Box>
+    </Container>
+  );
+}

--- a/web-app/src/pages/LessonDetail.tsx
+++ b/web-app/src/pages/LessonDetail.tsx
@@ -1,6 +1,5 @@
 import { useParams, useNavigate } from 'react-router-dom';
 import Markdown from 'markdown-to-jsx';
-import Alert from '@mui/material/Alert';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Chip from '@mui/material/Chip';
@@ -9,6 +8,8 @@ import Divider from '@mui/material/Divider';
 import Typography from '@mui/material/Typography';
 import { useState, useEffect, type ReactNode } from 'react';
 import AudioPlayer from '../components/AudioPlayer';
+import LessonCompleteScreen from '../components/LessonCompleteScreen';
+import type { LessonScore } from '../components/LessonCompleteScreen';
 import LessonPrevNext from '../components/LessonPrevNext';
 import SourceList from '../components/SourceList';
 import { getLessonBySlug, getAdjacentLessons } from '../lib/lesson-loader';
@@ -16,6 +17,8 @@ import { useProgress } from '../lib/progress';
 import { useExamTrack } from '../context/ExamTrackContext';
 import { TOPIC_LABELS } from '../lib/curriculum';
 import { LAST_SESSION_KEY } from '../components/home/StatusBar';
+
+const QUIZ_RESULT_KEY = (lessonId: string) => `ppl-quiz-result-${lessonId}`;
 
 function MarkdownTable({ children }: { children?: ReactNode }) {
   return (
@@ -83,7 +86,7 @@ export default function LessonDetail() {
   const navigate = useNavigate();
   const { store } = useExamTrack();
   const { isComplete, markComplete } = useProgress(store);
-  const [showSuccess, setShowSuccess] = useState(false);
+  const [showComplete, setShowComplete] = useState(false);
 
   const lesson = topic && slug ? getLessonBySlug(topic, slug) : undefined;
   const { prev, next } = topic && slug && lesson
@@ -130,7 +133,41 @@ export default function LessonDetail() {
 
   function handleMarkComplete() {
     markComplete(lesson!.id);
-    setShowSuccess(true);
+    setShowComplete(true);
+  }
+
+  function loadQuizScore(): LessonScore | null {
+    try {
+      const raw = localStorage.getItem(QUIZ_RESULT_KEY(lesson!.id));
+      if (!raw) return null;
+      const parsed = JSON.parse(raw) as { correct: number; total: number };
+      if (typeof parsed.correct !== 'number' || typeof parsed.total !== 'number') return null;
+      return parsed;
+    } catch {
+      return null;
+    }
+  }
+
+  if (showComplete) {
+    return (
+      <LessonCompleteScreen
+        lessonTitle={lesson.title}
+        score={loadQuizScore()}
+        hasNext={next !== null}
+        onNextLesson={() => {
+          if (next) {
+            navigate(`/lessons/${next.topic}/${next.slug}`);
+          } else {
+            navigate('/lessons');
+          }
+        }}
+        onReviewLesson={() => {
+          setShowComplete(false);
+          window.scrollTo({ top: 0 });
+        }}
+        onBackToTopics={() => navigate('/lessons')}
+      />
+    );
   }
 
   return (
@@ -191,12 +228,6 @@ export default function LessonDetail() {
       <SourceList sources={lesson.sources} />
 
       <Divider sx={{ mt: 4, mb: 3 }} />
-
-      {showSuccess && (
-        <Alert severity="success" sx={{ mb: 2 }} onClose={() => setShowSuccess(false)}>
-          Lesson marked as complete!
-        </Alert>
-      )}
 
       <Button
         variant={completed ? 'outlined' : 'contained'}

--- a/web-app/src/pages/LessonQuiz.tsx
+++ b/web-app/src/pages/LessonQuiz.tsx
@@ -76,6 +76,14 @@ export default function LessonQuiz() {
 
   function handleQuizComplete(answers: Record<string, string>) {
     const result = scoreQuiz(answers, lesson!.questions);
+    try {
+      localStorage.setItem(
+        `ppl-quiz-result-${lesson!.id}`,
+        JSON.stringify({ correct: result.correct, total: result.total }),
+      );
+    } catch {
+      // storage unavailable — non-fatal
+    }
     setQuizResult(result);
     setPhase('results');
   }


### PR DESCRIPTION
## Summary

- Creates `web-app/src/components/LessonCompleteScreen.tsx` — displays lesson title, quiz score (X/Y with success/danger color at 70% threshold), encouragement line, and three action buttons: Next Lesson, Review Lesson, Back to Topics
- Wires into `LessonDetail.tsx`: clicking **Mark Complete** renders `LessonCompleteScreen` in place of the lesson view; Review Lesson returns to the lesson at scroll-top
- `LessonQuiz.tsx`: persists last quiz result (`{ correct, total }`) to `localStorage` keyed by lesson ID so `LessonDetail` can surface the score on the complete screen

## Design compliance

- All colors via `theme.palette.success.main` / `theme.palette.error.main` — no hardcoded hex
- Monospace font from `typographyTokens.fontFamily.mono` for the score numeral
- Section header uses `overline` variant (`◆ LESSON COMPLETE`) per design system §5.4
- Buttons `minHeight: 48` (tap target rule §7.3); stack to column on `xs`
- Max-width 700 px (quiz/focus task container §7.2)
- No animations, no box-shadows in dark mode

Adheres to `docs/design/DESIGN-SYSTEM.md`.

## Test plan

- [ ] Navigate to any lesson, click **Mark Complete** → LessonCompleteScreen appears
- [ ] Score section absent when no quiz has been taken for that lesson
- [ ] Complete a quiz for a lesson, then click **Mark Complete** → score shown with correct color (green ≥70%, red <70%)
- [ ] **Next Lesson** navigates to next lesson in topic; on last lesson navigates to `/lessons`
- [ ] **Review Lesson** returns to lesson content, scrolls to top
- [ ] **Back to Topics** navigates to `/lessons`
- [ ] Renders correctly in dark and light mode
- [ ] No horizontal scroll at 360 px viewport

🤖 Generated with [Claude Code](https://claude.com/claude-code)