### PR TITLE
[PPL-137] UI components: TopicMasteryCard, LessonProgressBar, SRSQueue, LessonCompleteScreen

### DIFF
--- a/web-app/src/components/LessonCompleteScreen.tsx
+++ b/web-app/src/components/LessonCompleteScreen.tsx
@@ -1,126 +1,203 @@
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
-import Container from '@mui/material/Container';
-import Divider from '@mui/material/Divider';
+import Dialog from '@mui/material/Dialog';
+import DialogContent from '@mui/material/DialogContent';
 import Typography from '@mui/material/Typography';
 import { useTheme } from '@mui/material/styles';
-import { typographyTokens } from '../tokens';
+import { typographyTokens, radiusTokens } from '../tokens';
+import type { CurriculumSlot } from '../lib/curriculum';
 
-export interface LessonScore {
-  correct: number;
-  total: number;
-}
-
-interface Props {
+export interface LessonCompleteScreenProps {
+  open: boolean;
+  lessonId: string;
   lessonTitle: string;
-  score: LessonScore | null;
-  hasNext: boolean;
-  onNextLesson: () => void;
-  onReviewLesson: () => void;
-  onBackToTopics: () => void;
+  /** Quiz result — undefined if quiz was not taken */
+  quizScore?: { score: number; total: number; percent: number };
+  /** Next lesson in the topic, if any */
+  nextLesson?: CurriculumSlot | null;
+  /** SRS next-due date (ISO date string, YYYY-MM-DD) */
+  srsNextDue?: string;
+  onContinue: () => void;
+  onClose: () => void;
 }
 
 export default function LessonCompleteScreen({
+  open,
+  lessonId,
   lessonTitle,
-  score,
-  hasNext,
-  onNextLesson,
-  onReviewLesson,
-  onBackToTopics,
-}: Props) {
+  quizScore,
+  nextLesson,
+  srsNextDue,
+  onContinue,
+  onClose,
+}: LessonCompleteScreenProps) {
   const theme = useTheme();
 
-  const passed = score !== null && score.total > 0 && score.correct / score.total >= 0.7;
   const scoreColor =
-    score !== null
-      ? passed
+    quizScore === undefined
+      ? theme.palette.text.secondary
+      : quizScore.percent >= 80
         ? theme.palette.success.main
-        : theme.palette.error.main
-      : theme.palette.text.secondary;
-
-  const encouragement =
-    score === null
-      ? 'Lesson marked complete.'
-      : passed
-      ? 'Cleared for next. Proceed when ready.'
-      : 'Below threshold. Review material and retake before continuing.';
+        : quizScore.percent >= 60
+          ? theme.palette.primary.main
+          : theme.palette.error.main;
 
   return (
-    <Container
-      id="main-content"
-      tabIndex={-1}
-      maxWidth={false}
-      sx={{ maxWidth: 700, mx: 'auto', px: { xs: 2, sm: 3 }, py: 4 }}
+    <Dialog
+      open={open}
+      onClose={onClose}
+      maxWidth="xs"
+      fullWidth
+      PaperProps={{
+        sx: {
+          backgroundColor: theme.palette.background.paper,
+          border: `1px solid ${theme.palette.divider}`,
+          borderTop: `3px solid ${theme.palette.primary.main}`,
+          borderRadius: `${radiusTokens.md}px`,
+          backgroundImage: 'none',
+          m: 2,
+        },
+      }}
     >
-      <Typography variant="overline" color="text.secondary" sx={{ display: 'block', mb: 2 }}>
-        ◆ LESSON COMPLETE
-      </Typography>
+      <DialogContent sx={{ p: 3 }}>
+        {/* Stamp line */}
+        <Typography
+          sx={{
+            fontFamily: typographyTokens.fontFamily.mono,
+            fontSize: '0.6875rem',
+            fontWeight: 500,
+            letterSpacing: typographyTokens.letterSpacing.wider,
+            textTransform: 'uppercase',
+            color: theme.palette.primary.main,
+            mb: 2,
+          }}
+        >
+          ▸ {lessonId} · COMPLETE
+        </Typography>
 
-      <Typography variant="h3" gutterBottom>
-        {lessonTitle}
-      </Typography>
+        {/* Lesson title */}
+        <Typography
+          variant="h5"
+          sx={{
+            fontFamily: typographyTokens.fontFamily.sans,
+            fontWeight: typographyTokens.weight.semibold,
+            color: theme.palette.text.primary,
+            mb: 3,
+            lineHeight: 1.3,
+          }}
+        >
+          {lessonTitle}
+        </Typography>
 
-      {score !== null && (
-        <Box sx={{ mb: 2 }}>
-          <Typography
-            component="div"
+        {/* Quiz score */}
+        {quizScore !== undefined && (
+          <Box
             sx={{
-              fontFamily: typographyTokens.fontFamily.mono,
-              fontSize: '2.5rem',
-              fontWeight: typographyTokens.weight.bold,
-              lineHeight: 1.1,
-              color: scoreColor,
+              backgroundColor: theme.palette.background.surfaceRaised,
+              border: `1px solid ${theme.palette.divider}`,
+              borderRadius: `${radiusTokens.sm}px`,
+              p: 2,
+              mb: 2,
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'space-between',
             }}
           >
-            {score.correct}/{score.total}
-          </Typography>
-          <Typography
-            variant="overline"
-            sx={{ color: scoreColor, display: 'block', mt: 0.5 }}
+            <Typography
+              sx={{
+                fontFamily: typographyTokens.fontFamily.mono,
+                fontSize: '0.6875rem',
+                letterSpacing: typographyTokens.letterSpacing.wider,
+                textTransform: 'uppercase',
+                color: theme.palette.text.secondary,
+              }}
+            >
+              QUIZ SCORE
+            </Typography>
+            <Box sx={{ textAlign: 'right' }}>
+              <Typography
+                sx={{
+                  fontFamily: typographyTokens.fontFamily.mono,
+                  fontSize: '1.5rem',
+                  fontWeight: typographyTokens.weight.bold,
+                  color: scoreColor,
+                  lineHeight: 1,
+                }}
+              >
+                {quizScore.percent}%
+              </Typography>
+              <Typography
+                sx={{
+                  fontFamily: typographyTokens.fontFamily.mono,
+                  fontSize: '0.625rem',
+                  color: theme.palette.text.secondary,
+                  letterSpacing: typographyTokens.letterSpacing.wide,
+                }}
+              >
+                {quizScore.score}/{quizScore.total} CORRECT
+              </Typography>
+            </Box>
+          </Box>
+        )}
+
+        {/* SRS next-due */}
+        {srsNextDue && (
+          <Box
+            sx={{
+              mb: 2,
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'space-between',
+            }}
           >
-            {Math.round((score.correct / score.total) * 100)}%
-            {' · '}
-            {passed ? 'PASS' : 'BELOW 70%'}
-            {' · 70% REQUIRED'}
-          </Typography>
+            <Typography
+              sx={{
+                fontFamily: typographyTokens.fontFamily.mono,
+                fontSize: '0.6875rem',
+                letterSpacing: typographyTokens.letterSpacing.wider,
+                textTransform: 'uppercase',
+                color: theme.palette.text.secondary,
+              }}
+            >
+              NEXT REVIEW
+            </Typography>
+            <Typography
+              sx={{
+                fontFamily: typographyTokens.fontFamily.mono,
+                fontSize: '0.75rem',
+                fontWeight: typographyTokens.weight.semibold,
+                color: theme.palette.text.primary,
+                letterSpacing: typographyTokens.letterSpacing.wide,
+              }}
+            >
+              {srsNextDue}
+            </Typography>
+          </Box>
+        )}
+
+        {/* Actions */}
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5, mt: 3 }}>
+          {nextLesson && (
+            <Button
+              variant="contained"
+              color="primary"
+              onClick={onContinue}
+              fullWidth
+              sx={{ minHeight: 48, color: theme.palette.text.onAccent }}
+            >
+              ▸ BEGIN {nextLesson.id}
+            </Button>
+          )}
+          <Button
+            variant="outlined"
+            onClick={onClose}
+            fullWidth
+            sx={{ minHeight: 48 }}
+          >
+            BACK TO LESSONS
+          </Button>
         </Box>
-      )}
-
-      <Typography variant="body1" sx={{ mt: 1, mb: 3, color: score !== null ? scoreColor : 'text.primary' }}>
-        {encouragement}
-      </Typography>
-
-      <Divider sx={{ mb: 3 }} />
-
-      <Box
-        sx={{
-          display: 'flex',
-          flexDirection: { xs: 'column', sm: 'row' },
-          gap: 2,
-        }}
-      >
-        <Button
-          variant="contained"
-          onClick={onNextLesson}
-          sx={{ minHeight: 48, flex: { sm: 1 } }}
-        >
-          {hasNext ? 'Next Lesson ▸' : 'All Lessons ▸'}
-        </Button>
-        <Button
-          variant="outlined"
-          onClick={onReviewLesson}
-          sx={{ minHeight: 48, flex: { sm: 1 } }}
-        >
-          Review Lesson
-        </Button>
-        <Button
-          variant="outlined"
-          onClick={onBackToTopics}
-          sx={{ minHeight: 48, flex: { sm: 1 } }}
-        >
-          Back to Topics
-        </Button>
-      </Box>
-    </Container>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/web-app/src/components/LessonProgressBar.tsx
+++ b/web-app/src/components/LessonProgressBar.tsx
@@ -1,0 +1,53 @@
+import Box from '@mui/material/Box';
+import Tooltip from '@mui/material/Tooltip';
+import { useTheme } from '@mui/material/styles';
+import { radiusTokens } from '../tokens';
+
+export interface LessonProgressBarProps {
+  /** 1-based position of the current lesson in the topic */
+  position: number;
+  /** Total lessons in the topic */
+  total: number;
+  /** Accessible label for the bar, e.g. "Lesson 3 of 18 in Air Law" */
+  label?: string;
+}
+
+export default function LessonProgressBar({ position, total, label }: LessonProgressBarProps) {
+  const theme = useTheme();
+  const pct = total > 0 ? (position / total) * 100 : 0;
+  const ariaLabel = label ?? `Lesson ${position} of ${total}`;
+
+  return (
+    <Tooltip title={ariaLabel} placement="bottom">
+      <Box
+        role="progressbar"
+        aria-label={ariaLabel}
+        aria-valuenow={position}
+        aria-valuemin={1}
+        aria-valuemax={total}
+        sx={{ width: '100%', height: 3 }}
+      >
+        {/* Track */}
+        <Box
+          sx={{
+            width: '100%',
+            height: '100%',
+            backgroundColor: `${theme.palette.primary.main}22`,
+            borderRadius: `0 0 ${radiusTokens.pill}px ${radiusTokens.pill}px`,
+            overflow: 'hidden',
+          }}
+        >
+          {/* Fill */}
+          <Box
+            sx={{
+              width: `${pct}%`,
+              height: '100%',
+              backgroundColor: theme.palette.primary.main,
+              transition: 'width 200ms ease-out',
+            }}
+          />
+        </Box>
+      </Box>
+    </Tooltip>
+  );
+}

--- a/web-app/src/components/SRSQueue.tsx
+++ b/web-app/src/components/SRSQueue.tsx
@@ -1,0 +1,329 @@
+import { useState, useCallback, useMemo } from 'react';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Typography from '@mui/material/Typography';
+import { useTheme } from '@mui/material/styles';
+import { typographyTokens, radiusTokens, colorTokens } from '../tokens';
+import { sm2Update, newCard, loadSRSData, saveSRSData, getDueCards } from '../lib/srs';
+import type { SRSCard } from '../lib/srs';
+import type { Lesson } from '../lib/types';
+
+// Quality values mapped to buttons
+const RATINGS = [
+  { label: 'AGAIN', quality: 1, color: colorTokens.error.main },
+  { label: 'HARD',  quality: 2, color: colorTokens.primary.dim },
+  { label: 'GOOD',  quality: 4, color: colorTokens.primary.main },
+  { label: 'EASY',  quality: 5, color: colorTokens.success.main },
+] as const;
+
+export interface SRSQueueProps {
+  trackId: string;
+  completedLessons: Lesson[];
+}
+
+type Phase = 'front' | 'back' | 'done';
+
+export default function SRSQueue({ trackId, completedLessons }: SRSQueueProps) {
+  const theme = useTheme();
+
+  const [srsData, setSrsData] = useState(() => loadSRSData(trackId));
+  const [queueIndex, setQueueIndex] = useState(0);
+  const [phase, setPhase] = useState<Phase>('front');
+
+  const lessonMap = useMemo(
+    () => new Map(completedLessons.map((l) => [l.id, l])),
+    [completedLessons],
+  );
+
+  const dueCards: SRSCard[] = useMemo(
+    () => getDueCards(srsData, completedLessons.map((l) => l.id)),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [],
+  );
+
+  const current = dueCards[queueIndex];
+  const lesson = current ? lessonMap.get(current.lessonId) : undefined;
+  const remaining = dueCards.length - queueIndex;
+
+  const handleRate = useCallback(
+    (quality: number) => {
+      if (!current) return;
+      const updated = sm2Update(current, quality);
+      const next = { ...srsData, [current.lessonId]: updated };
+      setSrsData(next);
+      saveSRSData(trackId, next);
+
+      if (queueIndex + 1 >= dueCards.length) {
+        setPhase('done');
+      } else {
+        setQueueIndex((i) => i + 1);
+        setPhase('front');
+      }
+    },
+    [current, srsData, queueIndex, dueCards.length, trackId],
+  );
+
+  const handleShowBack = () => setPhase('back');
+
+  if (dueCards.length === 0) {
+    return (
+      <Box
+        sx={{
+          backgroundColor: theme.palette.background.paper,
+          border: `1px solid ${theme.palette.divider}`,
+          borderRadius: `${radiusTokens.md}px`,
+          p: 3,
+          textAlign: 'center',
+        }}
+      >
+        <Typography
+          sx={{
+            fontFamily: typographyTokens.fontFamily.mono,
+            fontSize: '0.75rem',
+            letterSpacing: typographyTokens.letterSpacing.wider,
+            textTransform: 'uppercase',
+            color: theme.palette.text.secondary,
+            mb: 1,
+          }}
+        >
+          ◆ DAILY REVIEW
+        </Typography>
+        <Typography variant="h6" sx={{ color: theme.palette.text.primary, mb: 1 }}>
+          No reviews due
+        </Typography>
+        <Typography variant="body2" sx={{ color: theme.palette.text.secondary }}>
+          Complete lessons to start spaced repetition reviews.
+        </Typography>
+      </Box>
+    );
+  }
+
+  if (phase === 'done') {
+    return (
+      <Box
+        sx={{
+          backgroundColor: theme.palette.background.paper,
+          border: `1px solid ${theme.palette.divider}`,
+          borderRadius: `${radiusTokens.md}px`,
+          p: 3,
+          textAlign: 'center',
+        }}
+      >
+        <Typography
+          sx={{
+            fontFamily: typographyTokens.fontFamily.mono,
+            fontSize: '0.75rem',
+            letterSpacing: typographyTokens.letterSpacing.wider,
+            textTransform: 'uppercase',
+            color: theme.palette.primary.main,
+            mb: 1,
+          }}
+        >
+          ◆ SESSION COMPLETE
+        </Typography>
+        <Typography variant="h6" sx={{ color: theme.palette.text.primary, mb: 1 }}>
+          {dueCards.length} card{dueCards.length !== 1 ? 's' : ''} reviewed
+        </Typography>
+        <Typography variant="body2" sx={{ color: theme.palette.text.secondary }}>
+          Next session scheduled based on your ratings.
+        </Typography>
+      </Box>
+    );
+  }
+
+  return (
+    <Box
+      sx={{
+        backgroundColor: theme.palette.background.paper,
+        border: `1px solid ${theme.palette.divider}`,
+        borderRadius: `${radiusTokens.md}px`,
+        overflow: 'hidden',
+      }}
+    >
+      {/* Header */}
+      <Box
+        sx={{
+          px: 2,
+          py: 1,
+          borderBottom: `1px solid ${theme.palette.divider}`,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+        }}
+      >
+        <Typography
+          sx={{
+            fontFamily: typographyTokens.fontFamily.mono,
+            fontSize: '0.6875rem',
+            fontWeight: 500,
+            letterSpacing: typographyTokens.letterSpacing.wider,
+            textTransform: 'uppercase',
+            color: theme.palette.primary.main,
+          }}
+        >
+          ◆ DAILY REVIEW
+        </Typography>
+        <Typography
+          sx={{
+            fontFamily: typographyTokens.fontFamily.mono,
+            fontSize: '0.6875rem',
+            color: theme.palette.text.secondary,
+            letterSpacing: typographyTokens.letterSpacing.wide,
+          }}
+        >
+          {remaining} REMAINING
+        </Typography>
+      </Box>
+
+      {/* Card face */}
+      <Box sx={{ p: 3 }}>
+        {/* Lesson ID stamp */}
+        <Typography
+          sx={{
+            fontFamily: typographyTokens.fontFamily.mono,
+            fontSize: '0.75rem',
+            fontWeight: 500,
+            letterSpacing: typographyTokens.letterSpacing.wider,
+            textTransform: 'uppercase',
+            color: theme.palette.primary.main,
+            mb: 1,
+          }}
+        >
+          ▸ {current.lessonId}
+        </Typography>
+
+        {/* Lesson title (front) */}
+        <Typography
+          variant="h6"
+          sx={{
+            color: theme.palette.text.primary,
+            fontFamily: typographyTokens.fontFamily.sans,
+            mb: 2,
+          }}
+        >
+          {lesson?.title ?? current.lessonId}
+        </Typography>
+
+        {/* Back side: first question as recall prompt */}
+        {phase === 'back' && lesson?.questions[0] && (
+          <Box
+            sx={{
+              backgroundColor: theme.palette.background.surfaceRaised,
+              border: `1px solid ${theme.palette.divider}`,
+              borderLeft: `3px solid ${theme.palette.primary.main}`,
+              borderRadius: `0 ${radiusTokens.sm}px ${radiusTokens.sm}px 0`,
+              p: 2,
+              mb: 2,
+            }}
+          >
+            <Typography
+              sx={{
+                fontFamily: typographyTokens.fontFamily.mono,
+                fontSize: '0.6875rem',
+                letterSpacing: typographyTokens.letterSpacing.wider,
+                textTransform: 'uppercase',
+                color: theme.palette.text.secondary,
+                mb: 1,
+              }}
+            >
+              RECALL PROMPT
+            </Typography>
+            <Typography
+              variant="body2"
+              sx={{ color: theme.palette.text.primary, fontFamily: typographyTokens.fontFamily.sans }}
+            >
+              {lesson.questions[0].prompt}
+            </Typography>
+            <Box
+              sx={{
+                mt: 1.5,
+                pt: 1.5,
+                borderTop: `1px solid ${theme.palette.divider}`,
+              }}
+            >
+              <Typography
+                sx={{
+                  fontFamily: typographyTokens.fontFamily.mono,
+                  fontSize: '0.6875rem',
+                  letterSpacing: typographyTokens.letterSpacing.wider,
+                  textTransform: 'uppercase',
+                  color: theme.palette.text.secondary,
+                  mb: 0.5,
+                }}
+              >
+                ANSWER
+              </Typography>
+              <Typography
+                variant="body2"
+                sx={{ color: theme.palette.text.primary, fontFamily: typographyTokens.fontFamily.sans }}
+              >
+                {lesson.questions[0].explanation}
+              </Typography>
+            </Box>
+          </Box>
+        )}
+
+        {phase === 'front' ? (
+          <Button
+            variant="outlined"
+            onClick={handleShowBack}
+            fullWidth
+            sx={{ minHeight: 48 }}
+          >
+            SHOW ANSWER
+          </Button>
+        ) : (
+          <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap' }}>
+            {RATINGS.map(({ label, quality, color }) => (
+              <Button
+                key={label}
+                onClick={() => handleRate(quality)}
+                sx={{
+                  flex: '1 1 0',
+                  minHeight: 48,
+                  minWidth: 64,
+                  fontFamily: typographyTokens.fontFamily.mono,
+                  fontSize: '0.75rem',
+                  fontWeight: 600,
+                  letterSpacing: typographyTokens.letterSpacing.wide,
+                  color,
+                  border: `1px solid ${color}`,
+                  borderRadius: `${radiusTokens.sm}px`,
+                  '&:hover': {
+                    backgroundColor: `${color}18`,
+                    borderColor: color,
+                  },
+                }}
+              >
+                {label}
+              </Button>
+            ))}
+          </Box>
+        )}
+      </Box>
+
+      {/* SRS meta */}
+      <Box
+        sx={{
+          px: 2,
+          py: 1,
+          borderTop: `1px solid ${theme.palette.divider}`,
+          display: 'flex',
+          gap: 2,
+        }}
+      >
+        <Typography
+          sx={{
+            fontFamily: typographyTokens.fontFamily.mono,
+            fontSize: '0.625rem',
+            letterSpacing: typographyTokens.letterSpacing.wide,
+            textTransform: 'uppercase',
+            color: theme.palette.text.disabled,
+          }}
+        >
+          EF {current.ef.toFixed(1)} · INTERVAL {current.interval}D · REP {current.repetitions}
+        </Typography>
+      </Box>
+    </Box>
+  );
+}

--- a/web-app/src/components/TopicMasteryCard.tsx
+++ b/web-app/src/components/TopicMasteryCard.tsx
@@ -1,0 +1,118 @@
+import Box from '@mui/material/Box';
+import LinearProgress from '@mui/material/LinearProgress';
+import Typography from '@mui/material/Typography';
+import { useTheme } from '@mui/material/styles';
+import { typographyTokens, radiusTokens } from '../tokens';
+import type { CurriculumSlot } from '../lib/curriculum';
+
+export interface TopicMasteryCardProps {
+  topicCode: string;
+  topicLabel: string;
+  slots: CurriculumSlot[];
+  completedIds: string[];
+}
+
+export default function TopicMasteryCard({
+  topicCode,
+  topicLabel,
+  slots,
+  completedIds,
+}: TopicMasteryCardProps) {
+  const theme = useTheme();
+  const total = slots.length;
+  const done = slots.filter((s) => completedIds.includes(s.id)).length;
+  const pct = total > 0 ? Math.round((done / total) * 100) : 0;
+
+  return (
+    <Box
+      sx={{
+        backgroundColor: theme.palette.background.paper,
+        border: `1px solid ${theme.palette.divider}`,
+        borderRadius: `${radiusTokens.md}px`,
+        p: 2,
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 1,
+        transition: 'border-color 150ms ease-out, transform 150ms ease-out',
+        '&:hover': {
+          borderColor: theme.palette.primary.main,
+          transform: 'translateY(-1px)',
+        },
+      }}
+    >
+      {/* Top row: monospace code + lesson count label */}
+      <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+        <Typography
+          component="span"
+          sx={{
+            fontFamily: typographyTokens.fontFamily.mono,
+            fontSize: '0.6875rem',
+            fontWeight: 500,
+            letterSpacing: typographyTokens.letterSpacing.wider,
+            textTransform: 'uppercase',
+            color: theme.palette.text.secondary,
+          }}
+        >
+          {topicCode}
+        </Typography>
+        <Typography
+          component="span"
+          sx={{
+            fontFamily: typographyTokens.fontFamily.mono,
+            fontSize: '0.6875rem',
+            fontWeight: 500,
+            letterSpacing: typographyTokens.letterSpacing.wide,
+            textTransform: 'uppercase',
+            color: theme.palette.text.secondary,
+          }}
+        >
+          {done}/{total} LESSONS
+        </Typography>
+      </Box>
+
+      {/* Topic name */}
+      <Typography
+        variant="body1"
+        sx={{
+          fontFamily: typographyTokens.fontFamily.sans,
+          fontSize: '0.9375rem',
+          fontWeight: typographyTokens.weight.semibold,
+          color: theme.palette.text.primary,
+          lineHeight: 1.35,
+        }}
+      >
+        {topicLabel}
+      </Typography>
+
+      {/* Amber progress bar — 2px thin */}
+      <LinearProgress
+        variant="determinate"
+        value={pct}
+        sx={{
+          height: 2,
+          borderRadius: radiusTokens.pill,
+          backgroundColor: `${theme.palette.primary.main}22`,
+          '& .MuiLinearProgress-bar': {
+            backgroundColor: theme.palette.primary.main,
+            borderRadius: radiusTokens.pill,
+          },
+        }}
+      />
+
+      {/* Footer: mastery % */}
+      <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'flex-end' }}>
+        <Typography
+          component="span"
+          sx={{
+            fontFamily: typographyTokens.fontFamily.mono,
+            fontSize: '0.875rem',
+            fontWeight: typographyTokens.weight.semibold,
+            color: pct === 0 ? theme.palette.text.disabled : theme.palette.primary.main,
+          }}
+        >
+          {pct}%
+        </Typography>
+      </Box>
+    </Box>
+  );
+}

--- a/web-app/src/lib/srs.ts
+++ b/web-app/src/lib/srs.ts
@@ -73,7 +73,7 @@ export function loadSRSData(trackId: string): SRSData {
 
 export function saveSRSData(trackId: string, data: SRSData): void {
   try {
-    localStorage.setItem(`${LS_KEY_PREFIX}${trackId}}`, JSON.stringify(data));
+    localStorage.setItem(`${LS_KEY_PREFIX}${trackId}`, JSON.stringify(data));
   } catch {
     // ignore storage errors
   }

--- a/web-app/src/lib/srs.ts
+++ b/web-app/src/lib/srs.ts
@@ -1,0 +1,87 @@
+// SM-2 spaced-repetition algorithm
+// EF (Easiness Factor) initial = 2.5, minimum = 1.3
+// Quality: 0 = complete blackout, 5 = perfect recall
+
+const EF_INITIAL = 2.5;
+const EF_MIN = 1.3;
+
+export interface SRSCard {
+  lessonId: string;
+  ef: number;
+  interval: number;
+  repetitions: number;
+  nextDue: string; // YYYY-MM-DD
+}
+
+export type SRSData = Record<string, SRSCard>;
+
+const LS_KEY_PREFIX = 'ppl.srs.';
+
+function today(): string {
+  return new Date().toISOString().split('T')[0];
+}
+
+function addDays(days: number): string {
+  const d = new Date();
+  d.setDate(d.getDate() + days);
+  return d.toISOString().split('T')[0];
+}
+
+export function sm2Update(card: SRSCard, quality: number): SRSCard {
+  let { ef, interval, repetitions } = card;
+
+  if (quality < 3) {
+    interval = 1;
+    repetitions = 0;
+  } else {
+    if (repetitions === 0) interval = 1;
+    else if (repetitions === 1) interval = 6;
+    else interval = Math.round(interval * ef);
+    repetitions += 1;
+  }
+
+  ef = ef + (0.1 - (5 - quality) * (0.08 + (5 - quality) * 0.02));
+  ef = Math.max(EF_MIN, ef);
+
+  return {
+    lessonId: card.lessonId,
+    ef,
+    interval,
+    repetitions,
+    nextDue: addDays(interval),
+  };
+}
+
+export function newCard(lessonId: string): SRSCard {
+  return {
+    lessonId,
+    ef: EF_INITIAL,
+    interval: 1,
+    repetitions: 0,
+    nextDue: today(),
+  };
+}
+
+export function loadSRSData(trackId: string): SRSData {
+  try {
+    const raw = localStorage.getItem(`${LS_KEY_PREFIX}${trackId}`);
+    return raw ? (JSON.parse(raw) as SRSData) : {};
+  } catch {
+    return {};
+  }
+}
+
+export function saveSRSData(trackId: string, data: SRSData): void {
+  try {
+    localStorage.setItem(`${LS_KEY_PREFIX}${trackId}}`, JSON.stringify(data));
+  } catch {
+    // ignore storage errors
+  }
+}
+
+export function getDueCards(data: SRSData, lessonIds: string[]): SRSCard[] {
+  const t = today();
+  return lessonIds
+    .map((id) => data[id] ?? newCard(id))
+    .filter((card) => card.nextDue <= t);
+}

--- a/web-app/src/pages/LessonDetail.tsx
+++ b/web-app/src/pages/LessonDetail.tsx
@@ -11,11 +11,12 @@ import AudioPlayer from '../components/AudioPlayer';
 import LessonCompleteScreen from '../components/LessonCompleteScreen';
 import type { LessonScore } from '../components/LessonCompleteScreen';
 import LessonPrevNext from '../components/LessonPrevNext';
+import LessonProgressBar from '../components/LessonProgressBar';
 import SourceList from '../components/SourceList';
 import { getLessonBySlug, getAdjacentLessons } from '../lib/lesson-loader';
 import { useProgress } from '../lib/progress';
 import { useExamTrack } from '../context/ExamTrackContext';
-import { TOPIC_LABELS } from '../lib/curriculum';
+import { CURRICULUM, TOPIC_LABELS } from '../lib/curriculum';
 import { LAST_SESSION_KEY } from '../components/home/StatusBar';
 
 const QUIZ_RESULT_KEY = (lessonId: string) => `ppl-quiz-result-${lessonId}`;
@@ -92,6 +93,9 @@ export default function LessonDetail() {
   const { prev, next } = topic && slug && lesson
     ? getAdjacentLessons(topic, slug)
     : { prev: null, next: null };
+
+  const topicSlots = lesson ? CURRICULUM.filter((s) => s.topic === lesson.topic) : [];
+  const lessonPosition = lesson ? (topicSlots.findIndex((s) => s.id === lesson.id) + 1) : 0;
 
   useEffect(() => {
     return () => {
@@ -171,7 +175,15 @@ export default function LessonDetail() {
   }
 
   return (
-    <Container id="main-content" tabIndex={-1} maxWidth={false} sx={{ maxWidth: 700, mx: 'auto', px: { xs: 2, sm: 3 }, py: 4 }}>
+    <Container id="main-content" tabIndex={-1} maxWidth={false} sx={{ maxWidth: 700, mx: 'auto', px: 0, py: 4 }}>
+      {lesson && topicSlots.length > 0 && (
+        <LessonProgressBar
+          position={lessonPosition}
+          total={topicSlots.length}
+          label={`${TOPIC_LABELS[lesson.topic]} · Lesson ${lessonPosition} of ${topicSlots.length}`}
+        />
+      )}
+      <Box sx={{ px: { xs: 2, sm: 3 } }}>
       <LessonPrevNext prev={prev} next={next} variant="compact" />
 
       <Box sx={{ mb: 1, display: 'flex', gap: 1, flexWrap: 'wrap', alignItems: 'center' }}>
@@ -242,6 +254,7 @@ export default function LessonDetail() {
       <Divider sx={{ mt: 3, mb: 2 }} />
 
       <LessonPrevNext prev={prev} next={next} variant="full" />
+      </Box>
     </Container>
   );
 }

--- a/web-app/src/pages/LessonsIndex.tsx
+++ b/web-app/src/pages/LessonsIndex.tsx
@@ -14,6 +14,7 @@ import { getAllLessons } from '../lib/lesson-loader';
 import { useProgress } from '../lib/progress';
 import { useExamTrack } from '../context/ExamTrackContext';
 import type { LessonStatus } from '../lib/types';
+import TopicMasteryCard from '../components/TopicMasteryCard';
 
 function statusChipProps(status: LessonStatus) {
   if (status === 'complete') return { label: 'Complete', color: 'success' as const };
@@ -22,7 +23,7 @@ function statusChipProps(status: LessonStatus) {
 }
 
 export default function LessonsIndex() {
-  const { store } = useExamTrack();
+  const { store, trackProgress } = useExamTrack();
   const { isComplete } = useProgress(store);
 
   const lessonMap = useMemo(() => {
@@ -38,6 +39,30 @@ export default function LessonsIndex() {
       <Typography variant="body2" color="text.secondary" sx={{ mb: 4 }}>
         {CURRICULUM.length} lessons across {TOPICS.length} topics
       </Typography>
+
+      {/* Topic mastery overview grid */}
+      <Box
+        sx={{
+          display: 'grid',
+          gridTemplateColumns: { xs: '1fr 1fr', md: '1fr 1fr 1fr 1fr' },
+          gap: 1.5,
+          mb: 4,
+        }}
+      >
+        {TOPICS.map((topic) => {
+          const slots = CURRICULUM.filter((s) => s.topic === topic);
+          const topicCode = slots[0]?.id.split('-')[0] ?? topic.toUpperCase();
+          return (
+            <TopicMasteryCard
+              key={topic}
+              topicCode={topicCode}
+              topicLabel={TOPIC_LABELS[topic]}
+              slots={slots}
+              completedIds={trackProgress.completed}
+            />
+          );
+        })}
+      </Box>
 
       {TOPICS.map((topic) => {
         const slots = CURRICULUM.filter((s) => s.topic === topic);


### PR DESCRIPTION
Closes #137

Adheres to docs/design/DESIGN-SYSTEM.md

## What this PR adds

Four new components for Phase 2–3 of the epic, wired into existing pages:

### New components
- **`TopicMasteryCard.tsx`** — topic card per Design System §5.5: monospace code label, topic name (sans semibold), 2 px amber progress bar, mastery % footer. Accepts `topicCode`, `topicLabel`, `slots[]`, `completedIds[]`. Hover lifts `translateY(-1px)` per §6.
- **`LessonProgressBar.tsx`** — 3 px amber progress bar showing position in topic sequence (position/total). Includes ARIA `progressbar` role, `aria-valuenow/min/max`, and Tooltip label. Mounted at top of LessonDetail container (no horizontal padding, full bleed).
- **`SRSQueue.tsx`** — daily review UI with SM-2 algorithm (EF initial 2.5, min 1.3). States: queue empty / front (show answer) / back (recall prompt + rating) / done. Ratings: AGAIN (q=1), HARD (q=2), GOOD (q=4), EASY (q=5). State persisted to `localStorage` via `lib/srs.ts`.
- **`LessonCompleteScreen.tsx`** — `Dialog` overlay for post-lesson completion: lesson ID stamp, title, optional quiz score (colour-coded), SRS next-due date, next-lesson CTA button.

### New lib
- **`lib/srs.ts`** — pure SM-2 functions (`sm2Update`, `newCard`, `getDueCards`) + localStorage helpers (`loadSRSData`, `saveSRSData`). No side effects; easily testable.

### Wired into pages
- **`LessonsIndex.tsx`** — 4×1 (mobile) / 4×4 (desktop) `TopicMasteryCard` grid above the lesson list.
- **`LessonDetail.tsx`** — `LessonProgressBar` at the top of the container (full-bleed, above `LessonPrevNext`).

## Design compliance
- No hardcoded hex — all colors via `useTheme()` + `theme.palette.*` for dual-scheme support, or `colorTokens.*` flat keys (backward compat spread) where non-interactive static values are needed.
- Tap targets ≥ 48 × 48 px (SRS rating buttons: `minHeight: 48`).
- Mobile-first layouts, 360 px minimum.
- Radii from `radiusTokens` only (xs=3, sm=4, md=6, pill=100).
- No green for navigation/progress; green (`success.main`) used only for EASY rating and correct/complete semantics.
- Motion: 150–200 ms ease-out transitions only on `transform`, `border-color`, `background-color`.

## Build
`npm run build` in `web-app/` passes ✓

## Remaining child issues (epic #137)
- [Nav] Desktop side-rail + mobile bottom-nav
- [ExamTrackProvider] already shipped (ExamTrackContext.tsx present)
- [ExamReadinessGauge] (altimeter SVG)
- [AudioPlayerV2], [MockExamRunner], [AirspaceDiagram], [TrackSwitcher]