### PR TITLE
[PPL-194] Fix playlist route integration: /topic/:topic, legacy redirect, smart 'due' kind, inline PlaylistPlayer

### DIFF
--- a/web-app/src/App.tsx
+++ b/web-app/src/App.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useMemo } from 'react';
-import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import { BrowserRouter, Routes, Route, Navigate, useParams } from 'react-router-dom';
 import { ThemeProvider, CssBaseline, Box } from '@mui/material';
 import { buildTheme } from './theme';
 import { useThemeMode } from './context/ThemeModeContext';
@@ -19,6 +19,11 @@ import SmartPlaylist from './pages/SmartPlaylist';
 import PlaylistEditor from './pages/PlaylistEditor';
 import UserPlaylistPage from './pages/UserPlaylistPage';
 import PSTARPath from './pages/PSTARPath';
+
+function PlaylistTopicRedirect() {
+  const { topic } = useParams<{ topic: string }>();
+  return <Navigate to={`/playlist/topic/${topic}`} replace />;
+}
 
 const RAIL_EXPANDED = 240;
 const RAIL_COLLAPSED = 64;
@@ -111,12 +116,13 @@ export default function App() {
               <Route path="/pstar-exam" element={<PSTARExam />} />
               <Route path="/plan" element={<Plan />} />
               <Route path="/playlist" element={<Playlist />} />
+              <Route path="/playlist/topic/:topic" element={<Playlist />} />
               <Route path="/playlist/smart/:kind" element={<SmartPlaylist />} />
               <Route path="/playlist/curated/:id" element={<Playlist />} />
-              <Route path="/playlist/:topic" element={<Playlist />} />
               <Route path="/playlist/new" element={<PlaylistEditor />} />
               <Route path="/playlist/user/:id" element={<UserPlaylistPage />} />
               <Route path="/playlist/user/:id/edit" element={<PlaylistEditor />} />
+              <Route path="/playlist/:topic" element={<PlaylistTopicRedirect />} />
               <Route path="/pstar" element={<PSTARPath />} />
             </Routes>
           </Box>

--- a/web-app/src/pages/Playlist.tsx
+++ b/web-app/src/pages/Playlist.tsx
@@ -1,4 +1,3 @@
-import { useEffect } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
@@ -13,7 +12,6 @@ import type { Lesson } from '../lib/types';
 import { CURATED_PLAYLISTS } from '../data/curated-playlists';
 import { getUserPlaylists } from '../lib/user-playlists';
 import { typographyTokens } from '../tokens';
-import { useStickyPlayer } from '../context/StickyPlayerContext';
 
 // ── Static metadata per topic ──────────────────────────────────────────────
 
@@ -420,7 +418,7 @@ function PlaylistLibrary() {
       tagline: TOPIC_TAGLINES[t],
       lessonCount: count,
       durationMin: count * 20,
-      href: `/playlist/${t}`,
+      href: `/playlist/topic/${t}`,
       coverCode: TOPIC_CODES[t],
       coverAngle: TOPIC_COVER_ANGLES[t],
     };
@@ -580,17 +578,9 @@ function PlaylistLibrary() {
 interface TopicPlaylistProps {
   topic: string;
   lessons: ReturnType<typeof getLessonsByTopic>;
-  setLessons: (lessons: ReturnType<typeof getLessonsByTopic>) => void;
 }
 
-function TopicPlaylist({ topic, lessons, setLessons }: TopicPlaylistProps) {
-  useEffect(() => {
-    setLessons(lessons);
-    // No cleanup: lessons persist in context so StickyPlayerBar stays visible
-    // when the user navigates away. A subsequent TopicPlaylist mount will replace
-    // them via setLessons; explicit clear only happens on app unmount.
-  }, [topic]); // eslint-disable-line react-hooks/exhaustive-deps
-
+function TopicPlaylist({ topic, lessons }: TopicPlaylistProps) {
   if (lessons.length === 0) {
     return (
       <Container maxWidth="md" sx={{ py: 4 }}>
@@ -609,9 +599,10 @@ function TopicPlaylist({ topic, lessons, setLessons }: TopicPlaylistProps) {
       <Typography variant="h4" gutterBottom>
         {TOPIC_LABELS[topic] ?? topic} — Playlist
       </Typography>
-      <Typography color="text.secondary" sx={{ mb: 2 }}>
-        {lessons.length} lesson{lessons.length !== 1 ? 's' : ''} queued — use the player bar at the bottom to play, skip, and control speed.
+      <Typography color="text.secondary" sx={{ mb: 3 }}>
+        {lessons.length} lesson{lessons.length !== 1 ? 's' : ''} · {fmtDuration(lessons.length * 20)} total
       </Typography>
+      <PlaylistPlayer lessons={lessons} />
     </Container>
   );
 }
@@ -620,7 +611,6 @@ function TopicPlaylist({ topic, lessons, setLessons }: TopicPlaylistProps) {
 
 export default function Playlist() {
   const { topic, id } = useParams<{ topic?: string; id?: string }>();
-  const { setLessons } = useStickyPlayer();
   const navigate = useNavigate();
 
   if (id !== undefined) {
@@ -671,7 +661,7 @@ export default function Playlist() {
       (l) => l.status !== 'planning' && l.audio !== null,
     );
 
-    return <TopicPlaylist topic={topic} lessons={lessons} setLessons={setLessons} />;
+    return <TopicPlaylist topic={topic} lessons={lessons} />;
   }
 
   return <PlaylistLibrary />;

--- a/web-app/src/pages/SmartPlaylist.tsx
+++ b/web-app/src/pages/SmartPlaylist.tsx
@@ -13,7 +13,7 @@ const KIND_META: Record<string, { label: string; description: string; empty: str
     empty:
       "No incomplete lessons with audio are available. You've covered everything — great work!",
   },
-  review: {
+  due: {
     label: 'Due for Review',
     description: 'Lessons you completed more than 7 days ago. Time to keep them fresh.',
     empty: 'No lessons are due for review right now. Check back in a few days!',
@@ -40,7 +40,7 @@ export default function SmartPlaylist() {
   const lessons =
     kind === 'weakest'
       ? weakestTopicFirst(progress)
-      : kind === 'review'
+      : kind === 'due'
         ? dueForReview(progress)
         : [];
 


### PR DESCRIPTION
## Summary

- **Add `/playlist/topic/:topic` canonical route** — all 4 playlist namespace routes (`/topic/:topic`, `/curated/:id`, `/user/:id`, `/smart/:kind`) are now mounted in `App.tsx` with `PlaylistPlayer` receiving correct lesson arrays
- **Legacy redirect** — `/playlist/:topic` now redirects to `/playlist/topic/:topic` via a `PlaylistTopicRedirect` component using React Router `<Navigate replace>`
- **Fix topic card hrefs** in `PlaylistLibrary` — were linking to `/playlist/${t}` (legacy), now correctly link to `/playlist/topic/${t}`
- **Fix smart playlist kind mismatch** — `SmartPlaylist.tsx` had key `'review'` but `/playlist/smart/due` URL produces `kind='due'`; renamed to `'due'` so the Due for Review card works end-to-end
- **Inline `PlaylistPlayer` in topic view** — `TopicPlaylist` previously used `StickyPlayerContext.setLessons` (bottom bar only) instead of rendering `PlaylistPlayer` inline, inconsistent with curated/user/smart views; now renders inline like the others

Closes #194

## Test plan

- [ ] Navigate to `/playlist` — index shows 4 sections (Topic, Curated, Your Playlists, Smart), each card has name/tagline/lesson count/duration
- [ ] Click a topic card → redirected via `/playlist/topic/air-law` (not legacy `/playlist/air-law`) → PlaylistPlayer renders with topic lessons
- [ ] Manually visit `/playlist/air-law` → browser redirects to `/playlist/topic/air-law`
- [ ] Click a curated playlist card → `/playlist/curated/weather-essentials` → PlaylistPlayer with curated lesson array
- [ ] Click a user playlist card (after creating one) → `/playlist/user/:id` → PlaylistPlayer
- [ ] Click "Weakest Topics" smart card → `/playlist/smart/weakest` → PlaylistPlayer with weakest-first ordering
- [ ] Click "Due for Review" smart card → `/playlist/smart/due` → PlaylistPlayer (previously "Unknown playlist type")
- [ ] `npm run build` passes (verified in CI and locally)
- [ ] Dark + light mode parity; tap targets ≥ 48px (ButtonBase cards have `minHeight: 48`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)