### PR TITLE
[PPL-270] Add LessonProgressBar to LessonDetail header

### DIFF
--- a/web-app/src/components/LessonProgressBar.tsx
+++ b/web-app/src/components/LessonProgressBar.tsx
@@ -1,0 +1,36 @@
+import Box from '@mui/material/Box';
+import { useTheme } from '@mui/material/styles';
+
+interface LessonProgressBarProps {
+  current: number;
+  total: number;
+}
+
+export default function LessonProgressBar({ current, total }: LessonProgressBarProps) {
+  const theme = useTheme();
+  const pct = total > 0 ? Math.min((current / total) * 100, 100) : 0;
+
+  return (
+    <Box
+      sx={{
+        width: '100%',
+        height: 4,
+        bgcolor: theme.palette.divider,
+        position: 'relative',
+        overflow: 'hidden',
+      }}
+    >
+      <Box
+        sx={{
+          position: 'absolute',
+          top: 0,
+          left: 0,
+          height: '100%',
+          width: `${pct}%`,
+          bgcolor: 'primary.main',
+          borderRadius: 0,
+        }}
+      />
+    </Box>
+  );
+}

--- a/web-app/src/pages/LessonDetail.tsx
+++ b/web-app/src/pages/LessonDetail.tsx
@@ -11,8 +11,9 @@ import AudioPlayer from '../components/AudioPlayer';
 import LessonCompleteScreen from '../components/LessonCompleteScreen';
 import type { LessonScore } from '../components/LessonCompleteScreen';
 import LessonPrevNext from '../components/LessonPrevNext';
+import LessonProgressBar from '../components/LessonProgressBar';
 import SourceList from '../components/SourceList';
-import { getLessonBySlug, getAdjacentLessons } from '../lib/lesson-loader';
+import { getLessonBySlug, getAdjacentLessons, getLessonsByTopic } from '../lib/lesson-loader';
 import { useProgress } from '../lib/progress';
 import { useExamTrack } from '../context/ExamTrackContext';
 import { TOPIC_LABELS } from '../lib/curriculum';
@@ -92,6 +93,11 @@ export default function LessonDetail() {
   const { prev, next } = topic && slug && lesson
     ? getAdjacentLessons(topic, slug)
     : { prev: null, next: null };
+
+  const topicLessons = topic ? getLessonsByTopic(topic) : [];
+  const lessonIndex = lesson ? topicLessons.findIndex((l) => l.slug === lesson.slug) : -1;
+  const progressCurrent = lessonIndex >= 0 ? lessonIndex + 1 : 1;
+  const progressTotal = topicLessons.length;
 
   useEffect(() => {
     return () => {
@@ -189,6 +195,8 @@ export default function LessonDetail() {
       <Typography variant="h3" gutterBottom sx={{ mt: 2 }}>
         {lesson.title}
       </Typography>
+
+      <LessonProgressBar current={progressCurrent} total={progressTotal} />
 
       <AudioPlayer
         key={lesson.id}


### PR DESCRIPTION
## Summary

- Adds `LessonProgressBar` component: full-width 4px bar, track color from `theme.palette.divider` (--border token), fill color from `theme.palette.primary.main` (amber), no border-radius on fill, no hardcoded hex
- Wires `<LessonProgressBar>` into `LessonDetail.tsx` between the lesson title and AudioPlayer; computes `current` (1-based index in topic) and `total` (lesson count for topic) via `getLessonsByTopic`
- Both dark and light modes verified via theme tokens only

Closes #270

Adheres to docs/design/DESIGN-SYSTEM.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)