### PR TITLE
[PPL-269] Add TopicMasteryCard component and render per topic in LessonsIndex

### DIFF
--- a/web-app/src/components/TopicMasteryCard.tsx
+++ b/web-app/src/components/TopicMasteryCard.tsx
@@ -1,0 +1,72 @@
+import Box from '@mui/material/Box';
+import LinearProgress from '@mui/material/LinearProgress';
+import Typography from '@mui/material/Typography';
+import { useTheme } from '@mui/material/styles';
+import { radiusTokens, typographyTokens } from '../tokens';
+
+interface Props {
+  topic: string;
+  lessonCount: number;
+  completedCount: number;
+  masteryPercent: number;
+}
+
+export default function TopicMasteryCard({
+  topic,
+  lessonCount,
+  completedCount,
+  masteryPercent,
+}: Props) {
+  const theme = useTheme();
+
+  return (
+    <Box
+      sx={{
+        backgroundColor: theme.palette.background.paper,
+        border: `1px solid ${theme.palette.divider}`,
+        borderRadius: `${radiusTokens.lg}px`,
+        p: 2,
+        overflow: 'hidden',
+        position: 'relative',
+      }}
+    >
+      <Typography
+        variant="h6"
+        sx={{ mb: 0.5, lineHeight: 1.35 }}
+      >
+        {topic}
+      </Typography>
+
+      <Typography
+        component="div"
+        sx={{
+          fontFamily: typographyTokens.fontFamily.mono,
+          fontSize: '0.6875rem',
+          fontWeight: typographyTokens.weight.medium,
+          letterSpacing: typographyTokens.letterSpacing.wider,
+          textTransform: 'uppercase',
+          color: theme.palette.text.secondary,
+          mb: 1.5,
+        }}
+      >
+        {completedCount} / {lessonCount} LESSONS
+      </Typography>
+
+      <LinearProgress
+        variant="determinate"
+        value={masteryPercent}
+        sx={{
+          position: 'absolute',
+          bottom: 0,
+          left: 0,
+          right: 0,
+          height: 4,
+          borderRadius: 0,
+          '& .MuiLinearProgress-bar': {
+            backgroundColor: theme.palette.primary.main,
+          },
+        }}
+      />
+    </Box>
+  );
+}

--- a/web-app/src/pages/LessonsIndex.tsx
+++ b/web-app/src/pages/LessonsIndex.tsx
@@ -14,6 +14,7 @@ import { getAllLessons } from '../lib/lesson-loader';
 import { useProgress } from '../lib/progress';
 import { useExamTrack } from '../context/ExamTrackContext';
 import type { LessonStatus } from '../lib/types';
+import TopicMasteryCard from '../components/TopicMasteryCard';
 
 function statusChipProps(status: LessonStatus) {
   if (status === 'complete') return { label: 'Complete', color: 'success' as const };
@@ -44,7 +45,13 @@ export default function LessonsIndex() {
 
         return (
           <Box key={topic} id={topic} sx={{ mb: 5 }}>
-            <Typography variant="h5" gutterBottom>
+            <TopicMasteryCard
+              topic={TOPIC_LABELS[topic]}
+              lessonCount={slots.length}
+              completedCount={0}
+              masteryPercent={0}
+            />
+            <Typography variant="h5" gutterBottom sx={{ mt: 2 }}>
               {TOPIC_LABELS[topic]}
             </Typography>
             <Divider sx={{ mb: 2 }} />

--- a/web-app/src/pages/LessonsIndex.tsx
+++ b/web-app/src/pages/LessonsIndex.tsx
@@ -51,9 +51,6 @@ export default function LessonsIndex() {
               completedCount={0}
               masteryPercent={0}
             />
-            <Typography variant="h5" gutterBottom sx={{ mt: 2 }}>
-              {TOPIC_LABELS[topic]}
-            </Typography>
             <Divider sx={{ mb: 2 }} />
 
             <Box


### PR DESCRIPTION
## Summary
- Adds `TopicMasteryCard` component with props `{topic, lessonCount, completedCount, masteryPercent}` displaying topic name, 'X / Y LESSONS' monospace label, and a 4px amber progress bar anchored to the card bottom
- Updates `LessonsIndex.tsx` to render `TopicMasteryCard` as the topic section header, replacing the plain `<Typography variant="h5">` heading
- All colors sourced from `theme.ts`/`tokens.ts` — no hardcoded hex values
- Card uses `background.paper` (--surface), `divider` (--border), `radiusTokens.lg` (8px max radius)
- `npm run build` passes

## Test plan
- [ ] Visit `/lessons` in dark mode — verify each topic section shows a card with topic name, \"0 / N LESSONS\", and an empty amber progress bar at the bottom
- [ ] Switch to light mode — verify card renders correctly with light palette tokens
- [ ] Verify no horizontal scroll at 360px viewport width
- [ ] Verify topic name appears only once per section (card is the only heading, no duplicate h5)
- [ ] Build passes: `cd web-app && npm run build`

Adheres to docs/design/DESIGN-SYSTEM.md

Closes #269

🤖 Generated with [Claude Code](https://claude.com/claude-code)