### PR TITLE
[PPL-272] Wire LessonCompleteScreen into LessonDetail after quiz submission

### DIFF
--- a/web-app/src/pages/LessonDetail.tsx
+++ b/web-app/src/pages/LessonDetail.tsx
@@ -1,4 +1,4 @@
-import { useParams, useNavigate } from 'react-router-dom';
+import { useParams, useNavigate, useLocation } from 'react-router-dom';
 import Markdown from 'markdown-to-jsx';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
@@ -85,9 +85,12 @@ const mdOptions = {
 export default function LessonDetail() {
   const { topic, slug } = useParams<{ topic: string; slug: string }>();
   const navigate = useNavigate();
+  const location = useLocation();
   const { store } = useExamTrack();
   const { isComplete, markComplete } = useProgress(store);
-  const [showComplete, setShowComplete] = useState(false);
+  const [showComplete, setShowComplete] = useState(
+    () => !!(location.state as { showComplete?: boolean } | null)?.showComplete,
+  );
 
   const lesson = topic && slug ? getLessonBySlug(topic, slug) : undefined;
   const { prev, next } = topic && slug && lesson

--- a/web-app/src/pages/LessonQuiz.tsx
+++ b/web-app/src/pages/LessonQuiz.tsx
@@ -172,9 +172,8 @@ export default function LessonQuiz() {
                   Retake
                 </Button>
                 <Button
-                  component={Link}
-                  to={lessonPath}
                   variant="contained"
+                  onClick={() => navigate(lessonPath, { state: { showComplete: true } })}
                   sx={TOUCH_TARGET}
                 >
                   Review lesson


### PR DESCRIPTION
Closes #272

## Summary

- `LessonQuiz.tsx`: the **Review lesson** button after quiz results now calls `navigate(lessonPath, { state: { showComplete: true } })` instead of using a `<Link>` component, passing the quiz-complete signal as navigation state.
- `LessonDetail.tsx`: `showComplete` state is now initialised via a lazy initialiser that reads `useLocation().state?.showComplete`, so arriving from the quiz automatically renders `LessonCompleteScreen`.

The `LessonCompleteScreen` component (created in #273) displays lesson title, quiz score X/Y with `success.main` (≥ 70%) or `error.main` (< 70%) color, an encouragement line, and three actions: **Next Lesson**, **Review Lesson**, **Back to Topics**. No hardcoded hex — all colors from theme tokens.

## Test plan

- [ ] Complete a quiz → click **Review lesson** → `LessonCompleteScreen` renders in LessonDetail with correct score and color
- [ ] Score ≥ 70% → green (`success.main`); score < 70% → red (`error.main`)
- [ ] **Next Lesson** navigates to next lesson in topic; on last lesson goes to `/lessons`
- [ ] **Review Lesson** dismisses the screen, scrolls to top, shows lesson content
- [ ] **Back to Topics** navigates to `/lessons`
- [ ] Mark Complete button still shows `LessonCompleteScreen` (existing path preserved)
- [ ] `npm run build` passes

Adheres to `docs/design/DESIGN-SYSTEM.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)