### PR TITLE
[PPL-282] al001-airspace-classifications: align visual with Canadian PPL standards

### DIFF
--- a/web-app/public/visuals/al001-airspace-classifications.html
+++ b/web-app/public/visuals/al001-airspace-classifications.html
@@ -18,6 +18,10 @@
   .req { font-size: 12px; color: var(--text); }
   .req small { color: var(--text-muted); display: block; margin-top: 2px; }
 
+  /* Aviation data-encoding colors — exempt from token substitution.
+     Each airspace class uses a distinct ICAO-convention hue so they are
+     instantly distinguishable on a single glance; swapping to design-system
+     tokens would collapse distinctions needed for safety-critical recall. */
   .a  { background: #0a1525; } .badge-a  { background: #880e4f; color:#fff; }
   .b  { background: #0a1a30; } .badge-b  { background: #1565c0; color:#fff; }
   .c  { background: #0a2040; } .badge-c  { background: #1976d2; color:#fff; }
@@ -75,8 +79,8 @@
   </div>
   <div class="layer f">
     <div style="display:flex;align-items:center;gap:10px;"><span class="class-badge badge-f">F</span><div class="alt-range">Special use<br>(varies)</div></div>
-    <div><span class="rule-tag" style="background:rgba(255,200,0,0.1);color:var(--accent);border:1px solid rgba(255,200,0,0.3);">F(R)/F(A)</span></div>
-    <div class="req">F(R) = Restricted (auth required)<small>F(A) = Advisory (hazard warning)</small></div>
+    <div><span class="rule-tag" style="background:rgba(255,200,0,0.1);color:var(--accent);border:1px solid rgba(255,200,0,0.3);">F(P)/F(R)/F(A)</span></div>
+    <div class="req">F(P) = Prohibited · F(R) = Restricted<small>F(A) = Advisory (hazard warning)</small></div>
     <div class="req">Check NOTAM</div>
   </div>
   <div class="layer g">
@@ -94,7 +98,7 @@
   <div class="hook-row"><span class="hook-badge">C</span><span class="hook-text"><strong>Clearance + radio</strong> — ATC separates IFR from VFR, not VFR from VFR.</span></div>
   <div class="hook-row"><span class="hook-badge">D</span><span class="hook-text"><strong>Radio contact only</strong> — no clearance, but must establish 2-way. ATC separates IFR only.</span></div>
   <div class="hook-row"><span class="hook-badge">E</span><span class="hook-text"><strong>No requirements for VFR</strong> — but it's still controlled (ATC serves IFR).</span></div>
-  <div class="hook-row"><span class="hook-badge">F</span><span class="hook-text"><strong>Special use</strong> — F(R) restricted, F(A) advisory. Always check NOTAM.</span></div>
+  <div class="hook-row"><span class="hook-badge">F</span><span class="hook-text"><strong>Special use</strong> — F(P) prohibited, F(R) restricted, F(A) advisory. Always check NOTAM.</span></div>
   <div class="hook-row"><span class="hook-badge">G</span><span class="hook-text"><strong>Uncontrolled</strong> — no ATC. Lower weather minimums. See and avoid.</span></div>
 </div>
 


### PR DESCRIPTION
## Summary

- **Visual updated:** `web-app/public/visuals/al001-airspace-classifications.html`
- **Factual fix:** Class F airspace in Canada has three sub-types per CARs 601.03 — F(P) Prohibited, F(R) Restricted, and F(A) Advisory. The visual previously showed only F(R)/F(A), omitting the Prohibited designation. Updated the rule tag, description cell, and memory hook to list all three.
- **Exemption comments added:** Inline CSS comment block added above the aviation data-encoding class colors (`.badge-a` through `.badge-g`) explaining why they are kept as hardcoded ICAO-convention hues rather than substituted with `var()` tokens.
- **Backlink:** Already present (`data-backlink="true"`); `add-visual-backlink.sh` confirmed skip.
- **No token duplicates:** Confirmed via automated check — no hardcoded hex values in this file duplicate `_common.css` token definitions.
- **Canadian units:** Altitudes use `ft ASL` (Canadian standard per TP 12880E); no speeds or frequencies appear in this visual. No unit corrections needed.
- **`npm run build`:** Skipped — `node_modules` not installed in this worktree.

## Epic context

This is **one file** of the PPL-282 visual standards pass epic (one PR per file rule). Remaining al002–al018 visuals are addressed in separate PRs.

Closes #282

## Test plan

- [ ] Open `/visuals/al001-airspace-classifications.html` directly and verify "← Back to lesson" button appears at top-left
- [ ] Confirm Class F row shows F(P)/F(R)/F(A) rule tag and memory hook lists all three sub-types
- [ ] Confirm no visual regressions to layout, colours, or table structure

🤖 Generated with [Claude Code](https://claude.com/claude-code)