### PR TITLE
[PPL-297] Fix al014: ELT procedures, hardcoded aviation colors, dark scheme

### DIFF
--- a/web-app/public/visuals/al014-emergency-procedures-law.html
+++ b/web-app/public/visuals/al014-emergency-procedures-law.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-scheme="dark">
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -7,36 +7,50 @@
 <title>AL-014: Emergency Procedures — Distress and Urgency</title>
 <style>
   .cards { display: grid; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); gap: 16px; margin-bottom: 36px; }
-  .card { background: var(--surface); border-radius: 10px; border: 1.5px solid var(--surface); padding: 20px; }
+  .card { background: var(--surface); border-radius: 8px; border: 1.5px solid var(--border); padding: 20px; }
   .card-header { display: flex; align-items: center; gap: 12px; margin-bottom: 12px; }
   .signal-badge { font-size: 18px; font-weight: 900; padding: 6px 14px; border-radius: 6px; letter-spacing: 2px; }
+  /* #ff7070: MAYDAY distress red — ICAO Annex 10 / AIM COM 5.16 domain color encoding grave and imminent danger */
   .mayday-badge { background: rgba(255,80,80,0.2); color: #ff7070; border: 1.5px solid rgba(255,80,80,0.4); }
-  .panpan-badge { background: rgba(255,200,0,0.15); color: var(--accent); border: 1.5px solid rgba(255,200,0,0.35); }
+  /* #f0c040: PAN-PAN amber — AIM COM 5.16 domain color encoding urgency (serious but not immediately life-threatening) */
+  .panpan-badge { background: rgba(240,192,64,0.15); color: #f0c040; border: 1.5px solid rgba(240,192,64,0.35); }
   .card-title { font-size: 15px; font-weight: 700; color: var(--text); }
   .card-sub { font-size: 11px; color: var(--text-muted); margin-top: 2px; }
   .card p { font-size: 13px; color: var(--text); line-height: 1.6; margin-bottom: 8px; }
   .card p:last-child { margin-bottom: 0; }
   .highlight { color: var(--accent); font-weight: 700; }
 
+  /* #ff7070: MAYDAY distress red — data-encoding color for distress signals (CARs 602.135) */
   .col-signal { color: var(--accent); font-weight: 700; }
   .col-distress { color: #ff7070; font-weight: 600; }
-  .col-urgency { color: var(--accent); font-weight: 600; }
+  .col-urgency { color: #f0c040; font-weight: 600; }
 
   .squawk-row { display: flex; gap: 12px; margin-bottom: 28px; flex-wrap: wrap; }
-  .squawk-box { background: var(--surface); border-radius: 10px; border: 1.5px solid var(--surface); padding: 16px; flex: 1; min-width: 180px; }
+  .squawk-box { background: var(--surface); border-radius: 8px; border: 1.5px solid var(--border); padding: 16px; flex: 1; min-width: 180px; }
   .squawk-code { font-size: 28px; font-weight: 900; letter-spacing: 4px; margin-bottom: 8px; }
+  /* #ff7070: transponder 7700 general emergency — distress red, matches MAYDAY signal severity */
   .squawk-7700 { color: #ff7070; }
   .squawk-7600 { color: var(--accent); }
+  /* #ff8080: transponder 7500 hijack — red-family severity indicator for unlawful interference */
   .squawk-7500 { color: #ff8080; }
   .squawk-label { font-size: 12px; font-weight: 700; color: var(--text); margin-bottom: 4px; }
   .squawk-desc { font-size: 12px; color: var(--text-muted); line-height: 1.5; }
 
-  .procedure-box { background: #1a2a1a; border: 1.5px solid #2d5a2d; border-radius: 10px; padding: 18px 22px; margin-bottom: 28px; }
+  .procedure-box { background: #1a2a1a; border: 1.5px solid #2d5a2d; border-radius: 8px; padding: 18px 22px; margin-bottom: 28px; }
   .procedure-box h2 { font-size: 12px; color: #80c880; text-transform: uppercase; letter-spacing: 1px; margin-bottom: 12px; }
   .proc-item { display: flex; gap: 10px; margin-bottom: 8px; align-items: flex-start; }
   .proc-num { background: #2d5a2d; color: #80c880; font-size: 10px; font-weight: 800; width: 22px; height: 22px; border-radius: 50%; display: flex; align-items: center; justify-content: center; flex-shrink: 0; margin-top: 1px; }
   .proc-text { font-size: 13px; color: #c8d8c8; line-height: 1.5; }
   .proc-text strong { color: var(--accent); }
+
+  .elt-box { background: var(--surface); border: 1.5px solid var(--border); border-radius: 8px; padding: 18px 22px; margin-bottom: 28px; }
+  .elt-box h2 { font-size: 12px; color: var(--text-muted); text-transform: uppercase; letter-spacing: 1px; margin-bottom: 14px; font-weight: 700; }
+  .elt-row { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 12px; margin-bottom: 14px; }
+  .elt-card { background: var(--surface2); border: 1.5px solid var(--border); border-radius: 6px; padding: 12px 14px; }
+  .elt-card-title { font-size: 11px; color: var(--text-muted); text-transform: uppercase; letter-spacing: 0.8px; margin-bottom: 6px; font-weight: 700; }
+  .elt-card-body { font-size: 13px; color: var(--text); line-height: 1.5; }
+  .elt-card-body strong { color: var(--accent); }
+  .elt-note { font-size: 12px; color: var(--text-muted); line-height: 1.5; border-top: 1px solid var(--border); padding-top: 10px; margin-top: 4px; }
 
   @media (max-width: 480px) {
     body { padding: 16px; font-size: 14px; }
@@ -51,7 +65,7 @@
   <style>.container{padding-top:56px!important;}@media(max-width:480px){.container{padding-top:60px!important;}}</style>
 
 <h1>AL-014 — Emergency Procedures: Distress and Urgency</h1>
-<p class="subtitle">Transport Canada · CARs 602.135 · AIM COM 5.0 · TP 12880E Ch.11 · PPL Written Exam</p>
+<p class="subtitle">Transport Canada · CARs 602.135 · AIM COM 5.16 · TP 12880E Ch.11 · PPL Written Exam</p>
 
 <!-- Emergency signals -->
 <div class="section-label">Emergency Signal Types</div>
@@ -110,7 +124,7 @@
     </tr>
     <tr>
       <td>Frequency</td>
-      <td colspan="2">121.5 MHz (emergency) or any assigned frequency</td>
+      <td colspan="2">121.5 MHz (emergency / ELT homing) or any assigned frequency</td>
     </tr>
     <tr>
       <td>Legal source</td>
@@ -150,6 +164,43 @@
   <div class="proc-item"><span class="proc-num">6</span><span class="proc-text"><strong>Heading</strong> — current magnetic heading</span></div>
   <div class="proc-item"><span class="proc-num">7</span><span class="proc-text"><strong>Pilot's intentions</strong> — e.g. "proceeding to CYWG", "forced landing on highway 1"</span></div>
   <div class="proc-item"><span class="proc-num">8</span><span class="proc-text"><strong>Squawk 7700</strong> — set transponder emergency code and ident if able</span></div>
+</div>
+
+<!-- ELT procedures — AIM COM 5.16 -->
+<div class="section-label">Emergency Locator Transmitter (ELT) — AIM COM 5.16</div>
+<div class="elt-box">
+  <h2>ELT Activation and Frequencies</h2>
+  <div class="elt-row">
+    <div class="elt-card">
+      <div class="elt-card-title">Frequencies</div>
+      <div class="elt-card-body">
+        <strong>121.5 MHz</strong> — homing / guard frequency (legacy analog signal)<br>
+        <strong>406 MHz</strong> — digital SARSAT satellite detection; provides GPS position fix
+      </div>
+    </div>
+    <div class="elt-card">
+      <div class="elt-card-title">Automatic Activation</div>
+      <div class="elt-card-body">
+        Triggered by G-force (impact). Activates without pilot action on hard impact or crash.
+      </div>
+    </div>
+    <div class="elt-card">
+      <div class="elt-card-title">Manual Activation</div>
+      <div class="elt-card-body">
+        Use the ELT unit switch (ARM → ON) or cockpit panel switch. Activate when no radio contact is possible or ditching is imminent.
+      </div>
+    </div>
+    <div class="elt-card">
+      <div class="elt-card-title">Inadvertent Activation</div>
+      <div class="elt-card-body">
+        Turn off within 5 minutes. Notify ATC or NavCanada to confirm false alarm. Failure to notify may trigger a SAR response.
+      </div>
+    </div>
+  </div>
+  <div class="elt-note">
+    Testing: permitted only in the first 5 minutes of each UTC hour — maximum 3 audio sweeps. Required by CARs; confirm ELT is OFF after test.
+    SARSAT satellites detect 406 MHz signals globally within ~90 min. 121.5 MHz is used by SAR aircraft for close-range homing once on-scene.
+  </div>
 </div>
 
 </body>


### PR DESCRIPTION
## Summary

- Add `data-scheme="dark"` to `<html>` element to force dark scheme regardless of OS preference
- Add ELT section (AIM COM 5.16): 121.5 MHz homing signal, 406 MHz SARSAT digital, auto-activation on impact, manual activation, inadvertent activation procedure, testing rules
- Hardcode `#f0c040` amber for PAN-PAN badge and urgency column (was `var(--accent)`); add aviation-meaning comments on all hardcoded colors (`#ff7070` MAYDAY red, `#f0c040` PAN-PAN amber, `#ff8080` hijack severity) per acceptance criteria
- Fix card and squawk-box borders from `var(--surface)` (invisible same-as-background) to `var(--border)` for visible outlines
- Fix `border-radius: 10px` → `8px` to comply with design-system constraint (no radii > 8 px outside full pills)

## Test plan

- [ ] `npm run build` passes (verified locally — no TypeScript errors)
- [ ] Visual opens in dark scheme regardless of OS light/dark preference
- [ ] ELT section shows 121.5 MHz / 406 MHz, activation modes, inadvertent procedure
- [ ] MAYDAY badge shows `#ff7070` with aviation-meaning comment in source
- [ ] PAN-PAN badge shows hardcoded `#f0c040` with aviation-meaning comment in source
- [ ] `data-backlink="true"` back-to-lesson button present and functional
- [ ] Squawk codes 7700/7600/7500 present with correct descriptions

Closes #297

🤖 Generated with [Claude Code](https://claude.com/claude-code)