### PR TITLE
[PPL-288] Fix al005 right-of-way rules visual

### DIFF
--- a/web-app/public/visuals/al005-right-of-way-rules.html
+++ b/web-app/public/visuals/al005-right-of-way-rules.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-scheme="dark">
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -117,9 +117,9 @@
       <td class="rule-col">CARs 602.19(3)</td>
     </tr>
     <tr>
-      <td class="scenario-col">Aircraft declaring emergency (MAYDAY / PAN-PAN)</td>
+      <td class="scenario-col">Aircraft in distress (MAYDAY)</td>
       <td class="gives-way-col">All other aircraft yield — absolute priority</td>
-      <td class="rule-col">Emergency overrides all other rules</td>
+      <td class="rule-col">Distress overrides all other right-of-way rules — CARs 602.19</td>
     </tr>
   </tbody>
 </table>
@@ -127,6 +127,7 @@
 <!-- Exam decision flow -->
 <div class="hook-box">
   <h2>Exam Decision Flow — Work Through in Order</h2>
+  <div class="hook-row"><span class="hook-badge">Step 0</span><span class="hook-text">Is any aircraft in <strong>distress (MAYDAY)</strong>? That aircraft has absolute priority — overrides every rule below.</span></div>
   <div class="hook-row"><span class="hook-badge">Step 1</span><span class="hook-text">Different aircraft categories? Apply <strong>category hierarchy</strong> — powered aircraft yields to glider, balloon, etc.</span></div>
   <div class="hook-row"><span class="hook-badge">Step 2</span><span class="hook-text">Is one aircraft on <strong>approach to land</strong>? Landing aircraft has priority over all others.</span></div>
   <div class="hook-row"><span class="hook-badge">Step 3</span><span class="hook-text">Same category, <strong>converging</strong>? The aircraft that has the other on its RIGHT gives way.</span></div>


### PR DESCRIPTION
## Summary

- Add `data-scheme="dark"` to `<html>` to enforce dark scheme regardless of OS preference (matches al004 standard)
- Fix emergency scenario: corrected "MAYDAY / PAN-PAN" → "MAYDAY (Distress)" — PAN-PAN is urgency, not distress; only distress overrides all right-of-way rules per CARs 602.19
- Add CARs 602.19 citation to the distress row
- Add Step 0 (distress check) to exam decision flow — distress has absolute priority over all other rules

## Accuracy check vs CARs 602.19

- ✅ Priority order: balloon > glider > airship > aircraft towing > powered
- ✅ Distress overrides all (now correctly limited to MAYDAY, not PAN-PAN)
- ✅ Converging: give way to aircraft on your right — CARs 602.19(2)
- ✅ Head-on: both turn right — CARs 602.20
- ✅ Overtaking: overtaking passes right — CARs 602.21
- ✅ Landing aircraft priority — CARs 602.19(3)
- ✅ `data-backlink="true"` back button present
- ✅ `_common.css` linked; no hardcoded colors beyond those used in canonical al001 sample
- ✅ `npm run build` passes

Closes #288

🤖 Generated with [Claude Code](https://claude.com/claude-code)