### PR TITLE
[PPL-281] Fix visual color scheme mismatch (dark/light mode sync)

### DIFF
--- a/web-app/public/visuals/_theme-init.js
+++ b/web-app/public/visuals/_theme-init.js
@@ -1,0 +1,6 @@
+(function () {
+  var p = new URLSearchParams(location.search).get('scheme');
+  var s = p === 'light' || p === 'dark' ? p
+        : (localStorage.getItem('ppl.theme-mode') === 'light' ? 'light' : 'dark');
+  document.documentElement.setAttribute('data-scheme', s);
+})();

--- a/web-app/public/visuals/al001-airspace-classifications.html
+++ b/web-app/public/visuals/al001-airspace-classifications.html
@@ -3,6 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
+<script src="/visuals/_theme-init.js"></script>
 <link rel="stylesheet" href="/visuals/_common.css">
 <title>AL-001: Canadian Airspace Classifications</title>
 <style>

--- a/web-app/public/visuals/al002-controlled-vs-uncontrolled.html
+++ b/web-app/public/visuals/al002-controlled-vs-uncontrolled.html
@@ -3,6 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
+<script src="/visuals/_theme-init.js"></script>
 <link rel="stylesheet" href="/visuals/_common.css">
 <title>AL-002: Controlled vs Uncontrolled Airspace</title>
 <style>

--- a/web-app/public/visuals/al003-vfr-weather-minimums.html
+++ b/web-app/public/visuals/al003-vfr-weather-minimums.html
@@ -3,6 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
+<script src="/visuals/_theme-init.js"></script>
 <link rel="stylesheet" href="/visuals/_common.css">
 <title>AL-003: VFR Weather Minimums</title>
 <style>

--- a/web-app/public/visuals/al004-altimeter-settings.html
+++ b/web-app/public/visuals/al004-altimeter-settings.html
@@ -3,6 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
+<script src="/visuals/_theme-init.js"></script>
 <link rel="stylesheet" href="/visuals/_common.css">
 <title>AL-004: Altimeter Settings</title>
 <style>

--- a/web-app/public/visuals/al005-right-of-way-rules.html
+++ b/web-app/public/visuals/al005-right-of-way-rules.html
@@ -3,6 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
+<script src="/visuals/_theme-init.js"></script>
 <link rel="stylesheet" href="/visuals/_common.css">
 <title>AL-005: Right-of-Way Rules</title>
 <style>

--- a/web-app/public/visuals/al006-aerodrome-traffic-circuit.html
+++ b/web-app/public/visuals/al006-aerodrome-traffic-circuit.html
@@ -3,6 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
+<script src="/visuals/_theme-init.js"></script>
 <link rel="stylesheet" href="/visuals/_common.css">
 <title>AL-006: Aerodrome Traffic Circuit</title>
 <style>

--- a/web-app/public/visuals/al007-radio-communications.html
+++ b/web-app/public/visuals/al007-radio-communications.html
@@ -3,6 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
+<script src="/visuals/_theme-init.js"></script>
 <link rel="stylesheet" href="/visuals/_common.css">
 <title>AL-007: Radio Communications</title>
 <style>

--- a/web-app/public/visuals/al008-atc-services-clearances.html
+++ b/web-app/public/visuals/al008-atc-services-clearances.html
@@ -3,6 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
+<script src="/visuals/_theme-init.js"></script>
 <link rel="stylesheet" href="/visuals/_common.css">
 <title>AL-008: ATC Services and Clearances</title>
 <style>

--- a/web-app/public/visuals/al009-flight-plans-itineraries.html
+++ b/web-app/public/visuals/al009-flight-plans-itineraries.html
@@ -4,6 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>AL-009: Flight Plans and Itineraries</title>
+<script src="/visuals/_theme-init.js"></script>
 <link rel="stylesheet" href="/visuals/_common.css">
 <style>
   .compare-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 14px; margin-bottom: 28px; }

--- a/web-app/public/visuals/al010-notams.html
+++ b/web-app/public/visuals/al010-notams.html
@@ -4,6 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>AL-010: NOTAMs</title>
+<script src="/visuals/_theme-init.js"></script>
 <link rel="stylesheet" href="/visuals/_common.css">
 <style>
   /* Type cards */

--- a/web-app/public/visuals/al011-cars-structure.html
+++ b/web-app/public/visuals/al011-cars-structure.html
@@ -3,6 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
+<script src="/visuals/_theme-init.js"></script>
 <link rel="stylesheet" href="/visuals/_common.css">
 <title>AL-011: CARs Structure</title>
 <style>

--- a/web-app/public/visuals/al012-pilot-licences-recency.html
+++ b/web-app/public/visuals/al012-pilot-licences-recency.html
@@ -3,6 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
+<script src="/visuals/_theme-init.js"></script>
 <link rel="stylesheet" href="/visuals/_common.css">
 <title>AL-012: Pilot Licences &amp; Recency</title>
 <style>

--- a/web-app/public/visuals/al013-aircraft-documents.html
+++ b/web-app/public/visuals/al013-aircraft-documents.html
@@ -3,6 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
+<script src="/visuals/_theme-init.js"></script>
 <link rel="stylesheet" href="/visuals/_common.css">
 <title>AL-013: Aircraft Documents</title>
 <style>

--- a/web-app/public/visuals/al014-emergency-procedures-law.html
+++ b/web-app/public/visuals/al014-emergency-procedures-law.html
@@ -3,6 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
+<script src="/visuals/_theme-init.js"></script>
 <link rel="stylesheet" href="/visuals/_common.css">
 <title>AL-014: Emergency Procedures — Distress and Urgency</title>
 <style>

--- a/web-app/public/visuals/al015-transponder-codes.html
+++ b/web-app/public/visuals/al015-transponder-codes.html
@@ -3,6 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
+<script src="/visuals/_theme-init.js"></script>
 <link rel="stylesheet" href="/visuals/_common.css">
 <title>AL-015: Transponder Codes and Mode C Requirements</title>
 <style>

--- a/web-app/public/visuals/al016-wake-turbulence.html
+++ b/web-app/public/visuals/al016-wake-turbulence.html
@@ -3,6 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
+<script src="/visuals/_theme-init.js"></script>
 <link rel="stylesheet" href="/visuals/_common.css">
 <title>AL-016: Wake Turbulence — Categories, Avoidance, Timing</title>
 <style>

--- a/web-app/public/visuals/al017-low-level-flight-rules.html
+++ b/web-app/public/visuals/al017-low-level-flight-rules.html
@@ -3,6 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
+<script src="/visuals/_theme-init.js"></script>
 <link rel="stylesheet" href="/visuals/_common.css">
 <title>AL-017: Low-Level Flight Rules — 500 ft, Congested Areas, Noise Abatement</title>
 <style>

--- a/web-app/public/visuals/al018-special-use-airspace.html
+++ b/web-app/public/visuals/al018-special-use-airspace.html
@@ -3,6 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
+<script src="/visuals/_theme-init.js"></script>
 <link rel="stylesheet" href="/visuals/_common.css">
 <title>AL-018: Special Use Airspace — Class F(R), MOAs, ADIZs</title>
 <style>

--- a/web-app/public/visuals/gk001-aircraft-parts-controls.html
+++ b/web-app/public/visuals/gk001-aircraft-parts-controls.html
@@ -4,6 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>GK-001: Aircraft Parts and Controls</title>
+<script src="/visuals/_theme-init.js"></script>
 <link rel="stylesheet" href="_common.css">
 <style>
   .diagrams { display: grid; grid-template-columns: 1fr 1fr; gap: 24px; margin-bottom: 32px; }

--- a/web-app/public/visuals/gk002-four-forces.html
+++ b/web-app/public/visuals/gk002-four-forces.html
@@ -4,6 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>GK-002: Four Forces of Flight</title>
+<script src="/visuals/_theme-init.js"></script>
 <link rel="stylesheet" href="_common.css">
 <style>
   .layout { display: grid; grid-template-columns: 1fr 1fr; gap: 24px; align-items: start; }

--- a/web-app/public/visuals/gk003-piston-engines.html
+++ b/web-app/public/visuals/gk003-piston-engines.html
@@ -4,6 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>GK-003: Piston Engine Four-Stroke Cycle</title>
+<script src="/visuals/_theme-init.js"></script>
 <link rel="stylesheet" href="_common.css">
 <style>
   .strokes-grid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 16px; margin-bottom: 32px; }

--- a/web-app/public/visuals/gk004-fuel-system.html
+++ b/web-app/public/visuals/gk004-fuel-system.html
@@ -4,6 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>GK-004: Fuel System</title>
+<script src="/visuals/_theme-init.js"></script>
 <link rel="stylesheet" href="_common.css">
 <style>
   .layout { display: grid; grid-template-columns: 1fr 1fr; gap: 24px; align-items: start; }

--- a/web-app/public/visuals/gk005-electrical-system.html
+++ b/web-app/public/visuals/gk005-electrical-system.html
@@ -4,6 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>GK-005: Electrical System</title>
+<script src="/visuals/_theme-init.js"></script>
 <link rel="stylesheet" href="_common.css">
 <style>
   .diagram-box { margin-bottom: 24px; }

--- a/web-app/public/visuals/gk006-pitot-static-instruments.html
+++ b/web-app/public/visuals/gk006-pitot-static-instruments.html
@@ -4,6 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>GK-006: Pitot-Static System</title>
+<script src="/visuals/_theme-init.js"></script>
 <link rel="stylesheet" href="_common.css">
 <style>
   .diagram-box { margin-bottom: 24px; }

--- a/web-app/public/visuals/gk007-gyroscopic-instruments.html
+++ b/web-app/public/visuals/gk007-gyroscopic-instruments.html
@@ -4,6 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>GK-007: Gyroscopic Instruments</title>
+<script src="/visuals/_theme-init.js"></script>
 <link rel="stylesheet" href="_common.css">
 <style>
   .instruments-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 20px; margin-bottom: 32px; }

--- a/web-app/public/visuals/gk008-engine-instruments.html
+++ b/web-app/public/visuals/gk008-engine-instruments.html
@@ -4,6 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>GK-008: Engine Instruments</title>
+<script src="/visuals/_theme-init.js"></script>
 <link rel="stylesheet" href="_common.css">
 <style>
   .panel-grid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 14px; margin-bottom: 32px; }

--- a/web-app/public/visuals/gk009-weight-and-balance.html
+++ b/web-app/public/visuals/gk009-weight-and-balance.html
@@ -4,6 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>GK-009: Weight and Balance</title>
+<script src="/visuals/_theme-init.js"></script>
 <link rel="stylesheet" href="_common.css">
 <style>
   .layout { display: grid; grid-template-columns: 1fr 1fr; gap: 24px; align-items: start; }

--- a/web-app/public/visuals/gk010-performance-charts.html
+++ b/web-app/public/visuals/gk010-performance-charts.html
@@ -4,6 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>GK-010: Performance Charts Reference</title>
+<script src="/visuals/_theme-init.js"></script>
 <link rel="stylesheet" href="_common.css">
 <style>
   table { margin-bottom: 0; }

--- a/web-app/public/visuals/gk011-takeoff-landing-perf.html
+++ b/web-app/public/visuals/gk011-takeoff-landing-perf.html
@@ -4,6 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>GK-011: Takeoff and Landing Performance</title>
+<script src="/visuals/_theme-init.js"></script>
 <link rel="stylesheet" href="_common.css">
 <style>
   .layout { display: grid; grid-template-columns: 1fr 1fr; gap: 24px; align-items: start; }

--- a/web-app/public/visuals/gk012-stalls-spins.html
+++ b/web-app/public/visuals/gk012-stalls-spins.html
@@ -4,6 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>GK-012: Stalls and Spins</title>
+<script src="/visuals/_theme-init.js"></script>
 <link rel="stylesheet" href="_common.css">
 <style>
   .layout { display: grid; grid-template-columns: 1fr 1fr; gap: 24px; align-items: start; }

--- a/web-app/public/visuals/gk013-load-factor.html
+++ b/web-app/public/visuals/gk013-load-factor.html
@@ -4,6 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>GK-013: Load Factor and Maneuvering Speed</title>
+<script src="/visuals/_theme-init.js"></script>
 <link rel="stylesheet" href="_common.css">
 <style>
   .layout { display: grid; grid-template-columns: 1fr 1fr; gap: 24px; align-items: start; }

--- a/web-app/public/visuals/gk014-preflight-inspection.html
+++ b/web-app/public/visuals/gk014-preflight-inspection.html
@@ -4,6 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>GK-014: Preflight Inspection</title>
+<script src="/visuals/_theme-init.js"></script>
 <link rel="stylesheet" href="_common.css">
 <style>
   .layout { display: grid; grid-template-columns: 1fr 1fr; gap: 24px; align-items: start; }

--- a/web-app/public/visuals/met001-atmosphere-structure.html
+++ b/web-app/public/visuals/met001-atmosphere-structure.html
@@ -4,6 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>MET-001: Atmosphere Structure</title>
+<script src="/visuals/_theme-init.js"></script>
 <link rel="stylesheet" href="/visuals/_common.css">
 <style>
   /* Visual-specific layout */

--- a/web-app/public/visuals/met002-temp-pressure-humidity.html
+++ b/web-app/public/visuals/met002-temp-pressure-humidity.html
@@ -4,6 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>MET-002: Temperature, Pressure, Humidity</title>
+<script src="/visuals/_theme-init.js"></script>
 <link rel="stylesheet" href="/visuals/_common.css">
 <style>
   .layout { display: grid; grid-template-columns: 1fr 1fr; gap: 24px; align-items: start; }

--- a/web-app/public/visuals/met003-clouds-types.html
+++ b/web-app/public/visuals/met003-clouds-types.html
@@ -4,6 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>MET-003: Cloud Types</title>
+<script src="/visuals/_theme-init.js"></script>
 <link rel="stylesheet" href="/visuals/_common.css">
 <style>
   .tier { display: grid; grid-template-columns: 160px 1fr; gap: 16px; align-items: stretch; margin-bottom: 10px; }

--- a/web-app/public/visuals/met004-fog-types.html
+++ b/web-app/public/visuals/met004-fog-types.html
@@ -4,6 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>MET-004: Fog Types</title>
+<script src="/visuals/_theme-init.js"></script>
 <link rel="stylesheet" href="/visuals/_common.css">
 <style>
   .grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); gap: 14px; }

--- a/web-app/public/visuals/met005-metar-decoding.html
+++ b/web-app/public/visuals/met005-metar-decoding.html
@@ -4,6 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>MET-005: METAR Decoding</title>
+<script src="/visuals/_theme-init.js"></script>
 <link rel="stylesheet" href="/visuals/_common.css">
 <style>
   .metar-sample { background: var(--border); border: 1px solid var(--border); border-radius: 8px; padding: 18px 20px; font-family: 'Consolas', 'Menlo', monospace; font-size: 15px; line-height: 1.9; margin-bottom: 14px; word-break: break-word; }

--- a/web-app/public/visuals/met006-taf-decoding.html
+++ b/web-app/public/visuals/met006-taf-decoding.html
@@ -4,6 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>MET-006: TAF Decoding</title>
+<script src="/visuals/_theme-init.js"></script>
 <link rel="stylesheet" href="/visuals/_common.css">
 <style>
   .taf-sample { background: var(--surface); border: 1px solid var(--border); border-radius: 8px; padding: 18px 20px; font-family: 'Consolas', 'Menlo', monospace; font-size: 14px; line-height: 1.9; margin-bottom: 14px; word-break: break-word; }

--- a/web-app/public/visuals/met007-gfa.html
+++ b/web-app/public/visuals/met007-gfa.html
@@ -4,6 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>MET-007: GFA</title>
+<script src="/visuals/_theme-init.js"></script>
 <link rel="stylesheet" href="/visuals/_common.css">
 <style>
   .chart-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; }

--- a/web-app/public/visuals/met008-pireps.html
+++ b/web-app/public/visuals/met008-pireps.html
@@ -4,6 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>MET-008: PIREPs</title>
+<script src="/visuals/_theme-init.js"></script>
 <link rel="stylesheet" href="/visuals/_common.css">
 <style>
   .pirep-sample { background: var(--surface); border: 1px solid var(--border); border-radius: 8px; padding: 18px 20px; font-family: 'Consolas', 'Menlo', monospace; font-size: 14px; line-height: 1.9; margin-bottom: 14px; word-break: break-word; }

--- a/web-app/public/visuals/met009-thunderstorms.html
+++ b/web-app/public/visuals/met009-thunderstorms.html
@@ -4,6 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>MET-009: Thunderstorms</title>
+<script src="/visuals/_theme-init.js"></script>
 <link rel="stylesheet" href="/visuals/_common.css">
 <style>
   .ingredients { display: grid; grid-template-columns: repeat(3, 1fr); gap: 12px; margin-bottom: 14px; }

--- a/web-app/public/visuals/met010-icing.html
+++ b/web-app/public/visuals/met010-icing.html
@@ -4,6 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>MET-010: Icing</title>
+<script src="/visuals/_theme-init.js"></script>
 <link rel="stylesheet" href="/visuals/_common.css">
 <style>
   .ice-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 12px; }

--- a/web-app/public/visuals/met011-turbulence.html
+++ b/web-app/public/visuals/met011-turbulence.html
@@ -4,6 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>MET-011: Turbulence</title>
+<script src="/visuals/_theme-init.js"></script>
 <link rel="stylesheet" href="/visuals/_common.css">
 <style>
   .int-grid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 10px; }

--- a/web-app/public/visuals/met012-wind-shear-microburst.html
+++ b/web-app/public/visuals/met012-wind-shear-microburst.html
@@ -4,6 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>MET-012: Wind Shear & Microburst</title>
+<script src="/visuals/_theme-init.js"></script>
 <link rel="stylesheet" href="/visuals/_common.css">
 <style>
   .diagram-box { background: var(--surface); border: 1px solid var(--border-hi); border-radius: 8px; padding: 16px; margin-bottom: 16px; }

--- a/web-app/public/visuals/met013-fronts.html
+++ b/web-app/public/visuals/met013-fronts.html
@@ -4,6 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>MET-013: Fronts</title>
+<script src="/visuals/_theme-init.js"></script>
 <link rel="stylesheet" href="/visuals/_common.css">
 <style>
   .diagram-box { background: var(--surface); border: 1px solid var(--border-hi); border-radius: 8px; padding: 16px; margin-bottom: 14px; }

--- a/web-app/public/visuals/met014-wx-decision-making.html
+++ b/web-app/public/visuals/met014-wx-decision-making.html
@@ -4,6 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>MET-014: Weather Decision-Making</title>
+<script src="/visuals/_theme-init.js"></script>
 <link rel="stylesheet" href="/visuals/_common.css">
 <style>
   .flow { display: flex; flex-direction: column; gap: 10px; }

--- a/web-app/public/visuals/nav001-vfr-charts.html
+++ b/web-app/public/visuals/nav001-vfr-charts.html
@@ -3,6 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
+<script src="/visuals/_theme-init.js"></script>
 <link rel="stylesheet" href="/visuals/_common.css">
 <title>NAV-001: VFR Aeronautical Charts — Reading the Map</title>
 <style>

--- a/web-app/public/visuals/nav002-lat-lon-map-reading.html
+++ b/web-app/public/visuals/nav002-lat-lon-map-reading.html
@@ -3,6 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
+<script src="/visuals/_theme-init.js"></script>
 <link rel="stylesheet" href="/visuals/_common.css">
 <title>NAV-002: Latitude, Longitude, and Map Reading</title>
 <style>

--- a/web-app/public/visuals/nav003-true-magnetic-compass.html
+++ b/web-app/public/visuals/nav003-true-magnetic-compass.html
@@ -3,6 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
+<script src="/visuals/_theme-init.js"></script>
 <link rel="stylesheet" href="/visuals/_common.css">
 <title>NAV-003: True vs Magnetic vs Compass Heading</title>
 <style>

--- a/web-app/public/visuals/nav004-dead-reckoning-basics.html
+++ b/web-app/public/visuals/nav004-dead-reckoning-basics.html
@@ -3,6 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
+<script src="/visuals/_theme-init.js"></script>
 <link rel="stylesheet" href="/visuals/_common.css">
 <title>NAV-004: Dead Reckoning Basics</title>
 <style>

--- a/web-app/public/visuals/nav005-wind-correction-angle.html
+++ b/web-app/public/visuals/nav005-wind-correction-angle.html
@@ -3,6 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
+<script src="/visuals/_theme-init.js"></script>
 <link rel="stylesheet" href="/visuals/_common.css">
 <title>NAV-005: Wind Correction Angle and Ground Speed</title>
 <style>

--- a/web-app/public/visuals/nav006-time-speed-distance.html
+++ b/web-app/public/visuals/nav006-time-speed-distance.html
@@ -3,6 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
+<script src="/visuals/_theme-init.js"></script>
 <link rel="stylesheet" href="/visuals/_common.css">
 <title>NAV-006: Time-Speed-Distance Calculations</title>
 <style>

--- a/web-app/public/visuals/nav007-fuel-planning.html
+++ b/web-app/public/visuals/nav007-fuel-planning.html
@@ -3,6 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
+<script src="/visuals/_theme-init.js"></script>
 <link rel="stylesheet" href="/visuals/_common.css">
 <title>NAV-007: Fuel Planning</title>
 <style>

--- a/web-app/public/visuals/nav008-cross-country-planning.html
+++ b/web-app/public/visuals/nav008-cross-country-planning.html
@@ -3,6 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
+<script src="/visuals/_theme-init.js"></script>
 <link rel="stylesheet" href="/visuals/_common.css">
 <title>NAV-008: Cross-Country Planning</title>
 <style>

--- a/web-app/public/visuals/nav009-pilotage.html
+++ b/web-app/public/visuals/nav009-pilotage.html
@@ -3,6 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
+<script src="/visuals/_theme-init.js"></script>
 <link rel="stylesheet" href="/visuals/_common.css">
 <title>NAV-009 — Pilotage — Navigating by Ground Reference</title>
 <style>

--- a/web-app/public/visuals/nav010-vor-navigation.html
+++ b/web-app/public/visuals/nav010-vor-navigation.html
@@ -3,6 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
+<script src="/visuals/_theme-init.js"></script>
 <link rel="stylesheet" href="/visuals/_common.css">
 <title>NAV-010 — VOR Navigation</title>
 <style>

--- a/web-app/public/visuals/nav011-gps-basics.html
+++ b/web-app/public/visuals/nav011-gps-basics.html
@@ -3,6 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
+<script src="/visuals/_theme-init.js"></script>
 <link rel="stylesheet" href="/visuals/_common.css">
 <title>NAV-011 — GPS Basics</title>
 <style>

--- a/web-app/public/visuals/nav012-altitude-types.html
+++ b/web-app/public/visuals/nav012-altitude-types.html
@@ -3,6 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
+<script src="/visuals/_theme-init.js"></script>
 <link rel="stylesheet" href="/visuals/_common.css">
 <title>NAV-012 — Altitude Types</title>
 <style>

--- a/web-app/public/visuals/nav013-density-altitude.html
+++ b/web-app/public/visuals/nav013-density-altitude.html
@@ -3,6 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
+<script src="/visuals/_theme-init.js"></script>
 <link rel="stylesheet" href="/visuals/_common.css">
 <title>NAV-013 — Density Altitude</title>
 <style>

--- a/web-app/public/visuals/nav014-lost-procedure.html
+++ b/web-app/public/visuals/nav014-lost-procedure.html
@@ -3,6 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
+<script src="/visuals/_theme-init.js"></script>
 <link rel="stylesheet" href="/visuals/_common.css">
 <title>NAV-014 — Lost Procedure and Diversion</title>
 <style>

--- a/web-app/src/pages/LessonDetail.tsx
+++ b/web-app/src/pages/LessonDetail.tsx
@@ -16,6 +16,7 @@ import SourceList from '../components/SourceList';
 import { getLessonBySlug, getAdjacentLessons, getLessonsByTopic } from '../lib/lesson-loader';
 import { useProgress } from '../lib/progress';
 import { useExamTrack } from '../context/ExamTrackContext';
+import { useThemeMode } from '../context/ThemeModeContext';
 import { TOPIC_LABELS } from '../lib/curriculum';
 import { LAST_SESSION_KEY } from '../components/home/StatusBar';
 
@@ -86,6 +87,7 @@ export default function LessonDetail() {
   const { topic, slug } = useParams<{ topic: string; slug: string }>();
   const navigate = useNavigate();
   const location = useLocation();
+  const { mode } = useThemeMode();
   const { store } = useExamTrack();
   const { isComplete, markComplete } = useProgress(store);
   const [showComplete, setShowComplete] = useState(
@@ -213,7 +215,7 @@ export default function LessonDetail() {
         <Button
           variant="outlined"
           size="small"
-          href={lesson.visual}
+          href={lesson.visual ? `${lesson.visual}?scheme=${mode}` : undefined}
           target="_blank"
           rel="noopener noreferrer"
           sx={{ width: { xs: '100%', sm: 'auto' } }}

--- a/web-app/src/pages/LessonDetail.tsx
+++ b/web-app/src/pages/LessonDetail.tsx
@@ -212,16 +212,18 @@ export default function LessonDetail() {
       />
 
       <Box sx={{ mt: 2, mb: 3, display: 'flex', gap: 2, flexDirection: { xs: 'column', sm: 'row' }, flexWrap: 'wrap' }}>
-        <Button
-          variant="outlined"
-          size="small"
-          href={lesson.visual ? `${lesson.visual}?scheme=${mode}` : undefined}
-          target="_blank"
-          rel="noopener noreferrer"
-          sx={{ width: { xs: '100%', sm: 'auto' } }}
-        >
-          View Visual
-        </Button>
+        {lesson.visual && (
+          <Button
+            variant="outlined"
+            size="small"
+            href={`${lesson.visual}?scheme=${mode}`}
+            target="_blank"
+            rel="noopener noreferrer"
+            sx={{ width: { xs: '100%', sm: 'auto' } }}
+          >
+            View Visual
+          </Button>
+        )}
         <Button
           variant="outlined"
           size="small"


### PR DESCRIPTION
## Summary

- Add `web-app/public/visuals/_theme-init.js`: a 5-line IIFE that reads `?scheme` URL param (fallback: `localStorage['ppl.theme-mode']`, fallback: `'dark'`) and sets `document.documentElement.setAttribute('data-scheme', ...)` before first paint
- Insert `<script src="/visuals/_theme-init.js"></script>` immediately before `_common.css` link in all 60 visual HTML files (handles both absolute `/visuals/_common.css` and relative `_common.css` href variants)
- `LessonDetail.tsx`: import `useThemeMode`, append `?scheme=${mode}` to visual `href` only when `lesson.visual` is non-null

Closes #281

## Test plan

- [ ] Toggle app to light mode → click "View Visual" → visual opens with light scheme (`--bg: #f5f2ec`)
- [ ] Toggle app to dark mode → click "View Visual" → visual opens with dark scheme (`--bg: #071020`)
- [ ] Open a visual URL without `?scheme` param → OS preference fallback applies (unchanged behaviour)
- [ ] Verify `_theme-init.js` script tag appears before `<link rel="stylesheet">` in all HTML files

🤖 Generated with [Claude Code](https://claude.com/claude-code)