### PR TITLE
[PPL-296] Fix al013 ARROW document citations and radio licence description

### DIFF
--- a/web-app/public/visuals/al013-aircraft-documents.html
+++ b/web-app/public/visuals/al013-aircraft-documents.html
@@ -63,32 +63,32 @@
   <div class="arrow-card">
     <div class="arrow-letter">A</div>
     <div class="arrow-word">Airworthiness Certificate</div>
-    <div class="arrow-desc">A valid <strong>Certificate of Airworthiness</strong> issued by Transport Canada. Must be carried on board and displayed (if aircraft design allows). Valid as long as aircraft is maintained in airworthy condition.</div>
-    <div class="arrow-cite">CARs 605.03(1)(a)</div>
+    <div class="arrow-desc">A valid <strong>Certificate of Airworthiness</strong> issued by Transport Canada. Must be carried on board. No expiry date — valid as long as the aircraft is maintained in an airworthy condition and passes required inspections.</div>
+    <div class="arrow-cite">CARs 605.03(1)(b)</div>
   </div>
   <div class="arrow-card">
     <div class="arrow-letter">R</div>
     <div class="arrow-word">Registration Certificate</div>
-    <div class="arrow-desc">Proof the aircraft is registered in Canada. Shows owner information, registration marks (C-XXXX). Must be on board — <strong>not required to be displayed</strong> but must be produced on request.</div>
-    <div class="arrow-cite">CARs 202.26 / 605.03(1)(b)</div>
+    <div class="arrow-desc">Proof the aircraft is registered in Canada. Shows owner information, registration marks (C-XXXX). Must be on board — <strong>not required to be displayed</strong> but must be produced on request. No expiry — valid until ownership changes or aircraft is deregistered.</div>
+    <div class="arrow-cite">CARs 202.27 / 605.03(1)(a)</div>
   </div>
   <div class="arrow-card">
     <div class="arrow-letter">R</div>
     <div class="arrow-word">Radio Licence (Station Licence)</div>
-    <div class="arrow-desc">An <strong>aeronautical station licence</strong> issued by ISED (Industry, Science and Economic Development Canada) for the aircraft's radio equipment. Required when operating outside Canada or if carrying a radio.</div>
-    <div class="arrow-cite">Radiocommunication Act / CARs 605.03</div>
+    <div class="arrow-desc">An <strong>aeronautical radio station licence</strong> issued under the Radiocommunication Act. Required on board whenever the aircraft is equipped with radio communication equipment — applies to all flights, domestic and international.</div>
+    <div class="arrow-cite">CARs 605.03(1)(d) / Radiocommunication Act</div>
   </div>
   <div class="arrow-card">
     <div class="arrow-letter">O</div>
     <div class="arrow-word">Operating Limitations / POH</div>
-    <div class="arrow-desc">The aircraft <strong>Flight Manual, Pilot's Operating Handbook (POH)</strong>, or equivalent approved document containing operating limitations. Must be accessible to the flight crew. Includes performance data, checklists, limitations.</div>
-    <div class="arrow-cite">CARs 605.03(1)(d) / 605.84</div>
+    <div class="arrow-desc">The aircraft <strong>Flight Manual (AFM) or Pilot's Operating Handbook (POH)</strong>, or equivalent approved document containing operating limitations. Must be accessible to the flight crew. Includes performance data, checklists, and limitations. Must be kept current with all amendments.</div>
+    <div class="arrow-cite">CARs 605.84</div>
   </div>
   <div class="arrow-card">
     <div class="arrow-letter">W</div>
     <div class="arrow-word">Weight &amp; Balance</div>
-    <div class="arrow-desc">Current <strong>weight and balance documentation</strong> — either in the flight manual or a separate approved document. Includes empty weight, CG datum, and equipment list. Must reflect actual aircraft configuration.</div>
-    <div class="arrow-cite">CARs 605.03(1)(e) / 605.92</div>
+    <div class="arrow-desc">Current <strong>weight and balance documentation</strong> — either in the flight manual or a separate approved document. Includes empty weight, CG datum, and equipment list. Must reflect the actual aircraft configuration; updated whenever equipment is added or removed.</div>
+    <div class="arrow-cite">CARs 605.92</div>
   </div>
 </div>
 
@@ -150,8 +150,8 @@
     </tr>
     <tr>
       <td>Radio Station Licence</td>
-      <td class="yes">Yes</td>
-      <td>Required when operating in international airspace</td>
+      <td class="yes">Yes *</td>
+      <td>* Required on board when aircraft is equipped with radio communication equipment (domestic and international)</td>
     </tr>
     <tr>
       <td>POH / Flight Manual</td>


### PR DESCRIPTION
Closes #296

## Changes

- **A card**: corrected CARs citation `605.03(1)(a)` → `605.03(1)(b)` (Airworthiness is subsection b, not a); added explicit "no expiry date" language
- **R (Registration) card**: corrected citation `605.03(1)(b)` → `605.03(1)(a)` and `202.26` → `202.27`; added "no expiry" clause
- **R (Radio) card**: fixed description — removed incorrect "outside Canada" framing; now correctly states the licence is required whenever the aircraft is **equipped with radio communication equipment**; added subsection `(1)(d)` to CARs cite
- **O card**: removed incorrect `CARs 605.03(1)(d)` reference (that subsection covers radio, not POH); citation is now correctly `CARs 605.84`; added note about keeping AFM current with amendments
- **W card**: removed incorrect `CARs 605.03(1)(e)` reference (catch-all, not specific to W&B); citation is now correctly `CARs 605.92`; clarified update trigger
- **On Board table**: Radio Station Licence note changed from "Required when operating in international airspace" (wrong trigger) to "Required on board when aircraft is equipped with radio communication equipment (domestic and international)"

No color tokens changed. `data-backlink="true"` button already present. `npm run build` passes.

## Test Plan

- [ ] Open `al013-aircraft-documents.html` in browser — dark scheme renders correctly, all ARROW cards visible
- [ ] Verify back-link button fixed top-left, `data-backlink="true"` attribute present
- [ ] Confirm CARs subsection letters match CARs 605.03(1): (a)=Registration, (b)=Airworthiness, (d)=Radio
- [ ] Confirm O card cites only CARs 605.84, W card cites only CARs 605.92
- [ ] Confirm radio table note describes radio-equipment trigger, not "international airspace"
- [ ] `npm run build` in `web-app/` exits 0