### PR TITLE
[PPL-285] Fix al002: Canadian airspace accuracy — vertical limits, CARs 602.113, RMZ/TMZ

### DIFF
--- a/web-app/public/visuals/al002-controlled-vs-uncontrolled.html
+++ b/web-app/public/visuals/al002-controlled-vs-uncontrolled.html
@@ -6,37 +6,50 @@
 <link rel="stylesheet" href="/visuals/_common.css">
 <title>AL-002: Controlled vs Uncontrolled Airspace</title>
 <style>
-  .two-col { display: grid; grid-template-columns: 1fr 1fr; gap: 20px; margin-bottom: 32px; }
-  .zone { border-radius: 10px; padding: 20px; }
-  .ctrl-zone { background: #0a1a35; border: 1.5px solid #1565c0; }
-  .unctrl-zone { background: #0a200a; border: 1.5px solid #2e7d32; }
-  .zone-title { font-size: 15px; font-weight: 800; margin-bottom: 6px; }
-  .ctrl-zone .zone-title { color: #5ba3f5; }
-  .unctrl-zone .zone-title { color: #80e080; }
+  /* Aviation data-encoding colors — exempt from token substitution.
+     Airspace class hues follow ICAO/Transport Canada chart convention so
+     students build immediate associations with official VNC/VTA symbology;
+     collapsing these to design-system tokens would destroy that recall cue. */
+  .ctrl-zone  { background: #0a1a35; border: 1.5px solid #1565c0; } /* controlled — blue family */
+  .uctrl-zone { background: #0a200a; border: 1.5px solid #2e7d32; } /* uncontrolled — green family */
+  .badge-a { background: #880e4f; color: #fff; }   /* deep magenta — Class A (IFR only) */
+  .badge-b { background: #1565c0; color: #fff; }   /* dark blue    — Class B (IFR only) */
+  .badge-c { background: #1976d2; color: #fff; }   /* medium blue  — Class C */
+  .badge-d { background: #0277bd; color: #fff; }   /* sky blue     — Class D */
+  .badge-e { background: #006064; color: #fff; }   /* teal         — Class E */
+  .badge-g { background: #2e7d32; color: #fff; }   /* green        — Class G (uncontrolled) */
+  .dot-ctrl  { background: #5ba3f5; } /* blue dot — controlled airspace bullet */
+  .dot-uctrl { background: #80e080; } /* green dot — uncontrolled airspace bullet */
+
+  .zone { border-radius: 8px; padding: 20px; }
+  .zone-title { font-size: 15px; font-weight: 800; margin-bottom: 4px; }
+  .ctrl-zone .zone-title  { color: #5ba3f5; }
+  .uctrl-zone .zone-title { color: #80e080; }
   .zone-classes { font-size: 12px; color: var(--text-muted); margin-bottom: 14px; }
   .badge-row { display: flex; gap: 6px; flex-wrap: wrap; margin-bottom: 16px; }
   .badge { display: inline-block; width: 30px; height: 30px; border-radius: 50%; text-align: center; line-height: 30px; font-size: 14px; font-weight: 800; }
-  .bg-c { background: #1565c0; } .bg-d { background: #0277bd; } .bg-e { background: #006064; } .bg-g { background: #2e7d32; }
   .point { display: flex; gap: 8px; margin-bottom: 8px; align-items: flex-start; }
   .dot { width: 6px; height: 6px; border-radius: 50%; flex-shrink: 0; margin-top: 6px; }
-  .dot-ctrl { background: #5ba3f5; }
-  .dot-uctrl { background: #80e080; }
   .point-text { font-size: 13px; color: var(--text); line-height: 1.5; }
+  .point-text small { color: var(--text-muted); display: block; }
 
-  th { background: var(--surface2); color: var(--text-muted); padding: 8px 12px; text-align: left; font-size: 11px; text-transform: uppercase; letter-spacing: 0.5px; }
-  td { padding: 9px 12px; border-bottom: 1px solid var(--border); vertical-align: middle; }
-  .partial { color: var(--accent); font-weight: 600; }
-  .ctrl-row { background: rgba(20,60,120,0.2); }
+  .ctrl-row  { background: rgba(20,60,120,0.2); }
   .uctrl-row { background: rgba(20,80,20,0.2); }
+  .partial { color: var(--accent); font-weight: 600; }
 
-  .section-label { font-size: 11px; color: var(--text-muted); letter-spacing: 1px; text-transform: uppercase; margin-bottom: 10px; font-weight: 600; }
-
-  .trap-box { background: #2a1a0a; border: 1.5px solid #8b4513; border-radius: 10px; padding: 16px 20px; margin-top: 20px; }
+  .trap-box { background: #2a1a0a; border: 1.5px solid #8b4513; border-radius: 8px; padding: 16px 20px; margin-top: 24px; }
   .trap-box h2 { font-size: 12px; color: #e08050; margin-bottom: 8px; text-transform: uppercase; letter-spacing: 1px; }
-  .trap-box p { font-size: 13px; color: #c8b8a8; line-height: 1.6; }
+  .trap-box p { font-size: 13px; color: var(--text); line-height: 1.6; }
+
+  /* RMZ / TMZ cards */
+  .special-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; margin-bottom: 32px; }
+  .special-card { background: var(--surface2); border: 1.5px solid var(--border-hi); border-radius: 8px; padding: 18px; }
+  .special-card-title { font-size: 13px; font-weight: 800; color: var(--accent); margin-bottom: 8px; letter-spacing: 0.5px; }
+  .special-card p { font-size: 13px; color: var(--text); line-height: 1.6; margin-bottom: 8px; }
+  .special-card .cite { font-size: 11px; color: var(--text-muted); }
 
   @media (max-width: 480px) {
-    .two-col { grid-template-columns: 1fr; }
+    .two-col, .special-grid { grid-template-columns: 1fr; }
   }
 </style>
 </head>
@@ -45,77 +58,112 @@
   <style>.container{padding-top:56px!important;}@media(max-width:480px){.container{padding-top:60px!important;}}</style>
 
 <h1>AL-002 — Controlled vs Uncontrolled Airspace</h1>
-<p class="subtitle">Transport Canada · CARs Part VI, TP 12880E Ch.7 · PPL Written Exam</p>
+<p class="subtitle">Transport Canada · CARs 601.02, 602.113 · TP 12880E Ch.7 · PPL Written Exam</p>
 
+<!-- Overview panels -->
 <div class="two-col">
   <div class="zone ctrl-zone">
     <div class="zone-title">Controlled Airspace</div>
     <div class="zone-classes">Classes A · B · C · D · E</div>
     <div class="badge-row">
-      <span class="badge" style="background:#880e4f">A</span>
-      <span class="badge bg-c">B</span>
-      <span class="badge bg-c">C</span>
-      <span class="badge bg-d">D</span>
-      <span class="badge bg-e">E</span>
+      <span class="badge badge-a">A</span>
+      <span class="badge badge-b">B</span>
+      <span class="badge badge-c">C</span>
+      <span class="badge badge-d">D</span>
+      <span class="badge badge-e">E</span>
     </div>
-    <div class="point"><div class="dot dot-ctrl"></div><div class="point-text">ATC provides services to IFR traffic</div></div>
-    <div class="point"><div class="dot dot-ctrl"></div><div class="point-text">Class C: separates IFR-IFR and IFR-VFR</div></div>
-    <div class="point"><div class="dot dot-ctrl"></div><div class="point-text">Class D: separates IFR only, info to VFR</div></div>
-    <div class="point"><div class="dot dot-ctrl"></div><div class="point-text">Class E: separates IFR only, no VFR service</div></div>
-    <div class="point"><div class="dot dot-ctrl"></div><div class="point-text">Radio required for C and D (not E)</div></div>
-    <div class="point"><div class="dot dot-ctrl"></div><div class="point-text">Clearance required only for A, B, C</div></div>
+    <div class="point"><div class="dot dot-ctrl"></div><div class="point-text"><strong>A &amp; B: IFR only</strong> — VFR not permitted<small>A: 18,000–60,000 ft ASL · B: 12,500–18,000 ft ASL</small></div></div>
+    <div class="point"><div class="dot dot-ctrl"></div><div class="point-text"><strong>C: Clearance + 2-way radio</strong> required for VFR<small>Major airports; ATC separates IFR-IFR and IFR-VFR</small></div></div>
+    <div class="point"><div class="dot dot-ctrl"></div><div class="point-text"><strong>D: 2-way radio contact</strong> before entry<small>Towered airports; ATC separates IFR only</small></div></div>
+    <div class="point"><div class="dot dot-ctrl"></div><div class="point-text"><strong>E: No clearance, no radio</strong> for VFR<small>Airways &amp; transition areas; ATC serves IFR only</small></div></div>
   </div>
-  <div class="zone unctrl-zone">
+  <div class="zone uctrl-zone">
     <div class="zone-title">Uncontrolled Airspace</div>
     <div class="zone-classes">Class G only</div>
     <div class="badge-row">
-      <span class="badge bg-g">G</span>
+      <span class="badge badge-g">G</span>
     </div>
-    <div class="point"><div class="dot dot-uctrl"></div><div class="point-text">No ATC service — for any aircraft</div></div>
-    <div class="point"><div class="dot dot-uctrl"></div><div class="point-text">No clearance required</div></div>
-    <div class="point"><div class="dot dot-uctrl"></div><div class="point-text">No radio required (CTAF recommended)</div></div>
-    <div class="point"><div class="dot dot-uctrl"></div><div class="point-text">Lower VFR weather minimums apply</div></div>
+    <div class="point"><div class="dot dot-uctrl"></div><div class="point-text">No ATC service for any aircraft</div></div>
+    <div class="point"><div class="dot dot-uctrl"></div><div class="point-text">No clearance or radio required<small>CTAF recommended near aerodromes</small></div></div>
+    <div class="point"><div class="dot dot-uctrl"></div><div class="point-text">Surface to base of overlying controlled airspace<small>Often surface to 2,200 ft ASL in rural Canada</small></div></div>
+    <div class="point"><div class="dot dot-uctrl"></div><div class="point-text">Lower VFR weather minimums apply<small>CARs 602.114–602.117</small></div></div>
     <div class="point"><div class="dot dot-uctrl"></div><div class="point-text">100% see-and-avoid pilot responsibility</div></div>
-    <div class="point"><div class="dot dot-uctrl"></div><div class="point-text">Most rural low-level GA flying is here</div></div>
   </div>
 </div>
 
-<!-- Services table -->
-<div class="section-label">ATC Services by Class</div>
+<!-- ATC Services table (all classes) -->
+<div class="section-label">ATC Services by Class — CARs 601.02</div>
+<div class="wide-table">
 <table>
   <thead>
     <tr>
       <th>Class</th>
-      <th>IFR Separation</th>
-      <th>VFR Separation from IFR</th>
-      <th>VFR-VFR Separation</th>
-      <th>Radio (VFR)</th>
-      <th>Clearance (VFR)</th>
+      <th>Typical Vertical Limits</th>
+      <th>VFR Permitted</th>
+      <th>Clearance for VFR</th>
+      <th>2-Way Radio (VFR)</th>
+      <th>IFR-VFR Separation</th>
     </tr>
   </thead>
   <tbody>
-    <tr class="ctrl-row"><td><strong>C</strong></td><td class="yes">Yes</td><td class="yes">Yes</td><td class="no">No</td><td class="yes">Required</td><td class="yes">Required</td></tr>
-    <tr class="ctrl-row"><td><strong>D</strong></td><td class="yes">Yes</td><td class="partial">Info only</td><td class="no">No</td><td class="yes">Required</td><td class="no">Not required</td></tr>
-    <tr class="ctrl-row"><td><strong>E</strong></td><td class="yes">Yes</td><td class="no">No</td><td class="no">No</td><td class="no">Not required</td><td class="no">Not required</td></tr>
-    <tr class="uctrl-row"><td><strong>G</strong></td><td class="no">None</td><td class="no">None</td><td class="no">None</td><td class="no">Not required</td><td class="no">Not required</td></tr>
+    <tr class="ctrl-row"><td><strong>A</strong></td><td>18,000 ft ASL – 60,000 ft ASL</td><td class="no">No</td><td class="yes">Required</td><td class="yes">Required</td><td style="color:var(--text-muted);font-style:italic;">N/A — IFR only</td></tr>
+    <tr class="ctrl-row"><td><strong>B</strong></td><td>12,500 ft ASL – 18,000 ft ASL</td><td class="no">No</td><td class="yes">Required</td><td class="yes">Required</td><td style="color:var(--text-muted);font-style:italic;">N/A — IFR only</td></tr>
+    <tr class="ctrl-row"><td><strong>C</strong></td><td>Surface – ~3,000 ft AGL (major airports)</td><td class="yes">Yes</td><td class="yes">Required</td><td class="yes">Required</td><td class="yes">Yes</td></tr>
+    <tr class="ctrl-row"><td><strong>D</strong></td><td>Surface – ~3,000 ft AGL (towered airports)</td><td class="yes">Yes</td><td class="no">Not required</td><td class="yes">Required</td><td class="partial">Info only</td></tr>
+    <tr class="ctrl-row"><td><strong>E</strong></td><td>700–1,200 ft AGL upward to Class B/A</td><td class="yes">Yes</td><td class="no">Not required</td><td class="no">Not required</td><td class="no">No</td></tr>
+    <tr class="uctrl-row"><td><strong>G</strong></td><td>Surface to base of controlled airspace</td><td class="yes">Yes</td><td class="no">Not required</td><td class="no">Not required</td><td class="no">None</td></tr>
   </tbody>
 </table>
+</div>
 
-<!-- Transponder -->
-<div class="section-label">Transponder (Mode C) Requirements</div>
+<!-- CARs 602.113 -->
+<div class="section-label">VFR in Controlled Airspace — CARs 602.113</div>
+<div class="note-box">
+  <p style="margin-bottom:10px;font-weight:700;">Class C — before entering:</p>
+  <div class="point"><div class="dot dot-ctrl"></div><div class="point-text">Obtain an <strong>ATC clearance</strong> (not just radio contact — ATC must say "cleared")</div></div>
+  <div class="point"><div class="dot dot-ctrl"></div><div class="point-text">Establish and <strong>maintain two-way radio communication</strong> on the assigned frequency</div></div>
+  <div class="point"><div class="dot dot-ctrl"></div><div class="point-text">Be in VMC — meet Class C VFR weather minimums (CARs 602.114)</div></div>
+  <p style="margin-top:14px;margin-bottom:10px;font-weight:700;">Class D — before entering:</p>
+  <div class="point"><div class="dot dot-ctrl"></div><div class="point-text">Establish <strong>two-way radio contact</strong> — ATC must acknowledge your call sign (even "standby" counts if your call sign is used)</div></div>
+  <div class="point"><div class="dot dot-ctrl"></div><div class="point-text">No formal clearance required — contact alone is sufficient</div></div>
+  <p style="margin-top:14px;font-size:12px;color:var(--text-muted);">Class E: no radio contact or clearance required for VFR — simply maintain VMC and comply with altitude rules.</p>
+</div>
+
+<!-- Transponder requirements -->
+<div class="section-label" style="margin-top:24px;">Transponder (Mode C) Requirements — CARs 605.35</div>
+<div class="wide-table">
 <table>
   <thead><tr><th>Airspace</th><th>Mode C Required?</th><th>Notes</th></tr></thead>
   <tbody>
-    <tr class="ctrl-row"><td>Class C</td><td class="yes">Yes</td><td style="color:var(--text-muted)">Within or through Class C</td></tr>
-    <tr class="ctrl-row"><td>Class D</td><td class="yes">Yes</td><td style="color:var(--text-muted)">Within or through Class D</td></tr>
-    <tr class="ctrl-row"><td>Class E</td><td class="no">Not required</td><td style="color:var(--text-muted)">Unless above specific altitude</td></tr>
-    <tr class="uctrl-row"><td>Class G</td><td class="no">Not required</td><td style="color:var(--text-muted)">Optional in most cases</td></tr>
+    <tr class="ctrl-row"><td>Class A &amp; B</td><td class="yes">Yes</td><td style="color:var(--text-muted)">IFR-only airspace; transponder always required</td></tr>
+    <tr class="ctrl-row"><td>Class C &amp; D</td><td class="yes">Yes</td><td style="color:var(--text-muted)">Required when operating within or transiting through</td></tr>
+    <tr class="ctrl-row"><td>Class E</td><td class="no">Not required</td><td style="color:var(--text-muted)">Unless above 12,500 ft ASL or in a designated area</td></tr>
+    <tr class="uctrl-row"><td>Class G</td><td class="no">Not required</td><td style="color:var(--text-muted)">Optional; check NOTAM or ATZ for local exceptions</td></tr>
   </tbody>
 </table>
+</div>
 
+<!-- RMZ and TMZ — Canadian-specific -->
+<div class="section-label">Canadian-Specific Designations: RMZ and TMZ</div>
+<div class="special-grid">
+  <div class="special-card">
+    <div class="special-card-title">RMZ — Radio Mandatory Zone</div>
+    <p>A designated volume of airspace (typically Class G) around an uncontrolled aerodrome where <strong>two-way radio communication is mandatory</strong> for all aircraft — IFR and VFR alike.</p>
+    <p>Pilots must monitor the published CTAF or MF frequency and make standard position reports as specified in the Canada Flight Supplement (CFS).</p>
+    <div class="cite">CARs 602.97 · AIP Canada RAC 2.8 · CFS airport entry</div>
+  </div>
+  <div class="special-card">
+    <div class="special-card-title">TMZ — Transponder Mandatory Zone</div>
+    <p>A designated volume of airspace where a <strong>Mode C (or Mode S) transponder is mandatory</strong> for all aircraft, regardless of airspace class, to ensure radar identification in areas of mixed IFR/VFR traffic.</p>
+    <p>TMZs are published in AIP Canada and charted on VNC/VTA charts. Operating without a transponder in a TMZ requires prior ATC authorization.</p>
+    <div class="cite">CARs 605.35 · AIP Canada RAC 2.8 · VNC/VTA chart notation</div>
+  </div>
+</div>
+
+<!-- Class E trap -->
 <div class="trap-box">
-  <h2>⚠️ Class E Trap</h2>
-  <p>Class E is <strong style="color:var(--accent)">controlled</strong> airspace — but VFR pilots need no clearance, no radio, and get no separation service. "Controlled" means ATC provides services to IFR aircraft there, not that VFR pilots are managed. This distinction trips up many exam candidates.</p>
+  <h2>&#9888;&#65039; Class E Trap</h2>
+  <p>Class E is <strong style="color:var(--accent)">controlled</strong> airspace — but VFR pilots need no clearance, no radio, and receive no separation service from ATC. "Controlled" means ATC provides separation services to <em>IFR</em> aircraft there, not that VFR pilots are actively managed. This distinction is a frequent PPL exam trap.</p>
 </div>
 
 </body>


### PR DESCRIPTION
## Summary

- Added Classes A and B to ATC services table (were absent; both are IFR-only and require clearance)
- Added Canadian vertical limits for every airspace class (A: 18,000–60,000 ft ASL; B: 12,500–18,000 ft ASL; G: surface to base of controlled)
- Added CARs 602.113 section explaining clearance (Class C) vs two-way radio contact (Class D) distinction, which is a common exam trap
- Added RMZ and TMZ panels with CARs citations (Canadian-specific designations not previously covered)
- Fixed transponder table to include Class A and B as required (not just C and D)
- Commented all hardcoded airspace hues per al001 convention (domain-specific, exempt from token substitution)
- Removed redundant `th` and `section-label` overrides that contradicted `_common.css`

## Test plan

- [ ] `npm run build` passes (verified ✓)
- [ ] Open `/visuals/al002-controlled-vs-uncontrolled.html` in browser — dark scheme renders correctly
- [ ] All six airspace classes appear in ATC services table (A through G)
- [ ] CARs 602.113 section is present with clearance vs contact distinction
- [ ] RMZ and TMZ cards are present with CARs citations
- [ ] Back-to-lesson button (`data-backlink="true"`) present and functional
- [ ] Mobile (≤360 px): two-column grids collapse to single column

Closes #285

🤖 Generated with [Claude Code](https://claude.com/claude-code)