### PR TITLE
[PPL-302] GK visuals quality review

### DIFF
--- a/web-app/public/visuals/gk001-aircraft-parts-controls.html
+++ b/web-app/public/visuals/gk001-aircraft-parts-controls.html
@@ -9,8 +9,8 @@
   .diagrams { display: grid; grid-template-columns: 1fr 1fr; gap: 24px; margin-bottom: 32px; }
   .diagram-box { border-color: var(--border); }
   .diagram-label { font-size: 12px; color: var(--text-muted); text-align: center; margin-bottom: 10px; letter-spacing: 0.5px; }
-  .tag-primary { display: inline-block; background: #0d2a1a; color: var(--success); font-size: 11px; padding: 2px 8px; border-radius: 3px; border: 1px solid var(--success); }
-  .tag-secondary { display: inline-block; background: #2a1a0d; color: #f0a040; font-size: 11px; padding: 2px 8px; border-radius: 3px; border: 1px solid #f0a040; }
+  .tag-primary { display: inline-block; background: rgba(76,175,125,0.12); color: var(--success); font-size: 11px; padding: 2px 8px; border-radius: 3px; border: 1px solid var(--success); }
+  .tag-secondary { display: inline-block; background: rgba(240,192,64,0.12); color: var(--accent); font-size: 11px; padding: 2px 8px; border-radius: 3px; border: 1px solid var(--accent); }
   .tables-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 24px; }
   @media (max-width: 480px) {
     body { font-size: 14px; }

--- a/web-app/public/visuals/gk002-four-forces.html
+++ b/web-app/public/visuals/gk002-four-forces.html
@@ -8,7 +8,7 @@
 <style>
   .layout { display: grid; grid-template-columns: 1fr 1fr; gap: 24px; align-items: start; }
   .force-amber { color: var(--accent); font-weight: bold; }
-  .force-blue { color: #5b9bd5; font-weight: bold; }
+  .force-blue { color: var(--info); font-weight: bold; }
   .force-green { color: var(--success); font-weight: bold; }
   .force-red { color: var(--danger); font-weight: bold; }
   @media (max-width: 480px) {

--- a/web-app/public/visuals/gk003-piston-engines.html
+++ b/web-app/public/visuals/gk003-piston-engines.html
@@ -12,8 +12,8 @@
   .stroke-name { font-size: 15px; color: var(--accent); font-weight: bold; margin-bottom: 10px; }
   .stroke-desc { font-size: 12px; color: var(--text); line-height: 1.5; margin-bottom: 10px; min-height: 48px; }
   .valve-state { font-size: 11px; padding: 4px 8px; border-radius: 4px; margin: 2px 0; }
-  .valve-open { background: #0d2a1a; color: var(--success); border: 1px solid var(--success); }
-  .valve-closed { background: #2a1a1a; color: var(--danger); border: 1px solid var(--danger); }
+  .valve-open { background: rgba(76,175,125,0.12); color: var(--success); border: 1px solid var(--success); }
+  .valve-closed { background: rgba(224,80,80,0.12); color: var(--danger); border: 1px solid var(--danger); }
   @media (max-width: 480px) {
     body { font-size: 14px; }
     .strokes-grid { grid-template-columns: 1fr 1fr; }

--- a/web-app/public/visuals/gk004-fuel-system.html
+++ b/web-app/public/visuals/gk004-fuel-system.html
@@ -8,9 +8,9 @@
 <style>
   .layout { display: grid; grid-template-columns: 1fr 1fr; gap: 24px; align-items: start; }
   .badge { display: inline-block; font-size: 11px; font-weight: bold; padding: 2px 10px; border-radius: 12px; }
-  .badge-blue { background: #0d1a3a; color: #5b9bd5; border: 1px solid #5b9bd5; }
-  .badge-red { background: #2a0d0d; color: var(--danger); border: 1px solid var(--danger); }
-  .badge-green { background: #0d2a1a; color: var(--success); border: 1px solid var(--success); }
+  .badge-blue { background: rgba(91,155,213,0.12); color: var(--info); border: 1px solid var(--info); }
+  .badge-red { background: rgba(224,80,80,0.12); color: var(--danger); border: 1px solid var(--danger); }
+  .badge-green { background: rgba(76,175,125,0.12); color: var(--success); border: 1px solid var(--success); }
   .warning-box { background: var(--surface); border-left: 3px solid var(--danger); border-radius: 4px; padding: 14px 18px; margin-top: 20px; font-size: 13px; color: var(--text); line-height: 1.6; }
   /* design-exception: Clear/Straw Jet-A fuel colour (#d0c040 straw-yellow on dark olive); no CSS-var equivalent in token set */
   .badge-straw { background: #2a2a0d; color: #d0c040; border: 1px solid #d0c040; }

--- a/web-app/public/visuals/gk006-pitot-static-instruments.html
+++ b/web-app/public/visuals/gk006-pitot-static-instruments.html
@@ -99,7 +99,7 @@
           <tr><th>Instrument</th><th>Pressure Used</th><th>Measures</th></tr>
         </thead>
         <tbody>
-          <tr><td><strong>Airspeed Indicator (ASI)</strong></td><td>Pitot + Static (differential)</td><td>Indicated airspeed (IAS) in knots or MPH</td></tr>
+          <tr><td><strong>Airspeed Indicator (ASI)</strong></td><td>Pitot + Static (differential)</td><td>Indicated airspeed (IAS) in knots or km/h</td></tr>
           <tr><td><strong>Altimeter</strong></td><td>Static only</td><td>Altitude based on atmospheric pressure; requires QNH setting</td></tr>
           <tr><td><strong>Vertical Speed Indicator (VSI)</strong></td><td>Static only (rate of change)</td><td>Rate of climb/descent in ft/min; ~6–9 second lag</td></tr>
         </tbody>

--- a/web-app/public/visuals/gk008-engine-instruments.html
+++ b/web-app/public/visuals/gk008-engine-instruments.html
@@ -38,8 +38,11 @@
       <div class="gauge-abbr">RPM</div>
       <svg viewBox="0 0 100 100" width="100%" height="90">
         <circle cx="50" cy="50" r="44" fill="#0d1b2a" stroke="#7a9ab5" stroke-width="2"/>
+        <!-- arc-green: instrument green-arc = normal operating range; hardcoded per design-exception, not a token alias -->
         <path d="M 10 70 A 44 44 0 0 1 90 70" fill="none" stroke="#4caf7d" stroke-width="7"/>
+        <!-- arc-yellow: instrument yellow-arc = caution range; hardcoded per design-exception -->
         <path d="M 72 28 A 44 44 0 0 1 90 70" fill="none" stroke="#f0c040" stroke-width="7"/>
+        <!-- arc-red: instrument red-line = never-exceed limit; hardcoded per design-exception -->
         <line x1="90" y1="70" x2="84" y2="66" stroke="#e05050" stroke-width="4" stroke-linecap="round"/>
         <!-- Needle -->
         <line x1="50" y1="50" x2="72" y2="22" stroke="white" stroke-width="2" stroke-linecap="round"/>
@@ -55,7 +58,9 @@
       <div class="gauge-abbr">MAP — in. Hg</div>
       <svg viewBox="0 0 100 100" width="100%" height="90">
         <circle cx="50" cy="50" r="44" fill="#0d1b2a" stroke="#7a9ab5" stroke-width="2"/>
+        <!-- arc-green: normal MAP range; hardcoded per design-exception -->
         <path d="M 10 70 A 44 44 0 0 1 90 70" fill="none" stroke="#4caf7d" stroke-width="7"/>
+        <!-- arc-yellow: high MAP caution; hardcoded per design-exception -->
         <path d="M 72 28 A 44 44 0 0 1 90 70" fill="none" stroke="#f0c040" stroke-width="7"/>
         <!-- Needle -->
         <line x1="50" y1="50" x2="55" y2="12" stroke="white" stroke-width="2" stroke-linecap="round"/>
@@ -207,7 +212,7 @@
   </table>
 
   <div class="note-box">
-    <strong>Critical Limits to Memorize:</strong> Oil pressure must be in the green within <strong>30 seconds</strong> of starting (cold) or engine must be shut down. Low oil pressure + high oil temperature = likely oil leak or pump failure — <strong>land immediately</strong>. EGT is used to lean the mixture: richest mixture at peak EGT minus ~50°F (rich of peak) or specific lean-of-peak per POH. Always refer to the specific aircraft POH for actual numerical limits.
+    <strong>Critical Limits to Memorize:</strong> Oil pressure must be in the green within <strong>30 seconds</strong> of starting (cold) or engine must be shut down. Low oil pressure + high oil temperature = likely oil leak or pump failure — <strong>land immediately</strong>. EGT is used to lean the mixture: richest mixture at peak EGT minus ~25°C (rich of peak) or specific lean-of-peak per POH. Always refer to the specific aircraft POH for actual numerical limits.
   </div>
 </div>
 </body>

--- a/web-app/public/visuals/gk009-weight-and-balance.html
+++ b/web-app/public/visuals/gk009-weight-and-balance.html
@@ -51,7 +51,7 @@
         <line x1="60" y1="220" x2="300" y2="220" stroke="#7a9ab5" stroke-width="1.5" marker-end="url(#arrowWB)"/>
 
         <!-- Axis labels -->
-        <text x="25" y="130" text-anchor="middle" fill="#7a9ab5" font-size="10" transform="rotate(-90, 25, 130)">Gross Weight (lbs)</text>
+        <text x="25" y="130" text-anchor="middle" fill="#7a9ab5" font-size="10" transform="rotate(-90, 25, 130)">Gross Weight (lb)</text>
         <text x="180" y="242" text-anchor="middle" fill="#7a9ab5" font-size="10">CG Position (inches aft of datum)</text>
 
         <!-- Envelope polygon -->
@@ -103,7 +103,7 @@
         <thead>
           <tr>
             <th>Item</th>
-            <th style="text-align:right;">Weight (lbs)</th>
+            <th style="text-align:right;">Weight (lb)</th>
             <th style="text-align:right;">Arm (in.)</th>
             <th style="text-align:right;">Moment (lb·in)</th>
           </tr>

--- a/web-app/public/visuals/gk010-performance-charts.html
+++ b/web-app/public/visuals/gk010-performance-charts.html
@@ -13,8 +13,8 @@
   .grid-4 { display: grid; grid-template-columns: repeat(4, 1fr); gap: 16px; margin-bottom: 24px; }
   .card { background: var(--surface); border: 1px solid var(--border); border-radius: 8px; padding: 16px; }
   .card-title { font-size: 12px; color: var(--accent); font-weight: bold; letter-spacing: 0.5px; margin-bottom: 10px; text-transform: uppercase; }
-  .isa-box { background: #0d2040; border: 2px solid #5b9bd5; border-radius: 8px; padding: 18px; text-align: center; margin-bottom: 24px; }
-  .isa-main { font-size: 18px; color: #5b9bd5; font-weight: bold; margin-bottom: 4px; }
+  .isa-box { background: var(--surface); border: 2px solid var(--info); border-radius: 8px; padding: 18px; text-align: center; margin-bottom: 24px; }
+  .isa-main { font-size: 18px; color: var(--info); font-weight: bold; margin-bottom: 4px; }
   .isa-sub { font-size: 12px; color: var(--text-muted); line-height: 1.6; }
   .better { color: var(--success); font-weight: bold; }
   .worse { color: var(--danger); font-weight: bold; }


### PR DESCRIPTION
## Summary

- Replaced hardcoded hex colors in CSS `<style>` blocks with `_common.css` token-based values (`var(--info)`, `rgba()` tints of `--success`/`--danger`/`--accent`/`--info`) across gk001–gk004 and gk010
- Preserved gk008 instrument arc colors (`#4caf7d` green / `#f0c040` yellow / `#e05050` red) as hardcoded SVG stroke attributes with explanatory `design-exception` comments — these represent physical instrument arc markings, not design-system roles
- **gk006:** Corrected airspeed unit label from `knots or MPH` → `knots or km/h` (Canadian standard; MPH not used in Canadian aviation)
- **gk008:** Fixed EGT lean reference from `~50°F` → `~25°C` (Canadian/SI units per TP 12880E)
- **gk009:** Corrected weight column header `lbs` → `lb` (correct SI unit symbol)
- All 14 GK visual files verified: `data-backlink="true"` present, `_common.css` linked, content aligned with TP 12880E Ch. 3–7

## Test plan

- [x] `npm run build` passes
- [x] All 14 files retain `data-backlink="true"` back-to-lesson button
- [x] All 14 files link `/visuals/_common.css`
- [x] No hardcoded hex in CSS style blocks (gk004 `badge-straw` retains existing `design-exception` comment)
- [x] gk008 arc colors preserved with `design-exception` comments
- [x] Canadian units throughout: km/h, °C, lb

Closes #302

🤖 Generated with [Claude Code](https://claude.com/claude-code)