### PR TITLE
[PPL-193] Add Listen nav entry linking to /playlist

### DIFF
--- a/web-app/src/components/Nav.tsx
+++ b/web-app/src/components/Nav.tsx
@@ -16,6 +16,7 @@ import MenuBookIcon from '@mui/icons-material/MenuBook';
 import QuizIcon from '@mui/icons-material/Quiz';
 import GradingIcon from '@mui/icons-material/Grading';
 import ChecklistIcon from '@mui/icons-material/Checklist';
+import HeadphonesIcon from '@mui/icons-material/Headphones';
 import ChevronLeftIcon from '@mui/icons-material/ChevronLeft';
 import ChevronRightIcon from '@mui/icons-material/ChevronRight';
 import { Link as RouterLink, useLocation, useNavigate } from 'react-router-dom';
@@ -30,6 +31,7 @@ const NAV_LINKS = [
   { label: 'Practice Quiz', shortLabel: 'Quiz', to: '/exam', icon: <QuizIcon /> },
   { label: 'Final Exam', shortLabel: 'Final', to: '/final-exam', icon: <GradingIcon /> },
   { label: 'Study Plan', shortLabel: 'Plan', to: '/plan', icon: <ChecklistIcon /> },
+  { label: 'Listen', shortLabel: 'Listen', to: '/playlist', icon: <HeadphonesIcon /> },
 ];
 
 const RAIL_EXPANDED = 240;


### PR DESCRIPTION
## Summary

- Adds `HeadphonesIcon` import from `@mui/icons-material/Headphones` to `Nav.tsx`
- Appends `{ label: 'Listen', shortLabel: 'Listen', to: '/playlist', icon: <HeadphonesIcon /> }` to `NAV_LINKS`
- Appears in both desktop side-rail (with full label and active amber-border highlight) and mobile bottom navigation (with `shortLabel`)
- No design-system violations: uses existing `colorTokens` tokens throughout — no hardcoded hex added
- `npm run build` passes cleanly

Closes #193

## Test plan

- [ ] Desktop: nav rail shows "Listen" item with headphones icon; clicking navigates to `/playlist`; active state shows primary-color border and background
- [ ] Desktop collapsed: shows headphones icon only with tooltip "Listen"
- [ ] Mobile: bottom nav shows "Listen" tab with headphones icon; selecting it navigates to `/playlist`
- [ ] 360 px width: no horizontal scroll; all tap targets ≥ 48×48 px (inherited from existing BottomNavigationAction and nav link styles)

🤖 Generated with [Claude Code](https://claude.com/claude-code)