### PR TITLE
[PPL-304] Fix NAV visuals: accuracy, backlink style, preserve comments

### DIFF
--- a/web-app/public/visuals/nav001-vfr-charts.html
+++ b/web-app/public/visuals/nav001-vfr-charts.html
@@ -16,6 +16,7 @@ body { max-width: 860px; margin: auto; }
   .scale-eq strong { color: var(--accent); }
   .scale-bar { height: 8px; border-radius: 4px; margin: 10px 0 4px; display: flex; overflow: hidden; }
   .scale-seg-dark { background: var(--border); flex: 1; }
+  /* hardcoded: chart-accurate alternating scale-bar color — do not replace with token */
   .scale-seg-light { background: #3a6a9a; flex: 1; }
   .scale-bar-label { display: flex; justify-content: space-between; font-size: 10px; color: var(--text-muted); }
 
@@ -97,7 +98,7 @@ body { max-width: 860px; margin: auto; }
   <div class="scale-card">
     <div class="scale-title">VNC — 1:500,000</div>
     <div class="scale-sub">VFR Navigation Chart · Primary cross-country chart</div>
-    <div class="scale-eq"><strong>1 cm = 5 km</strong> on the ground<br>≈ 2.7 nautical miles per cm<br>60° latitude grid every 30 min of arc</div>
+    <div class="scale-eq"><strong>1 cm = 5 km</strong> on the ground<br>≈ 2.7 nautical miles per cm<br>lat/lon grid every 30 min of arc</div>
     <div class="scale-bar">
       <div class="scale-seg-dark"></div><div class="scale-seg-light"></div>
       <div class="scale-seg-dark"></div><div class="scale-seg-light"></div>

--- a/web-app/public/visuals/nav005-wind-correction-angle.html
+++ b/web-app/public/visuals/nav005-wind-correction-angle.html
@@ -30,7 +30,7 @@ body { max-width: 860px; margin: auto; }
 <p class="subtitle">Transport Canada · TP 12880E Ch.9 · PPL Written Exam</p>
 
 <!-- ── WIND TRIANGLE DIAGRAM ─────────────────────────────────────────── -->
-<div class="section-label">Wind Triangle — TT 090°, Wind from 270° (30 kt), TAS 120 kt</div>
+<div class="section-label">Wind Triangle — TT 090°, Wind from 180° (30 kt), TAS 120 kt</div>
 <div class="grid-wrap">
   <svg width="780" height="310" viewBox="0 0 780 310" style="max-width:100%;">
 
@@ -57,12 +57,12 @@ body { max-width: 860px; margin: auto; }
     <circle cx="705" cy="190" r="7" fill="#c04040" stroke="#ff8080" stroke-width="2"/>
     <text x="705" y="218" text-anchor="middle" font-size="13" fill="#ff8080" font-weight="700">B</text>
 
-    <!-- Wind vector: from 270° (left side, pushes right/east) — dashed, cyan -->
-    <!-- Wind from 270° means air moves toward 090°, blowing the aircraft north (upward in diagram) -->
+    <!-- Wind vector: from 180° (south, from the right side when heading east) — dashed, cyan -->
+    <!-- Wind from 180° blows northward, pushing the aircraft north of the desired track -->
     <!-- Wind arrow: starts at A, goes 30kt worth of vector — pushes aircraft northward -->
     <line x1="80" y1="190" x2="225" y2="130" stroke="#40c8c8" stroke-width="2" stroke-dasharray="5 3"/>
     <polygon points="225,125 218,140 232,138" fill="#40c8c8"/>
-    <text x="120" y="145" text-anchor="middle" font-size="10" fill="#40c8c8">Wind 270°/30 kt</text>
+    <text x="120" y="145" text-anchor="middle" font-size="10" fill="#40c8c8">Wind 180°/30 kt</text>
 
     <!-- TAS vector: from A angled slightly north to reach the ground track line at destination -->
     <!-- Aircraft heading is TT + WCA (to the right/south to compensate for northward wind push) -->
@@ -73,8 +73,8 @@ body { max-width: 860px; margin: auto; }
     <polygon points="660,210 672,218 658,224" fill="#f08040"/>
     <text x="370" y="242" text-anchor="middle" font-size="11" fill="#f08040" font-weight="600">True Heading (TH) — aircraft nose points here</text>
 
-    <!-- GS vector along track from A to B -->
-    <text x="395" y="175" text-anchor="middle" font-size="11" fill="#80c880" font-weight="600">GS ≈ 149 kt →</text>
+    <!-- GS vector along track from A to B; GS = √(TAS²−crosswind²) = √(120²−30²) ≈ 116 kt -->
+    <text x="395" y="175" text-anchor="middle" font-size="11" fill="#80c880" font-weight="600">GS ≈ 116 kt →</text>
 
     <!-- WCA arc at departure -->
     <path d="M 140 190 A 60 60 0 0 0 127 156" fill="none" stroke="#f0c040" stroke-width="1.5"/>
@@ -105,8 +105,8 @@ body { max-width: 860px; margin: auto; }
     <h3>Wind Correction Angle (WCA)</h3>
     <div class="big">TH = TT + WCA</div>
     <div class="sub">Apply WCA to True Track to get True Heading</div>
-    <p style="margin-top:12px;">WCA is the angle between your intended track and the direction you must point the aircraft nose to stay on track. You <strong>crab into the wind</strong>: if wind is from the left, WCA is positive (turn right); wind from the right, turn left.<br><br>
-    Example: TT 090°, wind from left, WCA = +14°<br><strong>TH = 090° + 14° = 104°</strong></p>
+    <p style="margin-top:12px;">WCA is the angle between your intended track and the direction you must point the aircraft nose to stay on track. You <strong>crab into the wind</strong>: if wind is from the right, WCA is positive (crab right, TH &gt; TT); wind from the left, WCA is negative (crab left, TH &lt; TT).<br><br>
+    Example: TT 090°, wind from right (180°), WCA = +14°<br><strong>TH = 090° + 14° = 104°</strong></p>
   </div>
   <div class="info-card">
     <h3>Ground Speed (GS)</h3>

--- a/web-app/public/visuals/nav006-time-speed-distance.html
+++ b/web-app/public/visuals/nav006-time-speed-distance.html
@@ -11,6 +11,7 @@ body { max-width: 860px; margin: auto; }
   .info-card .big { font-size: 26px; font-weight: 800; color: var(--accent); text-align: center; padding: 8px 0; letter-spacing: 1px; }
   .info-card .sub { font-size: 11px; color: var(--text-muted); text-align: center; margin-top: 2px; }
 
+  /* assessment-state: hardcoded green for correct-answer cells — do not replace with token */
   td.solve { color: #80c880; font-weight: 700; }
 
   @media (max-width: 480px) {

--- a/web-app/public/visuals/nav008-cross-country-planning.html
+++ b/web-app/public/visuals/nav008-cross-country-planning.html
@@ -11,6 +11,7 @@ body { max-width: 860px; margin: auto; }
   .info-card .big { font-size: 20px; font-weight: 800; color: var(--accent); text-align: center; padding: 8px 0; letter-spacing: 0.5px; }
   .info-card .sub { font-size: 11px; color: var(--text-muted); text-align: center; margin-top: 2px; }
 
+  /* assessment-state: hardcoded green for sample nav-log row — do not replace with token */
   tr.sample-row td { background: var(--bg2); color: #80c880; }
 
   @media (max-width: 480px) {
@@ -167,7 +168,7 @@ body { max-width: 860px; margin: auto; }
       2. <strong>Weather:</strong> TAF, METAR, GFA, SIGMET/AIRMET<br>
       3. <strong>NOTAM/ATIS:</strong> Check departure, en-route, destination<br>
       4. <strong>Nav log:</strong> Complete all legs (TT → CH → GS → ETE)<br>
-      5. <strong>Fuel:</strong> Trip + 45 min reserve + taxi<br>
+      5. <strong>Fuel:</strong> Trip + 30 min VFR reserve (day) / 45 min (night) + taxi (CAR 602.88)<br>
       6. <strong>Weight &amp; Balance:</strong> Verify within limits<br>
       7. <strong>Performance:</strong> T/O, climb, cruise, landing distances<br>
       8. <strong>Flight plan:</strong> File VFR flight plan if required

--- a/web-app/public/visuals/nav009-pilotage.html
+++ b/web-app/public/visuals/nav009-pilotage.html
@@ -6,6 +6,7 @@
 <link rel="stylesheet" href="/visuals/_common.css">
 <title>NAV-009 — Pilotage — Navigating by Ground Reference</title>
 <style>
+  /* assessment-state: hardcoded green/red for checkpoint-quality ratings — do not replace with tokens */
   .good { color: #80c880; }
   .poor { color: #e07070; }
   td.good { color: #80c880; }

--- a/web-app/public/visuals/nav010-vor-navigation.html
+++ b/web-app/public/visuals/nav010-vor-navigation.html
@@ -80,6 +80,7 @@
       <text x="280" y="200" text-anchor="middle" fill="#f0c040" font-size="10" font-weight="700">VOR</text>
       <text x="280" y="212" text-anchor="middle" fill="#7a9ab5" font-size="9">YYZ</text>
 
+      <!-- assessment-state: #80c880 = on-course (green), #e07070 = off-course (red) — do not replace with tokens -->
       <!-- Aircraft on 045 radial (centered CDI) -->
       <g transform="translate(348,84) rotate(225)">
         <polygon points="0,-10 -5,7 0,3 5,7" fill="#80c880" stroke="#40a040" stroke-width="1"/>

--- a/web-app/public/visuals/nav011-gps-basics.html
+++ b/web-app/public/visuals/nav011-gps-basics.html
@@ -16,7 +16,7 @@
 </style>
 </head>
 <body>
-  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:color-mix(in srgb,var(--bg2) 90%,transparent);color:var(--accent);border:1.5px solid color-mix(in srgb,var(--accent) 40%,transparent);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
+  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:#f0c040;border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
   <style>
 .container{padding-top:56px!important;}@media(max-width:480px){.container{padding-top:60px!important;}}
 </style>

--- a/web-app/public/visuals/nav012-altitude-types.html
+++ b/web-app/public/visuals/nav012-altitude-types.html
@@ -13,7 +13,7 @@
 </style>
 </head>
 <body>
-  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:color-mix(in srgb,var(--bg2) 90%,transparent);color:var(--accent);border:1.5px solid color-mix(in srgb,var(--accent) 40%,transparent);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
+  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:#f0c040;border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
   <style>
 .container{padding-top:56px!important;}@media(max-width:480px){.container{padding-top:60px!important;}}
 </style>

--- a/web-app/public/visuals/nav013-density-altitude.html
+++ b/web-app/public/visuals/nav013-density-altitude.html
@@ -15,7 +15,7 @@
 </style>
 </head>
 <body>
-  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:color-mix(in srgb,var(--bg2) 90%,transparent);color:var(--accent);border:1.5px solid color-mix(in srgb,var(--accent) 40%,transparent);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
+  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:#f0c040;border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
   <style>
 .container{padding-top:56px!important;}@media(max-width:480px){.container{padding-top:60px!important;}}
 </style>
@@ -185,7 +185,7 @@
       <text x="660" y="130" fill="#c8d8e8" font-size="8">PA = 3,500 ft</text>
       <text x="660" y="142" fill="#c8d8e8" font-size="8">OAT = +30°C</text>
       <text x="660" y="154" fill="#c8d8e8" font-size="8">ISA at 3500ft ≈ +8°C</text>
-      <text x="660" y="166" fill="#e07070" font-size="9" font-weight="700">DA ≈ 5,600 ft</text>
+      <text x="660" y="166" fill="#e07070" font-size="9" font-weight="700">DA ≈ 6,140 ft</text>
 
       <!-- Entry point dot -->
       <circle cx="647" cy="222" r="5" fill="#f0c040" stroke="#c09000" stroke-width="1.5"/>

--- a/web-app/public/visuals/nav014-lost-procedure.html
+++ b/web-app/public/visuals/nav014-lost-procedure.html
@@ -18,7 +18,7 @@
 </style>
 </head>
 <body>
-  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:color-mix(in srgb,var(--bg2) 90%,transparent);color:var(--accent);border:1.5px solid color-mix(in srgb,var(--accent) 40%,transparent);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
+  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:#f0c040;border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
   <style>
 .container{padding-top:56px!important;}@media(max-width:480px){.container{padding-top:60px!important;}}
 </style>


### PR DESCRIPTION
## Summary

- **nav001**: Add `#3a6a9a` scale-bar preserve comment; fix misleading "60° latitude grid" wording → "lat/lon grid"
- **nav005**: Correct wind-triangle scenario — direction label 270°→180°, GS 149→116 kt (pure crosswind math), fix WCA crab-direction text in info-card (was reversed)
- **nav006**: Add assessment-state preserve comment for `#80c880` solve cells
- **nav008**: Fix fuel reserve "45 min" → "30 min day VFR / 45 min night VFR" per CAR 602.88; add `#80c880` preserve comment
- **nav009**: Add `#80c880`/`#e07070` checkpoint-rating preserve comments
- **nav010**: Add `#80c880`/`#e07070` on/off-course SVG preserve comment
- **nav011–014**: Replace non-canonical `color-mix()` backlink button style with spec-required `rgba(13,27,42,0.9)` / `rgba(240,192,64,0.4)` values
- **nav013**: Correct DA chart annotation 5,600 ft → 6,140 ft (matches the worked example below it; formula: PA=3500, OAT=30°C, ISA=8°C, DA=3500+22×120=6140)

## Test plan

- [x] `npm run build` passes in `web-app/`
- [x] All 14 files retain `data-backlink="true"` button
- [x] `_common.css` not modified
- [x] `#3a6a9a` (nav001 scale bar) preserved with comment
- [x] `#80c880`/`#e07070` (nav006–010 assessment states) preserved with comments
- [x] Content accuracy verified against TP 12880E Ch. 10–12 and CARs

Closes #304

🤖 Generated with [Claude Code](https://claude.com/claude-code)