### PR TITLE
[PPL-303] Fix MET visuals quality: fog threshold, data-encoding comments

### DIFF
--- a/web-app/public/visuals/met004-fog-types.html
+++ b/web-app/public/visuals/met004-fog-types.html
@@ -23,7 +23,7 @@
   <style>.container{padding-top:56px!important;}@media(max-width:480px){.container{padding-top:60px!important;}}</style>
 <div class="container">
   <h1>MET-004 — Fog Formation &amp; Types</h1>
-  <p class="subtitle">Transport Canada · TP 12880E · AIM MET 2.0 · Fog = visibility &lt; ½ SM (vs mist/BR)</p>
+  <p class="subtitle">Transport Canada · TP 12880E · AIM MET 2.0 · Fog = visibility &lt; 5/8 SM (vs mist/BR)</p>
 
   <div class="section-title" style="margin-top: 0;">The Five Fog Types</div>
   <div class="grid">
@@ -85,7 +85,7 @@
 
   <div class="memory-hook">
     <span class="badge">EXAM HOOK</span><br>
-    <strong>Radiation fog</strong> needs three things: <strong>clear sky, calm wind, high humidity</strong>. Remove any one and it doesn't form. <strong>Advection fog</strong> forms when warm moist air moves over a cold surface — it's the only type that tolerates steady wind up to ~15 kt. Any fog reduces vis below ½ SM — above that, it's <strong>mist (BR)</strong> or <strong>haze (HZ)</strong>.
+    <strong>Radiation fog</strong> needs three things: <strong>clear sky, calm wind, high humidity</strong>. Remove any one and it doesn't form. <strong>Advection fog</strong> forms when warm moist air moves over a cold surface — it's the only type that tolerates steady wind up to ~15 kt. Any fog reduces vis below 5/8 SM — above that, it's <strong>mist (BR)</strong> or <strong>haze (HZ)</strong>.
   </div>
 </div>
 </body>

--- a/web-app/public/visuals/met006-taf-decoding.html
+++ b/web-app/public/visuals/met006-taf-decoding.html
@@ -8,6 +8,7 @@
 <style>
   .taf-sample { background: var(--surface); border: 1px solid var(--border); border-radius: 8px; padding: 18px 20px; font-family: 'Consolas', 'Menlo', monospace; font-size: 14px; line-height: 1.9; margin-bottom: 14px; word-break: break-word; }
   .seg { padding: 2px 6px; border-radius: 3px; margin: 0 2px; display: inline-block; }
+  /* data-encoding: TAF change-group segment colours — exempt from CSS var migration */
   .s-hdr  { background: #2d3e50; color: var(--text); }
   .s-time { background: #4c5b8c; color: var(--text); }
   .s-base { background: #3a7a70; color: var(--text); }

--- a/web-app/public/visuals/met010-icing.html
+++ b/web-app/public/visuals/met010-icing.html
@@ -31,7 +31,10 @@
       <!-- Temperature scale bar -->
       <rect x="40" y="70" width="640" height="50" fill="#2a4a5a" stroke="#243d52"/>
 
-      <!-- Zones: clear ice (0 to -10), mixed (-10 to -15), rime (-15 to -40) -->
+      <!-- data-encoding: icing domain colours — hardcoded by aviation convention, exempt from CSS var migration -->
+      <!-- #5b9bd5 = CLEAR ICE (0 to −10 °C, large supercooled drops) -->
+      <!-- #c08040 = MIXED ICE (−10 to −15 °C, worst aerodynamic shape) -->
+      <!-- #e8edf2 = RIME ICE (−15 to −40 °C, small opaque drops) -->
       <rect x="40" y="70" width="160" height="50" fill="#5b9bd5" opacity="0.55"/>
       <rect x="200" y="70" width="80" height="50" fill="#c08040" opacity="0.6"/>
       <rect x="280" y="70" width="400" height="50" fill="#e8edf2" opacity="0.35"/>


### PR DESCRIPTION
## Summary

- **met004**: Correct fog visibility threshold from ½ SM → **5/8 SM** (ICAO/Transport Canada standard: `FG` is reported when vis < 5/8 SM; `BR` at or above). Both the subtitle and the exam hook were updated.
- **met006**: Add `/* data-encoding: TAF change-group segment colours */` comment above the `.s-*` CSS block, mirroring the existing comment in met005. Ensures reviewers know these hardcoded hex values are intentional aviation domain encoding.
- **met010**: Add HTML `<!-- data-encoding -->` comments on the three icing-zone SVG `fill` attributes, explaining that `#5b9bd5` (CLEAR ICE) and `#c08040` (MIXED ICE) are hardcoded by aviation convention and exempt from CSS var migration.

All 14 MET visuals (met001–met014) verified:
- `data-backlink="true"` button present on every file ✓
- met005 METAR segment colours (10× `.s-*` classes) retain hardcoded values with comment ✓
- met006 TAF segment colours (7× `.s-*` classes) retain hardcoded values, now with comment ✓
- met010 icing domain SVG fills retain hardcoded values, now with comments ✓
- `npm run build` passes ✓

Closes #303

## Test plan

- [ ] Open each of the three modified files in a browser and confirm dark-scheme rendering looks correct
- [ ] Verify `data-backlink="true"` button appears fixed top-left in each file
- [ ] Confirm met004 subtitle and exam hook now read "5/8 SM" not "½ SM"
- [ ] Confirm met006 CSS block has the data-encoding comment
- [ ] Confirm met010 SVG has the data-encoding HTML comments on the fill attributes

🤖 Generated with [Claude Code](https://claude.com/claude-code)