### PR TITLE
[PPL-294] Fix al011-cars-structure: add Part IX, correct PPL labels

### DIFF
--- a/web-app/public/visuals/al011-cars-structure.html
+++ b/web-app/public/visuals/al011-cars-structure.html
@@ -22,6 +22,7 @@
   .part-name { font-size: 13px; font-weight: 700; color: var(--text); margin-bottom: 6px; }
   .part-desc { font-size: 12px; color: var(--text-muted); line-height: 1.5; }
   .part-key { border-color: var(--accent-dim); }
+  .ppl-tag { display: inline-block; background: var(--accent-dim); color: var(--accent); font-size: 9px; font-weight: 800; text-transform: uppercase; letter-spacing: 0.5px; padding: 2px 6px; border-radius: 3px; margin-top: 8px; }
 
   .cite-box { background: var(--surface); border: 1.5px solid var(--border-hi); border-radius: 8px; padding: 18px 20px; margin-bottom: 32px; }
   .cite-box h2 { font-size: 12px; color: var(--text-muted); text-transform: uppercase; letter-spacing: 1px; margin-bottom: 14px; }
@@ -78,14 +79,15 @@
 </div>
 
 <!-- Key Parts -->
-<div class="section-label">Key CARs Parts for PPL Exam</div>
+<div class="section-label">CARs Parts I–IX — PPL Exam labelled</div>
 <div class="parts-grid">
   <div class="part-card part-key">
     <div class="part-num">100</div>
     <div class="part-name">General Provisions</div>
     <div class="part-desc">Definitions, abbreviations, and interpretation rules used throughout the CARs</div>
+    <div class="ppl-tag">PPL Exam</div>
   </div>
-  <div class="part-card part-key">
+  <div class="part-card">
     <div class="part-num">200</div>
     <div class="part-name">Aircraft Registration &amp; Marking</div>
     <div class="part-desc">Registration certificates, nationality marks (C-), aircraft markings</div>
@@ -99,6 +101,7 @@
     <div class="part-num">400</div>
     <div class="part-name">Personnel Licensing &amp; Training</div>
     <div class="part-desc">Pilot licences, medical standards, rating requirements, recency</div>
+    <div class="ppl-tag">PPL Exam</div>
   </div>
   <div class="part-card">
     <div class="part-num">500</div>
@@ -109,16 +112,23 @@
     <div class="part-num">600</div>
     <div class="part-name">General Operating &amp; Flight Rules</div>
     <div class="part-desc">VFR/IFR rules, altitudes, right-of-way, weather minima — most exam questions</div>
+    <div class="ppl-tag">PPL Exam</div>
   </div>
-  <div class="part-card">
+  <div class="part-card part-key">
     <div class="part-num">700</div>
-    <div class="part-name">Air Carrier Operations</div>
-    <div class="part-desc">Commercial air services, crew requirements, flight/duty time</div>
+    <div class="part-name">Commercial Air Services</div>
+    <div class="part-desc">Air operator certificates, crew requirements, flight/duty time limits</div>
+    <div class="ppl-tag">PPL Exam</div>
   </div>
   <div class="part-card">
     <div class="part-num">800</div>
-    <div class="part-name">Dangerous Goods</div>
-    <div class="part-desc">Transport of hazardous materials by air — classification, packaging</div>
+    <div class="part-name">Approved Maintenance Organizations</div>
+    <div class="part-desc">AMO certification, maintenance release requirements, technical records</div>
+  </div>
+  <div class="part-card">
+    <div class="part-num">900</div>
+    <div class="part-name">Special Flight Operations</div>
+    <div class="part-desc">Special Flight Operations Certificates (SFOCs) — aerobatics, formation flight, low-level ops, UAV operations</div>
   </div>
 </div>
 


### PR DESCRIPTION
## Summary

- Added Part IX (900 — Special Flight Operations / SFOCs) which was missing from the parts grid
- Fixed PPL Exam labels: removed from Part II (200 — not a primary PPL exam topic), added to Part VII (700 — Commercial Air Services)
- Added `.ppl-tag` amber badge for explicit text label on PPL-relevant Parts I, IV, VI, VII
- Corrected Part VIII name to "Approved Maintenance Organizations" (was incorrectly "Dangerous Goods")
- Updated section heading to "CARs Parts I–IX — PPL Exam labelled" for clarity
- All colors remain on `_common.css` tokens; `data-backlink="true"` button unchanged; dark scheme rendering verified; `npm run build` passes

## Test plan

- [ ] Open `al011-cars-structure.html` in browser — confirm 9 part cards render, Parts I/IV/VI/VII show amber "PPL Exam" badge
- [ ] Confirm Part 800 now reads "Approved Maintenance Organizations", Part 700 reads "Commercial Air Services"
- [ ] Confirm Part 900 card present with "Special Flight Operations" and SFOC description
- [ ] Verify `← Back to lesson` button visible and functional
- [ ] Run `npm run build` in `web-app/` — should pass with no errors
- [ ] Confirm no hardcoded hex colors in HTML `<style>` block (backlink inline style is canonical exception)

Closes #294

🤖 Generated with [Claude Code](https://claude.com/claude-code)