### PR TITLE
[PPL-280] Fix skip buttons seeking from 0 when duration is NaN

### DIFF
--- a/web-app/src/components/PlaylistPlayer.tsx
+++ b/web-app/src/components/PlaylistPlayer.tsx
@@ -145,14 +145,21 @@ export default function PlaylistPlayer({ lessons }: PlaylistPlayerProps) {
   function handleSkipBack() {
     const audio = audioRef.current;
     if (!audio) return;
+    if (audio.readyState < HTMLMediaElement.HAVE_METADATA) {
+      console.warn('[PlaylistPlayer] skip back ignored: audio not ready (readyState=%d)', audio.readyState);
+      return;
+    }
     audio.currentTime = Math.max(0, audio.currentTime - 15);
   }
 
   function handleSkipForward() {
     const audio = audioRef.current;
     if (!audio) return;
-    const dur = isFinite(audio.duration) ? audio.duration : 0;
-    audio.currentTime = Math.min(dur, audio.currentTime + 15);
+    if (isFinite(audio.duration)) {
+      audio.currentTime = Math.min(audio.duration, audio.currentTime + 15);
+    } else {
+      audio.currentTime = audio.currentTime + 15;
+    }
   }
 
   function handleKeyDown(e: React.KeyboardEvent) {


### PR DESCRIPTION
## Summary

- `handleSkipForward` was using `isFinite(duration) ? duration : 0` as the clamp ceiling, so when `audio.duration` is `NaN` (before metadata loads) or `Infinity`, `Math.min(0, currentTime+15)` would snap playback to position 0
- Fix: when duration is finite, clamp to duration; otherwise just add 15 s (no upper bound needed)
- Added `readyState < HAVE_METADATA` guard in `handleSkipBack` with a `console.warn` to silently ignore premature clicks
- ArrowLeft / ArrowRight keyboard shortcuts already delegate to the same handlers — no separate change needed
- `MediaSessionBridge.tsx` is unaffected (uses `duration || Infinity` which correctly passes Infinity to `Math.min`, allowing the seek)

Closes #280

## Test plan

- [ ] Start playing a lesson; press Skip Forward (button or ArrowRight) while `duration` is still NaN — playback should advance 15 s, not jump to 0
- [ ] Press Skip Back before metadata loads — should be a no-op (check console for warn)
- [ ] Normal skip forward/back while audio is loaded and playing — unchanged behaviour, clamped to duration
- [ ] `npm run build` passes (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)