### PR TITLE
[PPL-301] Fix al018: aviation color comments, canonical backlink, ADIZ position report

### DIFF
--- a/web-app/public/visuals/al018-special-use-airspace.html
+++ b/web-app/public/visuals/al018-special-use-airspace.html
@@ -16,23 +16,23 @@
   .type-label { font-size: 18px; font-weight: 900; margin-bottom: 4px; letter-spacing: 1px; }
   .label-fr { color: #ff7070; }
   .label-fa { color: #f0c040; }
-  .label-moa { color: #64a0ff; }
-  .label-adiz { color: #a080ff; }
+  .label-moa { color: #64a0ff; } /* hardcoded: MOA aviation domain color — no token equivalent */
+  .label-adiz { color: #a080ff; } /* hardcoded: ADIZ aviation domain color — no token equivalent */
   .type-name { font-size: 12px; color: var(--text-muted); margin-bottom: 10px; font-weight: 600; }
   .type-body { font-size: 13px; color: var(--text); line-height: 1.6; }
   .type-body strong { color: var(--text); }
   .entry-rule { font-size: 12px; font-weight: 700; margin-top: 8px; padding: 4px 8px; border-radius: 4px; display: inline-block; }
   .rule-restricted { background: rgba(255,80,80,0.15); color: #ff7070; }
   .rule-advisory { background: rgba(255,200,0,0.12); color: #f0c040; }
-  .rule-restricted-moa { background: rgba(100,160,255,0.15); color: #64a0ff; }
-  .rule-adiz { background: rgba(130,100,255,0.15); color: #a080ff; }
+  .rule-restricted-moa { background: rgba(100,160,255,0.15); color: #64a0ff; } /* hardcoded: MOA aviation domain color */
+  .rule-adiz { background: rgba(130,100,255,0.15); color: #a080ff; } /* hardcoded: ADIZ aviation domain color */
 
   .cond { color: var(--accent); font-weight: 600; }
 
   .adiz-box { background: rgba(130,100,255,0.06); border: 1.5px solid rgba(130,100,255,0.25); border-radius: 10px; padding: 18px 20px; margin-bottom: 28px; }
-  .adiz-box h2 { font-size: 12px; color: #a080ff; text-transform: uppercase; letter-spacing: 1px; margin-bottom: 12px; font-weight: 600; }
+  .adiz-box h2 { font-size: 12px; color: #a080ff; text-transform: uppercase; letter-spacing: 1px; margin-bottom: 12px; font-weight: 600; } /* hardcoded: ADIZ aviation domain color */
   .adiz-step { display: flex; gap: 10px; margin-bottom: 8px; align-items: flex-start; }
-  .adiz-num { background: rgba(130,100,255,0.2); color: #a080ff; font-size: 10px; font-weight: 800; width: 22px; height: 22px; border-radius: 50%; display: flex; align-items: center; justify-content: center; flex-shrink: 0; margin-top: 1px; }
+  .adiz-num { background: rgba(130,100,255,0.2); color: #a080ff; font-size: 10px; font-weight: 800; width: 22px; height: 22px; border-radius: 50%; display: flex; align-items: center; justify-content: center; flex-shrink: 0; margin-top: 1px; } /* hardcoded: ADIZ aviation domain color */
   .adiz-text { font-size: 13px; color: var(--text); line-height: 1.5; }
   .adiz-text strong { color: var(--accent); }
 
@@ -44,7 +44,7 @@
 </style>
 </head>
 <body>
-  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:var(--accent);border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
+  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:#f0c040;border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
   <style>.container{padding-top:56px!important;}@media(max-width:480px){.container{padding-top:60px!important;}}</style>
 
 <h1>AL-018 — Special Use Airspace: Class F(R), MOAs, ADIZs</h1>
@@ -126,7 +126,7 @@
   <div class="adiz-step"><span class="adiz-num">1</span><span class="adiz-text"><strong>File a DVFR (Defence VFR) flight plan</strong> before departure. Include entry point, estimated time of entry, and transponder code.</span></div>
   <div class="adiz-step"><span class="adiz-num">2</span><span class="adiz-text"><strong>Squawk assigned code</strong> — ATC assigns a discrete code for ADIZ tracking. Squawk it from departure.</span></div>
   <div class="adiz-step"><span class="adiz-num">3</span><span class="adiz-text"><strong>Maintain schedule</strong> — cross the ADIZ boundary within ±5 minutes of the filed ETA. Deviations beyond this may trigger an interception.</span></div>
-  <div class="adiz-step"><span class="adiz-num">4</span><span class="adiz-text"><strong>Report to ATC</strong> — position report at the ADIZ boundary if instructed, and maintain continuous monitoring of the assigned frequency.</span></div>
+  <div class="adiz-step"><span class="adiz-num">4</span><span class="adiz-text"><strong>Position report at the ADIZ boundary</strong> — required when crossing; report aircraft identification, position, and altitude on the assigned frequency (AIM RAC 9.1).</span></div>
   <div class="adiz-step"><span class="adiz-num">5</span><span class="adiz-text"><strong>Close flight plan</strong> on landing as required. Failure to close may trigger a search and rescue response.</span></div>
 </div>
 


### PR DESCRIPTION
## Summary

- Add `/* hardcoded */` comments to `#64a0ff` (MOA blue) and `#a080ff` (ADIZ purple) throughout the CSS, documenting that no token equivalent exists for these aviation domain colors
- Fix back-link button `color` from `var(--accent)` → hardcoded `#f0c040` per canonical snippet in `docs/visuals-standards.md`
- Fix ADIZ step 4: position report at the ADIZ boundary is **required** per AIM RAC 9.1 — removed inaccurate "if instructed" qualifier

## Acceptance criteria verified

- [x] Class F(R) vs F(A) correctly distinguished with entry requirements — was already correct
- [x] MOA described as advisory area; VFR pilots should contact controlling agency — was already correct
- [x] ADIZ requirements: DVFR flight plan + position reports — position report step corrected
- [x] `data-backlink="true"` button present — was already present; color fixed to canonical `#f0c040`
- [x] Hardcoded `#64a0ff` (MOA) and `#a080ff` (ADIZ) colors have explanatory comments
- [x] `npm run build` passes

## Test plan

- [ ] Open `al018-special-use-airspace.html` in browser; verify dark scheme renders correctly
- [ ] Verify back-link button is amber (#f0c040)
- [ ] Verify MOA card is blue, ADIZ card is purple
- [ ] Confirm `npm run build` exits 0

Closes #301

🤖 Generated with [Claude Code](https://claude.com/claude-code)