### PR TITLE
[PPL-331] fix: light mode text visibility in quiz components

### DIFF
--- a/web-app/src/components/QuizOption.tsx
+++ b/web-app/src/components/QuizOption.tsx
@@ -1,7 +1,7 @@
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
-import { alpha } from '@mui/material/styles';
-import { colorTokens, typographyTokens, radiusTokens } from '../tokens';
+import { alpha, useTheme } from '@mui/material/styles';
+import { typographyTokens, radiusTokens } from '../tokens';
 
 export type QuizOptionState = 'default' | 'selected' | 'correct' | 'wrong';
 
@@ -13,25 +13,27 @@ export interface QuizOptionProps {
   onClick?: () => void;
 }
 
-function accentColor(state: QuizOptionState): string {
-  switch (state) {
-    case 'correct': return colorTokens.success.main;
-    case 'wrong': return colorTokens.error.main;
-    case 'selected': return colorTokens.primary.main;
-    default: return colorTokens.divider;
-  }
-}
-
-function bgColor(state: QuizOptionState): string {
-  switch (state) {
-    case 'correct': return alpha(colorTokens.success.main, 0.1);
-    case 'wrong': return alpha(colorTokens.error.main, 0.1);
-    case 'selected': return alpha(colorTokens.primary.main, 0.08);
-    default: return colorTokens.background.paper;
-  }
-}
-
 export default function QuizOption({ optionKey, label, state, disabled, onClick }: QuizOptionProps) {
+  const theme = useTheme();
+
+  function accentColor(s: QuizOptionState): string {
+    switch (s) {
+      case 'correct': return theme.palette.success.main;
+      case 'wrong': return theme.palette.error.main;
+      case 'selected': return theme.palette.primary.main;
+      default: return theme.palette.divider;
+    }
+  }
+
+  function bgColor(s: QuizOptionState): string {
+    switch (s) {
+      case 'correct': return alpha(theme.palette.success.main, 0.1);
+      case 'wrong': return alpha(theme.palette.error.main, 0.1);
+      case 'selected': return alpha(theme.palette.primary.main, 0.08);
+      default: return theme.palette.background.paper;
+    }
+  }
+
   const accent = accentColor(state);
   const bg = bgColor(state);
   const isInteractive = !disabled && state === 'default' || state === 'selected';
@@ -58,7 +60,7 @@ export default function QuizOption({ optionKey, label, state, disabled, onClick 
         py: 1.25,
         gap: 1.5,
         backgroundColor: bg,
-        border: `1px solid ${colorTokens.divider}`,
+        border: `1px solid ${theme.palette.divider}`,
         borderLeft: `4px solid ${accent}`,
         borderRadius: `0 ${radiusTokens.sm}px ${radiusTokens.sm}px 0`,
         cursor: disabled ? 'default' : 'pointer',
@@ -69,7 +71,7 @@ export default function QuizOption({ optionKey, label, state, disabled, onClick 
           ? { transform: 'translateY(-1px)' }
           : {},
         '&:focus-visible': {
-          outline: `2px solid ${colorTokens.primary.main}`,
+          outline: `2px solid ${theme.palette.primary.main}`,
           outlineOffset: 2,
         },
       }}
@@ -80,7 +82,7 @@ export default function QuizOption({ optionKey, label, state, disabled, onClick 
           fontFamily: typographyTokens.fontFamily.mono,
           fontSize: '0.8125rem',
           fontWeight: 600,
-          color: accent === colorTokens.divider ? colorTokens.text.secondary : accent,
+          color: accent === theme.palette.divider ? theme.palette.text.secondary : accent,
           minWidth: 20,
           flexShrink: 0,
         }}
@@ -93,7 +95,7 @@ export default function QuizOption({ optionKey, label, state, disabled, onClick 
           fontFamily: typographyTokens.fontFamily.sans,
           fontSize: '1rem',
           lineHeight: 1.5,
-          color: colorTokens.text.primary,
+          color: theme.palette.text.primary,
         }}
       >
         {label}

--- a/web-app/src/pages/Exam.tsx
+++ b/web-app/src/pages/Exam.tsx
@@ -7,7 +7,7 @@ import CircularProgress from '@mui/material/CircularProgress';
 import Container from '@mui/material/Container';
 import Divider from '@mui/material/Divider';
 import Typography from '@mui/material/Typography';
-import { alpha } from '@mui/material/styles';
+import { alpha, useTheme } from '@mui/material/styles';
 import { getAllLessons } from '../lib/lesson-loader';
 import { useProgress } from '../lib/progress';
 import { useExamTrack } from '../context/ExamTrackContext';
@@ -18,7 +18,7 @@ import { TOPIC_LABELS, TOPICS } from '../lib/curriculum';
 import QuizRunner from '../components/QuizRunner';
 import QuizOption from '../components/QuizOption';
 import type { QuizOptionState } from '../components/QuizOption';
-import { colorTokens, typographyTokens, radiusTokens } from '../tokens';
+import { typographyTokens, radiusTokens } from '../tokens';
 
 type Phase = 'select' | 'quiz' | 'results';
 type TopicFilter = 'all' | typeof TOPICS[number];
@@ -40,6 +40,7 @@ function deriveOptionState(
 }
 
 export default function Exam() {
+  const theme = useTheme();
   const [searchParams] = useSearchParams();
   const { store: activeStore } = useExamTrack();
   const { progress, store } = useProgress(activeStore);
@@ -123,8 +124,8 @@ export default function Exam() {
           sx={{
             p: 2,
             borderRadius: `${radiusTokens.sm}px`,
-            border: `1px solid ${colorTokens.info.main}`,
-            backgroundColor: alpha(colorTokens.info.main, 0.1),
+            border: `1px solid ${theme.palette.info.main}`,
+            backgroundColor: alpha(theme.palette.info.main, 0.1),
           }}
         >
           <Typography variant="body1" color="info.main">
@@ -149,9 +150,9 @@ export default function Exam() {
           sx={{
             mb: 3,
             p: 2,
-            backgroundColor: colorTokens.background.surfaceRaised,
-            border: `1px solid ${colorTokens.divider}`,
-            borderLeft: `4px solid ${colorTokens.primary.main}`,
+            backgroundColor: theme.palette.background.surfaceRaised,
+            border: `1px solid ${theme.palette.divider}`,
+            borderLeft: `4px solid ${theme.palette.primary.main}`,
             borderRadius: `0 ${radiusTokens.sm}px ${radiusTokens.sm}px 0`,
           }}
         >
@@ -160,7 +161,7 @@ export default function Exam() {
             sx={{
               mb: 2,
               fontFamily: typographyTokens.fontFamily.sans,
-              color: colorTokens.text.primary,
+              color: theme.palette.text.primary,
             }}
           >
             Your current quiz progress will be lost. Switch to the new lesson?
@@ -228,16 +229,16 @@ export default function Exam() {
                   alignItems: 'center',
                   justifyContent: 'space-between',
                   backgroundColor: isSelected
-                    ? alpha(colorTokens.primary.main, 0.1)
-                    : colorTokens.background.paper,
-                  border: `1px solid ${colorTokens.divider}`,
-                  borderLeft: `4px solid ${isSelected ? colorTokens.primary.main : colorTokens.divider}`,
+                    ? alpha(theme.palette.primary.main, 0.1)
+                    : theme.palette.background.paper,
+                  border: `1px solid ${theme.palette.divider}`,
+                  borderLeft: `4px solid ${isSelected ? theme.palette.primary.main : theme.palette.divider}`,
                   borderRadius: `0 ${radiusTokens.sm}px ${radiusTokens.sm}px 0`,
                   cursor: 'pointer',
                   transition: 'transform 150ms ease-out',
                   '&:hover': { transform: 'translateY(-1px)' },
                   '&:focus-visible': {
-                    outline: `2px solid ${colorTokens.primary.main}`,
+                    outline: `2px solid ${theme.palette.primary.main}`,
                     outlineOffset: 2,
                   },
                 }}
@@ -377,9 +378,9 @@ export default function Exam() {
                         sx={{
                           p: 1.5,
                           mb: 1,
-                          border: `1px solid ${colorTokens.divider}`,
-                          borderLeft: `4px solid ${colorTokens.error.main}`,
-                          backgroundColor: alpha(colorTokens.error.main, 0.08),
+                          border: `1px solid ${theme.palette.divider}`,
+                          borderLeft: `4px solid ${theme.palette.error.main}`,
+                          backgroundColor: alpha(theme.palette.error.main, 0.08),
                           borderRadius: `0 ${radiusTokens.sm}px ${radiusTokens.sm}px 0`,
                         }}
                       >
@@ -391,7 +392,7 @@ export default function Exam() {
                         </Typography>
                         <Typography
                           variant="body2"
-                          sx={{ color: colorTokens.success.main }}
+                          sx={{ color: theme.palette.success.main }}
                         >
                           Correct: {pq.correctAnswer}. {q?.choices[pq.correctAnswer] ?? ''}
                         </Typography>

--- a/web-app/src/pages/FinalExam.tsx
+++ b/web-app/src/pages/FinalExam.tsx
@@ -18,10 +18,10 @@ import Radio from '@mui/material/Radio';
 import RadioGroup from '@mui/material/RadioGroup';
 import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
+import { useTheme } from '@mui/material/styles';
 
 import { buildExamPool, scoreExam, formatTime, POOL_CONFIGS } from '../lib/final-exam';
 import type { ExamQuestion, ExamResult } from '../lib/final-exam';
-import { colorTokens } from '../tokens';
 
 type Phase = 'config' | 'running' | 'results';
 type PoolType = 'full' | 'quick' | 'custom';
@@ -89,6 +89,7 @@ function poolLabel(type: PoolType): string {
 }
 
 export default function FinalExam() {
+  const theme = useTheme();
   const [searchParams] = useSearchParams();
   const seedParam = searchParams.get('seed');
   const seedValue = seedParam !== null ? Number(seedParam) : undefined;
@@ -280,7 +281,7 @@ export default function FinalExam() {
               border: '1px solid',
               borderColor: 'primary.main',
               borderRadius: 2,
-              bgcolor: colorTokens.primary.muted,
+              bgcolor: theme.palette.primaryMuted,
             }}
           >
             <Typography variant="overline" color="primary.main">
@@ -324,7 +325,7 @@ export default function FinalExam() {
                 borderColor: poolType === type ? 'primary.main' : 'divider',
                 borderRadius: 2,
                 cursor: 'pointer',
-                bgcolor: poolType === type ? colorTokens.primary.muted : 'transparent',
+                bgcolor: poolType === type ? theme.palette.primaryMuted : 'transparent',
                 '&:hover': { borderColor: 'primary.main' },
               }}
             >


### PR DESCRIPTION
## Summary

- Replace `colorTokens.*` flat-key references (which always resolve to dark-scheme values) with `theme.palette.*` via `useTheme()` in `QuizOption.tsx`, `Exam.tsx`, and `FinalExam.tsx`
- Fixes invisible text in Practice Quiz and Final Exam when the user switches to light mode
- `npm run build` passes with no TypeScript errors

Closes #331

## Files Changed

- `web-app/src/components/QuizOption.tsx` — moved accent/bg color logic inside component using `useTheme()`
- `web-app/src/pages/Exam.tsx` — 15 `colorTokens.*` references replaced with `theme.palette.*`
- `web-app/src/pages/FinalExam.tsx` — 2 `colorTokens.primary.muted` references replaced with `theme.palette.primaryMuted`

## Test plan

- [ ] Toggle to light mode — quiz option text, borders, and backgrounds should all be visible
- [ ] Toggle to dark mode — verify no regression in dark mode appearance
- [ ] Start a Practice Quiz in both modes and check selected/correct/wrong option states
- [ ] Open Final Exam config page in both modes — saved exam banner and pool selector backgrounds should use theme colours

🤖 Generated with [Claude Code](https://claude.com/claude-code)