### PR TITLE
[PPL-335] Remove ambiguous/redundant chips from lesson cards

### DIFF
--- a/web-app/src/pages/LessonsIndex.tsx
+++ b/web-app/src/pages/LessonsIndex.tsx
@@ -13,14 +13,7 @@ import { CURRICULUM, TOPIC_LABELS, TOPICS } from '../lib/curriculum';
 import { getAllLessons } from '../lib/lesson-loader';
 import { useProgress } from '../lib/progress';
 import { useExamTrack } from '../context/ExamTrackContext';
-import type { LessonStatus } from '../lib/types';
 import TopicMasteryCard from '../components/TopicMasteryCard';
-
-function statusChipProps(status: LessonStatus) {
-  if (status === 'complete') return { label: 'Complete', color: 'success' as const };
-  if (status === 'draft') return { label: 'Draft', color: 'warning' as const };
-  return { label: 'Planning', color: 'default' as const };
-}
 
 export default function LessonsIndex() {
   const { store } = useExamTrack();
@@ -70,7 +63,6 @@ export default function LessonsIndex() {
                       <CardContent sx={{ pb: '12px !important' }}>
                         <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 0.5 }}>
                           <Chip label={slot.id} size="small" variant="outlined" color="default" sx={{ fontFamily: 'monospace', fontWeight: 600 }} />
-                          <Chip label="Planning" size="small" color="default" />
                         </Box>
                         <Typography variant="body2" color="text.disabled">
                           {slot.title}
@@ -79,8 +71,6 @@ export default function LessonsIndex() {
                     </Card>
                   );
                 }
-
-                const chipProps = statusChipProps(lesson.status);
 
                 return (
                   <Card
@@ -112,13 +102,6 @@ export default function LessonsIndex() {
                             color="primary"
                             sx={{ fontFamily: 'monospace', fontWeight: 600 }}
                           />
-                          <Chip label={`${lesson.duration_min} min`} size="small" variant="outlined" color="info" />
-                          <Chip {...chipProps} size="small" />
-                          {lesson.audio ? (
-                            <Chip label="▶ Audio" size="small" color="warning" />
-                          ) : (
-                            <Chip label="Pending" size="small" color="default" />
-                          )}
                           {done && <Chip label="✓" size="small" color="success" />}
                         </Box>
                         <Typography variant="body2" sx={{ color: done ? 'text.secondary' : 'text.primary' }}>


### PR DESCRIPTION
## Summary
- Removed `Complete`/`Planning` authoring-status chips from lesson cards — the section header already shows progress (e.g. `0/18`) and these chips reflected ambiguous authoring state, not user progress
- Removed hardcoded `20 min` duration chip — no real duration source exists yet
- Removed `▶ Audio` / `Pending` chips — audio is the default state for all lessons, so it carries no information as a chip

Closes #335

## Test plan
- [ ] `npm run build` passes (verified locally — clean build)
- [ ] Lesson cards now show only the lesson ID chip and a `✓` chip when complete
- [ ] Planning-state (no lesson data) cards show only the slot ID chip

🤖 Generated with [Claude Code](https://claude.com/claude-code)