### PR TITLE
[PPL-345] Add playlist link to TopicMasteryCard

### DIFF
--- a/docs/design/DESIGN-SYSTEM.md
+++ b/docs/design/DESIGN-SYSTEM.md
@@ -210,6 +210,33 @@ Icon button, 100 px pill radius, 48 × 48 px, sun icon in light mode and moon in
 
 Pill button with accent-soft badge + track code + name + progress + chevron. Click opens menu with: active-track section, your-other-tracks section, locked/coming-soon tracks (50 % opacity), and "Add another track" placeholder. See `multi-track.html` for binding spec.
 
+### 5.10 Playlist link button (TopicMasteryCard)
+
+An optional inline `▶ Playlist` button rendered inside `TopicMasteryCard` when a `playlistUrl` prop is provided. It must be **entirely absent** (not disabled) when `playlistUrl` is falsy.
+
+- **Component:** MUI `Button` rendered as `<a>`, `size="small"`, `variant="outlined"`.
+- **Label:** `▶ Playlist` — monospace, uppercase, `0.6875rem`, letter-spacing `wide` (0.05em).
+- **Color:** `theme.palette.primary.main` for text and border; hover background uses `theme.palette.primaryMuted`.
+- **Radius:** `radiusTokens.xs` (3 px) — sharp, cockpit style.
+- **Link behavior:** `target="_blank"` + `rel="noopener noreferrer"` — always opens in a new tab.
+- **Token rule:** No hardcoded hex. All color references must go through `theme.palette.*` or `radiusTokens`.
+
+```tsx
+{playlistUrl && (
+  <Button
+    component="a"
+    href={playlistUrl}
+    target="_blank"
+    rel="noopener noreferrer"
+    size="small"
+    variant="outlined"
+    sx={{ /* see TopicMasteryCard.tsx for full sx */ }}
+  >
+    ▶ Playlist
+  </Button>
+)}
+```
+
 ### 5.9 Sticky player bar (StickyPlayerBar.tsx)
 
 Fixed-position audio player bar that persists across routes. Mounts at app root inside `BrowserRouter` so it survives navigation.

--- a/web-app/src/components/TopicMasteryCard.tsx
+++ b/web-app/src/components/TopicMasteryCard.tsx
@@ -1,4 +1,5 @@
 import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
 import LinearProgress from '@mui/material/LinearProgress';
 import Typography from '@mui/material/Typography';
 import { useTheme } from '@mui/material/styles';
@@ -9,6 +10,7 @@ interface Props {
   lessonCount: number;
   completedCount: number;
   masteryPercent: number;
+  playlistUrl?: string;
 }
 
 export default function TopicMasteryCard({
@@ -16,6 +18,7 @@ export default function TopicMasteryCard({
   lessonCount,
   completedCount,
   masteryPercent,
+  playlistUrl,
 }: Props) {
   const theme = useTheme();
 
@@ -37,20 +40,51 @@ export default function TopicMasteryCard({
         {topic}
       </Typography>
 
-      <Typography
-        component="div"
-        sx={{
-          fontFamily: typographyTokens.fontFamily.mono,
-          fontSize: '0.6875rem',
-          fontWeight: typographyTokens.weight.medium,
-          letterSpacing: typographyTokens.letterSpacing.wider,
-          textTransform: 'uppercase',
-          color: theme.palette.text.secondary,
-          mb: 1.5,
-        }}
-      >
-        {completedCount} / {lessonCount} LESSONS
-      </Typography>
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, mb: 1.5 }}>
+        <Typography
+          component="div"
+          sx={{
+            fontFamily: typographyTokens.fontFamily.mono,
+            fontSize: '0.6875rem',
+            fontWeight: typographyTokens.weight.medium,
+            letterSpacing: typographyTokens.letterSpacing.wider,
+            textTransform: 'uppercase',
+            color: theme.palette.text.secondary,
+          }}
+        >
+          {completedCount} / {lessonCount} LESSONS
+        </Typography>
+        {playlistUrl && (
+          <Button
+            component="a"
+            href={playlistUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            size="small"
+            variant="outlined"
+            sx={{
+              fontFamily: typographyTokens.fontFamily.mono,
+              fontSize: '0.6875rem',
+              fontWeight: typographyTokens.weight.medium,
+              letterSpacing: typographyTokens.letterSpacing.wide,
+              textTransform: 'uppercase',
+              color: theme.palette.primary.main,
+              borderColor: theme.palette.primary.main,
+              borderRadius: `${radiusTokens.xs}px`,
+              py: 0,
+              px: 1,
+              minWidth: 0,
+              lineHeight: 1.8,
+              '&:hover': {
+                borderColor: theme.palette.primary.main,
+                backgroundColor: theme.palette.primaryMuted,
+              },
+            }}
+          >
+            ▶ Playlist
+          </Button>
+        )}
+      </Box>
 
       <LinearProgress
         variant="determinate"

--- a/web-app/src/data/playlists.ts
+++ b/web-app/src/data/playlists.ts
@@ -1,0 +1,5 @@
+import type { Topic } from '../lib/types';
+
+export const TOPIC_PLAYLISTS: Partial<Record<Topic, string>> = {
+  'air-law': 'https://www.youtube.com/playlist?list=PLy0E7WT5XKMR4FKpD5M2xmTdKq_q5jCzv',
+};

--- a/web-app/src/pages/LessonsIndex.tsx
+++ b/web-app/src/pages/LessonsIndex.tsx
@@ -10,6 +10,7 @@ import Divider from '@mui/material/Divider';
 import Typography from '@mui/material/Typography';
 
 import { CURRICULUM, TOPIC_LABELS, TOPICS } from '../lib/curriculum';
+import { TOPIC_PLAYLISTS } from '../data/playlists';
 import { getAllLessons } from '../lib/lesson-loader';
 import { useProgress } from '../lib/progress';
 import { useExamTrack } from '../context/ExamTrackContext';
@@ -50,6 +51,7 @@ export default function LessonsIndex() {
               lessonCount={slots.length}
               completedCount={0}
               masteryPercent={0}
+              playlistUrl={TOPIC_PLAYLISTS[topic]}
             />
             <Divider sx={{ mb: 2 }} />
 


### PR DESCRIPTION
## Summary

- Add `web-app/src/data/playlists.ts` exporting `TOPIC_PLAYLISTS: Partial<Record<Topic, string>>` with a real air-law playlist URL
- Add optional `playlistUrl?: string` prop to `TopicMasteryCard`; renders a `▶ Playlist` MUI Button (as `<a>`) only when the URL is a non-empty string — entirely absent when falsy
- Import `TOPIC_PLAYLISTS` in `LessonsIndex.tsx` and pass `playlistUrl={TOPIC_PLAYLISTS[topic]}` to each `TopicMasteryCard`
- Document the playlist button pattern in `docs/design/DESIGN-SYSTEM.md` §5.10

## Design compliance

Adheres to `docs/design/DESIGN-SYSTEM.md`:
- No hardcoded hex — colors via `theme.palette.primary.main` and `theme.palette.primaryMuted`
- Radius via `radiusTokens.xs` (3 px)
- Button hidden entirely (not disabled) when `playlistUrl` is absent
- `target="_blank"` + `rel="noopener noreferrer"` on external link
- Typography via `typographyTokens.fontFamily.mono` and `typographyTokens.letterSpacing.wide`

## Test plan

- [ ] `npx tsc --noEmit` passes with no errors
- [ ] Lessons page shows `▶ Playlist` button on Air Law section only
- [ ] Clicking button opens playlist in a new tab
- [ ] Other topics show no button (playlistUrl is undefined)
- [ ] Both dark and light modes render correctly

Closes #345

🤖 Generated with [Claude Code](https://claude.com/claude-code)