### PR TITLE
[PPL-353] rebuild NAV visuals

### DIFF
--- a/web-app/public/visuals/nav003-true-magnetic-compass.html
+++ b/web-app/public/visuals/nav003-true-magnetic-compass.html
@@ -28,59 +28,151 @@ body { max-width: 860px; margin: auto; }
 <h1>NAV-003 — True vs Magnetic vs Compass Heading</h1>
 <p class="subtitle">Transport Canada · TP 12880E Ch.9 · AIM GEN 1.1 · PPL Written Exam</p>
 
-<div class="section-label">The Three North References and TVMDC Chain</div>
+<div class="section-label">Heading Indicator — Three North References (angles exaggerated for clarity)</div>
 <div class="diagram-wrap">
-  <svg width="720" height="320" viewBox="0 0 720 320" style="max-width:100%;">
-    <rect x="30" y="20" width="280" height="280" fill="#0d2040" rx="6"/>
-    <!-- True North arrow (straight up) -->
-    <line x1="170" y1="270" x2="170" y2="60" stroke="#3a7ad5" stroke-width="2.5" stroke-linecap="round"/>
-    <polygon points="170,55 164,72 176,72" fill="#3a7ad5"/>
-    <text x="170" y="47" fill="#3a7ad5" font-size="11" font-weight="700" text-anchor="middle" font-family="'Segoe UI',system-ui,sans-serif">TRUE NORTH</text>
-    <!-- Magnetic North — 10°W variation, offset left -->
-    <line x1="170" y1="270" x2="132" y2="62" stroke="#f0c040" stroke-width="2.5" stroke-linecap="round"/>
-    <polygon points="130,56 122,74 137,72" fill="#f0c040"/>
-    <text x="98" y="47" fill="#f0c040" font-size="11" font-weight="700" text-anchor="middle" font-family="'Segoe UI',system-ui,sans-serif">MAG NORTH</text>
-    <!-- Compass North — 4°W deviation, further left -->
-    <line x1="170" y1="270" x2="116" y2="64" stroke="#80c880" stroke-width="2" stroke-dasharray="6 3" stroke-linecap="round"/>
-    <polygon points="114,58 107,76 122,74" fill="#80c880"/>
-    <text x="56" y="47" fill="#80c880" font-size="10" font-weight="700" text-anchor="middle" font-family="'Segoe UI',system-ui,sans-serif">COMPASS N</text>
-    <!-- VAR arc -->
-    <path d="M 170 195 A 55 55 0 0 0 143 153" fill="none" stroke="#f0c040" stroke-width="1" stroke-dasharray="3 2"/>
-    <text x="210" y="178" fill="#f0c040" font-size="10" font-weight="600" font-family="'Segoe UI',system-ui,sans-serif">VAR 10°W</text>
-    <!-- DEV arc -->
-    <path d="M 143 158 A 18 18 0 0 0 128 145" fill="none" stroke="#80c880" stroke-width="1" stroke-dasharray="3 2"/>
-    <text x="45" y="168" fill="#80c880" font-size="10" font-weight="600" font-family="'Segoe UI',system-ui,sans-serif">DEV 4°W</text>
-    <!-- Aircraft -->
-    <polygon points="170,270 163,295 170,288 177,295" fill="#c8d8e8" opacity="0.7"/>
-    <text x="170" y="311" fill="#7a9ab5" font-size="10" text-anchor="middle" font-family="'Segoe UI',system-ui,sans-serif">Aircraft (Ontario)</text>
+  <svg width="740" height="340" viewBox="0 0 740 340" style="max-width:100%;">
 
-    <!-- Right panel: conversion chain -->
-    <rect x="340" y="20" width="340" height="280" rx="6" fill="#0a1a35" stroke="#1a3a5a" stroke-width="1.5"/>
-    <text x="510" y="46" fill="#7a9ab5" font-size="11" font-weight="700" text-anchor="middle" font-family="'Segoe UI',system-ui,sans-serif" letter-spacing="1">T V M D C — CONVERSION CHAIN</text>
+    <!-- ── LEFT PANEL: Compass Rose / Heading Indicator ──────────────── -->
+    <rect x="10" y="10" width="310" height="320" fill="#0d2040" rx="6"/>
+    <text x="165" y="35" text-anchor="middle" fill="#7a9ab5" font-size="10" font-weight="700" font-family="'Segoe UI',system-ui,sans-serif">HEADING INDICATOR (DI)</text>
+    <text x="165" y="48" text-anchor="middle" fill="#5a7a9a" font-size="9" font-family="'Segoe UI',system-ui,sans-serif">angles exaggerated — real VAR/DEV are smaller</text>
+
+    <!-- Compass rose outer bezel -->
+    <circle cx="165" cy="195" r="128" fill="#071830" stroke="#3a5a7a" stroke-width="3"/>
+    <circle cx="165" cy="195" r="122" fill="#0a1a35" stroke="#1a3a5a" stroke-width="1"/>
+
+    <!-- Major tick marks every 30° (length 10) and minor every 10° (length 5) -->
+    <!-- 0° (N) -->
+    <line x1="165" y1="67" x2="165" y2="77" stroke="#c8d8e8" stroke-width="2"/>
+    <!-- 10° -->
+    <line x1="187" y1="69" x2="184" y2="74" stroke="#7a9ab5" stroke-width="1.2"/>
+    <!-- 20° -->
+    <line x1="208" y1="75" x2="203" y2="79" stroke="#7a9ab5" stroke-width="1.2"/>
+    <!-- 30° (NE) -->
+    <line x1="229" y1="84" x2="224" y2="93" stroke="#c8d8e8" stroke-width="1.5"/>
+    <!-- 40° -->
+    <line x1="247" y1="97" x2="242" y2="103" stroke="#7a9ab5" stroke-width="1.2"/>
+    <!-- 50° -->
+    <line x1="262" y1="113" x2="256" y2="117" stroke="#7a9ab5" stroke-width="1.2"/>
+    <!-- 60° (E-NE) -->
+    <line x1="275" y1="133" x2="268" y2="137" stroke="#c8d8e8" stroke-width="1.5"/>
+    <!-- 90° (E) -->
+    <line x1="293" y1="195" x2="283" y2="195" stroke="#c8d8e8" stroke-width="2"/>
+    <!-- 120° -->
+    <line x1="276" y1="257" x2="269" y2="253" stroke="#c8d8e8" stroke-width="1.5"/>
+    <!-- 150° -->
+    <line x1="229" y1="306" x2="224" y2="297" stroke="#c8d8e8" stroke-width="1.5"/>
+    <!-- 180° (S) -->
+    <line x1="165" y1="323" x2="165" y2="313" stroke="#c8d8e8" stroke-width="2"/>
+    <!-- 210° -->
+    <line x1="101" y1="306" x2="106" y2="297" stroke="#c8d8e8" stroke-width="1.5"/>
+    <!-- 240° -->
+    <line x1="54" y1="257" x2="61" y2="253" stroke="#c8d8e8" stroke-width="1.5"/>
+    <!-- 270° (W) -->
+    <line x1="37" y1="195" x2="47" y2="195" stroke="#c8d8e8" stroke-width="2"/>
+    <!-- 300° -->
+    <line x1="55" y1="133" x2="62" y2="137" stroke="#c8d8e8" stroke-width="1.5"/>
+    <!-- 330° -->
+    <line x1="101" y1="84" x2="106" y2="93" stroke="#c8d8e8" stroke-width="1.5"/>
+
+    <!-- Cardinal direction labels -->
+    <text x="165" y="62" text-anchor="middle" fill="#c8d8e8" font-size="13" font-weight="800" font-family="'Segoe UI',system-ui,sans-serif">N</text>
+    <text x="297" y="199" text-anchor="start" fill="#c8d8e8" font-size="13" font-weight="800" font-family="'Segoe UI',system-ui,sans-serif">E</text>
+    <text x="165" y="331" text-anchor="middle" fill="#c8d8e8" font-size="13" font-weight="800" font-family="'Segoe UI',system-ui,sans-serif">S</text>
+    <text x="33" y="199" text-anchor="end" fill="#c8d8e8" font-size="13" font-weight="800" font-family="'Segoe UI',system-ui,sans-serif">W</text>
+
+    <!-- ── Three heading needles, all starting from TH=360°/000° ────── -->
+    <!--
+      Example (Ontario flight): TH = 000°, VAR = 20°W, DEV = 8°W
+      → MH = TH + VAR(W) = 000° + 20° = 020°
+      → CH = MH + DEV(W) = 020° + 8° = 028°
+      Values exaggerated so needle separation is visually clear.
+      Real Canadian values: VAR 10–19°W, DEV typically 2–5°.
+    -->
+
+    <!-- True Heading (TH 000°) — Blue: straight up to North -->
+    <!-- endpoint: (165, 195 - 118) = (165, 77) -->
+    <line x1="165" y1="195" x2="165" y2="77" stroke="#3a7ad5" stroke-width="3.5" stroke-linecap="round"/>
+    <polygon points="165,72 158,88 172,88" fill="#3a7ad5"/>
+
+    <!-- Magnetic Heading (MH 020°) — Yellow: offset 20° clockwise from TH -->
+    <!-- endpoint: (165 + 118*sin20°, 195 - 118*cos20°) = (165+40.4, 195-110.9) = (205.4, 84.1) -->
+    <line x1="165" y1="195" x2="205" y2="84" stroke="#f0c040" stroke-width="3" stroke-linecap="round"/>
+    <polygon points="205,79 196,92 213,90" fill="#f0c040"/>
+
+    <!-- Compass Heading (CH 028°) — Green dashed: further 8° clockwise from MH -->
+    <!-- endpoint: (165 + 118*sin28°, 195 - 118*cos28°) = (165+55.4, 195-104.2) = (220.4, 90.8) -->
+    <line x1="165" y1="195" x2="220" y2="91" stroke="#80c880" stroke-width="2.5" stroke-dasharray="7 3" stroke-linecap="round"/>
+    <polygon points="220,86 211,98 228,97" fill="#80c880"/>
+
+    <!-- ── Variation arc (r=72) from TH 000° to MH 020° ─────────────── -->
+    <!-- Start: (165, 195-72) = (165, 123) -->
+    <!-- End: (165+72*sin20°, 195-72*cos20°) = (165+24.6, 195-67.6) = (189.6, 127.4) -->
+    <path d="M 165 123 A 72 72 0 0 1 189.6 127.4"
+          fill="none" stroke="#f0c040" stroke-width="1.8" stroke-dasharray="4 3"/>
+    <!-- VAR label near midpoint of arc (at bearing 10°, r=82) -->
+    <!-- (165+82*sin10°, 195-82*cos10°) = (165+14.2, 195-80.7) = (179.2, 114.3) -->
+    <text x="190" y="112" fill="#f0c040" font-size="10" font-weight="700" font-family="'Segoe UI',system-ui,sans-serif">VAR 20°W</text>
+
+    <!-- ── Deviation arc (r=93) from MH 020° to CH 028° ─────────────── -->
+    <!-- Start: (165+93*sin20°, 195-93*cos20°) = (165+31.8, 195-87.4) = (196.8, 107.6) -->
+    <!-- End: (165+93*sin28°, 195-93*cos28°) = (165+43.7, 195-82.1) = (208.7, 112.9) -->
+    <path d="M 196.8 107.6 A 93 93 0 0 1 208.7 112.9"
+          fill="none" stroke="#80c880" stroke-width="1.8" stroke-dasharray="4 3"/>
+    <!-- DEV label near midpoint of arc (at bearing 24°, r=105) -->
+    <!-- (165+105*sin24°, 195-105*cos24°) = (165+42.7, 195-95.9) = (207.7, 99.1) -->
+    <text x="214" y="100" fill="#80c880" font-size="10" font-weight="700" font-family="'Segoe UI',system-ui,sans-serif">DEV 8°W</text>
+
+    <!-- Centre dot (aircraft position) -->
+    <circle cx="165" cy="195" r="6" fill="#1a3a5a" stroke="#3a7ad5" stroke-width="2"/>
+    <circle cx="165" cy="195" r="2" fill="#c8d8e8"/>
+
+    <!-- Needle legend (bottom of left panel) -->
+    <line x1="28" y1="300" x2="55" y2="300" stroke="#3a7ad5" stroke-width="2.5"/>
+    <text x="60" y="304" font-size="9" fill="#3a7ad5" font-family="'Segoe UI',system-ui,sans-serif">TH (True)</text>
+    <line x1="28" y1="314" x2="55" y2="314" stroke="#f0c040" stroke-width="2.5"/>
+    <text x="60" y="318" font-size="9" fill="#f0c040" font-family="'Segoe UI',system-ui,sans-serif">MH (Magnetic)</text>
+    <line x1="165" y1="300" x2="192" y2="300" stroke="#80c880" stroke-width="2" stroke-dasharray="6 3"/>
+    <text x="197" y="304" font-size="9" fill="#80c880" font-family="'Segoe UI',system-ui,sans-serif">CH (Compass)</text>
+
+    <!-- ── RIGHT PANEL: TVMDC Conversion Chain ────────────────────────── -->
+    <rect x="340" y="10" width="390" height="320" rx="6" fill="#0a1a35" stroke="#1a3a5a" stroke-width="1.5"/>
+    <text x="535" y="36" fill="#7a9ab5" font-size="11" font-weight="700" text-anchor="middle" font-family="'Segoe UI',system-ui,sans-serif" letter-spacing="1">T V M D C — CONVERSION CHAIN</text>
+
     <!-- TRUE box -->
-    <rect x="365" y="56" width="290" height="34" rx="6" fill="#3a7ad5" opacity="0.2"/>
-    <rect x="365" y="56" width="290" height="34" rx="6" fill="none" stroke="#3a7ad5" stroke-width="1.5"/>
-    <text x="510" y="71" fill="#3a7ad5" font-size="13" font-weight="800" text-anchor="middle" font-family="'Segoe UI',system-ui,sans-serif">T — TRUE HEADING (TH)</text>
-    <text x="510" y="84" fill="#7a9ab5" font-size="10" text-anchor="middle" font-family="'Segoe UI',system-ui,sans-serif">from VNC chart (geographic north)</text>
+    <rect x="365" y="46" width="340" height="38" rx="6" fill="#3a7ad5" opacity="0.18"/>
+    <rect x="365" y="46" width="340" height="38" rx="6" fill="none" stroke="#3a7ad5" stroke-width="1.5"/>
+    <text x="535" y="62" fill="#3a7ad5" font-size="13" font-weight="800" text-anchor="middle" font-family="'Segoe UI',system-ui,sans-serif">T — TRUE HEADING (TH)</text>
+    <text x="535" y="78" fill="#7a9ab5" font-size="10" text-anchor="middle" font-family="'Segoe UI',system-ui,sans-serif">from VNC chart (geographic north)</text>
+
     <!-- VAR step -->
-    <text x="510" y="113" fill="#f0c040" font-size="12" font-weight="700" text-anchor="middle" font-family="'Segoe UI',system-ui,sans-serif">V — ± Variation</text>
-    <text x="510" y="127" fill="#7a9ab5" font-size="10" text-anchor="middle" font-family="'Segoe UI',system-ui,sans-serif">West (+) add   East (−) subtract</text>
-    <line x1="510" y1="131" x2="510" y2="141" stroke="#f0c040" stroke-width="1.5" stroke-dasharray="3 2"/>
-    <polygon points="510,144 505,136 515,136" fill="#f0c040"/>
+    <text x="535" y="107" fill="#f0c040" font-size="12" font-weight="700" text-anchor="middle" font-family="'Segoe UI',system-ui,sans-serif">V — ± Variation</text>
+    <text x="535" y="121" fill="#7a9ab5" font-size="10" text-anchor="middle" font-family="'Segoe UI',system-ui,sans-serif">West (+) add · East (−) subtract</text>
+    <line x1="535" y1="125" x2="535" y2="137" stroke="#f0c040" stroke-width="1.5" stroke-dasharray="3 2"/>
+    <polygon points="535,141 529,131 541,131" fill="#f0c040"/>
+
     <!-- MAGNETIC box -->
-    <rect x="365" y="143" width="290" height="34" rx="6" fill="#f0c040" opacity="0.12"/>
-    <rect x="365" y="143" width="290" height="34" rx="6" fill="none" stroke="#f0c040" stroke-width="1.5"/>
-    <text x="510" y="158" fill="#f0c040" font-size="13" font-weight="800" text-anchor="middle" font-family="'Segoe UI',system-ui,sans-serif">M — MAGNETIC HEADING (MH)</text>
-    <text x="510" y="171" fill="#7a9ab5" font-size="10" text-anchor="middle" font-family="'Segoe UI',system-ui,sans-serif">set on Heading Indicator (DI)</text>
+    <rect x="365" y="141" width="340" height="38" rx="6" fill="#f0c040" opacity="0.12"/>
+    <rect x="365" y="141" width="340" height="38" rx="6" fill="none" stroke="#f0c040" stroke-width="1.5"/>
+    <text x="535" y="157" fill="#f0c040" font-size="13" font-weight="800" text-anchor="middle" font-family="'Segoe UI',system-ui,sans-serif">M — MAGNETIC HEADING (MH)</text>
+    <text x="535" y="172" fill="#7a9ab5" font-size="10" text-anchor="middle" font-family="'Segoe UI',system-ui,sans-serif">set on Heading Indicator (DI)</text>
+
     <!-- DEV step -->
-    <text x="510" y="200" fill="#80c880" font-size="12" font-weight="700" text-anchor="middle" font-family="'Segoe UI',system-ui,sans-serif">D — ± Deviation</text>
-    <text x="510" y="214" fill="#7a9ab5" font-size="10" text-anchor="middle" font-family="'Segoe UI',system-ui,sans-serif">compass correction card</text>
-    <line x1="510" y1="218" x2="510" y2="228" stroke="#80c880" stroke-width="1.5" stroke-dasharray="3 2"/>
-    <polygon points="510,231 505,223 515,223" fill="#80c880"/>
+    <text x="535" y="201" fill="#80c880" font-size="12" font-weight="700" text-anchor="middle" font-family="'Segoe UI',system-ui,sans-serif">D — ± Deviation</text>
+    <text x="535" y="215" fill="#7a9ab5" font-size="10" text-anchor="middle" font-family="'Segoe UI',system-ui,sans-serif">compass correction card · unique per aircraft</text>
+    <line x1="535" y1="219" x2="535" y2="230" stroke="#80c880" stroke-width="1.5" stroke-dasharray="3 2"/>
+    <polygon points="535,234 529,224 541,224" fill="#80c880"/>
+
     <!-- COMPASS box -->
-    <rect x="365" y="230" width="290" height="28" rx="6" fill="#80c880" opacity="0.12"/>
-    <rect x="365" y="230" width="290" height="28" rx="6" fill="none" stroke="#80c880" stroke-width="1.5"/>
-    <text x="510" y="248" fill="#80c880" font-size="13" font-weight="800" text-anchor="middle" font-family="'Segoe UI',system-ui,sans-serif">C — COMPASS HEADING (CH)</text>
+    <rect x="365" y="234" width="340" height="34" rx="6" fill="#80c880" opacity="0.12"/>
+    <rect x="365" y="234" width="340" height="34" rx="6" fill="none" stroke="#80c880" stroke-width="1.5"/>
+    <text x="535" y="254" fill="#80c880" font-size="13" font-weight="800" text-anchor="middle" font-family="'Segoe UI',system-ui,sans-serif">C — COMPASS HEADING (CH)</text>
+
+    <!-- Formula summary at bottom -->
+    <rect x="365" y="278" width="340" height="40" rx="4" fill="#0d2040"/>
+    <text x="535" y="294" fill="#7a9ab5" font-size="10" text-anchor="middle" font-family="'Segoe UI',system-ui,sans-serif">MH = TH ± VAR · CH = MH ± DEV</text>
+    <text x="535" y="309" fill="#5a7a9a" font-size="9" text-anchor="middle" font-family="'Segoe UI',system-ui,sans-serif">EAST = LEAST (subtract) · WEST = BEST (add)</text>
+
   </svg>
 </div>
 

--- a/web-app/public/visuals/nav005-wind-correction-angle.html
+++ b/web-app/public/visuals/nav005-wind-correction-angle.html
@@ -31,93 +31,129 @@ body { max-width: 860px; margin: auto; }
 <p class="subtitle">Transport Canada · TP 12880E Ch.9 · PPL Written Exam</p>
 
 <!-- ── WIND TRIANGLE DIAGRAM ─────────────────────────────────────────── -->
-<div class="section-label">Wind Triangle — TT 090°, Wind from 180° (30 kt), TAS 120 kt</div>
+<div class="section-label">Wind Triangle — TT 090°, Wind from 180° (30 kt), TAS 120 kt · Scale: 5 px / kt</div>
 <div class="grid-wrap">
-  <svg width="780" height="310" viewBox="0 0 780 310" style="max-width:100%;">
+  <!--
+    VECTOR DIAGRAM: GS = TAS + Wind  (all vectors at 5 px/kt scale)
+
+    Points:
+      A = (60, 230)   — departure
+      W = (60,  80)   — wind tip: A moved 150 px north (30 kt × 5 = 150 px, wind blows northward)
+      B = (641, 230)  — GS destination: A moved 581 px east (116.2 kt × 5 ≈ 581 px)
+
+    Vectors (head-to-tail → closed triangle):
+      Wind:  A → W  (cyan dashed, 30 kt northward, from 180°)
+      TAS:   W → B  (orange solid, 120 kt, heading ≈ 104°)  ← closes the triangle
+      GS:    A → B  (blue solid, 116 kt east, True Track 090°)
+
+    Verify TAS: |W→B| = |(641-60, 230-80)| = |(581,150)| = √(337561+22500) = √360061 ≈ 600 px = 120 kt ✓
+    WCA = arctan(150/581) ≈ 14.5° (TH = TT + WCA = 090° + 14° ≈ 104°) ✓
+  -->
+  <svg width="780" height="290" viewBox="0 0 780 290" style="max-width:100%;">
 
     <!-- Background -->
-    <rect x="10" y="10" width="760" height="290" fill="#0d2040" rx="6"/>
+    <rect x="10" y="10" width="760" height="270" fill="#0d2040" rx="6"/>
 
-    <!-- Grid -->
-    <line x1="10"  y1="155" x2="770" y2="155" stroke="#1a3a5a" stroke-width="0.8" stroke-dasharray="4 4"/>
-    <line x1="390" y1="10"  x2="390" y2="300" stroke="#1a3a5a" stroke-width="0.8" stroke-dasharray="4 4"/>
-    <line x1="10"  y1="90"  x2="770" y2="90"  stroke="#1a3a5a" stroke-width="0.6" stroke-dasharray="3 5"/>
-    <line x1="10"  y1="220" x2="770" y2="220" stroke="#1a3a5a" stroke-width="0.6" stroke-dasharray="3 5"/>
+    <!-- Grid lines (background) -->
+    <line x1="10"  y1="155" x2="770" y2="155" stroke="#1a3a5a" stroke-width="0.8" stroke-dasharray="4 5"/>
+    <line x1="60"  y1="10"  x2="60"  y2="280" stroke="#1a3a5a" stroke-width="0.8" stroke-dasharray="4 5"/>
+    <line x1="60"  y1="80"  x2="770" y2="80"  stroke="#1a3a5a" stroke-width="0.6" stroke-dasharray="3 5"/>
+    <line x1="641" y1="10"  x2="641" y2="280" stroke="#1a3a5a" stroke-width="0.6" stroke-dasharray="3 5"/>
 
-    <!-- True Track line (A to B, horizontal) -->
-    <line x1="80" y1="190" x2="690" y2="190" stroke="#3a7ad5" stroke-width="2" stroke-dasharray="6 4"/>
-    <!-- Track arrowhead -->
-    <polygon points="690,185 705,190 690,195" fill="#3a7ad5"/>
-    <text x="385" y="210" text-anchor="middle" font-size="11" fill="#3a7ad5">True Track 090° — Ground Track</text>
+    <!-- ── GS vector: A → B (True Track 090°, 116 kt east) ─────────── -->
+    <!-- A = (60,230), B = (641,230) -->
+    <line x1="60" y1="230" x2="641" y2="230" stroke="#3a7ad5" stroke-width="2.5" stroke-linecap="round"/>
+    <polygon points="641,225 657,230 641,235" fill="#3a7ad5"/>
+    <text x="348" y="248" text-anchor="middle" font-size="11" fill="#3a7ad5" font-weight="600" font-family="'Segoe UI',system-ui,sans-serif">GS ≈ 116 kt — True Track 090°</text>
 
-    <!-- Departure A -->
-    <circle cx="80" cy="190" r="7" fill="#f0c040" stroke="#0d2040" stroke-width="2"/>
-    <text x="80" y="218" text-anchor="middle" font-size="13" fill="#f0c040" font-weight="700">A</text>
+    <!-- ── Wind vector: A → W (wind from 180°, blows northward, 30 kt) -->
+    <!-- A = (60,230), W = (60,80) -->
+    <line x1="60" y1="230" x2="60" y2="80" stroke="#40c8c8" stroke-width="2.2" stroke-dasharray="7 4" stroke-linecap="round"/>
+    <polygon points="55,80 65,80 60,64" fill="#40c8c8"/>
+    <text x="18" y="162" text-anchor="middle" font-size="10" fill="#40c8c8" font-weight="600" font-family="'Segoe UI',system-ui,sans-serif" transform="rotate(-90,18,162)">Wind 180°/30 kt</text>
 
-    <!-- Destination B -->
-    <circle cx="705" cy="190" r="7" fill="#c04040" stroke="#ff8080" stroke-width="2"/>
-    <text x="705" y="218" text-anchor="middle" font-size="13" fill="#ff8080" font-weight="700">B</text>
+    <!-- ── TAS vector: W → B (closes the triangle, 120 kt, TH ≈ 104°) -->
+    <!-- W = (60,80), B = (641,230) -->
+    <line x1="60" y1="80" x2="641" y2="230" stroke="#f08040" stroke-width="2.5" stroke-linecap="round"/>
+    <polygon points="641,225 657,230 641,235" fill="#f08040" opacity="0"/>
+    <!-- arrowhead at B for TAS (offset slightly so both arrows are visible) -->
+    <polygon points="634,222 650,228 636,236" fill="#f08040"/>
+    <text x="356" y="148" text-anchor="middle" font-size="11" fill="#f08040" font-weight="600" font-family="'Segoe UI',system-ui,sans-serif">TAS 120 kt — TH ≈ 104°</text>
 
-    <!-- Wind vector: from 180° (south, from the right side when heading east) — dashed, cyan -->
-    <!-- Wind from 180° blows northward, pushing the aircraft north of the desired track -->
-    <!-- Wind arrow: starts at A, goes 30kt worth of vector — pushes aircraft northward -->
-    <line x1="80" y1="190" x2="225" y2="130" stroke="#40c8c8" stroke-width="2" stroke-dasharray="5 3"/>
-    <polygon points="225,125 218,140 232,138" fill="#40c8c8"/>
-    <text x="120" y="145" text-anchor="middle" font-size="10" fill="#40c8c8">Wind 180°/30 kt</text>
+    <!-- ── WCA arc at A, from track direction (east) to TAS direction ── -->
+    <!--
+      TAS direction from A: (B - W) = (581, 150) → unit vector (0.968, 0.250)
+      Arc at r=55: from (60+55, 230) = (115, 230) eastward
+                   to (60+55*0.968, 230+55*0.250) = (113.2, 243.8)
+      Sweep clockwise (sweep=1) from east to TAS direction.
+    -->
+    <path d="M 115 230 A 55 55 0 0 1 113.2 243.8"
+          fill="none" stroke="#f0c040" stroke-width="1.8"/>
+    <text x="130" y="252" font-size="10" fill="#f0c040" font-weight="700" font-family="'Segoe UI',system-ui,sans-serif">WCA ≈ 14°</text>
 
-    <!-- TAS vector: from A angled slightly north to reach the ground track line at destination -->
-    <!-- Aircraft heading is TT + WCA (to the right/south to compensate for northward wind push) -->
-    <!-- TAS arrow from A to destination, angled slightly south of track -->
-    <line x1="80" y1="190" x2="690" y2="190" stroke="#0d2040" stroke-width="0"/>
-    <!-- TH arrow (actual heading, angled slightly south) -->
-    <line x1="80" y1="190" x2="660" y2="215" stroke="#f08040" stroke-width="2.5"/>
-    <polygon points="660,210 672,218 658,224" fill="#f08040"/>
-    <text x="370" y="242" text-anchor="middle" font-size="11" fill="#f08040" font-weight="600">True Heading (TH) — aircraft nose points here</text>
+    <!-- ── Vertex labels ─────────────────────────────────────────────── -->
+    <!-- A (departure) -->
+    <circle cx="60" cy="230" r="7" fill="#f0c040" stroke="#0d2040" stroke-width="1.5"/>
+    <text x="60" y="262" text-anchor="middle" font-size="12" fill="#f0c040" font-weight="800" font-family="'Segoe UI',system-ui,sans-serif">A</text>
+    <text x="60" y="274" text-anchor="middle" font-size="9" fill="#7a9ab5" font-family="'Segoe UI',system-ui,sans-serif">departure</text>
 
-    <!-- GS vector along track from A to B; GS = √(TAS²−crosswind²) = √(120²−30²) ≈ 116 kt -->
-    <text x="395" y="175" text-anchor="middle" font-size="11" fill="#80c880" font-weight="600">GS ≈ 116 kt →</text>
+    <!-- W (wind tip) -->
+    <circle cx="60" cy="80" r="6" fill="#40c8c8" stroke="#0d2040" stroke-width="1.5"/>
+    <text x="76" y="77" font-size="11" fill="#40c8c8" font-weight="700" font-family="'Segoe UI',system-ui,sans-serif">W — wind tip</text>
+    <text x="76" y="90" font-size="9" fill="#5a9a9a" font-family="'Segoe UI',system-ui,sans-serif">30 kt × 5 = 150 px ↑</text>
 
-    <!-- WCA arc at departure -->
-    <path d="M 140 190 A 60 60 0 0 0 127 156" fill="none" stroke="#f0c040" stroke-width="1.5"/>
-    <text x="162" y="168" font-size="10" fill="#f0c040" font-weight="700">WCA ≈ 14°</text>
+    <!-- B (GS destination / TAS tip — same point) -->
+    <circle cx="641" cy="230" r="7" fill="#c04040" stroke="#ff8080" stroke-width="1.5"/>
+    <text x="655" y="226" font-size="12" fill="#ff8080" font-weight="800" font-family="'Segoe UI',system-ui,sans-serif">B</text>
+    <text x="655" y="238" font-size="9" fill="#7a9ab5" font-family="'Segoe UI',system-ui,sans-serif">destination</text>
 
-    <!-- North arrow (top right) -->
-    <line x1="720" y1="70" x2="720" y2="35" stroke="#c8d8e8" stroke-width="1.5"/>
-    <polygon points="720,30 715,45 725,45" fill="#c8d8e8"/>
-    <text x="720" y="85" text-anchor="middle" font-size="11" fill="#c8d8e8" font-weight="700">N</text>
+    <!-- ── Scale bar ─────────────────────────────────────────────────── -->
+    <line x1="500" y1="270" x2="750" y2="270" stroke="#7a9ab5" stroke-width="1.5"/>
+    <line x1="500" y1="265" x2="500" y2="275" stroke="#7a9ab5" stroke-width="1.5"/>
+    <line x1="750" y1="265" x2="750" y2="275" stroke="#7a9ab5" stroke-width="1.5"/>
+    <text x="625" y="283" text-anchor="middle" font-size="9" fill="#7a9ab5" font-family="'Segoe UI',system-ui,sans-serif">50 kt = 250 px</text>
 
-    <!-- Legend box -->
-    <rect x="20" y="228" width="230" height="68" fill="#0a1a35" rx="5" stroke="#1a3a5a" stroke-width="1"/>
-    <text x="35" y="245" font-size="10" fill="#7a9ab5" font-weight="600">LEGEND</text>
-    <line x1="35" y1="255" x2="65" y2="255" stroke="#3a7ad5" stroke-width="2" stroke-dasharray="5 3"/>
-    <text x="72" y="259" font-size="10" fill="#3a7ad5">True Track (090°)</text>
-    <line x1="35" y1="270" x2="65" y2="270" stroke="#40c8c8" stroke-width="2" stroke-dasharray="4 3"/>
-    <text x="72" y="274" font-size="10" fill="#40c8c8">Wind Vector</text>
-    <line x1="35" y1="285" x2="65" y2="285" stroke="#f08040" stroke-width="2"/>
-    <text x="72" y="289" font-size="10" fill="#f08040">True Heading (TH)</text>
+    <!-- ── North arrow ──────────────────────────────────────────────── -->
+    <line x1="730" y1="60" x2="730" y2="25" stroke="#c8d8e8" stroke-width="1.5"/>
+    <polygon points="730,20 725,35 735,35" fill="#c8d8e8"/>
+    <text x="730" y="75" text-anchor="middle" font-size="11" fill="#c8d8e8" font-weight="700" font-family="'Segoe UI',system-ui,sans-serif">N</text>
+
+    <!-- ── Legend ───────────────────────────────────────────────────── -->
+    <rect x="472" y="14" width="276" height="60" fill="#0a1a35" rx="5" stroke="#1a3a5a" stroke-width="1"/>
+    <text x="488" y="30" font-size="9" fill="#7a9ab5" font-weight="700" font-family="'Segoe UI',system-ui,sans-serif">LEGEND</text>
+    <line x1="488" y1="42" x2="518" y2="42" stroke="#3a7ad5" stroke-width="2.5"/>
+    <text x="523" y="46" font-size="9" fill="#3a7ad5" font-family="'Segoe UI',system-ui,sans-serif">GS (A→B along track)</text>
+    <line x1="488" y1="56" x2="518" y2="56" stroke="#40c8c8" stroke-width="2" stroke-dasharray="5 3"/>
+    <text x="523" y="60" font-size="9" fill="#40c8c8" font-family="'Segoe UI',system-ui,sans-serif">Wind vector (A→W)</text>
+    <line x1="620" y1="42" x2="650" y2="42" stroke="#f08040" stroke-width="2.5"/>
+    <text x="655" y="46" font-size="9" fill="#f08040" font-family="'Segoe UI',system-ui,sans-serif">TAS (W→B, heading)</text>
 
   </svg>
 </div>
 
-<!-- ── CONCEPT CARDS ──────────────────────────────────────────────────── -->
-<div class="section-label">Key Concepts</div>
+<!-- ── HOW THE TRIANGLE WORKS ─────────────────────────────────────────── -->
+<div class="section-label">Reading the Vector Triangle</div>
 <div class="two-col">
   <div class="info-card">
-    <h3>Wind Correction Angle (WCA)</h3>
+    <h3>The Three Vectors</h3>
+    <p>The wind triangle is a <strong>closed vector chain</strong>: GS = TAS + Wind.
+    The aircraft points its nose along <strong>TAS</strong> to compensate for wind drift so the
+    actual path over ground follows <strong>GS</strong> along the desired track.</p>
     <div class="big">TH = TT + WCA</div>
-    <div class="sub">Apply WCA to True Track to get True Heading</div>
-    <p style="margin-top:12px;">WCA is the angle between your intended track and the direction you must point the aircraft nose to stay on track. You <strong>crab into the wind</strong>: if wind is from the right, WCA is positive (crab right, TH &gt; TT); wind from the left, WCA is negative (crab left, TH &lt; TT).<br><br>
-    Example: TT 090°, wind from right (180°), WCA = +14°<br><strong>TH = 090° + 14° = 104°</strong></p>
+    <div class="sub">WCA is the crab angle measured at vertex A</div>
+    <p style="margin-top:12px;"><strong>Example:</strong> TT 090°, Wind 180°/30 kt, TAS 120 kt<br>
+    WCA = arcsin(30/120) ≈ <strong>14°</strong><br>
+    TH = 090° + 14° = <strong>104°</strong> (nose points south-of-east)</p>
   </div>
   <div class="info-card">
     <h3>Ground Speed (GS)</h3>
     <div class="big">GS ≠ TAS</div>
     <div class="sub">Wind changes your speed over the ground</div>
-    <p style="margin-top:12px;"><strong>Headwind</strong> component reduces GS below TAS.<br>
-    <strong>Tailwind</strong> component increases GS above TAS.<br>
-    <strong>Pure crosswind</strong> has only a small effect on GS (reduces it slightly).<br><br>
-    Example: TAS 120 kt, 30 kt direct tailwind<br><strong>GS ≈ 150 kt</strong><br>
-    30 kt direct headwind → <strong>GS ≈ 90 kt</strong></p>
+    <p style="margin-top:12px;"><strong>Pure crosswind example (above):</strong><br>
+    GS = √(TAS² − crosswind²)<br>
+    GS = √(120² − 30²) = √13,500 ≈ <strong>116 kt</strong><br><br>
+    <strong>Headwind 30 kt:</strong> GS = TAS − 30 = <strong>90 kt</strong><br>
+    <strong>Tailwind 30 kt:</strong> GS = TAS + 30 = <strong>150 kt</strong></p>
   </div>
 </div>
 
@@ -146,16 +182,16 @@ body { max-width: 860px; margin: auto; }
       <td>Minimum time en route; fly heading = track</td>
     </tr>
     <tr>
-      <td><strong>Left Crosswind (wind from left)</strong></td>
+      <td><strong>Left Crosswind (from left)</strong></td>
       <td>Crab left → TH &lt; TT</td>
       <td>GS slightly &lt; TAS</td>
-      <td>WCA is negative; subtract from TT</td>
+      <td>WCA negative; subtract from TT</td>
     </tr>
     <tr>
-      <td><strong>Right Crosswind (wind from right)</strong></td>
+      <td><strong>Right Crosswind (from right)</strong></td>
       <td>Crab right → TH &gt; TT</td>
       <td>GS slightly &lt; TAS</td>
-      <td>WCA is positive; add to TT</td>
+      <td>WCA positive; add to TT</td>
     </tr>
   </tbody>
 </table>

--- a/web-app/public/visuals/nav010-vor-navigation.html
+++ b/web-app/public/visuals/nav010-vor-navigation.html
@@ -7,10 +7,13 @@
 <link rel="stylesheet" href="/visuals/_common.css">
 <title>NAV-010 — VOR Navigation</title>
 <style>
+body { max-width: 860px; margin: auto; }
+
   @media (max-width: 480px) {
     body { font-size: 14px; overflow-x: hidden; }
     .two-col { grid-template-columns: 1fr; }
     .card table { display: block; overflow-x: auto; }
+    .grid-wrap svg { width: 100%; height: auto; }
   }
 </style>
 </head>
@@ -19,193 +22,265 @@
   <style>
 .container{padding-top:56px!important;}@media(max-width:480px){.container{padding-top:60px!important;}}
 </style>
-<div class="container">
-  <h1>NAV-010 — VOR Navigation</h1>
-  <div class="subtitle">Transport Canada · TP 12880E Ch.9 · AIM RAC 1.5 · PPL Written Exam</div>
+<h1>NAV-010 — VOR Navigation</h1>
+<p class="subtitle">Transport Canada · TP 12880E Ch.9 · AIM RAC 1.5 · PPL Written Exam</p>
 
-  <div class="section-label">VOR Station — Radials and CDI Indication</div>
-  <div class="card" style="padding: 12px 16px;">
-    <svg viewBox="0 0 820 340" width="100%" style="display:block;">
-      <rect width="820" height="340" fill="#0d2240" rx="8"/>
+<div class="section-label">VOR Station · Radials · CDI Instrument Faces</div>
+<div class="grid-wrap">
+  <!--
+    LEFT: VOR compass rose showing radials, station, two aircraft positions.
+    RIGHT: Two CDI instrument faces in proper circular gauge layout.
+    assessment-state: #80c880 = on-course (green), #e07070 = off-course (red) — do not replace with tokens
+  -->
+  <svg viewBox="0 0 840 360" width="100%" style="display:block;">
+    <rect width="840" height="360" fill="#0d2240" rx="8"/>
 
-      <!-- VOR station at center-left area -->
-      <!-- Compass rose -->
-      <circle cx="280" cy="170" r="110" fill="none" stroke="#1a3a5a" stroke-width="1.5"/>
-      <circle cx="280" cy="170" r="108" fill="none" stroke="#0a2040" stroke-width="8"/>
+    <!-- ══════════════════════════════════════════════════════════════ -->
+    <!-- LEFT PANEL: VOR Compass Rose (centre 260, 180) ═══════════════ -->
+    <!-- ══════════════════════════════════════════════════════════════ -->
 
-      <!-- Compass tick marks -->
-      <g stroke="#3a6a8a" stroke-width="1">
-        <line x1="280" y1="62" x2="280" y2="72"/>
-        <line x1="358" y1="92" x2="352" y2="100"/>
-        <line x1="388" y1="170" x2="378" y2="170"/>
-        <line x1="358" y1="248" x2="352" y2="240"/>
-        <line x1="280" y1="278" x2="280" y2="268"/>
-        <line x1="202" y1="248" x2="208" y2="240"/>
-        <line x1="172" y1="170" x2="182" y2="170"/>
-        <line x1="202" y1="92" x2="208" y2="100"/>
-      </g>
+    <!-- Outer compass ring -->
+    <circle cx="260" cy="180" r="128" fill="#071830" stroke="#3a5a7a" stroke-width="2.5"/>
+    <circle cx="260" cy="180" r="122" fill="#0a1a35" stroke="#1a3050" stroke-width="1"/>
 
-      <!-- Cardinal labels -->
-      <text x="280" y="56" text-anchor="middle" fill="#7a9ab5" font-size="11" font-weight="700">360/N</text>
-      <text x="394" y="174" text-anchor="start" fill="#7a9ab5" font-size="11" font-weight="700">090/E</text>
-      <text x="280" y="292" text-anchor="middle" fill="#7a9ab5" font-size="11" font-weight="700">180/S</text>
-      <text x="166" y="174" text-anchor="end" fill="#7a9ab5" font-size="11" font-weight="700">270/W</text>
+    <!-- Compass tick marks (major at cardinals + 45°, minor every 10°) -->
+    <!-- N (0°)  --> <line x1="260" y1="52"  x2="260" y2="62"  stroke="#c8d8e8" stroke-width="2"/>
+    <!-- NE (45°) --> <line x1="351" y1="89"  x2="344" y2="96"  stroke="#c8d8e8" stroke-width="1.5"/>
+    <!-- E (90°)  --> <line x1="388" y1="180" x2="378" y2="180" stroke="#c8d8e8" stroke-width="2"/>
+    <!-- SE (135°)--> <line x1="351" y1="271" x2="344" y2="264" stroke="#c8d8e8" stroke-width="1.5"/>
+    <!-- S (180°) --> <line x1="260" y1="308" x2="260" y2="298" stroke="#c8d8e8" stroke-width="2"/>
+    <!-- SW (225°)--> <line x1="169" y1="271" x2="176" y2="264" stroke="#c8d8e8" stroke-width="1.5"/>
+    <!-- W (270°) --> <line x1="132" y1="180" x2="142" y2="180" stroke="#c8d8e8" stroke-width="2"/>
+    <!-- NW (315°)--> <line x1="169" y1="89"  x2="176" y2="96"  stroke="#c8d8e8" stroke-width="1.5"/>
+    <!-- minor at 10°/20° etc. -->
+    <line x1="282" y1="53"  x2="279" y2="57"  stroke="#3a6a8a" stroke-width="1"/>
+    <line x1="303" y1="57"  x2="298" y2="61"  stroke="#3a6a8a" stroke-width="1"/>
+    <line x1="321" y1="66"  x2="315" y2="71"  stroke="#3a6a8a" stroke-width="1"/>
+    <line x1="238" y1="53"  x2="241" y2="57"  stroke="#3a6a8a" stroke-width="1"/>
+    <line x1="217" y1="57"  x2="222" y2="61"  stroke="#3a6a8a" stroke-width="1"/>
+    <line x1="199" y1="66"  x2="205" y2="71"  stroke="#3a6a8a" stroke-width="1"/>
 
-      <!-- Radial lines (every 45 degrees) -->
-      <!-- 000 -->
-      <line x1="280" y1="60" x2="280" y2="140" stroke="#2a5a8a" stroke-width="1.5" stroke-dasharray="4,3"/>
-      <!-- 045 radial (NE) -->
-      <line x1="280" y1="170" x2="358" y2="92" stroke="#f0c040" stroke-width="2.5"/>
-      <text x="368" y="84" fill="#f0c040" font-size="11" font-weight="700">045°</text>
-      <!-- 090 -->
-      <line x1="310" y1="170" x2="390" y2="170" stroke="#2a5a8a" stroke-width="1.5" stroke-dasharray="4,3"/>
-      <!-- 135 -->
-      <line x1="280" y1="170" x2="358" y2="248" stroke="#2a5a8a" stroke-width="1.5" stroke-dasharray="4,3"/>
-      <text x="365" y="262" fill="#7a9ab5" font-size="10">135°</text>
-      <!-- 180 -->
-      <line x1="280" y1="200" x2="280" y2="280" stroke="#2a5a8a" stroke-width="1.5" stroke-dasharray="4,3"/>
-      <!-- 225 -->
-      <line x1="280" y1="170" x2="202" y2="248" stroke="#2a5a8a" stroke-width="1.5" stroke-dasharray="4,3"/>
-      <text x="164" y="262" fill="#7a9ab5" font-size="10">225°</text>
-      <!-- 270 -->
-      <line x1="170" y1="170" x2="250" y2="170" stroke="#2a5a8a" stroke-width="1.5" stroke-dasharray="4,3"/>
-      <text x="142" y="165" fill="#7a9ab5" font-size="10">270°</text>
-      <!-- 315 -->
-      <line x1="280" y1="170" x2="202" y2="92" stroke="#2a5a8a" stroke-width="1.5" stroke-dasharray="4,3"/>
-      <text x="152" y="86" fill="#7a9ab5" font-size="10">315°</text>
+    <!-- Cardinal labels -->
+    <text x="260" y="47"  text-anchor="middle" fill="#c8d8e8" font-size="12" font-weight="700">360/N</text>
+    <text x="396" y="184" text-anchor="start"  fill="#c8d8e8" font-size="12" font-weight="700">090/E</text>
+    <text x="260" y="325" text-anchor="middle" fill="#c8d8e8" font-size="12" font-weight="700">180/S</text>
+    <text x="124" y="184" text-anchor="end"    fill="#c8d8e8" font-size="12" font-weight="700">270/W</text>
 
-      <!-- VOR station symbol -->
-      <circle cx="280" cy="170" r="18" fill="#0d2240" stroke="#f0c040" stroke-width="2"/>
-      <circle cx="280" cy="170" r="10" fill="#1a2d4a" stroke="#f0c040" stroke-width="1.5"/>
-      <polygon points="280,162 274,178 280,174 286,178" fill="#f0c040"/>
-      <text x="280" y="200" text-anchor="middle" fill="#f0c040" font-size="10" font-weight="700">VOR</text>
-      <text x="280" y="212" text-anchor="middle" fill="#7a9ab5" font-size="9">YYZ</text>
+    <!-- Dashed radials at every 45° (minor) -->
+    <line x1="260" y1="58"  x2="260" y2="148" stroke="#2a5a8a" stroke-width="1.2" stroke-dasharray="4,3"/>
+    <line x1="260" y1="212" x2="260" y2="302" stroke="#2a5a8a" stroke-width="1.2" stroke-dasharray="4,3"/>
+    <line x1="148" y1="180" x2="238" y2="180" stroke="#2a5a8a" stroke-width="1.2" stroke-dasharray="4,3"/>
+    <line x1="282" y1="180" x2="372" y2="180" stroke="#2a5a8a" stroke-width="1.2" stroke-dasharray="4,3"/>
+    <line x1="169" y1="89"  x2="214" y2="134" stroke="#2a5a8a" stroke-width="1.2" stroke-dasharray="4,3"/>
+    <line x1="306" y1="226" x2="351" y2="271" stroke="#2a5a8a" stroke-width="1.2" stroke-dasharray="4,3"/>
+    <line x1="169" y1="271" x2="214" y2="226" stroke="#2a5a8a" stroke-width="1.2" stroke-dasharray="4,3"/>
 
-      <!-- assessment-state: #80c880 = on-course (green), #e07070 = off-course (red) — do not replace with tokens -->
-      <!-- Aircraft on 045 radial (centered CDI) -->
-      <g transform="translate(348,84) rotate(225)">
-        <polygon points="0,-10 -5,7 0,3 5,7" fill="#80c880" stroke="#40a040" stroke-width="1"/>
-        <line x1="-8" y1="0" x2="8" y2="0" stroke="#80c880" stroke-width="1.5"/>
-      </g>
-      <text x="390" y="72" fill="#80c880" font-size="10">On 045 radial</text>
-      <text x="390" y="84" fill="#80c880" font-size="10">CDI centered</text>
-      <text x="390" y="96" fill="#80c880" font-size="10">FROM flag</text>
+    <!-- 045° radial (highlighted — aircraft tracking this one) -->
+    <line x1="260" y1="180" x2="351" y2="89"  stroke="#f0c040" stroke-width="2.5"/>
+    <text x="360" y="82"  fill="#f0c040" font-size="11" font-weight="700">045°</text>
 
-      <!-- Off-course aircraft (below the 045 radial) -->
-      <g transform="translate(340,132) rotate(225)">
-        <polygon points="0,-10 -5,7 0,3 5,7" fill="#e07070" stroke="#a04040" stroke-width="1"/>
-        <line x1="-8" y1="0" x2="8" y2="0" stroke="#e07070" stroke-width="1.5"/>
-      </g>
-      <text x="362" y="128" fill="#e07070" font-size="10">Off course</text>
-      <text x="362" y="140" fill="#e07070" font-size="10">CDI deflected</text>
-      <text x="362" y="152" fill="#e07070" font-size="10">needle RIGHT</text>
+    <!-- Radial degree labels (NW, SW) -->
+    <text x="148" y="82"  fill="#7a9ab5" font-size="10">315°</text>
+    <text x="148" y="268" fill="#7a9ab5" font-size="10">225°</text>
+    <text x="306" y="278" fill="#7a9ab5" font-size="10">135°</text>
 
-      <!-- CDI instruments panel -->
-      <!-- Instrument 1: Centered -->
-      <rect x="510" y="60" width="80" height="120" fill="#0a1828" stroke="#2a4a6a" stroke-width="1.5" rx="5"/>
-      <text x="550" y="78" text-anchor="middle" fill="#7a9ab5" font-size="9" font-weight="700">CDI — CENTERED</text>
-      <!-- CDI face -->
-      <circle cx="550" cy="128" r="38" fill="#0d2240" stroke="#3a5a7a" stroke-width="1"/>
-      <!-- Dots -->
-      <circle cx="524" cy="128" r="3" fill="#3a5a7a"/>
-      <circle cx="532" cy="128" r="3" fill="#3a5a7a"/>
-      <circle cx="540" cy="128" r="3" fill="#3a5a7a"/>
-      <circle cx="558" cy="128" r="3" fill="#3a5a7a"/>
-      <circle cx="566" cy="128" r="3" fill="#3a5a7a"/>
-      <circle cx="574" cy="128" r="3" fill="#3a5a7a"/>
-      <!-- Needle centered -->
-      <rect x="548" y="100" width="4" height="56" fill="#80c880" rx="2"/>
-      <!-- TO/FROM flag -->
-      <rect x="534" y="104" width="18" height="12" fill="#2d5a2d" rx="2"/>
-      <text x="543" y="114" text-anchor="middle" fill="#80c880" font-size="8" font-weight="700">FROM</text>
+    <!-- VOR station symbol (centre) -->
+    <circle cx="260" cy="180" r="20" fill="#0d2240" stroke="#f0c040" stroke-width="2"/>
+    <circle cx="260" cy="180" r="11" fill="#1a2d4a" stroke="#f0c040" stroke-width="1.5"/>
+    <polygon points="260,171 254,187 260,183 266,187" fill="#f0c040"/>
+    <text x="260" y="210" text-anchor="middle" fill="#f0c040" font-size="10" font-weight="700">VOR</text>
+    <text x="260" y="222" text-anchor="middle" fill="#7a9ab5" font-size="9">YYZ</text>
 
-      <!-- Instrument 2: Deflected right -->
-      <rect x="610" y="60" width="80" height="120" fill="#0a1828" stroke="#2a4a6a" stroke-width="1.5" rx="5"/>
-      <text x="650" y="78" text-anchor="middle" fill="#7a9ab5" font-size="9" font-weight="700">CDI — DEFLECTED</text>
-      <circle cx="650" cy="128" r="38" fill="#0d2240" stroke="#3a5a7a" stroke-width="1"/>
-      <circle cx="624" cy="128" r="3" fill="#3a5a7a"/>
-      <circle cx="632" cy="128" r="3" fill="#3a5a7a"/>
-      <circle cx="640" cy="128" r="3" fill="#3a5a7a"/>
-      <circle cx="658" cy="128" r="3" fill="#3a5a7a"/>
-      <circle cx="666" cy="128" r="3" fill="#3a5a7a"/>
-      <circle cx="674" cy="128" r="3" fill="#3a5a7a"/>
-      <!-- Needle deflected right (+16px) -->
-      <rect x="664" y="100" width="4" height="56" fill="#e07070" rx="2"/>
-      <rect x="634" y="104" width="18" height="12" fill="#2d5a2d" rx="2"/>
-      <text x="643" y="114" text-anchor="middle" fill="#80c880" font-size="8" font-weight="700">FROM</text>
+    <!-- Cone of silence ring -->
+    <circle cx="260" cy="180" r="24" fill="none" stroke="#c87040" stroke-width="1.5" stroke-dasharray="3,3"/>
+    <text x="260" y="254" text-anchor="middle" fill="#c87040" font-size="9">Cone of silence</text>
+    <text x="260" y="266" text-anchor="middle" fill="#c87040" font-size="9">(directly overhead)</text>
 
-      <!-- Labels below instruments -->
-      <text x="550" y="195" text-anchor="middle" fill="#80c880" font-size="10">On course</text>
-      <text x="650" y="195" text-anchor="middle" fill="#e07070" font-size="10">Fly RIGHT</text>
+    <!-- assessment-state: #80c880 = on-course (green), #e07070 = off-course (red) — do not replace with tokens -->
 
-      <!-- OBS knob label -->
-      <text x="510" y="220" fill="#7a9ab5" font-size="10">OBS set to 045°</text>
-      <text x="510" y="233" fill="#7a9ab5" font-size="10">Aircraft hdg: 225° (inbound)</text>
+    <!-- Aircraft on 045° radial (correct position, CDI centred) -->
+    <g transform="translate(342,87) rotate(225)">
+      <polygon points="0,-10 -5,8 0,4 5,8" fill="#80c880" stroke="#30a030" stroke-width="1"/>
+      <line x1="-8" y1="0" x2="8" y2="0" stroke="#80c880" stroke-width="1.5"/>
+    </g>
+    <text x="362" y="76"  fill="#80c880" font-size="10">On R-045 · CDI centred</text>
 
-      <!-- Cone of silence indicator -->
-      <circle cx="280" cy="170" r="22" fill="none" stroke="#c87040" stroke-width="1.5" stroke-dasharray="3,3"/>
-      <text x="280" y="265" text-anchor="middle" fill="#c87040" font-size="9">Cone of silence</text>
-      <text x="280" y="277" text-anchor="middle" fill="#c87040" font-size="9">(directly overhead)</text>
+    <!-- Aircraft south of 045° radial (off course → CDI deflects right) -->
+    <g transform="translate(336,130) rotate(225)">
+      <polygon points="0,-10 -5,8 0,4 5,8" fill="#e07070" stroke="#a02020" stroke-width="1"/>
+      <line x1="-8" y1="0" x2="8" y2="0" stroke="#e07070" stroke-width="1.5"/>
+    </g>
+    <text x="356" y="124" fill="#e07070" font-size="10">Off course (south)</text>
+    <text x="356" y="136" fill="#e07070" font-size="10">CDI deflects right</text>
 
-      <!-- Radial label on 045 line -->
-      <text x="318" y="118" fill="#f0c040" font-size="9" transform="rotate(-45,318,118)">Radial 045</text>
-    </svg>
-  </div>
+    <!-- Panel title -->
+    <text x="260" y="20" text-anchor="middle" fill="#5a8ab5" font-size="10" font-weight="700">VOR STATION — RADIALS &amp; AIRCRAFT POSITIONS</text>
 
-  <div class="section-label">VOR Terminology</div>
-  <div class="card" style="padding: 0; overflow: hidden;">
-    <table>
-      <thead>
-        <tr><th>Term</th><th>Stands For</th><th>Definition</th></tr>
-      </thead>
-      <tbody>
-        <tr><td><strong>Radial</strong></td><td>—</td><td>A magnetic bearing measured <strong>FROM</strong> the VOR station outward (e.g. R-045 is northeast of station)</td></tr>
-        <tr><td><strong>OBS</strong></td><td>Omnibearing Selector</td><td>Knob that selects the course (radial) you want to track or intercept</td></tr>
-        <tr><td><strong>CDI</strong></td><td>Course Deviation Indicator</td><td>Needle showing whether aircraft is left or right of selected course; each dot ≈ 2° off course</td></tr>
-        <tr><td><strong>TO Flag</strong></td><td>—</td><td>Station is ahead of you on the selected course; flying the OBS heading takes you toward the VOR</td></tr>
-        <tr><td><strong>FROM Flag</strong></td><td>—</td><td>Station is behind you on the selected course; flying the OBS heading takes you away from the VOR</td></tr>
-        <tr><td><strong>Cone of Silence</strong></td><td>—</td><td>Small area directly overhead the VOR where signal is unreliable; CDI may fluctuate and flag may show OFF</td></tr>
-        <tr><td><strong>Full-scale deflection</strong></td><td>—</td><td>CDI pegged at edge = 10° or more off the selected course</td></tr>
-      </tbody>
-    </table>
-  </div>
+    <!-- ══════════════════════════════════════════════════════════════ -->
+    <!-- RIGHT PANEL: Two CDI Instrument Faces ════════════════════════ -->
+    <!-- ══════════════════════════════════════════════════════════════ -->
 
-  <div class="section-label">Procedures</div>
-  <div class="two-col">
-    <div class="card">
-      <h3>Intercepting a Radial</h3>
-      <ul>
-        <li>1. Tune and identify the VOR (listen for Morse ident)</li>
-        <li>2. Twist OBS to the desired radial</li>
-        <li>3. Determine if TO or FROM and which side of course you are on</li>
-        <li>4. Turn to an intercept heading (30–45° cut toward the needle)</li>
-        <li>5. As CDI centers, turn to track the course</li>
-        <li>6. Apply wind correction angle to maintain centered CDI</li>
-      </ul>
-    </div>
-    <div class="card">
-      <h3>Tracking a Radial</h3>
-      <ul>
-        <li>Establish a wind correction angle (WCA) — try 10° initially</li>
-        <li>If CDI drifts, <strong style="color:var(--accent)">bracket and halve</strong>: double the correction, then halve when back on course</li>
-        <li>Keep corrections small — max 20° WCA in light winds</li>
-        <li>OBS setting does NOT change — only aircraft heading changes</li>
-        <li>Recheck station ident every 10–15 min en route</li>
-        <li>Station passage: flag flips FROM→TO, CDI swings</li>
-      </ul>
-    </div>
-  </div>
+    <!-- Panel background -->
+    <rect x="440" y="10" width="390" height="340" fill="#071830" rx="6" stroke="#1a3050" stroke-width="1"/>
+    <text x="635" y="30" text-anchor="middle" fill="#5a8ab5" font-size="10" font-weight="700">CDI INSTRUMENT FACES — OBS SET 045°</text>
 
-  <div class="section-label">Memory Hook</div>
-  <div class="memory-hook">
-    <div class="badge">Memory Hook</div>
+    <!-- ── CDI #1: ON COURSE (needle centred, FROM flag) ─────────────── -->
+    <!-- Centre: (530, 185), radius 72 -->
+
+    <!-- Outer bezel ring -->
+    <circle cx="530" cy="190" r="76" fill="#0a1020" stroke="#3a5a7a" stroke-width="3"/>
+    <circle cx="530" cy="190" r="70" fill="#071530" stroke="#1a3050" stroke-width="1"/>
+
+    <!-- Bezel notch / course index at top (OBS cursor triangle) -->
+    <polygon points="530,114 524,128 536,128" fill="#f0c040"/>
+    <line x1="530" y1="128" x2="530" y2="136" stroke="#f0c040" stroke-width="1.5"/>
+
+    <!-- OBS course label -->
+    <text x="530" y="108" text-anchor="middle" fill="#f0c040" font-size="10" font-weight="700">045°</text>
+    <text x="530" y="98"  text-anchor="middle" fill="#7a9ab5" font-size="9">OBS</text>
+
+    <!-- Scale dots — 4 left, 4 right, centre mark -->
+    <!-- Each dot is 8 px from center (8px ≈ 2° per dot) -->
+    <circle cx="498" cy="190" r="3.5" fill="#3a5a7a"/>
+    <circle cx="506" cy="190" r="3.5" fill="#3a5a7a"/>
+    <circle cx="514" cy="190" r="3.5" fill="#3a5a7a"/>
+    <circle cx="522" cy="190" r="3.5" fill="#3a5a7a"/>
+    <!-- centre reference -->
+    <circle cx="530" cy="190" r="3"   fill="#1a3050" stroke="#3a5a7a"/>
+    <circle cx="538" cy="190" r="3.5" fill="#3a5a7a"/>
+    <circle cx="546" cy="190" r="3.5" fill="#3a5a7a"/>
+    <circle cx="554" cy="190" r="3.5" fill="#3a5a7a"/>
+    <circle cx="562" cy="190" r="3.5" fill="#3a5a7a"/>
+
+    <!-- CDI Needle CENTRED — assessment-state: #80c880 = on course -->
+    <rect x="527" y="145" width="6" height="90" fill="#80c880" rx="3"/>
+
+    <!-- TO/FROM flag (green = FROM, aircraft departing VOR) -->
+    <rect x="517" y="152" width="26" height="15" fill="#1a3a1a" rx="3" stroke="#2d5a2d"/>
+    <text x="530" y="163" text-anchor="middle" fill="#80c880" font-size="9" font-weight="700">FROM</text>
+
+    <!-- Scale ticks on edge at ±90° (left/right) -->
+    <line x1="458" y1="190" x2="464" y2="190" stroke="#3a5a7a" stroke-width="1.5"/>
+    <line x1="596" y1="190" x2="602" y2="190" stroke="#3a5a7a" stroke-width="1.5"/>
+
+    <!-- Instrument label below -->
+    <text x="530" y="272" text-anchor="middle" fill="#80c880" font-size="11" font-weight="700">ON COURSE</text>
+    <text x="530" y="285" text-anchor="middle" fill="#7a9ab5" font-size="9">needle centred · FROM flag</text>
+
+    <!-- Bottom arrow label -->
+    <text x="530" y="302" text-anchor="middle" fill="#7a9ab5" font-size="9">Aircraft heading 225° (inbound)</text>
+    <text x="530" y="315" text-anchor="middle" fill="#7a9ab5" font-size="9">flying outbound on R-045</text>
+
+    <!-- CDI #1 label title -->
+    <text x="530" y="345" text-anchor="middle" fill="#5a8ab5" font-size="10" font-weight="700">CDI #1</text>
+
+    <!-- ── CDI #2: OFF COURSE (needle deflected right, FROM flag) ─────── -->
+    <!-- Centre: (720, 185), radius 72 -->
+
+    <!-- Outer bezel ring -->
+    <circle cx="720" cy="190" r="76" fill="#0a1020" stroke="#3a5a7a" stroke-width="3"/>
+    <circle cx="720" cy="190" r="70" fill="#071530" stroke="#1a3050" stroke-width="1"/>
+
+    <!-- OBS cursor at top -->
+    <polygon points="720,114 714,128 726,128" fill="#f0c040"/>
+    <line x1="720" y1="128" x2="720" y2="136" stroke="#f0c040" stroke-width="1.5"/>
+    <text x="720" y="108" text-anchor="middle" fill="#f0c040" font-size="10" font-weight="700">045°</text>
+    <text x="720" y="98"  text-anchor="middle" fill="#7a9ab5" font-size="9">OBS</text>
+
+    <!-- Scale dots — same layout as CDI #1 -->
+    <circle cx="688" cy="190" r="3.5" fill="#3a5a7a"/>
+    <circle cx="696" cy="190" r="3.5" fill="#3a5a7a"/>
+    <circle cx="704" cy="190" r="3.5" fill="#3a5a7a"/>
+    <circle cx="712" cy="190" r="3.5" fill="#3a5a7a"/>
+    <circle cx="720" cy="190" r="3"   fill="#1a3050" stroke="#3a5a7a"/>
+    <circle cx="728" cy="190" r="3.5" fill="#3a5a7a"/>
+    <circle cx="736" cy="190" r="3.5" fill="#3a5a7a"/>
+    <circle cx="744" cy="190" r="3.5" fill="#3a5a7a"/>
+    <circle cx="752" cy="190" r="3.5" fill="#3a5a7a"/>
+
+    <!-- CDI Needle DEFLECTED RIGHT — assessment-state: #e07070 = off course -->
+    <!-- shifted +24px (3 dots right ≈ 6° off radial) -->
+    <rect x="741" y="145" width="6" height="90" fill="#e07070" rx="3"/>
+
+    <!-- TO/FROM flag (green = FROM) -->
+    <rect x="707" y="152" width="26" height="15" fill="#1a3a1a" rx="3" stroke="#2d5a2d"/>
+    <text x="720" y="163" text-anchor="middle" fill="#80c880" font-size="9" font-weight="700">FROM</text>
+
+    <!-- Scale ticks on edge -->
+    <line x1="648" y1="190" x2="654" y2="190" stroke="#3a5a7a" stroke-width="1.5"/>
+    <line x1="786" y1="190" x2="792" y2="190" stroke="#3a5a7a" stroke-width="1.5"/>
+
+    <!-- Instrument label below -->
+    <text x="720" y="272" text-anchor="middle" fill="#e07070" font-size="11" font-weight="700">FLY RIGHT</text>
+    <text x="720" y="285" text-anchor="middle" fill="#7a9ab5" font-size="9">needle right → turn right</text>
+
+    <!-- Annotation arrow -->
+    <line x1="744" y1="155" x2="760" y2="143" stroke="#e07070" stroke-width="1.2" stroke-dasharray="3,2"/>
+    <text x="762" y="140" fill="#e07070" font-size="9">~6° off radial</text>
+
+    <!-- Fly toward needle reminder -->
+    <text x="720" y="302" text-anchor="middle" fill="#7a9ab5" font-size="9">Aircraft is SOUTH of R-045</text>
+    <text x="720" y="315" text-anchor="middle" fill="#7a9ab5" font-size="9">turn right to intercept radial</text>
+
+    <!-- CDI #2 label -->
+    <text x="720" y="345" text-anchor="middle" fill="#5a8ab5" font-size="10" font-weight="700">CDI #2</text>
+
+  </svg>
+</div>
+
+<div class="section-label">VOR Terminology</div>
+<div class="card" style="padding: 0; overflow: hidden;">
+  <table>
+    <thead>
+      <tr><th>Term</th><th>Stands For</th><th>Definition</th></tr>
+    </thead>
+    <tbody>
+      <tr><td><strong>Radial</strong></td><td>—</td><td>A magnetic bearing measured <strong>FROM</strong> the VOR station outward (e.g. R-045 is northeast of station)</td></tr>
+      <tr><td><strong>OBS</strong></td><td>Omnibearing Selector</td><td>Knob that selects the course (radial) you want to track or intercept</td></tr>
+      <tr><td><strong>CDI</strong></td><td>Course Deviation Indicator</td><td>Needle showing whether aircraft is left or right of selected course; each dot ≈ 2° off course</td></tr>
+      <tr><td><strong>TO Flag</strong></td><td>—</td><td>Station is ahead of you on the selected course; flying the OBS heading takes you toward the VOR</td></tr>
+      <tr><td><strong>FROM Flag</strong></td><td>—</td><td>Station is behind you on the selected course; flying the OBS heading takes you away from the VOR</td></tr>
+      <tr><td><strong>Cone of Silence</strong></td><td>—</td><td>Small area directly overhead the VOR where signal is unreliable; CDI may fluctuate and flag may show OFF</td></tr>
+      <tr><td><strong>Full-scale deflection</strong></td><td>—</td><td>CDI pegged at edge = 10° or more off the selected course</td></tr>
+    </tbody>
+  </table>
+</div>
+
+<div class="section-label">Procedures</div>
+<div class="two-col">
+  <div class="card">
+    <h3>Intercepting a Radial</h3>
     <ul>
-      <li><strong style="color:#80c880">Radials are FROM:</strong> A radial always goes FROM the station. R-090 is the line going east from the VOR. You are on R-090 when you are east of the station.</li>
-      <li><strong style="color:#80c880">OBS ≠ heading:</strong> The OBS sets the course line, not your heading. You fly a different heading to correct for wind while tracking the OBS course.</li>
-      <li><strong style="color:#80c880">Cone of silence:</strong> When directly overhead, the CDI goes crazy and the flag may go to OFF — this is normal. Note the time and continue.</li>
-      <li><strong style="color:#80c880">CDI "fly toward the needle":</strong> Needle deflected right = turn right to get back on course.</li>
+      <li>1. Tune and identify the VOR (listen for Morse ident)</li>
+      <li>2. Twist OBS to the desired radial</li>
+      <li>3. Determine if TO or FROM and which side of course you are on</li>
+      <li>4. Turn to an intercept heading (30–45° cut toward the needle)</li>
+      <li>5. As CDI centers, turn to track the course</li>
+      <li>6. Apply wind correction angle to maintain centered CDI</li>
     </ul>
   </div>
+  <div class="card">
+    <h3>Tracking a Radial</h3>
+    <ul>
+      <li>Establish a wind correction angle (WCA) — try 10° initially</li>
+      <li>If CDI drifts, <strong style="color:var(--accent)">bracket and halve</strong>: double the correction, then halve when back on course</li>
+      <li>Keep corrections small — max 20° WCA in light winds</li>
+      <li>OBS setting does NOT change — only aircraft heading changes</li>
+      <li>Recheck station ident every 10–15 min en route</li>
+      <li>Station passage: flag flips FROM→TO, CDI swings</li>
+    </ul>
+  </div>
+</div>
+
+<div class="section-label">Memory Hook</div>
+<div class="memory-hook">
+  <div class="badge">Memory Hook</div>
+  <ul>
+    <li><strong style="color:#80c880">Radials are FROM:</strong> A radial always goes FROM the station. R-090 is the line going east from the VOR. You are on R-090 when you are east of the station.</li>
+    <li><strong style="color:#80c880">OBS ≠ heading:</strong> The OBS sets the course line, not your heading. You fly a different heading to correct for wind while tracking the OBS course.</li>
+    <li><strong style="color:#80c880">Cone of silence:</strong> When directly overhead, the CDI goes crazy and the flag may go to OFF — this is normal. Note the time and continue.</li>
+    <li><strong style="color:#80c880">CDI "fly toward the needle":</strong> Needle deflected right = turn right to get back on course.</li>
+  </ul>
 </div>
 </body>
 </html>


### PR DESCRIPTION
Closes #353

## Changes

Rebuilt three NAV visuals flagged needs-rebuild, with these specifics from the issue:

- **NAV-003** (`nav003-true-magnetic-compass.html`): Replaced the arrow-schematic with a proper compass rose / heading indicator face. Three distinct needles (TH=blue, MH=yellow, CH=green dashed) show variation and deviation as visually offset angles with arc annotations. Values exaggerated for clarity (noted on diagram). TVMDC chain retained.

- **NAV-005** (`nav005-wind-correction-angle.html`): Replaced with a proper closed vector triangle at consistent scale (5 px/kt). Three vectors — GS (A→B, blue), Wind (A→W, cyan dashed 30kt northward), TAS (W→B, orange 120kt) — form a closed triangle satisfying GS = TAS + Wind. Scale bar, WCA arc at vertex A, and North arrow added.

- **NAV-010** (`nav010-vor-navigation.html`): Rebuilt CDI panels as proper circular instrument faces with outer bezel, OBS cursor triangle at top, 4-dot scale per side, circular gauge face, vertical CDI needle (centred or deflected), and TO/FROM flag. Assessment-state inline comments retained for `#80c880` (on-course) and `#e07070` (off-course).

**No changes to NAV-001, NAV-006–009** — these already satisfy all 8 audit criteria. `#3a6a9a` (NAV-001 scale bar), `#80c880`/`#e07070` (NAV-006, NAV-008, NAV-009, NAV-010) remain hardcoded with inline comments.

## Test Plan

- [ ] All three rebuilt files: `data-backlink="true"` button present and links `/visuals/_common.css`
- [ ] NAV-003: Compass rose shows three distinct needles at visually offset angles with VAR and DEV arcs labelled
- [ ] NAV-005: Wind triangle forms a closed vector triangle; all three vectors (GS, Wind, TAS) are drawn and labelled
- [ ] NAV-010: CDI instruments show circular gauge faces, OBS cursor, scale dots, needle, TO/FROM flag
- [ ] Dark scheme renders correctly at 360px viewport width (no overflow, no unreadable text)
- [ ] `npm run build` passes (confirmed locally)
- [ ] Assessment-state colours `#80c880`/`#e07070` hardcoded with inline comments in NAV-006–010
- [ ] `#3a6a9a` hardcoded with comment in NAV-001