### PR TITLE
[PPL-343] Add ROC-A reference cards (phonetic, phraseology, emergency, light signals)

### DIFF
--- a/web-app/public/visuals/roc-ref-emergency.html
+++ b/web-app/public/visuals/roc-ref-emergency.html
@@ -1,0 +1,304 @@
+<!DOCTYPE html>
+<html lang="en" data-scheme="dark">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<script src="/visuals/_theme-init.js"></script>
+<link rel="stylesheet" href="/visuals/_common.css">
+<title>ROC-A Reference — Emergency &amp; Urgency Procedures</title>
+<style>
+  .emerg-block {
+    background: var(--surface);
+    border: 1.5px solid var(--border);
+    border-radius: 8px;
+    padding: 18px 20px;
+    margin-bottom: 20px;
+  }
+  .emerg-header {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    margin-bottom: 14px;
+  }
+  .emerg-badge {
+    font-size: 13px;
+    font-weight: 800;
+    letter-spacing: 1.5px;
+    padding: 5px 14px;
+    border-radius: 4px;
+    white-space: nowrap;
+    min-width: 100px;
+    text-align: center;
+  }
+  /* MAYDAY — highest-priority distress call, red */
+  .badge-mayday {
+    background: rgba(224,80,80,0.20);
+    color: #e05050;          /* light-signal red: #e05050 */
+    border: 1.5px solid rgba(224,80,80,0.5);
+  }
+  /* PAN-PAN — urgency call, amber */
+  .badge-pan {
+    background: rgba(240,192,64,0.15);
+    color: #f0c040;          /* amber accent: #f0c040 */
+    border: 1.5px solid rgba(240,192,64,0.4);
+  }
+  .emerg-title {
+    font-size: 15px;
+    font-weight: 700;
+    color: var(--text);
+  }
+  .emerg-subtitle {
+    font-size: 12px;
+    color: var(--text-muted);
+    margin-top: 2px;
+  }
+
+  .format-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+  }
+  .format-list li {
+    display: flex;
+    gap: 10px;
+    align-items: flex-start;
+    padding: 7px 0;
+    border-bottom: 1px solid var(--border);
+    font-size: 13px;
+    color: var(--text);
+    line-height: 1.5;
+  }
+  .format-list li:last-child { border-bottom: none; }
+  .step-num {
+    display: inline-block;
+    min-width: 22px;
+    height: 22px;
+    background: var(--surface2);
+    border: 1px solid var(--border-hi);
+    border-radius: 50%;
+    text-align: center;
+    line-height: 22px;
+    font-size: 11px;
+    font-weight: 700;
+    color: var(--accent);
+    flex-shrink: 0;
+    margin-top: 1px;
+  }
+  .step-label {
+    font-weight: 600;
+    color: var(--accent);
+  }
+
+  /* Squawk code cards */
+  .squawk-grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 12px;
+    margin-bottom: 24px;
+  }
+  .squawk-card {
+    border-radius: 8px;
+    padding: 16px 14px;
+    text-align: center;
+    border: 1.5px solid transparent;
+  }
+  /* 7500 hijack — red */
+  .sq-7500 {
+    background: rgba(224,80,80,0.12);   /* red: #e05050 */
+    border-color: rgba(224,80,80,0.40);
+  }
+  /* 7600 lost comms — white/info */
+  .sq-7600 {
+    background: rgba(228,236,245,0.08); /* white: #e4ecf5 */
+    border-color: rgba(228,236,245,0.25);
+  }
+  /* 7700 emergency — amber */
+  .sq-7700 {
+    background: rgba(240,192,64,0.12);  /* amber: #f0c040 */
+    border-color: rgba(240,192,64,0.40);
+  }
+  .sq-code {
+    font-size: 28px;
+    font-weight: 800;
+    display: block;
+    margin-bottom: 4px;
+  }
+  .sq-7500 .sq-code { color: #e05050; }   /* red */
+  .sq-7600 .sq-code { color: #e4ecf5; }   /* white */
+  .sq-7700 .sq-code { color: #f0c040; }   /* amber */
+  .sq-meaning {
+    font-size: 12px;
+    font-weight: 700;
+    color: var(--text);
+    display: block;
+    margin-bottom: 4px;
+  }
+  .sq-note {
+    font-size: 11px;
+    color: var(--text-muted);
+    line-height: 1.5;
+  }
+
+  .lost-comms-steps {
+    counter-reset: lc-step;
+  }
+  .lc-step {
+    display: flex;
+    gap: 12px;
+    align-items: flex-start;
+    padding: 10px 0;
+    border-bottom: 1px solid var(--border);
+    font-size: 13px;
+    color: var(--text);
+    line-height: 1.5;
+  }
+  .lc-step:last-child { border-bottom: none; }
+  .lc-num {
+    display: inline-block;
+    min-width: 26px;
+    height: 26px;
+    background: rgba(91,155,213,0.15);
+    border: 1px solid rgba(91,155,213,0.35);
+    border-radius: 50%;
+    text-align: center;
+    line-height: 26px;
+    font-size: 12px;
+    font-weight: 700;
+    color: #5b9bd5;
+    flex-shrink: 0;
+  }
+
+  @media (max-width: 640px) {
+    .squawk-grid { grid-template-columns: 1fr; }
+  }
+</style>
+</head>
+<body>
+<button
+  data-backlink="true"
+  onclick="if(window.history.length<=1){window.close();}else{window.history.back();}"
+  style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:#f0c040;border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);"
+  aria-label="Back to lesson"
+>&#8592; Back to lesson</button>
+<style>.container{padding-top:56px!important;}@media(max-width:480px){.container{padding-top:60px!important;}}</style>
+
+<h1>ROC-A — Emergency &amp; Urgency Procedures</h1>
+<p class="subtitle">Canadian AIM RAC · Transport Canada · ROC-A Quick Reference</p>
+
+<!-- ── DISTRESS — MAYDAY ───────────────────────────────────────────────── -->
+<div class="section-label">Distress Call — MAYDAY</div>
+<div class="emerg-block">
+  <div class="emerg-header">
+    <span class="emerg-badge badge-mayday">MAYDAY</span>
+    <div>
+      <div class="emerg-title">Distress — Grave and Imminent Danger</div>
+      <div class="emerg-subtitle">Spoken 3 times. Use 121.5 MHz if unable to reach ATC. (AIM RAC 1.7)</div>
+    </div>
+  </div>
+  <ul class="format-list" aria-label="MAYDAY call format">
+    <li><span class="step-num">1</span><span><span class="step-label">Distress signal (×3):</span> "MAYDAY MAYDAY MAYDAY"</span></li>
+    <li><span class="step-num">2</span><span><span class="step-label">Station addressed:</span> Name of station (or "ALL STATIONS" if unknown)</span></li>
+    <li><span class="step-num">3</span><span><span class="step-label">Aircraft identification:</span> Call sign</span></li>
+    <li><span class="step-num">4</span><span><span class="step-label">Nature of distress:</span> Engine failure / fire / structural / etc.</span></li>
+    <li><span class="step-num">5</span><span><span class="step-label">Intentions:</span> Forced landing / ditching / etc.</span></li>
+    <li><span class="step-num">6</span><span><span class="step-label">Position:</span> Last known fix, bearing and distance from navaid, or lat/long</span></li>
+    <li><span class="step-num">7</span><span><span class="step-label">Altitude:</span> Current altitude / flight level</span></li>
+    <li><span class="step-num">8</span><span><span class="step-label">Persons on board (POB):</span> Number of souls on board</span></li>
+    <li><span class="step-num">9</span><span><span class="step-label">Any other information:</span> Fuel remaining, ELT status, aircraft colour, etc.</span></li>
+  </ul>
+  <div class="note-box" style="margin-top:14px;margin-bottom:0;">
+    <strong>Example:</strong> "MAYDAY MAYDAY MAYDAY, Ottawa Centre, Cessna Golf-Charlie-Foxtrot-Bravo, engine failure, forced landing, 15 miles south of Ottawa, 2,500 feet, 2 POB, Mayday."
+  </div>
+</div>
+
+<!-- ── URGENCY — PAN-PAN ───────────────────────────────────────────────── -->
+<div class="section-label">Urgency Call — PAN-PAN</div>
+<div class="emerg-block">
+  <div class="emerg-header">
+    <span class="emerg-badge badge-pan">PAN-PAN</span>
+    <div>
+      <div class="emerg-title">Urgency — Safety at Risk (Not Yet Grave)</div>
+      <div class="emerg-subtitle">Spoken 3 times. Used for medical, lost, low fuel, etc. (AIM RAC 1.7)</div>
+    </div>
+  </div>
+  <ul class="format-list" aria-label="PAN-PAN call format">
+    <li><span class="step-num">1</span><span><span class="step-label">Urgency signal (×3):</span> "PAN-PAN PAN-PAN PAN-PAN"</span></li>
+    <li><span class="step-num">2</span><span><span class="step-label">Station addressed:</span> Name of station or "ALL STATIONS"</span></li>
+    <li><span class="step-num">3</span><span><span class="step-label">Aircraft identification:</span> Call sign</span></li>
+    <li><span class="step-num">4</span><span><span class="step-label">Nature of urgency:</span> Medical / lost / fuel state / etc.</span></li>
+    <li><span class="step-num">5</span><span><span class="step-label">Intentions:</span> What you plan to do</span></li>
+    <li><span class="step-num">6</span><span><span class="step-label">Position:</span> Best known position</span></li>
+    <li><span class="step-num">7</span><span><span class="step-label">Altitude:</span> Current altitude</span></li>
+    <li><span class="step-num">8</span><span><span class="step-label">Persons on board:</span> Souls on board</span></li>
+    <li><span class="step-num">9</span><span><span class="step-label">Any other information:</span> Relevant details</span></li>
+  </ul>
+</div>
+
+<!-- ── TRANSPONDER CODES ───────────────────────────────────────────────── -->
+<div class="section-label">Emergency Transponder Codes</div>
+<!--
+  Light-signal colours hardcoded per spec:
+    green  #4caf7d  — not used for squawk cards (no green squawk)
+    red    #e05050  — 7500 hijack
+    white  #e4ecf5  — 7600 lost comms
+    amber  #f0c040  — 7700 emergency
+-->
+<div class="squawk-grid">
+  <div class="squawk-card sq-7500">
+    <span class="sq-code" aria-label="Squawk 7500">7500</span>
+    <span class="sq-meaning">HIJACK</span>
+    <span class="sq-note">Unlawful interference. Do NOT squawk unless actually under threat — ATC will immediately alert security services.</span>
+  </div>
+  <div class="squawk-card sq-7600">
+    <span class="sq-code" aria-label="Squawk 7600">7600</span>
+    <span class="sq-meaning">LOST COMMS</span>
+    <span class="sq-note">Radio failure. Squawk 7600 and follow lost-comms procedures below.</span>
+  </div>
+  <div class="squawk-card sq-7700">
+    <span class="sq-code" aria-label="Squawk 7700">7700</span>
+    <span class="sq-meaning">EMERGENCY</span>
+    <span class="sq-note">General emergency. Squawk 7700 with any MAYDAY situation; retains last assigned squawk on secondary systems.</span>
+  </div>
+</div>
+
+<!-- ── LOST COMMUNICATIONS ─────────────────────────────────────────────── -->
+<div class="section-label">Lost Communications — Step-by-Step</div>
+<div class="emerg-block">
+  <div class="lost-comms-steps" aria-label="Lost communications procedure">
+    <div class="lc-step">
+      <span class="lc-num">1</span>
+      <span><strong>Squawk 7600</strong> on the transponder to alert ATC of radio failure.</span>
+    </div>
+    <div class="lc-step">
+      <span class="lc-num">2</span>
+      <span><strong>Try all frequencies</strong> — attempt to re-establish contact on last assigned, guard (121.5 MHz), and other known frequencies.</span>
+    </div>
+    <div class="lc-step">
+      <span class="lc-num">3</span>
+      <span><strong>Check equipment</strong> — confirm volume, headset plugs, avionics master switch, breakers, and that squelch is not too high.</span>
+    </div>
+    <div class="lc-step">
+      <span class="lc-num">4</span>
+      <span><strong>Listen and look</strong> — ATC may continue to give instructions; watch for light signals from the control tower (see Light Signals reference card).</span>
+    </div>
+    <div class="lc-step">
+      <span class="lc-num">5</span>
+      <span><strong>If in controlled airspace:</strong> remain in VMC if possible; follow the expected routing and altitude. Proceed to destination, rock wings to acknowledge light signals.</span>
+    </div>
+    <div class="lc-step">
+      <span class="lc-num">6</span>
+      <span><strong>Arrival at controlled aerodrome:</strong> Enter the circuit normally; watch the tower for a <em>steady green</em> light signal (cleared to land). Rock wings to confirm receipt.</span>
+    </div>
+    <div class="lc-step">
+      <span class="lc-num">7</span>
+      <span><strong>After landing:</strong> Telephone ATC immediately to report the failure. (AIM RAC 1.9, CARs 602.136)</span>
+    </div>
+  </div>
+</div>
+
+<div class="note-box">
+  <strong>MAYDAY vs PAN-PAN:</strong> MAYDAY = grave and imminent danger requiring immediate assistance. PAN-PAN = urgent but not yet catastrophic — time to think and plan. Upgrade a PAN-PAN to MAYDAY if the situation deteriorates. Cancel either with "MAYDAY/PAN-PAN [call sign] cancel distress/urgency." (Source: AIM RAC 1.7)
+</div>
+
+</body>
+</html>

--- a/web-app/public/visuals/roc-ref-light-signals.html
+++ b/web-app/public/visuals/roc-ref-light-signals.html
@@ -1,0 +1,352 @@
+<!DOCTYPE html>
+<html lang="en" data-scheme="dark">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<script src="/visuals/_theme-init.js"></script>
+<link rel="stylesheet" href="/visuals/_common.css">
+<title>ROC-A Reference — ATC Light Signals (AIM RAC 4.5)</title>
+<style>
+  /*
+   * ATC light-signal colours hardcoded per spec (colour-only is not sufficient
+   * for accessibility — every cell also carries a text label):
+   *   green   #4caf7d  — cleared / safe to proceed
+   *   red     #e05050  — stop / do not land / unsafe
+   *   white   #e4ecf5  — return to start / land here (combined with green)
+   *   amber   #f0c040  — exercise caution (alternating red/green uses both)
+   *
+   * Source: AIM RAC 4.5.7 (Light Signals from ATC Tower)
+   */
+
+  .sig-grid {
+    width: 100%;
+    border-collapse: collapse;
+    margin-bottom: 28px;
+  }
+  .sig-grid th {
+    background: var(--surface2);
+    color: var(--accent);
+    font-size: 12px;
+    padding: 10px 14px;
+    letter-spacing: 0.5px;
+    text-align: left;
+  }
+  .sig-grid td {
+    font-size: 13px;
+    color: var(--text);
+    padding: 11px 14px;
+    border-bottom: 1px solid var(--border);
+    vertical-align: top;
+    line-height: 1.5;
+  }
+  .sig-grid tr:last-child td { border-bottom: none; }
+
+  /* Colour dot + label — paired so colour is not the sole indicator */
+  .sig-light {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    font-weight: 700;
+    white-space: nowrap;
+  }
+  .dot {
+    display: inline-block;
+    width: 16px;
+    height: 16px;
+    border-radius: 50%;
+    flex-shrink: 0;
+    border: 1.5px solid rgba(255,255,255,0.15);
+  }
+  /* Green dot */
+  .dot-green { background: #4caf7d; }   /* #4caf7d — cleared/safe */
+  /* Red dot */
+  .dot-red   { background: #e05050; }   /* #e05050 — stop/danger */
+  /* White dot */
+  .dot-white { background: #e4ecf5; }   /* #e4ecf5 — return/land with green */
+  /* Amber (alternating) — split half/half */
+  .dot-alt {
+    background: linear-gradient(135deg, #e05050 50%, #4caf7d 50%);
+    /* alternating red #e05050 / green #4caf7d */
+  }
+
+  .sig-type-badge {
+    display: inline-block;
+    font-size: 10px;
+    font-weight: 700;
+    letter-spacing: 0.7px;
+    padding: 2px 7px;
+    border-radius: 3px;
+    white-space: nowrap;
+    vertical-align: middle;
+    margin-left: 6px;
+  }
+  /* Steady light badge */
+  .badge-steady {
+    background: rgba(91,155,213,0.15);
+    color: #5b9bd5;
+    border: 1px solid rgba(91,155,213,0.3);
+  }
+  /* Flashing light badge */
+  .badge-flash {
+    background: rgba(240,192,64,0.12);
+    color: var(--accent);
+    border: 1px solid rgba(240,192,64,0.3);
+  }
+  /* Alternating badge */
+  .badge-alt {
+    background: rgba(224,80,80,0.12);
+    color: #e05050;
+    border: 1px solid rgba(224,80,80,0.3);
+  }
+
+  .section-note {
+    font-size: 11px;
+    color: var(--text-muted);
+    margin-bottom: 20px;
+    line-height: 1.7;
+  }
+
+  .colour-legend {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 14px;
+    margin-bottom: 24px;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 14px 16px;
+  }
+  .legend-item {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 12px;
+    color: var(--text-muted);
+  }
+  .legend-item strong {
+    color: var(--text);
+  }
+
+  @media (max-width: 640px) {
+    .sig-grid th:nth-child(3),
+    .sig-grid td:nth-child(3) { display: none; }
+  }
+</style>
+</head>
+<body>
+<button
+  data-backlink="true"
+  onclick="if(window.history.length<=1){window.close();}else{window.history.back();}"
+  style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:#f0c040;border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);"
+  aria-label="Back to lesson"
+>&#8592; Back to lesson</button>
+<style>.container{padding-top:56px!important;}@media(max-width:480px){.container{padding-top:60px!important;}}</style>
+
+<h1>ROC-A — ATC Light Signals</h1>
+<p class="subtitle">Canadian AIM RAC 4.5.7 · Transport Canada · ROC-A Quick Reference</p>
+
+<p class="section-note">
+  Used by ATC when radio communication is impossible or has failed. Colour alone does not fully convey meaning —
+  the <em>type</em> of signal (steady, flashing, alternating) is equally important.
+  Acknowledge receipt by rocking wings (day) or flashing landing/navigation lights (night).
+</p>
+
+<!-- Colour legend — pairs colour with text so info is not colour-only -->
+<div class="colour-legend" aria-label="Colour legend">
+  <div class="legend-item"><span class="dot dot-green" aria-hidden="true"></span><strong>Green</strong> — cleared / proceed</div>
+  <div class="legend-item"><span class="dot dot-red"   aria-hidden="true"></span><strong>Red</strong> — stop / danger / do not land</div>
+  <div class="legend-item"><span class="dot dot-white" aria-hidden="true"></span><strong>White</strong> — return / land here (with green)</div>
+  <div class="legend-item"><span class="dot dot-alt"   aria-hidden="true"></span><strong>Alt. Red/Green</strong> — extreme caution</div>
+</div>
+
+<!-- ── AIRCRAFT ON THE GROUND ─────────────────────────────────────────── -->
+<div class="section-label">Aircraft on the Ground</div>
+<div class="wide-table">
+<table class="sig-grid" aria-label="Light signals for aircraft on the ground">
+  <thead>
+    <tr>
+      <th>Signal</th>
+      <th>Type</th>
+      <th>Colour</th>
+      <th>Meaning for Aircraft on Ground</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>
+        <span class="sig-light">
+          <span class="dot dot-green" aria-hidden="true"></span>
+          Green
+        </span>
+        <span class="sig-type-badge badge-steady">STEADY</span>
+      </td>
+      <td>Steady Green</td>
+      <td style="color:#4caf7d;font-weight:700;">#4caf7d</td>
+      <td><strong>Cleared to take off.</strong> ATC has approved your departure from the runway in use.</td>
+    </tr>
+    <tr>
+      <td>
+        <span class="sig-light">
+          <span class="dot dot-green" aria-hidden="true"></span>
+          Green
+        </span>
+        <span class="sig-type-badge badge-flash">FLASHING</span>
+      </td>
+      <td>Flashing Green</td>
+      <td style="color:#4caf7d;font-weight:700;">#4caf7d</td>
+      <td><strong>Cleared to taxi.</strong> You may taxi but are NOT cleared for takeoff.</td>
+    </tr>
+    <tr>
+      <td>
+        <span class="sig-light">
+          <span class="dot dot-red" aria-hidden="true"></span>
+          Red
+        </span>
+        <span class="sig-type-badge badge-steady">STEADY</span>
+      </td>
+      <td>Steady Red</td>
+      <td style="color:#e05050;font-weight:700;">#e05050</td>
+      <td><strong>Stop.</strong> Halt immediately. Do not proceed until cleared.</td>
+    </tr>
+    <tr>
+      <td>
+        <span class="sig-light">
+          <span class="dot dot-red" aria-hidden="true"></span>
+          Red
+        </span>
+        <span class="sig-type-badge badge-flash">FLASHING</span>
+      </td>
+      <td>Flashing Red</td>
+      <td style="color:#e05050;font-weight:700;">#e05050</td>
+      <td><strong>Taxi clear of the runway in use.</strong> An aircraft on approach or another runway conflict requires you to clear immediately.</td>
+    </tr>
+    <tr>
+      <td>
+        <span class="sig-light">
+          <span class="dot dot-white" aria-hidden="true"></span>
+          White
+        </span>
+        <span class="sig-type-badge badge-flash">FLASHING</span>
+      </td>
+      <td>Flashing White</td>
+      <td style="color:#e4ecf5;font-weight:700;">#e4ecf5</td>
+      <td><strong>Return to starting point on the aerodrome.</strong> You are directed back to where you began your taxi.</td>
+    </tr>
+    <tr>
+      <td>
+        <span class="sig-light">
+          <span class="dot dot-alt" aria-hidden="true"></span>
+          Alt. R/G
+        </span>
+        <span class="sig-type-badge badge-alt">ALTERNATING</span>
+      </td>
+      <td>Alternating Red &amp; Green</td>
+      <td style="color:#e05050;font-weight:700;">#e05050 <span style="color:var(--text-muted)">/</span> <span style="color:#4caf7d;">#4caf7d</span></td>
+      <td><strong>Exercise extreme caution.</strong> A hazard exists — proceed with maximum vigilance.</td>
+    </tr>
+  </tbody>
+</table>
+</div>
+
+<!-- ── AIRCRAFT IN FLIGHT ──────────────────────────────────────────────── -->
+<div class="section-label">Aircraft in Flight</div>
+<div class="wide-table">
+<table class="sig-grid" aria-label="Light signals for aircraft in flight">
+  <thead>
+    <tr>
+      <th>Signal</th>
+      <th>Type</th>
+      <th>Colour</th>
+      <th>Meaning for Aircraft in Flight</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>
+        <span class="sig-light">
+          <span class="dot dot-green" aria-hidden="true"></span>
+          Green
+        </span>
+        <span class="sig-type-badge badge-steady">STEADY</span>
+      </td>
+      <td>Steady Green</td>
+      <td style="color:#4caf7d;font-weight:700;">#4caf7d</td>
+      <td><strong>Cleared to land.</strong> The runway is clear and you are authorised for landing.</td>
+    </tr>
+    <tr>
+      <td>
+        <span class="sig-light">
+          <span class="dot dot-green" aria-hidden="true"></span>
+          Green
+        </span>
+        <span class="sig-type-badge badge-flash">FLASHING</span>
+      </td>
+      <td>Flashing Green</td>
+      <td style="color:#4caf7d;font-weight:700;">#4caf7d</td>
+      <td><strong>Return for landing.</strong> Continue to circuit; a steady green will follow when cleared to land.</td>
+    </tr>
+    <tr>
+      <td>
+        <span class="sig-light">
+          <span class="dot dot-red" aria-hidden="true"></span>
+          Red
+        </span>
+        <span class="sig-type-badge badge-steady">STEADY</span>
+      </td>
+      <td>Steady Red</td>
+      <td style="color:#e05050;font-weight:700;">#e05050</td>
+      <td><strong>Give way to other aircraft and continue circling.</strong> Do not land — continue the circuit and await further signals.</td>
+    </tr>
+    <tr>
+      <td>
+        <span class="sig-light">
+          <span class="dot dot-red" aria-hidden="true"></span>
+          Red
+        </span>
+        <span class="sig-type-badge badge-flash">FLASHING</span>
+      </td>
+      <td>Flashing Red</td>
+      <td style="color:#e05050;font-weight:700;">#e05050</td>
+      <td><strong>Airport unsafe — do not land.</strong> A hazard exists on or near the runway; divert or continue circling.</td>
+    </tr>
+    <tr>
+      <td>
+        <span class="sig-light">
+          <span class="dot dot-white" aria-hidden="true"></span>
+          White
+        </span>
+        <span class="sig-type-badge badge-flash">FLASHING</span>
+      </td>
+      <td>Flashing White</td>
+      <td style="color:#e4ecf5;font-weight:700;">#e4ecf5</td>
+      <td><strong>Land at this aerodrome and proceed to the apron.</strong> A flashing green will follow when you may land.</td>
+    </tr>
+    <tr>
+      <td>
+        <span class="sig-light">
+          <span class="dot dot-alt" aria-hidden="true"></span>
+          Alt. R/G
+        </span>
+        <span class="sig-type-badge badge-alt">ALTERNATING</span>
+      </td>
+      <td>Alternating Red &amp; Green</td>
+      <td style="color:#e05050;font-weight:700;">#e05050 <span style="color:var(--text-muted)">/</span> <span style="color:#4caf7d;">#4caf7d</span></td>
+      <td><strong>Exercise extreme caution.</strong> A hazard exists — you may proceed but with maximum vigilance.</td>
+    </tr>
+  </tbody>
+</table>
+</div>
+
+<div class="note-box">
+  <strong>Acknowledge receipt:</strong> In flight, rock wings (day) or flash landing/navigation lights (night).
+  On the ground, flash landing lights or move ailerons.
+  <br><br>
+  <strong>Key distinctions:</strong> Steady Green on ground = <em>take off</em>; in flight = <em>land</em>.
+  Flashing Green on ground = <em>taxi</em>; in flight = <em>return for landing</em>.
+  Steady Red on ground = <em>stop</em>; in flight = <em>circle and give way</em>.
+  <br><br>
+  Source: AIM RAC 4.5.7 — Light Signals from ATC Tower. These signals apply when radio communication cannot be established or has failed.
+</div>
+
+</body>
+</html>

--- a/web-app/public/visuals/roc-ref-phonetic-alphabet.html
+++ b/web-app/public/visuals/roc-ref-phonetic-alphabet.html
@@ -1,0 +1,149 @@
+<!DOCTYPE html>
+<html lang="en" data-scheme="dark">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<script src="/visuals/_theme-init.js"></script>
+<link rel="stylesheet" href="/visuals/_common.css">
+<title>ROC-A Reference — Phonetic Alphabet &amp; Number Pronunciation</title>
+<style>
+  .alpha-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 6px;
+    margin-bottom: 32px;
+  }
+  .alpha-row {
+    display: grid;
+    grid-template-columns: 36px 1fr 1fr;
+    align-items: center;
+    gap: 10px;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    padding: 8px 12px;
+  }
+  .alpha-letter {
+    font-size: 18px;
+    font-weight: 800;
+    color: var(--accent);
+    text-align: center;
+  }
+  .alpha-word {
+    font-size: 13px;
+    color: var(--text);
+    font-weight: 600;
+  }
+  .alpha-stress {
+    font-size: 11px;
+    color: var(--text-muted);
+    font-style: italic;
+  }
+
+  .digit-grid {
+    display: grid;
+    grid-template-columns: repeat(5, 1fr);
+    gap: 8px;
+    margin-bottom: 32px;
+  }
+  .digit-card {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    padding: 10px 8px;
+    text-align: center;
+  }
+  .digit-num {
+    font-size: 22px;
+    font-weight: 800;
+    color: var(--accent);
+    display: block;
+  }
+  .digit-say {
+    font-size: 12px;
+    color: var(--text);
+    font-weight: 600;
+    display: block;
+    margin-top: 4px;
+  }
+  .digit-stress {
+    font-size: 10px;
+    color: var(--text-muted);
+    font-style: italic;
+    display: block;
+    margin-top: 2px;
+  }
+
+  @media (max-width: 640px) {
+    .alpha-grid { grid-template-columns: 1fr; }
+    .digit-grid  { grid-template-columns: repeat(3, 1fr); }
+  }
+  @media (max-width: 480px) {
+    .digit-grid  { grid-template-columns: repeat(2, 1fr); }
+  }
+</style>
+</head>
+<body>
+<button
+  data-backlink="true"
+  onclick="if(window.history.length<=1){window.close();}else{window.history.back();}"
+  style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:#f0c040;border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);"
+  aria-label="Back to lesson"
+>&#8592; Back to lesson</button>
+<style>.container{padding-top:56px!important;}@media(max-width:480px){.container{padding-top:60px!important;}}</style>
+
+<h1>ROC-A — Phonetic Alphabet &amp; Number Pronunciation</h1>
+<p class="subtitle">ICAO/Transport Canada · AIM RAC · ROC-A Written Exam Quick Reference</p>
+
+<div class="section-label">NATO Phonetic Alphabet — A to Z</div>
+<div class="alpha-grid">
+  <div class="alpha-row"><span class="alpha-letter">A</span><span class="alpha-word">Alpha</span><span class="alpha-stress">AL-fah</span></div>
+  <div class="alpha-row"><span class="alpha-letter">B</span><span class="alpha-word">Bravo</span><span class="alpha-stress">BRAH-voh</span></div>
+  <div class="alpha-row"><span class="alpha-letter">C</span><span class="alpha-word">Charlie</span><span class="alpha-stress">CHAR-lee</span></div>
+  <div class="alpha-row"><span class="alpha-letter">D</span><span class="alpha-word">Delta</span><span class="alpha-stress">DEL-tah</span></div>
+  <div class="alpha-row"><span class="alpha-letter">E</span><span class="alpha-word">Echo</span><span class="alpha-stress">EK-oh</span></div>
+  <div class="alpha-row"><span class="alpha-letter">F</span><span class="alpha-word">Foxtrot</span><span class="alpha-stress">FOKS-trot</span></div>
+  <div class="alpha-row"><span class="alpha-letter">G</span><span class="alpha-word">Golf</span><span class="alpha-stress">GOLF</span></div>
+  <div class="alpha-row"><span class="alpha-letter">H</span><span class="alpha-word">Hotel</span><span class="alpha-stress">hoh-TEL</span></div>
+  <div class="alpha-row"><span class="alpha-letter">I</span><span class="alpha-word">India</span><span class="alpha-stress">IN-dee-ah</span></div>
+  <div class="alpha-row"><span class="alpha-letter">J</span><span class="alpha-word">Juliet</span><span class="alpha-stress">JEW-lee-et</span></div>
+  <div class="alpha-row"><span class="alpha-letter">K</span><span class="alpha-word">Kilo</span><span class="alpha-stress">KEY-loh</span></div>
+  <div class="alpha-row"><span class="alpha-letter">L</span><span class="alpha-word">Lima</span><span class="alpha-stress">LEE-mah</span></div>
+  <div class="alpha-row"><span class="alpha-letter">M</span><span class="alpha-word">Mike</span><span class="alpha-stress">MIKE</span></div>
+  <div class="alpha-row"><span class="alpha-letter">N</span><span class="alpha-word">November</span><span class="alpha-stress">no-VEM-ber</span></div>
+  <div class="alpha-row"><span class="alpha-letter">O</span><span class="alpha-word">Oscar</span><span class="alpha-stress">OSS-kah</span></div>
+  <div class="alpha-row"><span class="alpha-letter">P</span><span class="alpha-word">Papa</span><span class="alpha-stress">PAH-pah</span></div>
+  <div class="alpha-row"><span class="alpha-letter">Q</span><span class="alpha-word">Quebec</span><span class="alpha-stress">keh-BEK</span></div>
+  <div class="alpha-row"><span class="alpha-letter">R</span><span class="alpha-word">Romeo</span><span class="alpha-stress">ROH-mee-oh</span></div>
+  <div class="alpha-row"><span class="alpha-letter">S</span><span class="alpha-word">Sierra</span><span class="alpha-stress">see-AIR-ah</span></div>
+  <div class="alpha-row"><span class="alpha-letter">T</span><span class="alpha-word">Tango</span><span class="alpha-stress">TANG-go</span></div>
+  <div class="alpha-row"><span class="alpha-letter">U</span><span class="alpha-word">Uniform</span><span class="alpha-stress">YOU-nee-form</span></div>
+  <div class="alpha-row"><span class="alpha-letter">V</span><span class="alpha-word">Victor</span><span class="alpha-stress">VIK-tah</span></div>
+  <div class="alpha-row"><span class="alpha-letter">W</span><span class="alpha-word">Whiskey</span><span class="alpha-stress">WISS-key</span></div>
+  <div class="alpha-row"><span class="alpha-letter">X</span><span class="alpha-word">X-ray</span><span class="alpha-stress">ECKS-ray</span></div>
+  <div class="alpha-row"><span class="alpha-letter">Y</span><span class="alpha-word">Yankee</span><span class="alpha-stress">YANG-key</span></div>
+  <div class="alpha-row"><span class="alpha-letter">Z</span><span class="alpha-word">Zulu</span><span class="alpha-stress">ZOO-loo</span></div>
+</div>
+
+<div class="section-label">ICAO Number Pronunciation — 0 to 9</div>
+<div class="digit-grid">
+  <div class="digit-card"><span class="digit-num">0</span><span class="digit-say">ZE-RO</span><span class="digit-stress">ZEE-ro</span></div>
+  <div class="digit-card"><span class="digit-num">1</span><span class="digit-say">WUN</span><span class="digit-stress">wun</span></div>
+  <div class="digit-card"><span class="digit-num">2</span><span class="digit-say">TOO</span><span class="digit-stress">too</span></div>
+  <div class="digit-card"><span class="digit-num">3</span><span class="digit-say">TREE</span><span class="digit-stress">tree</span></div>
+  <div class="digit-card"><span class="digit-num">4</span><span class="digit-say">FOW-er</span><span class="digit-stress">fow-er</span></div>
+  <div class="digit-card"><span class="digit-num">5</span><span class="digit-say">FIFE</span><span class="digit-stress">fyfe</span></div>
+  <div class="digit-card"><span class="digit-num">6</span><span class="digit-say">SIX</span><span class="digit-stress">six</span></div>
+  <div class="digit-card"><span class="digit-num">7</span><span class="digit-say">SEV-en</span><span class="digit-stress">sev-en</span></div>
+  <div class="digit-card"><span class="digit-num">8</span><span class="digit-say">AIT</span><span class="digit-stress">ayt</span></div>
+  <div class="digit-card"><span class="digit-num">9</span><span class="digit-say">NIN-er</span><span class="digit-stress">nyn-er</span></div>
+</div>
+
+<div class="note-box">
+  <strong>Why altered pronunciations?</strong> ICAO chose these to reduce confusion over radio when English is spoken by non-native speakers or in noisy RF environments. "TREE" (3) can't be mistaken for "free"; "FIFE" (5) is distinct from "fire"; "NIN-er" (9) avoids confusion with the German "nein" (no).
+  <br><br>
+  <strong>Hundreds and thousands:</strong> Each digit is spoken individually. Altitude 3,500 ft = "TREE FIFE ZE-RO ZE-RO". Frequency 126.7 MHz = "WUN TOO SIX DECIMAL SEV-en". (Source: AIM RAC 1.4, ICAO Doc 9432)
+</div>
+
+</body>
+</html>

--- a/web-app/public/visuals/roc-ref-phraseology.html
+++ b/web-app/public/visuals/roc-ref-phraseology.html
@@ -1,0 +1,257 @@
+<!DOCTYPE html>
+<html lang="en" data-scheme="dark">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<script src="/visuals/_theme-init.js"></script>
+<link rel="stylesheet" href="/visuals/_common.css">
+<title>ROC-A Reference — Standard Radio Phraseology (Canadian AIM RAC)</title>
+<style>
+  .call-block {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 16px 18px;
+    margin-bottom: 14px;
+  }
+  .call-title {
+    font-size: 12px;
+    font-weight: 700;
+    color: var(--accent);
+    text-transform: uppercase;
+    letter-spacing: 0.8px;
+    margin-bottom: 10px;
+  }
+  .call-template {
+    font-size: 13px;
+    color: var(--text);
+    line-height: 1.7;
+    background: var(--surface2);
+    border-left: 3px solid var(--accent-dim);
+    padding: 10px 14px;
+    border-radius: 0 4px 4px 0;
+    margin-bottom: 8px;
+    font-family: 'Courier New', Courier, monospace;
+  }
+  .call-template .var {
+    color: var(--text-muted);
+    font-style: italic;
+  }
+  .call-example {
+    font-size: 12px;
+    color: var(--text-muted);
+    line-height: 1.6;
+    padding-left: 4px;
+  }
+  .call-example strong {
+    color: var(--accent);
+  }
+  .airport-type-label {
+    font-size: 11px;
+    display: inline-block;
+    padding: 2px 8px;
+    border-radius: 4px;
+    font-weight: 700;
+    letter-spacing: 0.5px;
+    margin-bottom: 10px;
+  }
+  .controlled-label {
+    background: rgba(91,155,213,0.15);
+    color: #5b9bd5;
+    border: 1px solid rgba(91,155,213,0.3);
+  }
+  .uncontrolled-label {
+    background: rgba(76,175,125,0.15);
+    color: #4caf7d;
+    border: 1px solid rgba(76,175,125,0.3);
+  }
+  .circuit-flow {
+    display: flex;
+    gap: 6px;
+    align-items: center;
+    flex-wrap: wrap;
+    margin-bottom: 16px;
+  }
+  .circuit-step {
+    background: var(--surface2);
+    border: 1px solid var(--border-hi);
+    border-radius: 6px;
+    padding: 6px 12px;
+    font-size: 12px;
+    color: var(--text-muted);
+    white-space: nowrap;
+  }
+  .circuit-arrow {
+    color: var(--accent-dim);
+    font-size: 14px;
+  }
+  .circuit-step.active {
+    background: rgba(240,192,64,0.12);
+    border-color: rgba(240,192,64,0.4);
+    color: var(--accent);
+    font-weight: 600;
+  }
+</style>
+</head>
+<body>
+<button
+  data-backlink="true"
+  onclick="if(window.history.length<=1){window.close();}else{window.history.back();}"
+  style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:#f0c040;border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);"
+  aria-label="Back to lesson"
+>&#8592; Back to lesson</button>
+<style>.container{padding-top:56px!important;}@media(max-width:480px){.container{padding-top:60px!important;}}</style>
+
+<h1>ROC-A — Standard Radio Phraseology</h1>
+<p class="subtitle">Canadian AIM RAC · Transport Canada · ROC-A Quick Reference — NOT FAA phraseology</p>
+
+<!-- ── CONTROLLED AIRPORT ─────────────────────────────────────────────── -->
+<div class="section-label">Controlled Airport (Tower / Ground)</div>
+
+<div class="call-block">
+  <div class="airport-type-label controlled-label">CONTROLLED — Initial Call to Ground</div>
+  <div class="call-title">Taxi Request</div>
+  <div class="call-template">
+    <span class="var">[Airport] Ground</span>, <span class="var">[call sign]</span>,
+    at <span class="var">[location]</span>, request taxi,
+    runway <span class="var">[##]</span>, with <span class="var">[ATIS info letter / weather]</span>.
+  </div>
+  <div class="call-example">
+    <strong>Example:</strong> "Buttonville Ground, Cessna Golf-Charlie-Foxtrot-Bravo, at the main apron, request taxi, runway 15, with information Alpha."
+  </div>
+</div>
+
+<div class="call-block">
+  <div class="airport-type-label controlled-label">CONTROLLED — Before Runway Departure</div>
+  <div class="call-title">Takeoff Clearance Request (Contacting Tower)</div>
+  <div class="call-template">
+    <span class="var">[Airport] Tower</span>, <span class="var">[call sign]</span>,
+    holding short runway <span class="var">[##]</span>, ready for departure,
+    <span class="var">[VFR / IFR]</span>.
+  </div>
+  <div class="call-example">
+    <strong>Example:</strong> "Buttonville Tower, Cessna Golf-Charlie-Foxtrot-Bravo, holding short runway 15, ready for departure, VFR."
+    <br><br>
+    <strong>Note:</strong> ATC issues takeoff clearance; you do NOT depart until you hear "Cleared for takeoff runway ##."
+  </div>
+</div>
+
+<!-- ── UNCONTROLLED AIRPORT — CIRCUIT CALLS ──────────────────────────── -->
+<div class="section-label">Uncontrolled Airport — Circuit Position Reports (MF/ATF)</div>
+
+<div class="note-box" style="margin-bottom:16px;">
+  At an uncontrolled aerodrome with a <strong>Mandatory Frequency (MF)</strong> or
+  <strong>Aerodrome Traffic Frequency (ATF)</strong>, all pilots broadcast their
+  intentions and position. There is no ATC — these are <em>self-announce</em> calls.
+  Format: <strong>[Airport] traffic, [call sign], [position/intention], runway [##], [airport] traffic.</strong>
+  (AIM RAC 4.5.2, TP 14371)
+</div>
+
+<div class="circuit-flow" aria-label="Circuit sequence">
+  <span class="circuit-step active">Taxi / Departure</span>
+  <span class="circuit-arrow">→</span>
+  <span class="circuit-step">Upwind</span>
+  <span class="circuit-arrow">→</span>
+  <span class="circuit-step">Crosswind</span>
+  <span class="circuit-arrow">→</span>
+  <span class="circuit-step">Downwind</span>
+  <span class="circuit-arrow">→</span>
+  <span class="circuit-step">Base</span>
+  <span class="circuit-arrow">→</span>
+  <span class="circuit-step">Final</span>
+  <span class="circuit-arrow">→</span>
+  <span class="circuit-step">Clear of runway</span>
+</div>
+
+<div class="call-block">
+  <div class="call-title">Taxiing / Departing</div>
+  <div class="call-template">
+    <span class="var">[Airport]</span> traffic,
+    <span class="var">[call sign]</span>,
+    taxiing runway <span class="var">[##]</span>,
+    departing <span class="var">[direction / to destination]</span>,
+    <span class="var">[airport]</span> traffic.
+  </div>
+  <div class="call-example">
+    <strong>Example:</strong> "Rockcliffe traffic, Cessna Golf-Charlie-Foxtrot-Bravo, taxiing runway 09, departing to the west, Rockcliffe traffic."
+  </div>
+</div>
+
+<div class="call-block">
+  <div class="call-title">Upwind (after lift-off)</div>
+  <div class="call-template">
+    <span class="var">[Airport]</span> traffic,
+    <span class="var">[call sign]</span>,
+    upwind runway <span class="var">[##]</span>,
+    <span class="var">[airport]</span> traffic.
+  </div>
+</div>
+
+<div class="call-block">
+  <div class="call-title">Crosswind</div>
+  <div class="call-template">
+    <span class="var">[Airport]</span> traffic,
+    <span class="var">[call sign]</span>,
+    crosswind runway <span class="var">[##]</span>,
+    <span class="var">[airport]</span> traffic.
+  </div>
+</div>
+
+<div class="call-block">
+  <div class="call-title">Downwind</div>
+  <div class="call-template">
+    <span class="var">[Airport]</span> traffic,
+    <span class="var">[call sign]</span>,
+    left/right downwind runway <span class="var">[##]</span>,
+    <span class="var">[airport]</span> traffic.
+  </div>
+  <div class="call-example">
+    <strong>Example:</strong> "Rockcliffe traffic, Cessna Golf-Charlie-Foxtrot-Bravo, left downwind runway 09, Rockcliffe traffic."
+  </div>
+</div>
+
+<div class="call-block">
+  <div class="call-title">Base</div>
+  <div class="call-template">
+    <span class="var">[Airport]</span> traffic,
+    <span class="var">[call sign]</span>,
+    left/right base runway <span class="var">[##]</span>,
+    <span class="var">[airport]</span> traffic.
+  </div>
+</div>
+
+<div class="call-block">
+  <div class="call-title">Final</div>
+  <div class="call-template">
+    <span class="var">[Airport]</span> traffic,
+    <span class="var">[call sign]</span>,
+    final runway <span class="var">[##]</span>,
+    <span class="var">[airport]</span> traffic.
+  </div>
+  <div class="call-example">
+    <strong>Example:</strong> "Rockcliffe traffic, Cessna Golf-Charlie-Foxtrot-Bravo, final runway 09, Rockcliffe traffic."
+  </div>
+</div>
+
+<div class="call-block">
+  <div class="call-title">Clear of Active Runway (after landing)</div>
+  <div class="call-template">
+    <span class="var">[Airport]</span> traffic,
+    <span class="var">[call sign]</span>,
+    clear of runway <span class="var">[##]</span>,
+    taxiing to parking,
+    <span class="var">[airport]</span> traffic.
+  </div>
+</div>
+
+<div class="note-box">
+  <strong>Arriving aircraft (first call entering the MF/ATF zone):</strong><br>
+  "[Airport] traffic, [call sign], [aircraft type], [position relative to airport, altitude],
+  inbound for landing, runway [##], [airport] traffic."<br><br>
+  Always end self-announce calls by repeating the airport name — this helps
+  pilots on other frequencies recognise which airport the call belongs to.
+  (Source: AIM RAC 4.5.2)
+</div>
+
+</body>
+</html>


### PR DESCRIPTION
## Summary

- Adds 4 standalone dark-aviation HTML reference cards for the ROC-A exam
- `roc-ref-phonetic-alphabet.html` — NATO A–Z + ICAO digit pronunciation 0–9, two-column quick-scan layout
- `roc-ref-phraseology.html` — Canadian AIM RAC standard radio calls: taxi (controlled), takeoff clearance request, circuit position reports (upwind/crosswind/downwind/base/final at MF/ATF aerodromes), and post-landing clear-of-runway call
- `roc-ref-emergency.html` — MAYDAY format, PAN-PAN format, emergency squawk codes 7500/7600/7700 with colour coding, and lost-comms step-by-step procedure
- `roc-ref-light-signals.html` — ATC light signals (ground + in-flight) in colour-coded grid per AIM RAC 4.5.7

## Standards compliance

- All files link `/visuals/_common.css`, no external resources
- `data-backlink="true"` back-to-lesson button included in all 4 files
- Dark scheme locked via `data-scheme="dark"` on `<html>`
- Light-signal colours hardcoded with explanatory comments: green `#4caf7d`, red `#e05050`, white `#e4ecf5`, amber `#f0c040`
- Canadian AIM RAC phraseology throughout — not FAA
- Colour never used as sole indicator (every cell includes text label)

Closes #343

🤖 Generated with [Claude Code](https://claude.com/claude-code)