### PR TITLE
[PPL-342] ROC-A: add 9 visual HTML diagrams and link from lessons

### DIFF
--- a/lessons/radio/001-phonetic-alphabet-numbers.md
+++ b/lessons/radio/001-phonetic-alphabet-numbers.md
@@ -7,7 +7,7 @@ title: "Phonetic Alphabet and Number Pronunciation"
 duration_min: 20
 status: complete
 audio: null
-visual: ''
+visual: '/visuals/roc001-phonetic-alphabet-numbers.html'
 sources:
   - ISED RIC-21
   - AIM COM 4.0

--- a/lessons/radio/002-standard-phraseology-readback.md
+++ b/lessons/radio/002-standard-phraseology-readback.md
@@ -7,7 +7,7 @@ title: "Standard Phraseology and Readback Requirements"
 duration_min: 20
 status: complete
 audio: null
-visual: ''
+visual: '/visuals/roc002-standard-phraseology-readback.html'
 sources:
   - ISED RIC-21
   - AIM COM 4.0

--- a/lessons/radio/003-frequencies-reference.md
+++ b/lessons/radio/003-frequencies-reference.md
@@ -7,7 +7,7 @@ title: "Aviation Frequency Reference"
 duration_min: 20
 status: complete
 audio: null
-visual: ''
+visual: '/visuals/roc003-frequencies-reference.html'
 sources:
   - ISED RIC-21
   - AIM COM 4.0

--- a/lessons/radio/004-position-reporting.md
+++ b/lessons/radio/004-position-reporting.md
@@ -7,7 +7,7 @@ title: "Position Reporting — MF and ATF Procedures"
 duration_min: 20
 status: complete
 audio: null
-visual: ''
+visual: '/visuals/roc004-position-reporting.html'
 sources:
   - AIM RAC 4.5
   - AIM RAC 4.4

--- a/lessons/radio/005-vfr-ifr-comms-overview.md
+++ b/lessons/radio/005-vfr-ifr-comms-overview.md
@@ -7,7 +7,7 @@ title: "VFR and IFR Communications Overview"
 duration_min: 20
 status: complete
 audio: null
-visual: ''
+visual: '/visuals/roc005-vfr-ifr-comms-overview.html'
 sources:
   - AIM RAC 4.3
   - AIM COM 4.0

--- a/lessons/radio/006-emergency-comms.md
+++ b/lessons/radio/006-emergency-comms.md
@@ -7,7 +7,7 @@ title: "Emergency Communications"
 duration_min: 20
 status: complete
 audio: null
-visual: ''
+visual: '/visuals/roc006-emergency-comms.html'
 sources:
   - AIM SAR 3.0
   - AIM COM 4.0

--- a/lessons/radio/007-light-signals.md
+++ b/lessons/radio/007-light-signals.md
@@ -7,7 +7,7 @@ title: "Light Gun Signals"
 duration_min: 20
 status: complete
 audio: null
-visual: ''
+visual: '/visuals/roc007-light-signals.html'
 sources:
   - AIM RAC 4.6
   - CARs 602.98

--- a/lessons/radio/008-regulatory-framework.md
+++ b/lessons/radio/008-regulatory-framework.md
@@ -7,7 +7,7 @@ title: "Radio Regulatory Framework — Radiocommunication Act and ROC-A"
 duration_min: 20
 status: complete
 audio: null
-visual: ''
+visual: '/visuals/roc008-regulatory-framework.html'
 sources:
   - Radiocommunication Act R.S.C. 1985 c. R-2
   - ISED RIC-21

--- a/lessons/radio/009-radio-etiquette.md
+++ b/lessons/radio/009-radio-etiquette.md
@@ -7,7 +7,7 @@ title: "Radio Etiquette and Professional Practice"
 duration_min: 20
 status: complete
 audio: null
-visual: ''
+visual: '/visuals/roc009-radio-etiquette.html'
 sources:
   - ISED RIC-21
   - AIM COM 4.0

--- a/web-app/public/visuals/roc001-phonetic-alphabet-numbers.html
+++ b/web-app/public/visuals/roc001-phonetic-alphabet-numbers.html
@@ -1,0 +1,166 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>ROC-001: Phonetic Alphabet and Number Pronunciation</title>
+<link rel="stylesheet" href="/visuals/_common.css">
+<style>
+  .alpha-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
+    gap: 8px;
+    margin-bottom: 32px;
+  }
+  .alpha-card {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    padding: 10px 12px;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+  }
+  .letter-badge {
+    display: inline-block;
+    width: 32px;
+    height: 32px;
+    background: var(--surface2);
+    border: 1px solid var(--border-hi);
+    border-radius: 4px;
+    text-align: center;
+    line-height: 32px;
+    font-size: 18px;
+    font-weight: 800;
+    color: var(--accent);
+    flex-shrink: 0;
+  }
+  .alpha-word {
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--text);
+    line-height: 1.3;
+  }
+  .alpha-pron {
+    font-size: 11px;
+    color: var(--text-muted);
+    font-style: italic;
+  }
+  .digit-grid {
+    display: grid;
+    grid-template-columns: repeat(5, 1fr);
+    gap: 8px;
+    margin-bottom: 32px;
+  }
+  .digit-card {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    padding: 12px 8px;
+    text-align: center;
+  }
+  .digit-num {
+    font-size: 24px;
+    font-weight: 800;
+    color: var(--accent);
+    display: block;
+    line-height: 1.1;
+  }
+  .digit-say {
+    font-size: 13px;
+    color: var(--text);
+    font-weight: 600;
+    display: block;
+    margin-top: 4px;
+  }
+  .digit-pron {
+    font-size: 11px;
+    color: var(--text-muted);
+    font-style: italic;
+    display: block;
+    margin-top: 2px;
+  }
+  @media (max-width: 480px) {
+    .alpha-grid { grid-template-columns: repeat(auto-fill, minmax(100px, 1fr)); }
+    .digit-grid { grid-template-columns: repeat(5, 1fr); gap: 4px; }
+  }
+</style>
+</head>
+<body>
+  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:#f0c040;border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
+  <style>.container{padding-top:56px!important;}@media(max-width:480px){.container{padding-top:60px!important;}}</style>
+
+<div class="container">
+  <h1>ROC-001 — Phonetic Alphabet &amp; Number Pronunciation</h1>
+  <p class="subtitle">ISED RIC-21 · ICAO Annex 10 Vol. II · AIM COM 4.0 · ROC-A Written Exam</p>
+
+  <div class="section-title">NATO Phonetic Alphabet — A to Z</div>
+  <div class="alpha-grid">
+    <div class="alpha-card"><span class="letter-badge">A</span><div><div class="alpha-word">Alfa</div><div class="alpha-pron">AL-fah</div></div></div>
+    <div class="alpha-card"><span class="letter-badge">B</span><div><div class="alpha-word">Bravo</div><div class="alpha-pron">BRAH-voh</div></div></div>
+    <div class="alpha-card"><span class="letter-badge">C</span><div><div class="alpha-word">Charlie</div><div class="alpha-pron">CHAR-lee</div></div></div>
+    <div class="alpha-card"><span class="letter-badge">D</span><div><div class="alpha-word">Delta</div><div class="alpha-pron">DEL-tah</div></div></div>
+    <div class="alpha-card"><span class="letter-badge">E</span><div><div class="alpha-word">Echo</div><div class="alpha-pron">EK-oh</div></div></div>
+    <div class="alpha-card"><span class="letter-badge">F</span><div><div class="alpha-word">Foxtrot</div><div class="alpha-pron">FOKS-trot</div></div></div>
+    <div class="alpha-card"><span class="letter-badge">G</span><div><div class="alpha-word">Golf</div><div class="alpha-pron">GOLF</div></div></div>
+    <div class="alpha-card"><span class="letter-badge">H</span><div><div class="alpha-word">Hotel</div><div class="alpha-pron">HOH-tel</div></div></div>
+    <div class="alpha-card"><span class="letter-badge">I</span><div><div class="alpha-word">India</div><div class="alpha-pron">IN-dee-ah</div></div></div>
+    <div class="alpha-card"><span class="letter-badge">J</span><div><div class="alpha-word">Juliett</div><div class="alpha-pron">JEW-lee-et</div></div></div>
+    <div class="alpha-card"><span class="letter-badge">K</span><div><div class="alpha-word">Kilo</div><div class="alpha-pron">KEY-loh</div></div></div>
+    <div class="alpha-card"><span class="letter-badge">L</span><div><div class="alpha-word">Lima</div><div class="alpha-pron">LEE-mah</div></div></div>
+    <div class="alpha-card"><span class="letter-badge">M</span><div><div class="alpha-word">Mike</div><div class="alpha-pron">MIKE</div></div></div>
+    <div class="alpha-card"><span class="letter-badge">N</span><div><div class="alpha-word">November</div><div class="alpha-pron">no-VEM-ber</div></div></div>
+    <div class="alpha-card"><span class="letter-badge">O</span><div><div class="alpha-word">Oscar</div><div class="alpha-pron">OSS-car</div></div></div>
+    <div class="alpha-card"><span class="letter-badge">P</span><div><div class="alpha-word">Papa</div><div class="alpha-pron">PAH-pah</div></div></div>
+    <div class="alpha-card"><span class="letter-badge">Q</span><div><div class="alpha-word">Quebec</div><div class="alpha-pron">keh-BEK</div></div></div>
+    <div class="alpha-card"><span class="letter-badge">R</span><div><div class="alpha-word">Romeo</div><div class="alpha-pron">ROH-me-oh</div></div></div>
+    <div class="alpha-card"><span class="letter-badge">S</span><div><div class="alpha-word">Sierra</div><div class="alpha-pron">see-AIR-ah</div></div></div>
+    <div class="alpha-card"><span class="letter-badge">T</span><div><div class="alpha-word">Tango</div><div class="alpha-pron">TANG-go</div></div></div>
+    <div class="alpha-card"><span class="letter-badge">U</span><div><div class="alpha-word">Uniform</div><div class="alpha-pron">YOU-nee-form</div></div></div>
+    <div class="alpha-card"><span class="letter-badge">V</span><div><div class="alpha-word">Victor</div><div class="alpha-pron">VIK-tor</div></div></div>
+    <div class="alpha-card"><span class="letter-badge">W</span><div><div class="alpha-word">Whiskey</div><div class="alpha-pron">WISS-key</div></div></div>
+    <div class="alpha-card"><span class="letter-badge">X</span><div><div class="alpha-word">X-ray</div><div class="alpha-pron">ECKS-ray</div></div></div>
+    <div class="alpha-card"><span class="letter-badge">Y</span><div><div class="alpha-word">Yankee</div><div class="alpha-pron">YANG-key</div></div></div>
+    <div class="alpha-card"><span class="letter-badge">Z</span><div><div class="alpha-word">Zulu</div><div class="alpha-pron">ZOO-loo</div></div></div>
+  </div>
+
+  <div class="section-title">Digit Pronunciation — Aviation Standard</div>
+  <div class="digit-grid">
+    <div class="digit-card"><span class="digit-num">0</span><span class="digit-say">Zero</span><span class="digit-pron">ZEE-ro</span></div>
+    <div class="digit-card"><span class="digit-num">1</span><span class="digit-say">One</span><span class="digit-pron">WUN</span></div>
+    <div class="digit-card"><span class="digit-num">2</span><span class="digit-say">Two</span><span class="digit-pron">TOO</span></div>
+    <div class="digit-card"><span class="digit-num">3</span><span class="digit-say">Tree</span><span class="digit-pron">TREE</span></div>
+    <div class="digit-card"><span class="digit-num">4</span><span class="digit-say">Four</span><span class="digit-pron">FOW-er</span></div>
+    <div class="digit-card"><span class="digit-num">5</span><span class="digit-say">Fife</span><span class="digit-pron">FIFE</span></div>
+    <div class="digit-card"><span class="digit-num">6</span><span class="digit-say">Six</span><span class="digit-pron">SIX</span></div>
+    <div class="digit-card"><span class="digit-num">7</span><span class="digit-say">Seven</span><span class="digit-pron">SEV-en</span></div>
+    <div class="digit-card"><span class="digit-num">8</span><span class="digit-say">Eight</span><span class="digit-pron">AIT</span></div>
+    <div class="digit-card"><span class="digit-num">9</span><span class="digit-say">Niner</span><span class="digit-pron">NYE-ner</span></div>
+  </div>
+
+  <div class="section-title">Altitude and Frequency Conventions</div>
+  <table>
+    <thead>
+      <tr><th>What you read</th><th>What you say</th><th>Note</th></tr>
+    </thead>
+    <tbody>
+      <tr><td>3,500 ft</td><td>"Tree thousand fife hundred"</td><td>Each digit group spoken separately</td></tr>
+      <tr><td>FL240</td><td>"Flight level two four zero"</td><td>Each digit individually</td></tr>
+      <tr><td>122.8 MHz</td><td>"One two two decimal eight"</td><td>Decimal point said as "decimal"</td></tr>
+      <tr><td>Squawk 7700</td><td>"Squawk seven seven zero zero"</td><td>Each digit individually</td></tr>
+      <tr><td>Runway 28L</td><td>"Runway two eight left"</td><td>Two-digit runway number</td></tr>
+      <tr><td>Wind 270° / 15 kts</td><td>"Wind two seven zero at one fife"</td><td>Three digits for heading</td></tr>
+    </tbody>
+  </table>
+
+  <div class="note-box">
+    <strong>Why "Niner" and "Tree"?</strong> "Niner" avoids confusion with the German word <em>Nein</em> (no). "Tree" prevents "three" being misheard as "free" over noisy radio. "Fife" for 5 reduces confusion with "fire". These deviations are ICAO-mandated, not optional. (ICAO Annex 10 Vol. II §5.2.1.7)
+  </div>
+
+  <div class="memory-hook">
+    <span class="badge">EXAM HOOK</span><br>
+    <strong>Three digits to memorise:</strong> 3 = Tree · 5 = Fife · 9 = Niner. All other digits use normal English. Frequencies always include "decimal" for the decimal point. Flight levels are spoken digit-by-digit: FL240 = "two four zero" — never "two hundred forty."
+  </div>
+</div>
+</body>
+</html>

--- a/web-app/public/visuals/roc002-standard-phraseology-readback.html
+++ b/web-app/public/visuals/roc002-standard-phraseology-readback.html
@@ -1,0 +1,190 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>ROC-002: Standard Phraseology and Readback</title>
+<link rel="stylesheet" href="/visuals/_common.css">
+<style>
+  .call-template {
+    background: var(--surface);
+    border: 1.5px solid var(--border-hi);
+    border-radius: 8px;
+    padding: 18px 20px;
+    margin-bottom: 24px;
+  }
+  .call-template h3 {
+    font-size: 12px;
+    color: var(--text-muted);
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    margin-bottom: 12px;
+  }
+  .call-parts {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    gap: 8px;
+  }
+  .call-part {
+    background: var(--surface2);
+    border: 1px solid var(--border);
+    border-radius: 5px;
+    padding: 10px 12px;
+  }
+  .call-part-num {
+    font-size: 10px;
+    color: var(--text-muted);
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    margin-bottom: 4px;
+  }
+  .call-part-label {
+    font-size: 13px;
+    font-weight: 700;
+    color: var(--accent);
+    margin-bottom: 2px;
+  }
+  .call-part-eg {
+    font-size: 11px;
+    color: var(--text-muted);
+    font-style: italic;
+  }
+  .readback-must { color: #4caf7d; font-weight: 700; }
+  .readback-opt  { color: var(--text-muted); }
+  .example-exchange {
+    background: var(--surface);
+    border-left: 3px solid var(--accent);
+    border-radius: 4px;
+    padding: 14px 18px;
+    margin-bottom: 20px;
+    font-size: 13px;
+    line-height: 1.8;
+  }
+  .tx-atc   { color: var(--info); }
+  .tx-pilot { color: #4caf7d; }
+  .tx-label { font-size: 10px; text-transform: uppercase; letter-spacing: 1px; margin-right: 6px; opacity: 0.7; }
+</style>
+</head>
+<body>
+  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:#f0c040;border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
+  <style>.container{padding-top:56px!important;}@media(max-width:480px){.container{padding-top:60px!important;}}</style>
+
+<div class="container">
+  <h1>ROC-002 — Standard Phraseology &amp; Readback</h1>
+  <p class="subtitle">ISED RIC-21 · AIM COM 4.0 · ICAO Annex 10 Vol. II · ROC-A Written Exam</p>
+
+  <div class="section-title">Standard Initial Call Format</div>
+  <div class="call-template">
+    <h3>Structure — say it in this order every time</h3>
+    <div class="call-parts">
+      <div class="call-part">
+        <div class="call-part-num">Part 1</div>
+        <div class="call-part-label">Who you're calling</div>
+        <div class="call-part-eg">"Ottawa Tower"</div>
+      </div>
+      <div class="call-part">
+        <div class="call-part-num">Part 2</div>
+        <div class="call-part-label">Who you are</div>
+        <div class="call-part-eg">"Cessna Golf Charlie Delta Foxtrot"</div>
+      </div>
+      <div class="call-part">
+        <div class="call-part-num">Part 3</div>
+        <div class="call-part-label">Where you are</div>
+        <div class="call-part-eg">"ten miles south"</div>
+      </div>
+      <div class="call-part">
+        <div class="call-part-num">Part 4</div>
+        <div class="call-part-label">What you want</div>
+        <div class="call-part-eg">"request landing"</div>
+      </div>
+    </div>
+  </div>
+
+  <div class="section-title">Example Radio Exchange</div>
+  <div class="example-exchange">
+    <div class="tx-atc"><span class="tx-label">ATC</span> "Golf Charlie Delta Foxtrot, Ottawa Tower, runway two five, cleared to land, wind two four zero at one zero."</div>
+    <div class="tx-pilot"><span class="tx-label">Pilot</span> "Runway two five, cleared to land, Golf Charlie Delta Foxtrot."</div>
+  </div>
+  <div class="note-box" style="margin-bottom:24px;">
+    After initial contact ATC will use abbreviated callsigns. A pilot may abbreviate only after ATC does so first. Once established, use the same abbreviation ATC uses. (AIM COM 4.1.2)
+  </div>
+
+  <div class="section-title">Mandatory Readback Items</div>
+  <table>
+    <thead>
+      <tr><th>Instruction</th><th>Readback</th><th>Example readback</th></tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>Runway in use / take-off / landing clearance</td>
+        <td><span class="readback-must">Mandatory</span></td>
+        <td>"Runway three six, cleared for takeoff, C-GCDF"</td>
+      </tr>
+      <tr>
+        <td>Cleared to cross active runway</td>
+        <td><span class="readback-must">Mandatory</span></td>
+        <td>"Cross runway two five, C-GCDF"</td>
+      </tr>
+      <tr>
+        <td>Holding short of active runway</td>
+        <td><span class="readback-must">Mandatory</span></td>
+        <td>"Hold short runway two five, C-GCDF"</td>
+      </tr>
+      <tr>
+        <td>Assigned heading</td>
+        <td><span class="readback-must">Mandatory</span></td>
+        <td>"Turn left heading two seven zero, C-GCDF"</td>
+      </tr>
+      <tr>
+        <td>Assigned altitude / FL</td>
+        <td><span class="readback-must">Mandatory</span></td>
+        <td>"Climb and maintain five thousand five hundred, C-GCDF"</td>
+      </tr>
+      <tr>
+        <td>Altimeter setting</td>
+        <td><span class="readback-must">Mandatory</span></td>
+        <td>"QNH two niner niner two, C-GCDF"</td>
+      </tr>
+      <tr>
+        <td>Transponder code (squawk)</td>
+        <td><span class="readback-must">Mandatory</span></td>
+        <td>"Squawk four five three two, C-GCDF"</td>
+      </tr>
+      <tr>
+        <td>Frequency change</td>
+        <td><span class="readback-must">Mandatory</span></td>
+        <td>"One two two decimal eight, C-GCDF, good day"</td>
+      </tr>
+      <tr>
+        <td>Taxi route instructions</td>
+        <td><span class="readback-opt">Recommended</span></td>
+        <td>Read back turns and hold-short points</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <div class="section-title">Standard Acknowledgement Words</div>
+  <table>
+    <thead>
+      <tr><th>Word / Phrase</th><th>Meaning</th></tr>
+    </thead>
+    <tbody>
+      <tr><td><strong>Roger</strong></td><td>I have received your last transmission (not an acknowledgement of compliance)</td></tr>
+      <tr><td><strong>Wilco</strong></td><td>I understand and will comply (replaces both "Roger" and "Affirmative" + intent)</td></tr>
+      <tr><td><strong>Affirmative</strong></td><td>Yes / that is correct</td></tr>
+      <tr><td><strong>Negative</strong></td><td>No / that is not correct</td></tr>
+      <tr><td><strong>Standby</strong></td><td>I must pause — wait for further transmission</td></tr>
+      <tr><td><strong>Say again</strong></td><td>Repeat your last transmission (never "repeat" — that is an artillery term)</td></tr>
+      <tr><td><strong>Correction</strong></td><td>An error was made; correct version follows</td></tr>
+      <tr><td><strong>Over</strong></td><td>My transmission is complete and I expect a response</td></tr>
+      <tr><td><strong>Out</strong></td><td>Conversation is complete — no response expected</td></tr>
+    </tbody>
+  </table>
+
+  <div class="memory-hook">
+    <span class="badge">EXAM HOOK</span><br>
+    <strong>Readback rule:</strong> Always read back runway, clearance, heading, altitude, altimeter, squawk, and frequency. "Roger" does NOT confirm compliance — use "Wilco" if you intend to comply. Never say "repeat" on aviation radio — say <em>say again</em>.
+  </div>
+</div>
+</body>
+</html>

--- a/web-app/public/visuals/roc003-frequencies-reference.html
+++ b/web-app/public/visuals/roc003-frequencies-reference.html
@@ -1,0 +1,140 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>ROC-003: Frequencies Reference</title>
+<link rel="stylesheet" href="/visuals/_common.css">
+<style>
+  .freq-band {
+    display: inline-block;
+    border-radius: 4px;
+    padding: 2px 8px;
+    font-size: 11px;
+    font-weight: 700;
+    white-space: nowrap;
+  }
+  /* Data-encoding domain colours — hardcoded per visuals-standards.md */
+  .band-emergency  { background: rgba(224,80,80,0.18); color: #e05050; border: 1px solid rgba(224,80,80,0.35); }
+  .band-guard      { background: rgba(224,80,80,0.10); color: #f07070; border: 1px solid rgba(224,80,80,0.25); }
+  .band-atc        { background: rgba(91,155,213,0.15); color: #5b9bd5; border: 1px solid rgba(91,155,213,0.3); }
+  .band-unicom     { background: rgba(76,175,125,0.15); color: #4caf7d; border: 1px solid rgba(76,175,125,0.3); }
+  .band-enroute    { background: rgba(240,192,64,0.12); color: var(--accent); border: 1px solid rgba(240,192,64,0.3); }
+  .band-nav        { background: rgba(138,110,180,0.15); color: #9b82c8; border: 1px solid rgba(138,110,180,0.3); }
+  .band-military   { background: rgba(160,120,60,0.18); color: #c89840; border: 1px solid rgba(160,120,60,0.3); }
+
+  .freq-mhz {
+    font-size: 15px;
+    font-weight: 800;
+    color: var(--accent);
+    letter-spacing: 0.5px;
+    font-variant-numeric: tabular-nums;
+  }
+  .freq-range {
+    font-size: 12px;
+    color: var(--text-muted);
+  }
+</style>
+</head>
+<body>
+  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:#f0c040;border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
+  <style>.container{padding-top:56px!important;}@media(max-width:480px){.container{padding-top:60px!important;}}</style>
+
+<div class="container">
+  <h1>ROC-003 — Frequencies Reference</h1>
+  <p class="subtitle">AIM COM 4.0 · Canada Flight Supplement · ISED RIC-21 · ROC-A Written Exam</p>
+
+  <div class="section-title">Critical and Fixed Frequencies</div>
+  <div class="wide-table">
+    <table>
+      <thead>
+        <tr><th>Frequency</th><th>Type</th><th>Purpose</th><th>Notes</th></tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><span class="freq-mhz">121.5 MHz</span></td>
+          <td><span class="freq-band band-emergency">DISTRESS / GUARD</span></td>
+          <td>International aeronautical distress, ELT activation</td>
+          <td>All aircraft should monitor when possible. ELTs transmit here automatically on impact. (AIM COM 4.3.1)</td>
+        </tr>
+        <tr>
+          <td><span class="freq-mhz">243.0 MHz</span></td>
+          <td><span class="freq-band band-military">MILITARY GUARD</span></td>
+          <td>Military equivalent of 121.5 MHz (UHF)</td>
+          <td>Not used by civil VHF radios; mil aircraft monitor. Noted in AIM.</td>
+        </tr>
+        <tr>
+          <td><span class="freq-mhz">122.8 MHz</span></td>
+          <td><span class="freq-band band-unicom">UNICOM / MF</span></td>
+          <td>Non-towered aerodrome traffic advisories and ground-to-air communications</td>
+          <td>Used at Mandatory Frequency (MF) aerodromes. Pilots self-announce position and intentions. (AIM RAC 4.5)</td>
+        </tr>
+        <tr>
+          <td><span class="freq-mhz">126.7 MHz</span></td>
+          <td><span class="freq-band band-enroute">EN ROUTE / FSS</span></td>
+          <td>En-route advisory, FSS relay, air-to-ground away from controlled aerodromes</td>
+          <td>Common enroute frequency. Also used for FSS contacts on airways. (AIM COM 4.1.4)</td>
+        </tr>
+        <tr>
+          <td><span class="freq-mhz">123.45 MHz</span></td>
+          <td><span class="freq-band band-enroute">AIR-TO-AIR</span></td>
+          <td>GA air-to-air coordination</td>
+          <td>Informal air-to-air; not for ATC contact. Widely used by GA pilots for air-to-air when in vicinity.</td>
+        </tr>
+        <tr>
+          <td><span class="freq-mhz">122.75 MHz</span></td>
+          <td><span class="freq-band band-enroute">AIR-TO-AIR (alt)</span></td>
+          <td>Alternative air-to-air coordination frequency</td>
+          <td>Used when 123.45 is congested. Check CFS for local conventions.</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+
+  <div class="section-title">Frequency Bands by Service</div>
+  <div class="wide-table">
+    <table>
+      <thead>
+        <tr><th>Band / Range</th><th>Service</th><th>Typical use</th></tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><span class="freq-mhz">118.000–136.975 MHz</span><br><span class="freq-range">VHF COM</span></td>
+          <td><span class="freq-band band-atc">ATC / COM</span></td>
+          <td>Tower, approach, departure, ground, centre (ACC). All controlled-airspace comms. 25 kHz spacing.</td>
+        </tr>
+        <tr>
+          <td><span class="freq-mhz">108.000–117.975 MHz</span><br><span class="freq-range">VHF NAV</span></td>
+          <td><span class="freq-band band-nav">VOR / ILS / LOC</span></td>
+          <td>VOR navigation, ILS localizer, marker beacons. NAV radios only — not COM. Odd tenths = VOR; even tenths = ILS loc.</td>
+        </tr>
+        <tr>
+          <td>ATIS (discrete)</td>
+          <td><span class="freq-band band-atc">ATIS</span></td>
+          <td>Automatic Terminal Information Service — continuous weather and NOTAM broadcast. Frequency in CFS per airport. Obtain before calling tower.</td>
+        </tr>
+        <tr>
+          <td>Ground Control (discrete)</td>
+          <td><span class="freq-band band-atc">GROUND</span></td>
+          <td>Taxi instructions at towered airports. Below ~118 MHz. Check CFS. Contact before taxiing.</td>
+        </tr>
+        <tr>
+          <td>Clearance Delivery (discrete)</td>
+          <td><span class="freq-band band-atc">CLNC DEL</span></td>
+          <td>IFR clearance pickup before pushback/taxi at busy airports. See CFS.</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+
+  <div class="note-box">
+    <strong>Canada Flight Supplement (CFS):</strong> all aerodrome frequencies are listed in the CFS entry for each airport. Always check the CFS for the correct ATIS, ground, tower, and approach frequencies before flight. Frequencies listed here are defaults — confirm locally.
+  </div>
+
+  <div class="memory-hook">
+    <span class="badge">EXAM HOOK</span><br>
+    <strong>The numbers to memorise:</strong> 121.5 = International distress / ELT guard · 122.8 = Non-towered / MF · 126.7 = En route / FSS. VHF COM range is 118–137 MHz; VHF NAV is 108–118 MHz. ATIS: get it first, then call tower.
+  </div>
+</div>
+</body>
+</html>

--- a/web-app/public/visuals/roc004-position-reporting.html
+++ b/web-app/public/visuals/roc004-position-reporting.html
@@ -1,0 +1,208 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>ROC-004: Position Reporting</title>
+<link rel="stylesheet" href="/visuals/_common.css">
+<style>
+  .report-flow {
+    display: flex;
+    flex-direction: column;
+    gap: 0;
+    margin-bottom: 32px;
+  }
+  .report-step {
+    display: flex;
+    align-items: flex-start;
+    gap: 14px;
+    padding: 14px 16px;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-bottom: none;
+  }
+  .report-step:first-child { border-radius: 8px 8px 0 0; }
+  .report-step:last-child  { border-radius: 0 0 8px 8px; border-bottom: 1px solid var(--border); }
+  .step-num {
+    width: 28px;
+    height: 28px;
+    min-width: 28px;
+    background: var(--surface2);
+    border: 1px solid var(--border-hi);
+    border-radius: 50%;
+    text-align: center;
+    line-height: 28px;
+    font-size: 13px;
+    font-weight: 800;
+    color: var(--accent);
+    flex-shrink: 0;
+  }
+  .step-body { flex: 1; }
+  .step-label {
+    font-size: 12px;
+    color: var(--text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.8px;
+    margin-bottom: 2px;
+  }
+  .step-content {
+    font-size: 13px;
+    color: var(--text);
+    line-height: 1.5;
+  }
+  .step-eg {
+    font-size: 12px;
+    color: var(--accent);
+    font-style: italic;
+    margin-top: 3px;
+  }
+  .example-block {
+    background: var(--surface);
+    border-left: 3px solid var(--accent);
+    border-radius: 4px;
+    padding: 14px 18px;
+    margin-bottom: 24px;
+    font-size: 13px;
+    line-height: 1.8;
+    color: var(--text);
+  }
+  .mf-tag {
+    display: inline-block;
+    background: rgba(76,175,125,0.15);
+    color: #4caf7d;
+    border: 1px solid rgba(76,175,125,0.3);
+    border-radius: 4px;
+    padding: 2px 8px;
+    font-size: 11px;
+    font-weight: 700;
+  }
+  .atc-tag {
+    display: inline-block;
+    background: rgba(91,155,213,0.15);
+    color: #5b9bd5;
+    border: 1px solid rgba(91,155,213,0.3);
+    border-radius: 4px;
+    padding: 2px 8px;
+    font-size: 11px;
+    font-weight: 700;
+  }
+</style>
+</head>
+<body>
+  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:#f0c040;border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
+  <style>.container{padding-top:56px!important;}@media(max-width:480px){.container{padding-top:60px!important;}}</style>
+
+<div class="container">
+  <h1>ROC-004 — Position Reporting</h1>
+  <p class="subtitle">AIM COM 4.0 · AIM RAC 3.7 · ICAO Annex 10 · ROC-A Written Exam</p>
+
+  <div class="section-title">Standard Position Report — 7 Elements</div>
+  <div class="report-flow">
+    <div class="report-step">
+      <div class="step-num">1</div>
+      <div class="step-body">
+        <div class="step-label">Aircraft identification</div>
+        <div class="step-content">Your callsign as filed (or abbreviated if ATC has abbreviated).</div>
+        <div class="step-eg">"Golf Charlie Delta Foxtrot"</div>
+      </div>
+    </div>
+    <div class="report-step">
+      <div class="step-num">2</div>
+      <div class="step-body">
+        <div class="step-label">Position</div>
+        <div class="step-content">Named waypoint, VOR, fix, or distance &amp; bearing from known point.</div>
+        <div class="step-eg">"over GOSPO intersection" / "five miles north of Smiths Falls"</div>
+      </div>
+    </div>
+    <div class="report-step">
+      <div class="step-num">3</div>
+      <div class="step-body">
+        <div class="step-label">Time</div>
+        <div class="step-content">UTC time at position (minutes only if within the hour).</div>
+        <div class="step-eg">"at two three" (0023Z) or "at one four three zero" (1430Z)</div>
+      </div>
+    </div>
+    <div class="report-step">
+      <div class="step-num">4</div>
+      <div class="step-body">
+        <div class="step-label">Altitude or Flight Level</div>
+        <div class="step-content">Cruising altitude (ASL) or flight level. State if climbing/descending.</div>
+        <div class="step-eg">"five thousand five hundred" / "flight level one eight zero"</div>
+      </div>
+    </div>
+    <div class="report-step">
+      <div class="step-num">5</div>
+      <div class="step-body">
+        <div class="step-label">Type of flight plan</div>
+        <div class="step-content">VFR or IFR (if relevant to context / required by ATC).</div>
+        <div class="step-eg">"VFR"</div>
+      </div>
+    </div>
+    <div class="report-step">
+      <div class="step-num">6</div>
+      <div class="step-body">
+        <div class="step-label">Next reporting point and ETA</div>
+        <div class="step-content">The next waypoint and estimated time of arrival there.</div>
+        <div class="step-eg">"estimating Pembroke at four five"</div>
+      </div>
+    </div>
+    <div class="report-step">
+      <div class="step-num">7</div>
+      <div class="step-body">
+        <div class="step-label">Remarks (if required)</div>
+        <div class="step-content">Anything operationally significant: weather deviations, souls on board if declaring urgency, fuel state.</div>
+        <div class="step-eg">"light turbulence at this altitude"</div>
+      </div>
+    </div>
+  </div>
+
+  <div class="section-title">Example Position Report</div>
+  <div class="example-block">
+    "Ottawa Radio, Golf Charlie Delta Foxtrot, over Almonte at three five, five thousand five hundred VFR, estimating Pembroke at five two, nil remarks."
+  </div>
+
+  <div class="section-title">When Are Position Reports Required?</div>
+  <table>
+    <thead>
+      <tr><th>Situation</th><th>Requirement</th><th>Frequency</th></tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>IFR flight — compulsory reporting points</td>
+        <td>Mandatory</td>
+        <td>ATC / FSS (as assigned)</td>
+      </tr>
+      <tr>
+        <td>VFR flight with a flight plan — reporting points noted in plan</td>
+        <td>Mandatory at each point</td>
+        <td>FSS (126.7 or local)</td>
+      </tr>
+      <tr>
+        <td>Arriving at or departing from an MF aerodrome</td>
+        <td><span class="mf-tag">MF Required</span> — announce intentions</td>
+        <td>122.8 MHz</td>
+      </tr>
+      <tr>
+        <td>Operating within ATZ (Aerodrome Traffic Zone) at MF field</td>
+        <td><span class="mf-tag">MF Required</span> — circuit positions</td>
+        <td>122.8 MHz</td>
+      </tr>
+      <tr>
+        <td>VFR flight in controlled airspace with ATC</td>
+        <td><span class="atc-tag">ATC Directed</span> — when requested</td>
+        <td>Assigned ATC frequency</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <div class="note-box">
+    <strong>MF vs UNICOM:</strong> A Mandatory Frequency (MF) aerodrome requires pilots to broadcast position and intentions on 122.8 MHz — not to receive a clearance, but to share traffic information. No ATC clearance exists at an MF field; it is a self-announce system. Always monitor the MF frequency within the MF area and broadcast 5 minutes before entering.
+  </div>
+
+  <div class="memory-hook">
+    <span class="badge">EXAM HOOK</span><br>
+    <strong>7-element report order:</strong> ID → Position → Time → Altitude → Flight type → Next fix + ETA → Remarks. At MF aerodromes use 122.8 MHz and self-announce — no clearance exists. VFR flight plans require position reports to FSS at each reported point.
+  </div>
+</div>
+</body>
+</html>

--- a/web-app/public/visuals/roc005-vfr-ifr-comms-overview.html
+++ b/web-app/public/visuals/roc005-vfr-ifr-comms-overview.html
@@ -1,0 +1,153 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>ROC-005: VFR/IFR Communications Overview</title>
+<link rel="stylesheet" href="/visuals/_common.css">
+<style>
+  .col-vfr { background: rgba(76,175,125,0.08); border-top: 3px solid #4caf7d; }
+  .col-ifr { background: rgba(91,155,213,0.08); border-top: 3px solid #5b9bd5; }
+
+  .compare-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 16px;
+    margin-bottom: 32px;
+  }
+  .compare-col {
+    border-radius: 8px;
+    padding: 18px 16px;
+    border: 1px solid var(--border);
+  }
+  .compare-col h3 {
+    font-size: 14px;
+    font-weight: 700;
+    margin-bottom: 14px;
+    letter-spacing: 0.5px;
+  }
+  .col-vfr h3 { color: #4caf7d; }
+  .col-ifr h3 { color: #5b9bd5; }
+  .compare-col ul {
+    padding-left: 16px;
+    margin: 0;
+  }
+  .compare-col li {
+    font-size: 12px;
+    color: var(--text);
+    line-height: 1.7;
+    margin-bottom: 4px;
+  }
+  .phase-tag {
+    display: inline-block;
+    border-radius: 4px;
+    padding: 1px 7px;
+    font-size: 10px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    margin-right: 4px;
+    white-space: nowrap;
+  }
+  .ph-pre    { background: rgba(240,192,64,0.12); color: var(--accent); border: 1px solid rgba(240,192,64,0.3); }
+  .ph-dep    { background: rgba(76,175,125,0.12); color: #4caf7d; border: 1px solid rgba(76,175,125,0.3); }
+  .ph-enr    { background: rgba(91,155,213,0.12); color: #5b9bd5; border: 1px solid rgba(91,155,213,0.3); }
+  .ph-arr    { background: rgba(224,80,80,0.12); color: #e05050; border: 1px solid rgba(224,80,80,0.3); }
+
+  @media (max-width: 560px) {
+    .compare-grid { grid-template-columns: 1fr; }
+  }
+</style>
+</head>
+<body>
+  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:#f0c040;border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
+  <style>.container{padding-top:56px!important;}@media(max-width:480px){.container{padding-top:60px!important;}}</style>
+
+<div class="container">
+  <h1>ROC-005 — VFR / IFR Communications Overview</h1>
+  <p class="subtitle">AIM COM 4.0 · CARs Part VI · ISED RIC-21 · ROC-A Written Exam</p>
+
+  <div class="section-title">VFR vs IFR at a Glance</div>
+  <div class="compare-grid">
+    <div class="compare-col col-vfr">
+      <h3>VFR Communications</h3>
+      <ul>
+        <li>Radio required in Class B, C, D airspace and at MF aerodromes</li>
+        <li>Class E and G: no radio required (recommended)</li>
+        <li>Self-announce at non-towered (MF) aerodromes on 122.8 MHz</li>
+        <li>No ATC clearance required in Class D — radio contact only</li>
+        <li>VFR flight plans reported to FSS; not mandatory but strongly recommended</li>
+        <li>ATIS must be obtained before contacting tower at controlled airports</li>
+        <li>Transponder required in Class B and C (Mode C); recommended elsewhere</li>
+      </ul>
+    </div>
+    <div class="compare-col col-ifr">
+      <h3>IFR Communications</h3>
+      <ul>
+        <li>Radio mandatory at all times while operating IFR</li>
+        <li>ATC clearance required before entering controlled airspace IFR</li>
+        <li>Position reports at all compulsory reporting points</li>
+        <li>Must acknowledge all ATC instructions and read back clearances</li>
+        <li>Transponder Mode C required in all controlled airspace</li>
+        <li>Lost communications procedures defined: squawk 7600, attempt 121.5</li>
+        <li>Clearance delivery before taxi at large airports</li>
+      </ul>
+    </div>
+  </div>
+
+  <div class="section-title">Communication Flow by Flight Phase</div>
+  <table>
+    <thead>
+      <tr><th>Phase</th><th>VFR (Controlled Airport)</th><th>IFR</th><th>VFR (Non-Towered / MF)</th></tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><span class="phase-tag ph-pre">Pre-flight</span></td>
+        <td>Obtain ATIS</td>
+        <td>File IFR flight plan; obtain ATIS; call Clearance Delivery</td>
+        <td>Check NOTAMs; note MF frequency</td>
+      </tr>
+      <tr>
+        <td><span class="phase-tag ph-dep">Departure</span></td>
+        <td>Ground → Tower; squawk as assigned; contact Departure when directed</td>
+        <td>Clearance Delivery → Ground → Tower → Departure; fly SID if assigned</td>
+        <td>Self-announce on 122.8 MHz: "taxiing for runway XX"</td>
+      </tr>
+      <tr>
+        <td><span class="phase-tag ph-enr">Enroute</span></td>
+        <td>Contact Centre/Area if transiting controlled; file position reports with FSS</td>
+        <td>Continuous ATC contact; report at compulsory fixes; request altitude changes</td>
+        <td>Monitor 126.7 MHz for FSS; file VFR position reports; blind calls for traffic</td>
+      </tr>
+      <tr>
+        <td><span class="phase-tag ph-arr">Arrival</span></td>
+        <td>Obtain ATIS; contact Approach or Tower; read back runway and clearance</td>
+        <td>Contact Approach; obtain ILS/RNAV clearance; read back all items; cancel IFR on ground</td>
+        <td>Self-announce on 122.8 MHz: circuit position calls at each leg; landing intention</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <div class="section-title">Key Radio Equipment Requirements by Airspace</div>
+  <table>
+    <thead>
+      <tr><th>Airspace</th><th>VHF Radio</th><th>Transponder</th><th>ATIS before contact</th></tr>
+    </thead>
+    <tbody>
+      <tr><td><strong>Class A</strong></td><td class="yes">Required (IFR only)</td><td class="yes">Mode C</td><td>N/A</td></tr>
+      <tr><td><strong>Class B</strong></td><td class="yes">Required</td><td class="yes">Mode C</td><td class="yes">Yes</td></tr>
+      <tr><td><strong>Class C</strong></td><td class="yes">Required</td><td class="yes">Mode C</td><td class="yes">Yes</td></tr>
+      <tr><td><strong>Class D</strong></td><td class="yes">Required</td><td>Recommended</td><td class="yes">Yes (if available)</td></tr>
+      <tr><td><strong>Class E</strong></td><td class="no">Not required (VFR)</td><td class="no">Not required (VFR)</td><td>N/A</td></tr>
+      <tr><td><strong>Class G</strong></td><td class="no">Not required</td><td class="no">Not required</td><td>N/A</td></tr>
+      <tr><td><strong>MF Aerodrome</strong></td><td class="yes">Required (on 122.8)</td><td>Recommended</td><td>Check CFS</td></tr>
+    </tbody>
+  </table>
+
+  <div class="memory-hook">
+    <span class="badge">EXAM HOOK</span><br>
+    <strong>VFR radio rule:</strong> Radio required in B, C, D, and at MF aerodromes. Not required in E or G (but strongly recommended). <strong>IFR:</strong> always on radio, always on ATC, always read back clearances. ATIS first — then call ATC at any towered airport.
+  </div>
+</div>
+</body>
+</html>

--- a/web-app/public/visuals/roc006-emergency-comms.html
+++ b/web-app/public/visuals/roc006-emergency-comms.html
@@ -1,0 +1,300 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>ROC-006: Emergency Communications</title>
+<link rel="stylesheet" href="/visuals/_common.css">
+<style>
+  /* ── Squawk code colour tiles — data-encoding domain colours ─────────── */
+  /* 7700 Emergency: red — immediate danger */
+  .sq-7700 { background: rgba(224,80,80,0.18); border: 2px solid #e05050; color: #e05050; }
+  /* 7600 Lost comms: amber — impaired but not immediately lethal */
+  .sq-7600 { background: rgba(240,192,64,0.15); border: 2px solid #f0c040; color: #f0c040; }
+  /* 7500 Hijack: orange-amber — unlawful interference */
+  .sq-7500 { background: rgba(224,140,40,0.18); border: 2px solid #e08828; color: #e08828; }
+
+  .squawk-grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 12px;
+    margin-bottom: 32px;
+  }
+  .squawk-card {
+    border-radius: 8px;
+    padding: 18px 14px;
+    text-align: center;
+  }
+  .sq-code {
+    font-size: 32px;
+    font-weight: 900;
+    letter-spacing: 3px;
+    font-variant-numeric: tabular-nums;
+    display: block;
+    line-height: 1;
+    margin-bottom: 8px;
+  }
+  .sq-name {
+    font-size: 13px;
+    font-weight: 700;
+    margin-bottom: 6px;
+    display: block;
+  }
+  .sq-desc {
+    font-size: 11px;
+    color: var(--text-muted);
+    line-height: 1.5;
+  }
+
+  /* ── MAYDAY signal flow ────────────────────────────────────────────────── */
+  .flow-container {
+    display: flex;
+    flex-direction: column;
+    gap: 0;
+    margin-bottom: 32px;
+  }
+  .flow-step {
+    display: flex;
+    align-items: flex-start;
+    gap: 14px;
+    padding: 14px 16px;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-bottom: none;
+    position: relative;
+  }
+  .flow-step:first-child { border-radius: 8px 8px 0 0; }
+  .flow-step:last-child  { border-radius: 0 0 8px 8px; border-bottom: 1px solid var(--border); }
+  .flow-arrow {
+    width: 100%;
+    text-align: center;
+    font-size: 16px;
+    color: var(--text-muted);
+    padding: 2px 0;
+    background: var(--surface);
+    border-left: 1px solid var(--border);
+    border-right: 1px solid var(--border);
+    border-bottom: none;
+  }
+  .flow-icon {
+    width: 32px;
+    height: 32px;
+    min-width: 32px;
+    border-radius: 50%;
+    text-align: center;
+    line-height: 32px;
+    font-size: 15px;
+    font-weight: 800;
+    flex-shrink: 0;
+  }
+  .icon-emergency { background: rgba(224,80,80,0.2); color: #e05050; border: 1.5px solid #e05050; }
+  .icon-action    { background: rgba(76,175,125,0.15); color: #4caf7d; border: 1.5px solid #4caf7d; }
+  .icon-freq      { background: rgba(91,155,213,0.15); color: #5b9bd5; border: 1.5px solid #5b9bd5; }
+  .icon-xpdr      { background: rgba(224,80,80,0.15); color: #e05050; border: 1.5px solid rgba(224,80,80,0.5); }
+
+  .flow-body { flex: 1; }
+  .flow-label {
+    font-size: 11px;
+    color: var(--text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.8px;
+    margin-bottom: 2px;
+  }
+  .flow-main {
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--text);
+    line-height: 1.4;
+  }
+  .flow-detail {
+    font-size: 12px;
+    color: var(--text-muted);
+    margin-top: 4px;
+    line-height: 1.5;
+  }
+  .flow-quote {
+    font-size: 12px;
+    color: var(--accent);
+    font-style: italic;
+    margin-top: 4px;
+  }
+
+  /* ── MAYDAY content elements ─────────────────────────────────────────── */
+  .mayday-badge {
+    display: inline-block;
+    background: rgba(224,80,80,0.18);
+    color: #e05050;
+    border: 1.5px solid rgba(224,80,80,0.5);
+    border-radius: 5px;
+    padding: 4px 10px;
+    font-size: 14px;
+    font-weight: 900;
+    letter-spacing: 1px;
+  }
+  .panpan-badge {
+    display: inline-block;
+    background: rgba(240,192,64,0.15);
+    color: #f0c040;
+    border: 1.5px solid rgba(240,192,64,0.4);
+    border-radius: 5px;
+    padding: 4px 10px;
+    font-size: 14px;
+    font-weight: 900;
+    letter-spacing: 1px;
+  }
+  .distress-compare {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 12px;
+    margin-bottom: 32px;
+  }
+  .distress-card {
+    border-radius: 8px;
+    padding: 16px;
+    border: 1.5px solid;
+  }
+  .card-mayday { background: rgba(224,80,80,0.08); border-color: rgba(224,80,80,0.4); }
+  .card-panpan { background: rgba(240,192,64,0.08); border-color: rgba(240,192,64,0.4); }
+  .distress-card h3 { font-size: 14px; font-weight: 700; margin-bottom: 8px; }
+  .card-mayday h3 { color: #e05050; }
+  .card-panpan h3 { color: #f0c040; }
+  .distress-card p  { font-size: 12px; color: var(--text); line-height: 1.6; }
+  .distress-card ul { padding-left: 16px; margin: 6px 0 0; }
+  .distress-card li { font-size: 12px; color: var(--text-muted); line-height: 1.6; }
+
+  @media (max-width: 560px) {
+    .squawk-grid { grid-template-columns: 1fr; }
+    .distress-compare { grid-template-columns: 1fr; }
+  }
+</style>
+</head>
+<body>
+  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:#f0c040;border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
+  <style>.container{padding-top:56px!important;}@media(max-width:480px){.container{padding-top:60px!important;}}</style>
+
+<div class="container">
+  <h1>ROC-006 — Emergency Communications</h1>
+  <p class="subtitle">AIM COM 4.3 · CARs 602.135–602.138 · ICAO Annex 10 · ROC-A Written Exam</p>
+
+  <!-- ── Squawk codes ───────────────────────────────────────────────────── -->
+  <div class="section-title">Emergency Transponder Codes</div>
+  <div class="squawk-grid">
+    <div class="squawk-card sq-7700" role="region" aria-label="Squawk 7700 — Emergency">
+      <span class="sq-code">7700</span>
+      <span class="sq-name">Emergency</span>
+      <span class="sq-desc">General emergency — grave and imminent danger, immediate assistance required. Set immediately upon declaring MAYDAY.</span>
+    </div>
+    <div class="squawk-card sq-7600" role="region" aria-label="Squawk 7600 — Lost Communications">
+      <span class="sq-code">7600</span>
+      <span class="sq-name">Lost Comms</span>
+      <span class="sq-desc">Radio failure — cannot receive or transmit. ATC will provide light signals. Fly expected clearance or squawk 7700 if also in distress.</span>
+    </div>
+    <div class="squawk-card sq-7500" role="region" aria-label="Squawk 7500 — Hijacking">
+      <span class="sq-code">7500</span>
+      <span class="sq-name">Hijacking</span>
+      <span class="sq-desc">Unlawful interference (hijacking in progress). Do not confirm verbally over radio unless safe to do so. ATC will initiate response.</span>
+    </div>
+  </div>
+
+  <!-- ── MAYDAY vs PAN PAN ─────────────────────────────────────────────── -->
+  <div class="section-title">MAYDAY vs PAN PAN</div>
+  <div class="distress-compare">
+    <div class="distress-card card-mayday">
+      <h3>&#9888; MAYDAY (×3)</h3>
+      <p><strong>Grave and imminent danger</strong> — immediate assistance required.</p>
+      <ul>
+        <li>Declare for: engine failure, fire, loss of control, medical emergency with incapacitation</li>
+        <li>Squawk <strong>7700</strong></li>
+        <li>Transmit on <strong>121.5 MHz</strong> if possible</li>
+        <li>ATC provides priority handling and may alert SAR</li>
+      </ul>
+    </div>
+    <div class="distress-card card-panpan">
+      <h3>&#9998; PAN PAN (×3)</h3>
+      <p><strong>Urgency condition</strong> — safety of aircraft or person, but not immediately life-threatening.</p>
+      <ul>
+        <li>Declare for: fuel state concern, passenger medical (non-incapacitating), lost (unsure of position), minor system failure</li>
+        <li>Squawk <strong>7700</strong> or as directed by ATC</li>
+        <li>Maintain working frequency; switch to 121.5 if no response</li>
+        <li>Can be upgraded to MAYDAY if situation worsens</li>
+      </ul>
+    </div>
+  </div>
+
+  <!-- ── MAYDAY signal flow ─────────────────────────────────────────────── -->
+  <div class="section-title">MAYDAY — Signal Flow &amp; Response Sequence</div>
+  <div class="flow-container">
+    <div class="flow-step">
+      <div class="flow-icon icon-emergency">!</div>
+      <div class="flow-body">
+        <div class="flow-label">Step 1 — Declare</div>
+        <div class="flow-main">Transmit MAYDAY three times</div>
+        <div class="flow-quote">"MAYDAY MAYDAY MAYDAY — [callsign], [nature of emergency], [position], [altitude], [intentions], [souls on board], [fuel endurance]"</div>
+      </div>
+    </div>
+    <div class="flow-step">
+      <div class="flow-icon icon-freq">▶</div>
+      <div class="flow-body">
+        <div class="flow-label">Step 2 — Frequency</div>
+        <div class="flow-main">Transmit on 121.5 MHz if working frequency cannot be raised</div>
+        <div class="flow-detail">121.5 MHz is the international distress frequency — all ATC facilities and SAR units monitor it continuously.</div>
+      </div>
+    </div>
+    <div class="flow-step">
+      <div class="flow-icon icon-xpdr">T</div>
+      <div class="flow-body">
+        <div class="flow-label">Step 3 — Squawk</div>
+        <div class="flow-main">Select squawk <strong>7700</strong> on transponder (if not already assigned a code)</div>
+        <div class="flow-detail">Squawk 7700 alerts radar facilities immediately. ATC can track and coordinate SAR response from your radar return.</div>
+      </div>
+    </div>
+    <div class="flow-step">
+      <div class="flow-icon icon-action">&#10003;</div>
+      <div class="flow-body">
+        <div class="flow-label">Step 4 — Communicate</div>
+        <div class="flow-main">Maintain frequency; respond to ATC; state intentions clearly</div>
+        <div class="flow-detail">ATC will clear other traffic and offer vectors to nearest suitable airport. Continue giving position updates as the situation develops.</div>
+      </div>
+    </div>
+    <div class="flow-step">
+      <div class="flow-icon icon-action">&#9992;</div>
+      <div class="flow-body">
+        <div class="flow-label">Step 5 — SAR Activation (if needed)</div>
+        <div class="flow-main">GMDSS / JRCC notified by ATC — Search and Rescue activated</div>
+        <div class="flow-detail">Joint Rescue Coordination Centre (JRCC) coordinates SAR assets. ELT activates automatically on impact (121.5 MHz and 406 MHz digital). Provide souls on board and fuel endurance early — these determine SAR resource dispatch.</div>
+      </div>
+    </div>
+  </div>
+
+  <!-- ── ELT note ───────────────────────────────────────────────────────── -->
+  <div class="section-title">Emergency Locator Transmitter (ELT)</div>
+  <table>
+    <thead>
+      <tr><th>Type</th><th>Activation</th><th>Frequencies</th><th>Coverage</th></tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>Automatic (impact-activated)</td>
+        <td>G-force impact threshold (~5g)</td>
+        <td>121.5 MHz (analogue) + 406 MHz (digital)</td>
+        <td>406 MHz received by COSPAS-SARSAT satellite; global</td>
+      </tr>
+      <tr>
+        <td>Manual activation</td>
+        <td>Pilot activates on panel or via external switch</td>
+        <td>121.5 MHz + 406 MHz</td>
+        <td>Same as automatic</td>
+      </tr>
+    </tbody>
+  </table>
+  <div class="note-box">
+    <strong>Cancel the MAYDAY:</strong> Once the emergency is resolved, cancel the distress message on the same frequency and/or on 121.5 MHz to prevent unnecessary SAR activation. State: <em>"All stations, [callsign], cancel MAYDAY, [reason]."</em>  (AIM COM 4.3.2)
+  </div>
+
+  <div class="memory-hook">
+    <span class="badge">EXAM HOOK</span><br>
+    <strong>Squawk codes:</strong> 7700 = Emergency (red alert) · 7600 = Lost comms (radio failure) · 7500 = Hijack. <strong>MAYDAY</strong> = imminent danger; <strong>PAN PAN</strong> = urgency but not yet life-threatening. Emergency frequency = <strong>121.5 MHz</strong>. Always give: position, nature, intentions, souls on board, fuel endurance.
+  </div>
+</div>
+</body>
+</html>

--- a/web-app/public/visuals/roc007-light-signals.html
+++ b/web-app/public/visuals/roc007-light-signals.html
@@ -1,0 +1,256 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>ROC-007: Light Signals</title>
+<link rel="stylesheet" href="/visuals/_common.css">
+<style>
+  /* ── Light signal colour indicators — data-encoding domain colours ────── */
+  /* Steady green = cleared / safe to proceed */
+  .sig-green-steady   { background: #4caf7d; }
+  /* Flashing green = conditional clearance */
+  .sig-green-flash    { background: #4caf7d; opacity: 0.65; }
+  /* Steady red = stop / do not land */
+  .sig-red-steady     { background: #e05050; }
+  /* Flashing red = danger / clear area */
+  .sig-red-flash      { background: #e05050; opacity: 0.65; }
+  /* Flashing white = return to start / stop */
+  .sig-white-flash    { background: #e4ecf5; opacity: 0.75; }
+  /* Alternating red/green = extreme caution */
+  .sig-alt            { background: linear-gradient(135deg, #e05050 50%, #4caf7d 50%); }
+
+  .sig-dot {
+    display: inline-block;
+    width: 20px;
+    height: 20px;
+    border-radius: 50%;
+    vertical-align: middle;
+    flex-shrink: 0;
+    border: 1px solid rgba(255,255,255,0.12);
+  }
+  .sig-cell {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+  .sig-label-text {
+    font-size: 12px;
+    color: var(--text);
+    line-height: 1.4;
+  }
+
+  /* Meaning severity shading */
+  .meaning-safe    { color: #4caf7d; font-weight: 600; }
+  .meaning-caution { color: #f0c040; font-weight: 600; }
+  .meaning-stop    { color: #e05050; font-weight: 600; }
+  .meaning-warn    { color: #f07030; font-weight: 600; }
+
+  .ack-table { margin-top: 24px; }
+
+  .flash-indicator {
+    display: inline-block;
+    font-size: 10px;
+    letter-spacing: 1px;
+    color: var(--text-muted);
+    text-transform: uppercase;
+  }
+</style>
+</head>
+<body>
+  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:#f0c040;border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
+  <style>.container{padding-top:56px!important;}@media(max-width:480px){.container{padding-top:60px!important;}}</style>
+
+<div class="container">
+  <h1>ROC-007 — Light Signals</h1>
+  <p class="subtitle">CARs 602.101 · AIM RAC 4.5.5 · ICAO Annex 2 · ROC-A Written Exam</p>
+
+  <div class="note-box" style="margin-bottom:24px;">
+    Light signals are used when radio communication is unavailable or to communicate with aircraft on the ground or in the circuit. The tower light gun is the authoritative source — obey even if you have radio contact. (CARs 602.101)
+  </div>
+
+  <!-- ── From tower to aircraft in flight ─────────────────────────────── -->
+  <div class="section-title">Signals from Tower → Aircraft in Flight</div>
+  <div class="wide-table">
+    <table>
+      <thead>
+        <tr>
+          <th style="width:180px;">Signal</th>
+          <th>Colour / Type</th>
+          <th>Meaning</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            <div class="sig-cell">
+              <span class="sig-dot sig-green-steady" aria-label="Steady green light"></span>
+              <span class="sig-label-text">Steady Green</span>
+            </div>
+          </td>
+          <td>Continuous green beam</td>
+          <td><span class="meaning-safe">Cleared to land</span></td>
+        </tr>
+        <tr>
+          <td>
+            <div class="sig-cell">
+              <span class="sig-dot sig-green-flash" aria-label="Flashing green light"></span>
+              <span class="sig-label-text">Flashing Green <span class="flash-indicator">●●●</span></span>
+            </div>
+          </td>
+          <td>Flashing green beam</td>
+          <td><span class="meaning-caution">Return for landing</span> (follow-up clearance to land will be given)</td>
+        </tr>
+        <tr>
+          <td>
+            <div class="sig-cell">
+              <span class="sig-dot sig-red-steady" aria-label="Steady red light"></span>
+              <span class="sig-label-text">Steady Red</span>
+            </div>
+          </td>
+          <td>Continuous red beam</td>
+          <td><span class="meaning-stop">Give way to other aircraft and continue circling</span></td>
+        </tr>
+        <tr>
+          <td>
+            <div class="sig-cell">
+              <span class="sig-dot sig-red-flash" aria-label="Flashing red light"></span>
+              <span class="sig-label-text">Flashing Red <span class="flash-indicator">●●●</span></span>
+            </div>
+          </td>
+          <td>Flashing red beam</td>
+          <td><span class="meaning-warn">Aerodrome unsafe — do not land</span></td>
+        </tr>
+        <tr>
+          <td>
+            <div class="sig-cell">
+              <span class="sig-dot sig-white-flash" aria-label="Flashing white light"></span>
+              <span class="sig-label-text">Flashing White <span class="flash-indicator">●●●</span></span>
+            </div>
+          </td>
+          <td>Flashing white beam</td>
+          <td><span class="meaning-caution">Not applicable in flight</span> — used on ground only</td>
+        </tr>
+        <tr>
+          <td>
+            <div class="sig-cell">
+              <span class="sig-dot sig-alt" aria-label="Alternating red and green light"></span>
+              <span class="sig-label-text">Alternating Red / Green</span>
+            </div>
+          </td>
+          <td>Alternating red and green</td>
+          <td><span class="meaning-warn">Exercise extreme caution</span></td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+
+  <!-- ── From tower to aircraft on ground ─────────────────────────────── -->
+  <div class="section-title">Signals from Tower → Aircraft on Ground</div>
+  <div class="wide-table">
+    <table>
+      <thead>
+        <tr>
+          <th style="width:180px;">Signal</th>
+          <th>Colour / Type</th>
+          <th>Meaning</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            <div class="sig-cell">
+              <span class="sig-dot sig-green-steady" aria-label="Steady green light"></span>
+              <span class="sig-label-text">Steady Green</span>
+            </div>
+          </td>
+          <td>Continuous green beam</td>
+          <td><span class="meaning-safe">Cleared for take-off</span></td>
+        </tr>
+        <tr>
+          <td>
+            <div class="sig-cell">
+              <span class="sig-dot sig-green-flash" aria-label="Flashing green light"></span>
+              <span class="sig-label-text">Flashing Green <span class="flash-indicator">●●●</span></span>
+            </div>
+          </td>
+          <td>Flashing green beam</td>
+          <td><span class="meaning-safe">Cleared to taxi</span></td>
+        </tr>
+        <tr>
+          <td>
+            <div class="sig-cell">
+              <span class="sig-dot sig-red-steady" aria-label="Steady red light"></span>
+              <span class="sig-label-text">Steady Red</span>
+            </div>
+          </td>
+          <td>Continuous red beam</td>
+          <td><span class="meaning-stop">Stop</span></td>
+        </tr>
+        <tr>
+          <td>
+            <div class="sig-cell">
+              <span class="sig-dot sig-red-flash" aria-label="Flashing red light"></span>
+              <span class="sig-label-text">Flashing Red <span class="flash-indicator">●●●</span></span>
+            </div>
+          </td>
+          <td>Flashing red beam</td>
+          <td><span class="meaning-warn">Taxi clear of runway in use</span></td>
+        </tr>
+        <tr>
+          <td>
+            <div class="sig-cell">
+              <span class="sig-dot sig-white-flash" aria-label="Flashing white light"></span>
+              <span class="sig-label-text">Flashing White <span class="flash-indicator">●●●</span></span>
+            </div>
+          </td>
+          <td>Flashing white beam</td>
+          <td><span class="meaning-caution">Return to starting point on aerodrome</span></td>
+        </tr>
+        <tr>
+          <td>
+            <div class="sig-cell">
+              <span class="sig-dot sig-alt" aria-label="Alternating red and green light"></span>
+              <span class="sig-label-text">Alternating Red / Green</span>
+            </div>
+          </td>
+          <td>Alternating red and green</td>
+          <td><span class="meaning-warn">Exercise extreme caution</span></td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+
+  <!-- ── Acknowledgement signals from aircraft ──────────────────────────── -->
+  <div class="section-title">How to Acknowledge a Light Signal</div>
+  <table class="ack-table">
+    <thead>
+      <tr><th>Situation</th><th>Aircraft in Flight</th><th>Aircraft on Ground (day)</th><th>Aircraft on Ground (night)</th></tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>Acknowledge signal received</td>
+        <td>Rock wings (day) or flash landing lights on/off twice (night)</td>
+        <td>Move ailerons or rudder</td>
+        <td>Flash navigation lights on/off twice</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <div class="note-box" style="margin-top:24px;">
+    <strong>Memory pattern — steady vs flashing:</strong> Steady signals mean <em>immediate action</em> (cleared or stop). Flashing signals mean <em>conditional or upcoming</em> (return for landing later; taxi; clear the runway). Alternating red/green always means <em>caution</em> regardless of phase. Colour is the dominant cue: <span style="color:#4caf7d;font-weight:700;">Green = go / proceed</span> · <span style="color:#e05050;font-weight:700;">Red = stop / danger</span> · <span style="color:#e4ecf5;font-weight:700;">White = administrative</span>
+  </div>
+
+  <div class="memory-hook">
+    <span class="badge">EXAM HOOK</span><br>
+    <strong>Six light signals — both phases:</strong><br>
+    Steady green: Land (air) / Take off (ground) ·
+    Flashing green: Return (air) / Taxi (ground) ·
+    Steady red: Circle (air) / Stop (ground) ·
+    Flashing red: Unsafe–don't land (air) / Clear runway (ground) ·
+    Flashing white: N/A (air) / Return to start (ground) ·
+    Alt red/green: Caution (both)
+  </div>
+</div>
+</body>
+</html>

--- a/web-app/public/visuals/roc008-regulatory-framework.html
+++ b/web-app/public/visuals/roc008-regulatory-framework.html
@@ -1,0 +1,149 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>ROC-008: Regulatory Framework</title>
+<link rel="stylesheet" href="/visuals/_common.css">
+<style>
+  .reg-pillar {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 16px 18px;
+    margin-bottom: 14px;
+  }
+  .reg-pillar h3 {
+    font-size: 13px;
+    font-weight: 700;
+    color: var(--accent);
+    margin-bottom: 6px;
+  }
+  .reg-pillar p {
+    font-size: 12px;
+    color: var(--text);
+    line-height: 1.6;
+    margin: 0;
+  }
+  .reg-pillar ul {
+    padding-left: 16px;
+    margin: 6px 0 0;
+  }
+  .reg-pillar li {
+    font-size: 12px;
+    color: var(--text-muted);
+    line-height: 1.7;
+  }
+  .org-tag {
+    display: inline-block;
+    border-radius: 4px;
+    padding: 2px 8px;
+    font-size: 10px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    margin-left: 6px;
+    vertical-align: middle;
+  }
+  .org-ised { background: rgba(91,155,213,0.15); color: #5b9bd5; border: 1px solid rgba(91,155,213,0.3); }
+  .org-tc   { background: rgba(76,175,125,0.15); color: #4caf7d; border: 1px solid rgba(76,175,125,0.3); }
+  .org-icao { background: rgba(240,192,64,0.12); color: var(--accent); border: 1px solid rgba(240,192,64,0.3); }
+</style>
+</head>
+<body>
+  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:#f0c040;border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
+  <style>.container{padding-top:56px!important;}@media(max-width:480px){.container{padding-top:60px!important;}}</style>
+
+<div class="container">
+  <h1>ROC-008 — Regulatory Framework</h1>
+  <p class="subtitle">Radiocommunication Act · ISED RIC-21 · ICAO Annex 10 · ROC-A Written Exam</p>
+
+  <div class="section-title">Regulatory Pillars</div>
+
+  <div class="reg-pillar">
+    <h3>Radiocommunication Act (Canada) <span class="org-tag org-ised">ISED</span></h3>
+    <p>Federal statute administered by Innovation, Science and Economic Development Canada (ISED). Governs all radio transmitters in Canada — including aircraft.</p>
+    <ul>
+      <li>Prohibits operating a radio transmitter without a valid licence or authorization</li>
+      <li>Aeronautical radio operators must hold a <strong>Restricted Operator Certificate — Aeronautical</strong> (ROC-A)</li>
+      <li>Aircraft must hold a <strong>Aeronautical Station Licence</strong> (issued by ISED) to operate a transmitter on board</li>
+      <li>The ROC-A is an ISED certificate — it is separate from Transport Canada pilot licensing</li>
+    </ul>
+  </div>
+
+  <div class="reg-pillar">
+    <h3>Restricted Operator Certificate — Aeronautical (ROC-A) <span class="org-tag org-ised">ISED</span></h3>
+    <p>The individual certificate required by any person who operates an aeronautical mobile radio station (the aircraft radio).</p>
+    <ul>
+      <li>Examined and issued by ISED-accredited examiners</li>
+      <li>Tests: radio operation, phonetic alphabet, distress procedures, frequencies, regulations</li>
+      <li>Valid for life (no renewal required) once issued</li>
+      <li>Endorsements exist for HF and satellite operations (not required for basic VHF)</li>
+      <li>Not the same as a pilot licence — a non-pilot ground operator needs one too</li>
+    </ul>
+  </div>
+
+  <div class="reg-pillar">
+    <h3>Aeronautical Station Licence <span class="org-tag org-ised">ISED</span></h3>
+    <p>The station (aircraft) licence for the radio equipment installed in the aircraft.</p>
+    <ul>
+      <li>Required for Canadian-registered aircraft operating in Canada and abroad</li>
+      <li>Document must be carried on board while the aircraft is operated</li>
+      <li>The pilot certificate and station licence together satisfy ROC-A operational requirements</li>
+    </ul>
+  </div>
+
+  <div class="reg-pillar">
+    <h3>Canadian Aviation Regulations (CARs) <span class="org-tag org-tc">TC</span></h3>
+    <p>Transport Canada regulations governing aviation operations, including when radio use is required, airspace communications, and phraseology standards.</p>
+    <ul>
+      <li>CARs Part VI sets radio requirements per airspace class</li>
+      <li>Phraseology standards in AIM (Aeronautical Information Manual) supplement the CARs</li>
+      <li>TC enforces CARs; ISED enforces Radiocommunication Act — separate agencies</li>
+    </ul>
+  </div>
+
+  <div class="reg-pillar">
+    <h3>ICAO Annex 10 — Aeronautical Telecommunications <span class="org-tag org-icao">ICAO</span></h3>
+    <p>International standards adopted by Canada. Sets phonetic alphabet, distress phraseology, and frequency allocations used globally.</p>
+    <ul>
+      <li>Annex 10 Vol. II covers communication procedures (phonetic alphabet, readback, MAYDAY)</li>
+      <li>Canada's domestic rules must meet or exceed ICAO standards</li>
+    </ul>
+  </div>
+
+  <div class="section-title">Station Log Requirements</div>
+  <table>
+    <thead>
+      <tr><th>Operation type</th><th>Log required?</th><th>Notes</th></tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>Commercial air operations (CAR 702/703/704/705)</td>
+        <td class="yes">Required</td>
+        <td>Radio log must record all distress and urgency communications; operational communications as required by ops spec</td>
+      </tr>
+      <tr>
+        <td>Private pilot VFR flight (CAR 401)</td>
+        <td class="no">Not required</td>
+        <td>No station log required for private non-commercial operations under the Radiocommunication Act for aeronautical mobile</td>
+      </tr>
+      <tr>
+        <td>Distress / MAYDAY communications (any operation)</td>
+        <td class="yes">Required</td>
+        <td>Record in any available log or note; preserve for investigation. ISED and TC may require the record.</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <div class="note-box">
+    <strong>ROC-A vs Pilot Licence:</strong> The ROC-A (ISED) and the PPL/CPL (Transport Canada) are two separate credentials from two different federal departments. You need both to legally operate an aircraft radio in Canada. A student pilot who has not yet obtained a ROC-A must operate under the supervision of a person who holds one. (Radiocommunication Act s. 13)
+  </div>
+
+  <div class="memory-hook">
+    <span class="badge">EXAM HOOK</span><br>
+    <strong>Two agencies, two documents:</strong> ISED issues the ROC-A (operator certificate) and the Aeronautical Station Licence (aircraft licence). TC issues the pilot licence. The ROC-A exam tests radio operation — it is ISED's exam, not TC's. Log required for commercial ops and all distress communications.
+  </div>
+</div>
+</body>
+</html>

--- a/web-app/public/visuals/roc009-radio-etiquette.html
+++ b/web-app/public/visuals/roc009-radio-etiquette.html
@@ -1,0 +1,201 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>ROC-009: Radio Etiquette</title>
+<link rel="stylesheet" href="/visuals/_common.css">
+<style>
+  .rule-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 12px;
+    margin-bottom: 32px;
+  }
+  .rule-card {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 14px 16px;
+  }
+  .rule-num {
+    display: inline-block;
+    font-size: 10px;
+    font-weight: 800;
+    color: var(--accent);
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    margin-bottom: 6px;
+  }
+  .rule-card h3 {
+    font-size: 13px;
+    font-weight: 700;
+    color: var(--text);
+    margin-bottom: 6px;
+  }
+  .rule-card p {
+    font-size: 12px;
+    color: var(--text-muted);
+    line-height: 1.6;
+    margin: 0;
+  }
+  .do-dont {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 16px;
+    margin-bottom: 32px;
+  }
+  .do-col   { border-top: 3px solid #4caf7d; }
+  .dont-col { border-top: 3px solid #e05050; }
+  .do-col h3   { color: #4caf7d; }
+  .dont-col h3 { color: #e05050; }
+  .dd-block {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 0 0 8px 8px;
+    padding: 16px;
+  }
+  .dd-block h3 {
+    font-size: 13px;
+    font-weight: 700;
+    margin-bottom: 12px;
+  }
+  .dd-block ul {
+    padding-left: 16px;
+    margin: 0;
+  }
+  .dd-block li {
+    font-size: 12px;
+    color: var(--text);
+    line-height: 1.7;
+    margin-bottom: 4px;
+  }
+  .dd-block .example {
+    font-size: 11px;
+    color: var(--accent);
+    font-style: italic;
+    display: block;
+    margin-top: 1px;
+    padding-left: 12px;
+  }
+  @media (max-width: 560px) {
+    .rule-grid { grid-template-columns: 1fr; }
+    .do-dont   { grid-template-columns: 1fr; }
+  }
+</style>
+</head>
+<body>
+  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:#f0c040;border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
+  <style>.container{padding-top:56px!important;}@media(max-width:480px){.container{padding-top:60px!important;}}</style>
+
+<div class="container">
+  <h1>ROC-009 — Radio Etiquette</h1>
+  <p class="subtitle">ISED RIC-21 · AIM COM 4.0 · ICAO Annex 10 Vol. II · ROC-A Written Exam</p>
+
+  <div class="section-title">Core Rules</div>
+  <div class="rule-grid">
+    <div class="rule-card">
+      <div class="rule-num">Rule 1</div>
+      <h3>Listen before transmitting</h3>
+      <p>Monitor the frequency for at least 5 seconds before keying the PTT. Transmitting while others are talking causes both transmissions to be lost (stepped-on). This is the single most important habit.</p>
+    </div>
+    <div class="rule-card">
+      <div class="rule-num">Rule 2</div>
+      <h3>Keep transmissions brief</h3>
+      <p>Radio time is shared. Plan what you're going to say before pressing PTT. Avoid filler words, pauses mid-transmission, and unnecessary repetition. State who, where, what — then release.</p>
+    </div>
+    <div class="rule-card">
+      <div class="rule-num">Rule 3</div>
+      <h3>Use standard phraseology</h3>
+      <p>ICAO/ISED standard words carry precise meaning. Plain language is permitted when standard phrases don't cover the situation, but standard phrases reduce ambiguity and speed up communication.</p>
+    </div>
+    <div class="rule-card">
+      <div class="rule-num">Rule 4</div>
+      <h3>Speak at a moderate pace</h3>
+      <p>Speak clearly at a conversational pace — not fast (hard to write down) and not slow (wastes airtime). Slow down slightly when giving alphanumeric strings (frequencies, squawk codes, clearances).</p>
+    </div>
+    <div class="rule-card">
+      <div class="rule-num">Rule 5</div>
+      <h3>Correct microphone technique</h3>
+      <p>Hold the mic 2–5 cm from your mouth. Press PTT, pause 1 second before speaking (to let the transmitter activate), then speak. Release PTT only after finishing. Avoid wind and breathing noise.</p>
+    </div>
+    <div class="rule-card">
+      <div class="rule-num">Rule 6</div>
+      <h3>Read back mandatory items</h3>
+      <p>Always read back: runway, take-off/landing clearance, hold-short instructions, heading, altitude, altimeter, transponder code, and frequency changes. Omitting a readback signals non-receipt to ATC.</p>
+    </div>
+    <div class="rule-card">
+      <div class="rule-num">Rule 7</div>
+      <h3>Callsign every transmission</h3>
+      <p>End every transmission with your callsign (abbreviated after first contact). This lets ATC and other traffic identify who just transmitted, especially important on busy tower frequencies.</p>
+    </div>
+    <div class="rule-card">
+      <div class="rule-num">Rule 8</div>
+      <h3>"Standby" buys time</h3>
+      <p>If you cannot respond immediately (head-down, busy), say "Standby, [callsign]" and ATC will wait. Never leave ATC without an acknowledgement — a missed call may lead ATC to assume a radio failure.</p>
+    </div>
+  </div>
+
+  <div class="section-title">Do vs Don't</div>
+  <div class="do-dont">
+    <div class="do-col">
+      <div class="dd-block">
+        <h3>&#10003; Do</h3>
+        <ul>
+          <li>Use phonetic alphabet for all letters<span class="example">"Golf Charlie Delta Foxtrot" not "G-C-D-F"</span></li>
+          <li>Say "say again" to request a repeat<span class="example">"Say again altitude, C-GCDF"</span></li>
+          <li>State "Correction" then re-transmit if you made an error</li>
+          <li>Use "Affirmative" and "Negative" for yes/no</li>
+          <li>Say "Wilco" if you intend to comply<span class="example">Means "understood, will comply"</span></li>
+          <li>Cancel VFR flight plan when safely on ground</li>
+          <li>Monitor 121.5 MHz whenever a second radio is available</li>
+        </ul>
+      </div>
+    </div>
+    <div class="dont-col">
+      <div class="dd-block">
+        <h3>&#10007; Don't</h3>
+        <ul>
+          <li>Say "repeat" — this is artillery jargon; say "say again"</li>
+          <li>Transmit personal information, profanity, or music</li>
+          <li>Use "Over and out" — "Over" expects a reply; "Out" ends the call. Don't mix them.</li>
+          <li>Say "Roger" when you mean "Wilco" — "Roger" means received, not agreed</li>
+          <li>Transmit on guard (121.5 MHz) for routine calls</li>
+          <li>Hold PTT without speaking — this blocks the frequency for all users</li>
+          <li>Abbreviate callsign before ATC does so first</li>
+        </ul>
+      </div>
+    </div>
+  </div>
+
+  <div class="section-title">Blocked / Jammed Frequency</div>
+  <table>
+    <thead>
+      <tr><th>Symptom</th><th>Likely cause</th><th>Action</th></tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>Continuous carrier noise, no voice</td>
+        <td>Stuck PTT somewhere on the frequency</td>
+        <td>Attempt to reach ATC on alternate frequency or 121.5 MHz; report the block</td>
+      </tr>
+      <tr>
+        <td>Squealing / heterodyne on frequency</td>
+        <td>Two stations transmitting simultaneously</td>
+        <td>Listen before transmitting; try again after the squeal clears</td>
+      </tr>
+      <tr>
+        <td>No response from ATC after two calls</td>
+        <td>Frequency congestion, weak signal, or radio failure</td>
+        <td>Try alternate ATC frequency; try 121.5 MHz; squawk 7600 if radio failure confirmed</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <div class="memory-hook">
+    <span class="badge">EXAM HOOK</span><br>
+    <strong>Radio etiquette summary:</strong> Listen → Think → Transmit → Identify. Never say "repeat" (say <em>say again</em>). "Roger" = received; "Wilco" = will comply. End every call with your callsign. Monitor 121.5 MHz on second radio whenever possible.
+  </div>
+</div>
+</body>
+</html>


### PR DESCRIPTION
## Summary

- Creates 9 standalone dark-aviation HTML visual files (`roc001` through `roc009`) in `web-app/public/visuals/`
- Each file links `/visuals/_common.css`, uses `var(--token)` for chrome, and includes the canonical `data-backlink="true"` back-to-lesson button
- ROC-006 emergency comms: MAYDAY signal flow, GMDSS/SAR context, squawk codes 7500/7600/7700 colour-coded with hardcoded data-encoding domain colours
- ROC-007 light signals: full table (steady/flashing green, steady/flashing red, flashing white, alternating red/green) for both tower→flight and tower→ground
- Updates `visual:` frontmatter in all 9 `lessons/radio/*.md` files to point to the corresponding `/visuals/roc00N-*.html` path
- No external resources; dark scheme only; `npm run build` passes

Closes #342

## Test plan

- [ ] Open each of the 9 HTML files in a browser and verify dark-aviation styling renders correctly
- [ ] Confirm `data-backlink="true"` button appears fixed top-left on each file
- [ ] Verify no external `<script src>`, CDN fonts, or remote images in any file
- [ ] Confirm `visual:` frontmatter in each `lessons/radio/NNN-*.md` points to the correct path
- [ ] `npm run build` in `web-app/` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)