### PR TITLE
[PPL-337] ROC-A: type system + curriculum + RROE track activation

### DIFF
--- a/web-app/src/lib/curriculum.ts
+++ b/web-app/src/lib/curriculum.ts
@@ -76,6 +76,17 @@ export const CURRICULUM: CurriculumSlot[] = [
   { id: 'GK-012', slug: 'stalls-spins', title: 'Stalls and Spins', topic: 'general-knowledge', order: 12 },
   { id: 'GK-013', slug: 'load-factor', title: 'Load Factor and Maneuvering Speed', topic: 'general-knowledge', order: 13 },
   { id: 'GK-014', slug: 'preflight-inspection', title: 'Pre-Flight Inspection and Maintenance', topic: 'general-knowledge', order: 14 },
+
+  // Radio — ROC-A (9)
+  { id: 'ROC-001', slug: 'roc-a-overview', title: 'ROC-A Overview and Exam Requirements', topic: 'radio', order: 1 },
+  { id: 'ROC-002', slug: 'phonetic-alphabet-numbers', title: 'Phonetic Alphabet and Number Pronunciation', topic: 'radio', order: 2 },
+  { id: 'ROC-003', slug: 'radiotelephony-procedures', title: 'Standard Radiotelephony Procedures', topic: 'radio', order: 3 },
+  { id: 'ROC-004', slug: 'vhf-frequency-bands', title: 'VHF Frequency Bands and Uses', topic: 'radio', order: 4 },
+  { id: 'ROC-005', slug: 'atc-ground-communications', title: 'ATC and Ground Communications', topic: 'radio', order: 5 },
+  { id: 'ROC-006', slug: 'distress-urgency-signals', title: 'Distress and Urgency Signals', topic: 'radio', order: 6 },
+  { id: 'ROC-007', slug: 'atis-unicom-multicom', title: 'ATIS, UNICOM, and MULTICOM', topic: 'radio', order: 7 },
+  { id: 'ROC-008', slug: 'radio-equipment-licencing', title: 'Radio Equipment and Station Licencing', topic: 'radio', order: 8 },
+  { id: 'ROC-009', slug: 'roc-a-practice-scenarios', title: 'ROC-A Practice Scenarios', topic: 'radio', order: 9 },
 ];
 
 export const TOPIC_LABELS: Record<string, string> = {
@@ -83,6 +94,7 @@ export const TOPIC_LABELS: Record<string, string> = {
   'navigation': 'Navigation',
   'meteorology': 'Meteorology',
   'general-knowledge': 'General Knowledge',
+  'radio': 'Radio (ROC-A)',
 };
 
-export const TOPICS = ['air-law', 'navigation', 'meteorology', 'general-knowledge'] as const;
+export const TOPICS = ['air-law', 'navigation', 'meteorology', 'general-knowledge', 'radio'] as const;

--- a/web-app/src/lib/exam-tracks.ts
+++ b/web-app/src/lib/exam-tracks.ts
@@ -41,8 +41,8 @@ export const EXAM_TRACKS: ExamTrack[] = [
     code: 'RROE',
     name: 'Radio Operator',
     tagline: 'Restricted Radiotelephone Operator Certificate (Aeronautical)',
-    status: 'coming-soon',
-    lessonFilter: noLessons,
+    status: 'active',
+    lessonFilter: (l) => l.topic === 'radio',
   },
   {
     id: 'ppl-h',

--- a/web-app/src/lib/types.ts
+++ b/web-app/src/lib/types.ts
@@ -1,4 +1,4 @@
-export type Topic = 'air-law' | 'navigation' | 'meteorology' | 'general-knowledge';
+export type Topic = 'air-law' | 'navigation' | 'meteorology' | 'general-knowledge' | 'radio';
 export type LessonStatus = 'planning' | 'draft' | 'complete';
 
 export interface Question {


### PR DESCRIPTION
## Summary

- Add `'radio'` to `Topic` union in `types.ts`
- Add `TOPIC_LABELS['radio'] = 'Radio (ROC-A)'` and append `'radio'` to `TOPICS` in `curriculum.ts`
- Add 9 `CurriculumSlot` entries (`ROC-001`–`ROC-009`) in `curriculum.ts`
- Activate RROE exam track in `exam-tracks.ts`: `status: 'active'`, `lessonFilter: (l) => l.topic === 'radio'`

Refs #337

## Test plan

- [x] `npm run build` passes
- [ ] Lessons index renders a "Radio (ROC-A)" section (once #341 lesson files are authored)
- [ ] RROE track appears active in the track switcher

🤖 Generated with [Claude Code](https://claude.com/claude-code)