### PR TITLE
[PPL-339] Add radio topic to type system, curriculum, activate RROE track

### DIFF
--- a/web-app/src/lib/curriculum.ts
+++ b/web-app/src/lib/curriculum.ts
@@ -6,6 +6,8 @@ export interface CurriculumSlot {
   title: string;
   topic: Topic;
   order: number;
+  audio?: string | null;
+  visual?: string;
 }
 
 export const CURRICULUM: CurriculumSlot[] = [
@@ -76,6 +78,17 @@ export const CURRICULUM: CurriculumSlot[] = [
   { id: 'GK-012', slug: 'stalls-spins', title: 'Stalls and Spins', topic: 'general-knowledge', order: 12 },
   { id: 'GK-013', slug: 'load-factor', title: 'Load Factor and Maneuvering Speed', topic: 'general-knowledge', order: 13 },
   { id: 'GK-014', slug: 'preflight-inspection', title: 'Pre-Flight Inspection and Maintenance', topic: 'general-knowledge', order: 14 },
+
+  // Radio (ROC-A) (9)
+  { id: 'ROC-001', slug: 'phonetic-alphabet-numbers', title: 'Phonetic Alphabet and Numbers', topic: 'radio', order: 1, audio: null, visual: '' },
+  { id: 'ROC-002', slug: 'standard-phraseology-readback', title: 'Standard Phraseology and Readback', topic: 'radio', order: 2, audio: null, visual: '' },
+  { id: 'ROC-003', slug: 'frequencies-reference', title: 'Frequencies Reference', topic: 'radio', order: 3, audio: null, visual: '' },
+  { id: 'ROC-004', slug: 'position-reporting', title: 'Position Reporting', topic: 'radio', order: 4, audio: null, visual: '' },
+  { id: 'ROC-005', slug: 'vfr-ifr-comms-overview', title: 'VFR/IFR Communications Overview', topic: 'radio', order: 5, audio: null, visual: '' },
+  { id: 'ROC-006', slug: 'emergency-comms', title: 'Emergency Communications', topic: 'radio', order: 6, audio: null, visual: '' },
+  { id: 'ROC-007', slug: 'light-signals', title: 'Light Signals', topic: 'radio', order: 7, audio: null, visual: '' },
+  { id: 'ROC-008', slug: 'regulatory-framework', title: 'Regulatory Framework', topic: 'radio', order: 8, audio: null, visual: '' },
+  { id: 'ROC-009', slug: 'radio-etiquette', title: 'Radio Etiquette', topic: 'radio', order: 9, audio: null, visual: '' },
 ];
 
 export const TOPIC_LABELS: Record<string, string> = {
@@ -83,6 +96,7 @@ export const TOPIC_LABELS: Record<string, string> = {
   'navigation': 'Navigation',
   'meteorology': 'Meteorology',
   'general-knowledge': 'General Knowledge',
+  'radio': 'Radio (ROC-A)',
 };
 
-export const TOPICS = ['air-law', 'navigation', 'meteorology', 'general-knowledge'] as const;
+export const TOPICS = ['air-law', 'navigation', 'meteorology', 'general-knowledge', 'radio'] as const;

--- a/web-app/src/lib/exam-tracks.ts
+++ b/web-app/src/lib/exam-tracks.ts
@@ -41,8 +41,8 @@ export const EXAM_TRACKS: ExamTrack[] = [
     code: 'RROE',
     name: 'Radio Operator',
     tagline: 'Restricted Radiotelephone Operator Certificate (Aeronautical)',
-    status: 'coming-soon',
-    lessonFilter: noLessons,
+    status: 'active',
+    lessonFilter: (l) => l.topic === 'radio',
   },
   {
     id: 'ppl-h',

--- a/web-app/src/lib/types.ts
+++ b/web-app/src/lib/types.ts
@@ -1,4 +1,4 @@
-export type Topic = 'air-law' | 'navigation' | 'meteorology' | 'general-knowledge';
+export type Topic = 'air-law' | 'navigation' | 'meteorology' | 'general-knowledge' | 'radio';
 export type LessonStatus = 'planning' | 'draft' | 'complete';
 
 export interface Question {


### PR DESCRIPTION
## Summary
- Adds `'radio'` to the `Topic` union in `types.ts`
- Adds optional `audio?` / `visual?` fields to `CurriculumSlot` interface for forward-compatibility
- Adds `TOPIC_LABELS['radio'] = 'Radio (ROC-A)'` and appends `'radio'` to the `TOPICS` array
- Adds 9 placeholder `CurriculumSlot` entries (ROC-001–ROC-009) with the correct slugs, all with `audio: null, visual: ''`
- Activates the `rroe` exam track (`status: 'active'`), filtered to `l.topic === 'radio'`

Closes #339

## Test plan
- [x] `npm run build` passes with zero TypeScript errors
- [ ] RROE track appears as active in the track switcher UI
- [ ] 9 radio lessons appear when RROE track is selected

🤖 Generated with [Claude Code](https://claude.com/claude-code)