### PR TITLE
[PPL-338] Fix TrackSwitcher: replace hard-coded dark tokens with theme.palette

### DIFF
--- a/web-app/src/components/TrackSwitcher.tsx
+++ b/web-app/src/components/TrackSwitcher.tsx
@@ -6,14 +6,15 @@ import Divider from '@mui/material/Divider';
 import Menu from '@mui/material/Menu';
 import MenuItem from '@mui/material/MenuItem';
 import Typography from '@mui/material/Typography';
+import { useTheme } from '@mui/material/styles';
 import AddIcon from '@mui/icons-material/Add';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import LockIcon from '@mui/icons-material/Lock';
 import { useExamTrack } from '../context/ExamTrackContext';
 import { getLessonsByTrack } from '../lib/lesson-loader';
-import { colorTokens } from '../tokens';
 
 export default function TrackSwitcher() {
+  const theme = useTheme();
   const { activeTrack, setActiveTrack, availableTracks, trackProgress } = useExamTrack();
 
   const progressPct = useMemo(() => {
@@ -50,14 +51,14 @@ export default function TrackSwitcher() {
           fontWeight: 600,
           letterSpacing: '0.06em',
           textTransform: 'uppercase',
-          color: colorTokens.primary.main,
-          border: `1px solid ${colorTokens.primary.main}`,
+          color: theme.palette.primary.main,
+          border: `1px solid ${theme.palette.primary.main}`,
           minWidth: 0,
           whiteSpace: 'nowrap',
           lineHeight: 1.5,
           '&:hover': {
-            backgroundColor: colorTokens.primary.muted,
-            borderColor: colorTokens.primary.main,
+            backgroundColor: theme.palette.primaryMuted,
+            borderColor: theme.palette.primary.main,
           },
         }}
       >
@@ -73,8 +74,8 @@ export default function TrackSwitcher() {
             sx: {
               minWidth: 240,
               maxWidth: 'min(280px, calc(100vw - 32px))',
-              backgroundColor: colorTokens.background.paper,
-              border: `1px solid ${colorTokens.divider}`,
+              backgroundColor: theme.palette.background.paper,
+              border: `1px solid ${theme.palette.divider}`,
               backgroundImage: 'none',
             },
           },
@@ -108,11 +109,11 @@ export default function TrackSwitcher() {
                 py: 1,
                 cursor: isSelectable ? 'pointer' : 'default',
                 '&.Mui-selected': {
-                  backgroundColor: colorTokens.primary.muted,
-                  '&:hover': { backgroundColor: colorTokens.primary.muted },
+                  backgroundColor: theme.palette.primaryMuted,
+                  '&:hover': { backgroundColor: theme.palette.primaryMuted },
                 },
                 '&:hover': {
-                  backgroundColor: isSelectable ? colorTokens.primary.muted : 'transparent',
+                  backgroundColor: isSelectable ? theme.palette.primaryMuted : 'transparent',
                 },
               }}
             >
@@ -142,8 +143,8 @@ export default function TrackSwitcher() {
                     fontSize: '0.5625rem',
                     height: 16,
                     flexShrink: 0,
-                    backgroundColor: colorTokens.background.surfaceRaised,
-                    color: colorTokens.text.secondary,
+                    backgroundColor: theme.palette.background.surfaceRaised,
+                    color: theme.palette.text.secondary,
                     '& .MuiChip-label': { px: 0.75 },
                   }}
                 />


### PR DESCRIPTION
## Summary

- Replaced all `colorTokens.*` direct references in `TrackSwitcher.tsx` with `useTheme()` / `theme.palette.*` so the component correctly follows the active light/dark theme.
- `colorTokens` exports a flat spread of the dark scheme for backward-compat (see `tokens.ts:75`), causing the dropdown button and menu to always render with dark-mode colors even in light mode.
- `Soon` badges use `theme.palette.background.surfaceRaised` + `theme.palette.text.secondary`, remaining visually distinct but readable in both schemes.

## Decision: Exam Track dropdown placement

**Finding:** The `TrackSwitcher` component is rendered in the **Nav sidebar** (both desktop drawer and mobile), not on the Playlist Library page itself. It is always visible regardless of active route.

**Assessment:** 5 of 7 tracks are `coming-soon` or `locked`. However, two tracks are fully active (`PPL-A`, `PSTAR`) and the switcher correctly gates which lessons count toward progress for each. The dropdown serves a real purpose today.

**Decision: keep in Nav sidebar.** The component is not misplaced on a specific page — it is a global nav element. Hiding it would regress the PPL-A ↔ PSTAR switching flow. The `coming-soon` entries follow the existing design (muted, non-interactive, "Soon" chip).

A follow-up issue has been opened to define the intended UX for the full exam-track selection experience once more tracks ship.

## Test plan

- [ ] `npm run build` passes ✅
- [ ] Dark mode: pill button shows amber border/text; menu has dark background
- [ ] Light mode: pill button shows `#a05000` border/text; menu has white background
- [ ] `Soon` chips remain readable (muted secondary text on raised surface) in both themes
- [ ] Selecting PPL-A / PSTAR still works

Closes #338

🤖 Generated with [Claude Code](https://claude.com/claude-code)