### PR TITLE
[PPL-342] ROC-A: visual HTML diagrams (ROC-001–ROC-009)

### DIFF
--- a/lessons/radio/001-phonetic-alphabet-numbers.md
+++ b/lessons/radio/001-phonetic-alphabet-numbers.md
@@ -7,7 +7,7 @@ title: "Phonetic Alphabet and Number Pronunciation"
 duration_min: 20
 status: complete
 audio: https://media.suprun.workers.dev/ppl/lessons/radio/001-phonetic-alphabet-numbers.m4a
-visual: ''
+visual: '/visuals/roc001-phonetic-alphabet-numbers.html'
 sources:
   - ISED RIC-21
   - AIM COM 4.0

--- a/lessons/radio/002-standard-phraseology-readback.md
+++ b/lessons/radio/002-standard-phraseology-readback.md
@@ -7,7 +7,7 @@ title: "Standard Phraseology and Readback Requirements"
 duration_min: 20
 status: complete
 audio: https://media.suprun.workers.dev/ppl/lessons/radio/002-standard-phraseology-readback.m4a
-visual: ''
+visual: '/visuals/roc002-standard-phraseology-readback.html'
 sources:
   - ISED RIC-21
   - AIM COM 4.0

--- a/lessons/radio/003-frequencies-reference.md
+++ b/lessons/radio/003-frequencies-reference.md
@@ -7,7 +7,7 @@ title: "Aviation Frequency Reference"
 duration_min: 20
 status: complete
 audio: https://media.suprun.workers.dev/ppl/lessons/radio/003-frequencies-reference.m4a
-visual: ''
+visual: '/visuals/roc003-frequencies-reference.html'
 sources:
   - ISED RIC-21
   - AIM COM 4.0

--- a/lessons/radio/004-position-reporting.md
+++ b/lessons/radio/004-position-reporting.md
@@ -7,7 +7,7 @@ title: "Position Reporting — MF and ATF Procedures"
 duration_min: 20
 status: complete
 audio: https://media.suprun.workers.dev/ppl/lessons/radio/004-position-reporting.m4a
-visual: ''
+visual: '/visuals/roc004-position-reporting.html'
 sources:
   - AIM RAC 4.5
   - AIM RAC 4.4

--- a/lessons/radio/005-vfr-ifr-comms-overview.md
+++ b/lessons/radio/005-vfr-ifr-comms-overview.md
@@ -7,7 +7,7 @@ title: "VFR and IFR Communications Overview"
 duration_min: 20
 status: complete
 audio: https://media.suprun.workers.dev/ppl/lessons/radio/005-vfr-ifr-comms-overview.m4a
-visual: ''
+visual: '/visuals/roc005-vfr-ifr-comms-overview.html'
 sources:
   - AIM RAC 4.3
   - AIM COM 4.0

--- a/lessons/radio/006-emergency-comms.md
+++ b/lessons/radio/006-emergency-comms.md
@@ -7,7 +7,7 @@ title: "Emergency Communications"
 duration_min: 20
 status: complete
 audio: https://media.suprun.workers.dev/ppl/lessons/radio/006-emergency-comms.m4a
-visual: ''
+visual: '/visuals/roc006-emergency-comms.html'
 sources:
   - AIM SAR 3.0
   - AIM COM 4.0

--- a/lessons/radio/007-light-signals.md
+++ b/lessons/radio/007-light-signals.md
@@ -7,7 +7,7 @@ title: "Light Gun Signals"
 duration_min: 20
 status: complete
 audio: https://media.suprun.workers.dev/ppl/lessons/radio/007-light-signals.m4a
-visual: ''
+visual: '/visuals/roc007-light-signals.html'
 sources:
   - AIM RAC 4.6
   - CARs 602.98

--- a/lessons/radio/008-regulatory-framework.md
+++ b/lessons/radio/008-regulatory-framework.md
@@ -7,7 +7,7 @@ title: "Radio Regulatory Framework — Radiocommunication Act and ROC-A"
 duration_min: 20
 status: complete
 audio: https://media.suprun.workers.dev/ppl/lessons/radio/008-regulatory-framework.m4a
-visual: ''
+visual: '/visuals/roc008-regulatory-framework.html'
 sources:
   - Radiocommunication Act R.S.C. 1985 c. R-2
   - ISED RIC-21

--- a/lessons/radio/009-radio-etiquette.md
+++ b/lessons/radio/009-radio-etiquette.md
@@ -7,7 +7,7 @@ title: "Radio Etiquette and Professional Practice"
 duration_min: 20
 status: complete
 audio: https://media.suprun.workers.dev/ppl/lessons/radio/009-radio-etiquette.m4a
-visual: ''
+visual: '/visuals/roc009-radio-etiquette.html'
 sources:
   - ISED RIC-21
   - AIM COM 4.0

--- a/web-app/public/visuals/roc001-phonetic-alphabet-numbers.html
+++ b/web-app/public/visuals/roc001-phonetic-alphabet-numbers.html
@@ -1,0 +1,143 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<link rel="stylesheet" href="/visuals/_common.css">
+<title>ROC-001: Phonetic Alphabet and Number Pronunciation</title>
+<style>
+  .alpha-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(118px, 1fr));
+    gap: 8px;
+    margin-bottom: 32px;
+  }
+  .alpha-card {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    padding: 10px 12px;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+  }
+  .letter-badge {
+    display: inline-block;
+    width: 32px;
+    height: 32px;
+    min-width: 32px;
+    background: var(--surface2);
+    border: 1px solid var(--border-hi);
+    border-radius: 4px;
+    text-align: center;
+    line-height: 32px;
+    font-size: 18px;
+    font-weight: 800;
+    color: var(--accent);
+  }
+  .alpha-word { font-size: 13px; font-weight: 600; color: var(--text); line-height: 1.3; }
+  .alpha-pron { font-size: 11px; color: var(--text-muted); font-style: italic; }
+
+  .digit-grid {
+    display: grid;
+    grid-template-columns: repeat(5, 1fr);
+    gap: 8px;
+    margin-bottom: 32px;
+  }
+  .digit-card {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    padding: 12px 8px;
+    text-align: center;
+  }
+  .digit-num  { font-size: 24px; font-weight: 800; color: var(--accent); display: block; line-height: 1.1; }
+  .digit-say  { font-size: 13px; color: var(--text); font-weight: 600; display: block; margin-top: 4px; }
+  .digit-pron { font-size: 11px; color: var(--text-muted); font-style: italic; display: block; margin-top: 2px; }
+
+  @media (max-width: 480px) {
+    .alpha-grid { grid-template-columns: repeat(auto-fill, minmax(100px, 1fr)); }
+  }
+</style>
+</head>
+<body>
+  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:#f0c040;border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
+  <style>.container{padding-top:56px!important;}@media(max-width:480px){.container{padding-top:60px!important;}}</style>
+
+<h1>ROC-001 — Phonetic Alphabet &amp; Number Pronunciation</h1>
+<p class="subtitle">ISED RIC-21 · ICAO Annex 10 Vol. II · AIM COM 4.0 · ROC-A Written Exam</p>
+
+<div class="section-label">NATO Phonetic Alphabet — A to Z</div>
+<div class="alpha-grid">
+  <div class="alpha-card"><span class="letter-badge">A</span><div><div class="alpha-word">Alfa</div><div class="alpha-pron">AL-fah</div></div></div>
+  <div class="alpha-card"><span class="letter-badge">B</span><div><div class="alpha-word">Bravo</div><div class="alpha-pron">BRAH-voh</div></div></div>
+  <div class="alpha-card"><span class="letter-badge">C</span><div><div class="alpha-word">Charlie</div><div class="alpha-pron">CHAR-lee</div></div></div>
+  <div class="alpha-card"><span class="letter-badge">D</span><div><div class="alpha-word">Delta</div><div class="alpha-pron">DEL-tah</div></div></div>
+  <div class="alpha-card"><span class="letter-badge">E</span><div><div class="alpha-word">Echo</div><div class="alpha-pron">EK-oh</div></div></div>
+  <div class="alpha-card"><span class="letter-badge">F</span><div><div class="alpha-word">Foxtrot</div><div class="alpha-pron">FOKS-trot</div></div></div>
+  <div class="alpha-card"><span class="letter-badge">G</span><div><div class="alpha-word">Golf</div><div class="alpha-pron">GOLF</div></div></div>
+  <div class="alpha-card"><span class="letter-badge">H</span><div><div class="alpha-word">Hotel</div><div class="alpha-pron">HOH-tel</div></div></div>
+  <div class="alpha-card"><span class="letter-badge">I</span><div><div class="alpha-word">India</div><div class="alpha-pron">IN-dee-ah</div></div></div>
+  <div class="alpha-card"><span class="letter-badge">J</span><div><div class="alpha-word">Juliett</div><div class="alpha-pron">JEW-lee-et</div></div></div>
+  <div class="alpha-card"><span class="letter-badge">K</span><div><div class="alpha-word">Kilo</div><div class="alpha-pron">KEY-loh</div></div></div>
+  <div class="alpha-card"><span class="letter-badge">L</span><div><div class="alpha-word">Lima</div><div class="alpha-pron">LEE-mah</div></div></div>
+  <div class="alpha-card"><span class="letter-badge">M</span><div><div class="alpha-word">Mike</div><div class="alpha-pron">MIKE</div></div></div>
+  <div class="alpha-card"><span class="letter-badge">N</span><div><div class="alpha-word">November</div><div class="alpha-pron">no-VEM-ber</div></div></div>
+  <div class="alpha-card"><span class="letter-badge">O</span><div><div class="alpha-word">Oscar</div><div class="alpha-pron">OSS-car</div></div></div>
+  <div class="alpha-card"><span class="letter-badge">P</span><div><div class="alpha-word">Papa</div><div class="alpha-pron">PAH-pah</div></div></div>
+  <div class="alpha-card"><span class="letter-badge">Q</span><div><div class="alpha-word">Quebec</div><div class="alpha-pron">keh-BEK</div></div></div>
+  <div class="alpha-card"><span class="letter-badge">R</span><div><div class="alpha-word">Romeo</div><div class="alpha-pron">ROH-me-oh</div></div></div>
+  <div class="alpha-card"><span class="letter-badge">S</span><div><div class="alpha-word">Sierra</div><div class="alpha-pron">see-AIR-ah</div></div></div>
+  <div class="alpha-card"><span class="letter-badge">T</span><div><div class="alpha-word">Tango</div><div class="alpha-pron">TANG-go</div></div></div>
+  <div class="alpha-card"><span class="letter-badge">U</span><div><div class="alpha-word">Uniform</div><div class="alpha-pron">YOU-nee-form</div></div></div>
+  <div class="alpha-card"><span class="letter-badge">V</span><div><div class="alpha-word">Victor</div><div class="alpha-pron">VIK-tor</div></div></div>
+  <div class="alpha-card"><span class="letter-badge">W</span><div><div class="alpha-word">Whiskey</div><div class="alpha-pron">WISS-key</div></div></div>
+  <div class="alpha-card"><span class="letter-badge">X</span><div><div class="alpha-word">X-ray</div><div class="alpha-pron">ECKS-ray</div></div></div>
+  <div class="alpha-card"><span class="letter-badge">Y</span><div><div class="alpha-word">Yankee</div><div class="alpha-pron">YANG-key</div></div></div>
+  <div class="alpha-card"><span class="letter-badge">Z</span><div><div class="alpha-word">Zulu</div><div class="alpha-pron">ZOO-loo</div></div></div>
+</div>
+
+<div class="section-label">Digit Pronunciation — Aviation Standard</div>
+<div class="digit-grid">
+  <div class="digit-card"><span class="digit-num">0</span><span class="digit-say">Zero</span><span class="digit-pron">ZEE-ro</span></div>
+  <div class="digit-card"><span class="digit-num">1</span><span class="digit-say">One</span><span class="digit-pron">WUN</span></div>
+  <div class="digit-card"><span class="digit-num">2</span><span class="digit-say">Two</span><span class="digit-pron">TOO</span></div>
+  <div class="digit-card"><span class="digit-num">3</span><span class="digit-say">Tree</span><span class="digit-pron">TREE</span></div>
+  <div class="digit-card"><span class="digit-num">4</span><span class="digit-say">Four</span><span class="digit-pron">FOW-er</span></div>
+  <div class="digit-card"><span class="digit-num">5</span><span class="digit-say">Fife</span><span class="digit-pron">FIFE</span></div>
+  <div class="digit-card"><span class="digit-num">6</span><span class="digit-say">Six</span><span class="digit-pron">SIX</span></div>
+  <div class="digit-card"><span class="digit-num">7</span><span class="digit-say">Seven</span><span class="digit-pron">SEV-en</span></div>
+  <div class="digit-card"><span class="digit-num">8</span><span class="digit-say">Eight</span><span class="digit-pron">AIT</span></div>
+  <div class="digit-card"><span class="digit-num">9</span><span class="digit-say">Niner</span><span class="digit-pron">NYE-ner</span></div>
+</div>
+
+<div class="section-label">Altitude and Frequency Conventions</div>
+<table>
+  <thead>
+    <tr><th>What you read</th><th>What you say</th><th>Rule</th></tr>
+  </thead>
+  <tbody>
+    <tr><td>3,500 ft</td><td>"Tree thousand fife hundred"</td><td>Each number group spoken separately</td></tr>
+    <tr><td>FL240</td><td>"Flight level two four zero"</td><td>Three digits spoken individually</td></tr>
+    <tr><td>122.8 MHz</td><td>"One two two decimal eight"</td><td>Decimal point = "decimal"</td></tr>
+    <tr><td>Squawk 7700</td><td>"Squawk seven seven zero zero"</td><td>Each digit individually</td></tr>
+    <tr><td>Runway 28L</td><td>"Runway two eight left"</td><td>Two-digit designator</td></tr>
+    <tr><td>Wind 270°/15 kt</td><td>"Wind two seven zero at one fife"</td><td>Three digits for direction</td></tr>
+  </tbody>
+</table>
+
+<div class="note-box">
+  <strong>Why "Niner" and "Tree"?</strong> "Niner" prevents confusion with the German word <em>Nein</em> (no). "Tree" avoids misreading "three" as "free" on a noisy radio. "Fife" reduces confusion with "fire." These deviations are ICAO-mandated, not optional. (ICAO Annex 10 Vol. II §5.2.1.7)
+</div>
+
+<div class="hook-box">
+  <h2>Memory Hook</h2>
+  <div class="hook-row"><span class="hook-badge">3</span><span class="hook-text"><strong>Tree</strong> — not "three"</span></div>
+  <div class="hook-row"><span class="hook-badge">5</span><span class="hook-text"><strong>Fife</strong> — not "five"</span></div>
+  <div class="hook-row"><span class="hook-badge">9</span><span class="hook-text"><strong>Niner</strong> — not "nine"</span></div>
+  <div class="hook-row"><span class="hook-badge">.</span><span class="hook-text">Decimal point → say <strong>"decimal"</strong> (never "point")</span></div>
+  <div class="hook-row"><span class="hook-badge">FL</span><span class="hook-text">FL240 → <strong>"two four zero"</strong> — never "two hundred forty"</span></div>
+</div>
+
+</body>
+</html>

--- a/web-app/public/visuals/roc002-standard-phraseology-readback.html
+++ b/web-app/public/visuals/roc002-standard-phraseology-readback.html
@@ -1,0 +1,125 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<link rel="stylesheet" href="/visuals/_common.css">
+<title>ROC-002: Standard Phraseology and Readback</title>
+<style>
+  .call-parts {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+    gap: 8px;
+    margin-bottom: 24px;
+  }
+  .call-part {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    padding: 12px 14px;
+  }
+  .call-part-num   { font-size: 10px; color: var(--text-muted); text-transform: uppercase; letter-spacing: 1px; margin-bottom: 4px; }
+  .call-part-label { font-size: 13px; font-weight: 700; color: var(--accent); margin-bottom: 3px; }
+  .call-part-eg    { font-size: 11px; color: var(--text-muted); font-style: italic; }
+
+  .exchange {
+    background: var(--surface);
+    border-left: 3px solid var(--accent);
+    border-radius: 4px;
+    padding: 14px 18px;
+    margin-bottom: 24px;
+    font-size: 13px;
+    line-height: 1.9;
+  }
+  .tx-atc   { color: var(--info); }
+  .tx-pilot { color: var(--success); }
+  .tx-label { font-size: 10px; text-transform: uppercase; letter-spacing: 1px; margin-right: 6px; opacity: 0.65; }
+
+  /* mandatory/recommended indicators — data-encoding colours */
+  .must { color: #4caf7d; font-weight: 700; }
+  .opt  { color: var(--text-muted); }
+</style>
+</head>
+<body>
+  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:#f0c040;border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
+  <style>.container{padding-top:56px!important;}@media(max-width:480px){.container{padding-top:60px!important;}}</style>
+
+<h1>ROC-002 — Standard Phraseology &amp; Readback</h1>
+<p class="subtitle">ISED RIC-21 · AIM COM 4.0 · ICAO Annex 10 Vol. II · ROC-A Written Exam</p>
+
+<div class="section-label">Standard Initial Call — 4-Part Format</div>
+<div class="call-parts">
+  <div class="call-part">
+    <div class="call-part-num">Part 1</div>
+    <div class="call-part-label">Who you are calling</div>
+    <div class="call-part-eg">"Ottawa Tower"</div>
+  </div>
+  <div class="call-part">
+    <div class="call-part-num">Part 2</div>
+    <div class="call-part-label">Who you are</div>
+    <div class="call-part-eg">"Cessna Golf Charlie Delta Foxtrot"</div>
+  </div>
+  <div class="call-part">
+    <div class="call-part-num">Part 3</div>
+    <div class="call-part-label">Where you are</div>
+    <div class="call-part-eg">"ten miles south"</div>
+  </div>
+  <div class="call-part">
+    <div class="call-part-num">Part 4</div>
+    <div class="call-part-label">What you want</div>
+    <div class="call-part-eg">"request landing"</div>
+  </div>
+</div>
+
+<div class="section-label">Example Exchange</div>
+<div class="exchange">
+  <div class="tx-atc"><span class="tx-label">ATC</span>"Golf Charlie Delta Foxtrot, Ottawa Tower, runway two five, cleared to land, wind two four zero at one zero."</div>
+  <div class="tx-pilot"><span class="tx-label">Pilot</span>"Runway two five, cleared to land, Golf Charlie Delta Foxtrot."</div>
+</div>
+
+<div class="section-label">Mandatory Readback Items</div>
+<table>
+  <thead>
+    <tr><th>Instruction type</th><th>Readback</th><th>Example</th></tr>
+  </thead>
+  <tbody>
+    <tr><td>Runway / take-off / landing clearance</td><td><span class="must">Mandatory</span></td><td>"Runway three six, cleared take-off, C-GCDF"</td></tr>
+    <tr><td>Cleared to cross active runway</td><td><span class="must">Mandatory</span></td><td>"Cross runway two five, C-GCDF"</td></tr>
+    <tr><td>Hold short of active runway</td><td><span class="must">Mandatory</span></td><td>"Hold short runway two five, C-GCDF"</td></tr>
+    <tr><td>Assigned heading</td><td><span class="must">Mandatory</span></td><td>"Turn left heading two seven zero, C-GCDF"</td></tr>
+    <tr><td>Assigned altitude / flight level</td><td><span class="must">Mandatory</span></td><td>"Climb maintain five thousand five hundred, C-GCDF"</td></tr>
+    <tr><td>Altimeter setting</td><td><span class="must">Mandatory</span></td><td>"QNH two niner niner two, C-GCDF"</td></tr>
+    <tr><td>Transponder code (squawk)</td><td><span class="must">Mandatory</span></td><td>"Squawk four five three two, C-GCDF"</td></tr>
+    <tr><td>Frequency change</td><td><span class="must">Mandatory</span></td><td>"One two two decimal eight, C-GCDF"</td></tr>
+    <tr><td>Taxi routing</td><td><span class="opt">Recommended</span></td><td>Read back turns and hold-short points</td></tr>
+  </tbody>
+</table>
+
+<div class="section-label">Standard Acknowledgement Words</div>
+<table>
+  <thead>
+    <tr><th>Word / Phrase</th><th>Meaning</th></tr>
+  </thead>
+  <tbody>
+    <tr><td><strong>Roger</strong></td><td>I have received your last transmission (does <em>not</em> confirm compliance)</td></tr>
+    <tr><td><strong>Wilco</strong></td><td>Understood; will comply (replaces "Roger" when compliance is intended)</td></tr>
+    <tr><td><strong>Affirmative</strong></td><td>Yes / that is correct</td></tr>
+    <tr><td><strong>Negative</strong></td><td>No / that is not correct</td></tr>
+    <tr><td><strong>Standby</strong></td><td>Wait — I cannot respond immediately</td></tr>
+    <tr><td><strong>Say again</strong></td><td>Repeat your last transmission (never "repeat")</td></tr>
+    <tr><td><strong>Correction</strong></td><td>An error was made; the correct version follows</td></tr>
+    <tr><td><strong>Over</strong></td><td>My transmission is complete; I expect a response</td></tr>
+    <tr><td><strong>Out</strong></td><td>Conversation complete; no reply expected</td></tr>
+  </tbody>
+</table>
+
+<div class="hook-box">
+  <h2>Memory Hook</h2>
+  <div class="hook-row"><span class="hook-badge">MUST</span><span class="hook-text">Always read back: <strong>runway, clearance, heading, altitude, altimeter, squawk, frequency</strong></span></div>
+  <div class="hook-row"><span class="hook-badge">!</span><span class="hook-text"><strong>"Roger"</strong> means received — NOT compliance. Use <strong>"Wilco"</strong> to confirm you will comply.</span></div>
+  <div class="hook-row"><span class="hook-badge">!</span><span class="hook-text">Never say <strong>"repeat"</strong> on aviation radio — that is an artillery term. Say <em>say again</em>.</span></div>
+  <div class="hook-row"><span class="hook-badge">!</span><span class="hook-text">Never say <strong>"over and out"</strong> — "over" expects a reply; "out" ends the call. Pick one.</span></div>
+</div>
+
+</body>
+</html>

--- a/web-app/public/visuals/roc003-frequencies-reference.html
+++ b/web-app/public/visuals/roc003-frequencies-reference.html
@@ -1,0 +1,129 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<link rel="stylesheet" href="/visuals/_common.css">
+<title>ROC-003: Aviation Frequency Reference</title>
+<style>
+  /* Data-encoding domain colours for frequency category bands */
+  .band-emergency { background: rgba(224,80,80,0.18);  color: #e05050; border: 1px solid rgba(224,80,80,0.4); }
+  .band-military  { background: rgba(200,130,40,0.18); color: #c88828; border: 1px solid rgba(200,130,40,0.4); }
+  .band-mf        { background: rgba(76,175,125,0.15); color: #4caf7d; border: 1px solid rgba(76,175,125,0.35); }
+  .band-enroute   { background: rgba(240,192,64,0.12); color: var(--accent); border: 1px solid rgba(240,192,64,0.3); }
+  .band-atc       { background: rgba(91,155,213,0.15); color: #5b9bd5; border: 1px solid rgba(91,155,213,0.3); }
+  .band-nav       { background: rgba(138,110,180,0.15); color: #9b82c8; border: 1px solid rgba(138,110,180,0.3); }
+
+  .freq-tag {
+    display: inline-block;
+    border-radius: 4px;
+    padding: 2px 8px;
+    font-size: 10px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    white-space: nowrap;
+  }
+  .freq-mhz {
+    font-size: 15px;
+    font-weight: 800;
+    color: var(--accent);
+    letter-spacing: 0.5px;
+    font-variant-numeric: tabular-nums;
+  }
+  .freq-range { font-size: 12px; color: var(--text-muted); }
+</style>
+</head>
+<body>
+  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:#f0c040;border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
+  <style>.container{padding-top:56px!important;}@media(max-width:480px){.container{padding-top:60px!important;}}</style>
+
+<h1>ROC-003 — Aviation Frequency Reference</h1>
+<p class="subtitle">AIM COM 4.0 · Canada Flight Supplement · ISED RIC-21 · ROC-A Written Exam</p>
+
+<div class="section-label">Critical Fixed Frequencies</div>
+<div class="wide-table">
+  <table>
+    <thead>
+      <tr><th>Frequency</th><th>Type</th><th>Purpose</th><th>Notes</th></tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><span class="freq-mhz">121.5 MHz</span></td>
+        <td><span class="freq-tag band-emergency">DISTRESS / GUARD</span></td>
+        <td>International aeronautical distress; ELT</td>
+        <td>All aircraft should monitor when a second radio is available. ELTs transmit here on impact. (AIM COM 4.3.1)</td>
+      </tr>
+      <tr>
+        <td><span class="freq-mhz">243.0 MHz</span></td>
+        <td><span class="freq-tag band-military">MILITARY GUARD</span></td>
+        <td>Military UHF equivalent of 121.5 MHz</td>
+        <td>Not on civil VHF radios; military aircraft monitor. Noted in AIM.</td>
+      </tr>
+      <tr>
+        <td><span class="freq-mhz">122.8 MHz</span></td>
+        <td><span class="freq-tag band-mf">UNICOM / MF</span></td>
+        <td>Non-towered aerodrome traffic advisories; Mandatory Frequency (MF)</td>
+        <td>Self-announce position and intentions at MF aerodromes. (AIM RAC 4.5)</td>
+      </tr>
+      <tr>
+        <td><span class="freq-mhz">126.7 MHz</span></td>
+        <td><span class="freq-tag band-enroute">EN ROUTE / FSS</span></td>
+        <td>Enroute advisory; FSS relay; air-to-ground</td>
+        <td>Common enroute frequency away from controlled aerodromes. (AIM COM 4.1.4)</td>
+      </tr>
+      <tr>
+        <td><span class="freq-mhz">123.45 MHz</span></td>
+        <td><span class="freq-tag band-enroute">AIR-TO-AIR</span></td>
+        <td>GA air-to-air coordination</td>
+        <td>Informal; not for ATC contact. Widely used when aircraft are in proximity.</td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+
+<div class="section-label">Frequency Bands by Service</div>
+<div class="wide-table">
+  <table>
+    <thead>
+      <tr><th>Band / Range</th><th>Service</th><th>Typical use</th></tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><span class="freq-mhz">118.000 – 136.975 MHz</span><br><span class="freq-range">VHF COM</span></td>
+        <td><span class="freq-tag band-atc">ATC / COM</span></td>
+        <td>Tower, approach, departure, ground, centre (ACC). All controlled-airspace communications. 25 kHz channel spacing.</td>
+      </tr>
+      <tr>
+        <td><span class="freq-mhz">108.000 – 117.975 MHz</span><br><span class="freq-range">VHF NAV</span></td>
+        <td><span class="freq-tag band-nav">VOR / ILS / LOC</span></td>
+        <td>VOR navigation, ILS localizer. NAV radio only — not COM. Odd tenth-decimal = VOR; even = ILS localizer.</td>
+      </tr>
+      <tr>
+        <td>ATIS (discrete)</td>
+        <td><span class="freq-tag band-atc">ATIS</span></td>
+        <td>Continuous weather and NOTAM broadcast. Frequency listed per airport in CFS. Obtain ATIS before calling tower.</td>
+      </tr>
+      <tr>
+        <td>Ground (discrete)</td>
+        <td><span class="freq-tag band-atc">GROUND</span></td>
+        <td>Taxi instructions at towered airports. Frequency in CFS. Contact before taxiing.</td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+
+<div class="note-box">
+  <strong>Canada Flight Supplement (CFS):</strong> All aerodrome-specific frequencies (ATIS, ground, tower, approach) are listed in the CFS entry for each airport. Always check the CFS before flight — frequencies listed here are system-wide defaults.
+</div>
+
+<div class="hook-box">
+  <h2>Memory Hook — Numbers to Memorise</h2>
+  <div class="hook-row"><span class="hook-badge">121.5</span><span class="hook-text"><strong>International distress / ELT guard</strong> — monitor whenever possible</span></div>
+  <div class="hook-row"><span class="hook-badge">122.8</span><span class="hook-text"><strong>Non-towered / MF aerodrome</strong> — self-announce on this frequency</span></div>
+  <div class="hook-row"><span class="hook-badge">126.7</span><span class="hook-text"><strong>Enroute / FSS</strong> — VFR flight plan reports, enroute advisories</span></div>
+  <div class="hook-row"><span class="hook-badge">VHF</span><span class="hook-text">COM: 118–137 MHz &nbsp;|&nbsp; NAV: 108–118 MHz &nbsp;|&nbsp; ATIS first, then tower</span></div>
+</div>
+
+</body>
+</html>

--- a/web-app/public/visuals/roc004-position-reporting.html
+++ b/web-app/public/visuals/roc004-position-reporting.html
@@ -1,0 +1,179 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<link rel="stylesheet" href="/visuals/_common.css">
+<title>ROC-004: Position Reporting</title>
+<style>
+  .report-flow {
+    display: flex;
+    flex-direction: column;
+    margin-bottom: 32px;
+    border-radius: 8px;
+    overflow: hidden;
+    border: 1.5px solid var(--border);
+  }
+  .report-step {
+    display: flex;
+    align-items: flex-start;
+    gap: 14px;
+    padding: 13px 16px;
+    background: var(--surface);
+    border-bottom: 1px solid rgba(255,255,255,0.05);
+  }
+  .report-step:last-child { border-bottom: none; }
+  .step-num {
+    width: 26px;
+    height: 26px;
+    min-width: 26px;
+    background: var(--surface2);
+    border: 1px solid var(--border-hi);
+    border-radius: 50%;
+    text-align: center;
+    line-height: 26px;
+    font-size: 12px;
+    font-weight: 800;
+    color: var(--accent);
+    flex-shrink: 0;
+  }
+  .step-label   { font-size: 11px; color: var(--text-muted); text-transform: uppercase; letter-spacing: 0.8px; margin-bottom: 2px; }
+  .step-content { font-size: 13px; color: var(--text); line-height: 1.5; }
+  .step-eg      { font-size: 12px; color: var(--accent); font-style: italic; margin-top: 3px; }
+
+  .example-block {
+    background: var(--surface);
+    border-left: 3px solid var(--accent);
+    border-radius: 4px;
+    padding: 14px 18px;
+    margin-bottom: 24px;
+    font-size: 13px;
+    line-height: 1.8;
+    color: var(--text);
+  }
+
+  /* Data-encoding tags for requirement level */
+  .tag-mand { background: rgba(224,80,80,0.15); color: #e05050; border: 1px solid rgba(224,80,80,0.3); font-size: 11px; font-weight: 700; padding: 2px 8px; border-radius: 4px; white-space: nowrap; }
+  .tag-mf   { background: rgba(76,175,125,0.12); color: #4caf7d; border: 1px solid rgba(76,175,125,0.3); font-size: 11px; font-weight: 700; padding: 2px 8px; border-radius: 4px; white-space: nowrap; }
+  .tag-atc  { background: rgba(91,155,213,0.12); color: #5b9bd5; border: 1px solid rgba(91,155,213,0.3); font-size: 11px; font-weight: 700; padding: 2px 8px; border-radius: 4px; white-space: nowrap; }
+</style>
+</head>
+<body>
+  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:#f0c040;border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
+  <style>.container{padding-top:56px!important;}@media(max-width:480px){.container{padding-top:60px!important;}}</style>
+
+<h1>ROC-004 — Position Reporting</h1>
+<p class="subtitle">AIM COM 4.0 · AIM RAC 3.7 · ICAO Annex 10 · ROC-A Written Exam</p>
+
+<div class="section-label">Standard Position Report — 7 Elements</div>
+<div class="report-flow">
+  <div class="report-step">
+    <div class="step-num">1</div>
+    <div>
+      <div class="step-label">Aircraft identification</div>
+      <div class="step-content">Your callsign as filed (or abbreviated if ATC has done so).</div>
+      <div class="step-eg">"Golf Charlie Delta Foxtrot"</div>
+    </div>
+  </div>
+  <div class="report-step">
+    <div class="step-num">2</div>
+    <div>
+      <div class="step-label">Position</div>
+      <div class="step-content">Named waypoint, fix, or distance/bearing from a known point.</div>
+      <div class="step-eg">"over GOSPO intersection" / "five miles north of Smiths Falls"</div>
+    </div>
+  </div>
+  <div class="report-step">
+    <div class="step-num">3</div>
+    <div>
+      <div class="step-label">Time (UTC)</div>
+      <div class="step-content">Time at position — minutes only if within the hour.</div>
+      <div class="step-eg">"at two three" (0023Z) or "at one four three zero" (1430Z)</div>
+    </div>
+  </div>
+  <div class="report-step">
+    <div class="step-num">4</div>
+    <div>
+      <div class="step-label">Altitude or Flight Level</div>
+      <div class="step-content">Cruising altitude ASL or flight level. State climbing/descending if applicable.</div>
+      <div class="step-eg">"five thousand five hundred" / "flight level one eight zero"</div>
+    </div>
+  </div>
+  <div class="report-step">
+    <div class="step-num">5</div>
+    <div>
+      <div class="step-label">Type of flight plan</div>
+      <div class="step-content">VFR or IFR (when relevant to context or required by ATC).</div>
+      <div class="step-eg">"VFR"</div>
+    </div>
+  </div>
+  <div class="report-step">
+    <div class="step-num">6</div>
+    <div>
+      <div class="step-label">Next reporting point and ETA</div>
+      <div class="step-content">The next waypoint and estimated arrival time.</div>
+      <div class="step-eg">"estimating Pembroke at four five"</div>
+    </div>
+  </div>
+  <div class="report-step">
+    <div class="step-num">7</div>
+    <div>
+      <div class="step-label">Remarks (if any)</div>
+      <div class="step-content">Operationally significant information: weather deviations, turbulence, fuel state.</div>
+      <div class="step-eg">"light turbulence at this level"</div>
+    </div>
+  </div>
+</div>
+
+<div class="section-label">Example Position Report</div>
+<div class="example-block">
+  "Ottawa Radio, Golf Charlie Delta Foxtrot, over Almonte at three five, five thousand five hundred VFR, estimating Pembroke at five two, nil remarks."
+</div>
+
+<div class="section-label">When Position Reports Are Required</div>
+<table>
+  <thead>
+    <tr><th>Situation</th><th>Requirement</th><th>Frequency</th></tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>IFR — compulsory reporting points</td>
+      <td><span class="tag-mand">Mandatory</span></td>
+      <td>ATC/FSS as assigned</td>
+    </tr>
+    <tr>
+      <td>VFR with flight plan — points noted in plan</td>
+      <td><span class="tag-mand">Mandatory</span></td>
+      <td>FSS (126.7 or local)</td>
+    </tr>
+    <tr>
+      <td>Arriving/departing MF aerodrome</td>
+      <td><span class="tag-mf">MF Required</span> — announce intentions</td>
+      <td>122.8 MHz</td>
+    </tr>
+    <tr>
+      <td>Within ATZ at MF aerodrome</td>
+      <td><span class="tag-mf">MF Required</span> — circuit positions</td>
+      <td>122.8 MHz</td>
+    </tr>
+    <tr>
+      <td>VFR in controlled airspace</td>
+      <td><span class="tag-atc">ATC Directed</span> — when requested</td>
+      <td>Assigned ATC frequency</td>
+    </tr>
+  </tbody>
+</table>
+
+<div class="note-box">
+  <strong>MF vs UNICOM:</strong> At a Mandatory Frequency (MF) aerodrome, pilots broadcast position and intentions on 122.8 MHz — not to receive a clearance, but to share traffic information. No ATC clearance exists at an MF field. Monitor the MF within the MF area and broadcast 5 minutes before entering.
+</div>
+
+<div class="hook-box">
+  <h2>Memory Hook</h2>
+  <div class="hook-row"><span class="hook-badge">7</span><span class="hook-text">ID → Position → Time → Altitude → Flight type → Next fix + ETA → Remarks</span></div>
+  <div class="hook-row"><span class="hook-badge">MF</span><span class="hook-text">122.8 MHz — self-announce at MF aerodromes. <strong>No clearance.</strong> Just traffic information.</span></div>
+  <div class="hook-row"><span class="hook-badge">FSS</span><span class="hook-text">VFR flight plan → report to FSS at each plan fix. Call 126.7 or local FSS frequency.</span></div>
+</div>
+
+</body>
+</html>

--- a/web-app/public/visuals/roc005-vfr-ifr-comms-overview.html
+++ b/web-app/public/visuals/roc005-vfr-ifr-comms-overview.html
@@ -1,0 +1,143 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<link rel="stylesheet" href="/visuals/_common.css">
+<title>ROC-005: VFR/IFR Communications Overview</title>
+<style>
+  .compare-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 16px;
+    margin-bottom: 32px;
+  }
+  .compare-col {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 16px;
+  }
+  /* Data-encoding: green = VFR (safe/go), blue = IFR (controlled/formal) */
+  .col-vfr { border-top: 3px solid #4caf7d; }
+  .col-ifr { border-top: 3px solid #5b9bd5; }
+  .col-vfr h3 { color: #4caf7d; font-size: 14px; font-weight: 700; margin-bottom: 12px; }
+  .col-ifr h3 { color: #5b9bd5; font-size: 14px; font-weight: 700; margin-bottom: 12px; }
+  .compare-col ul { padding-left: 16px; margin: 0; }
+  .compare-col li { font-size: 12px; color: var(--text); line-height: 1.7; margin-bottom: 3px; }
+
+  .phase-tag {
+    display: inline-block;
+    border-radius: 4px;
+    padding: 1px 7px;
+    font-size: 10px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    white-space: nowrap;
+  }
+  .ph-pre  { background: rgba(240,192,64,0.12); color: var(--accent);  border: 1px solid rgba(240,192,64,0.3); }
+  .ph-dep  { background: rgba(76,175,125,0.12); color: #4caf7d;        border: 1px solid rgba(76,175,125,0.3); }
+  .ph-enr  { background: rgba(91,155,213,0.12); color: #5b9bd5;        border: 1px solid rgba(91,155,213,0.3); }
+  .ph-arr  { background: rgba(224,80,80,0.12);  color: #e05050;        border: 1px solid rgba(224,80,80,0.3); }
+
+  @media (max-width: 560px) {
+    .compare-grid { grid-template-columns: 1fr; }
+  }
+</style>
+</head>
+<body>
+  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:#f0c040;border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
+  <style>.container{padding-top:56px!important;}@media(max-width:480px){.container{padding-top:60px!important;}}</style>
+
+<h1>ROC-005 — VFR / IFR Communications Overview</h1>
+<p class="subtitle">AIM COM 4.0 · CARs Part VI · ISED RIC-21 · ROC-A Written Exam</p>
+
+<div class="section-label">VFR vs IFR — Key Differences</div>
+<div class="compare-grid">
+  <div class="compare-col col-vfr">
+    <h3>VFR Communications</h3>
+    <ul>
+      <li>Radio <strong>required</strong> in Class B, C, D and at MF aerodromes</li>
+      <li>Class E and G: no radio required (but recommended)</li>
+      <li>Self-announce at non-towered (MF) aerodromes on 122.8 MHz</li>
+      <li>Class D: radio contact required — no ATC clearance needed for VFR</li>
+      <li>VFR flight plans reported to FSS; not mandatory but strongly advised</li>
+      <li>Obtain ATIS before calling tower at controlled airports</li>
+      <li>Transponder Mode C required in Class B and C</li>
+    </ul>
+  </div>
+  <div class="compare-col col-ifr">
+    <h3>IFR Communications</h3>
+    <ul>
+      <li>Radio mandatory at <strong>all times</strong> while operating IFR</li>
+      <li>ATC clearance required before entering controlled airspace</li>
+      <li>Position reports at all compulsory reporting points</li>
+      <li>Read back all ATC clearances — every mandatory item</li>
+      <li>Transponder Mode C required in all controlled airspace</li>
+      <li>Lost comms: squawk 7600, attempt 121.5 MHz</li>
+      <li>Cancel IFR on the ground or in the air when VMC</li>
+    </ul>
+  </div>
+</div>
+
+<div class="section-label">Communication Flow by Flight Phase</div>
+<div class="wide-table">
+  <table>
+    <thead>
+      <tr><th>Phase</th><th>VFR (controlled airport)</th><th>IFR</th><th>VFR (non-towered / MF)</th></tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><span class="phase-tag ph-pre">Pre-flight</span></td>
+        <td>Obtain ATIS</td>
+        <td>File IFR plan; ATIS; call Clearance Delivery</td>
+        <td>Check NOTAMs; note MF frequency</td>
+      </tr>
+      <tr>
+        <td><span class="phase-tag ph-dep">Departure</span></td>
+        <td>Ground → Tower; squawk assigned; Departure when directed</td>
+        <td>Clearance Del → Ground → Tower → Departure; fly SID if assigned</td>
+        <td>Self-announce on 122.8: "taxiing runway XX"</td>
+      </tr>
+      <tr>
+        <td><span class="phase-tag ph-enr">Enroute</span></td>
+        <td>Contact Centre if transiting controlled; file VFR position reports with FSS</td>
+        <td>Continuous ATC contact; report at compulsory fixes; request altitude changes</td>
+        <td>Monitor 126.7 MHz; VFR position reports; blind calls for traffic</td>
+      </tr>
+      <tr>
+        <td><span class="phase-tag ph-arr">Arrival</span></td>
+        <td>ATIS; Approach or Tower; read back runway and clearance</td>
+        <td>Approach; ILS/RNAV clearance; read back all items; cancel IFR on ground</td>
+        <td>Self-announce on 122.8 at each circuit leg; landing intention</td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+
+<div class="section-label">Radio Equipment Requirements by Airspace</div>
+<table>
+  <thead>
+    <tr><th>Airspace</th><th>VHF Radio</th><th>Transponder</th><th>ATIS first?</th></tr>
+  </thead>
+  <tbody>
+    <tr><td><strong>Class A</strong></td><td class="yes">Required (IFR only)</td><td class="yes">Mode C</td><td>N/A</td></tr>
+    <tr><td><strong>Class B</strong></td><td class="yes">Required</td><td class="yes">Mode C</td><td class="yes">Yes</td></tr>
+    <tr><td><strong>Class C</strong></td><td class="yes">Required</td><td class="yes">Mode C</td><td class="yes">Yes</td></tr>
+    <tr><td><strong>Class D</strong></td><td class="yes">Required</td><td>Recommended</td><td class="yes">Yes (if avail.)</td></tr>
+    <tr><td><strong>Class E</strong></td><td class="no">Not req. (VFR)</td><td class="no">Not req. (VFR)</td><td>N/A</td></tr>
+    <tr><td><strong>Class G</strong></td><td class="no">Not required</td><td class="no">Not required</td><td>N/A</td></tr>
+    <tr><td><strong>MF Aerodrome</strong></td><td class="yes">Required (122.8)</td><td>Recommended</td><td>Check CFS</td></tr>
+  </tbody>
+</table>
+
+<div class="hook-box">
+  <h2>Memory Hook</h2>
+  <div class="hook-row"><span class="hook-badge">VFR</span><span class="hook-text">Radio required in B, C, D and at MF. Not required in E or G (but use it).</span></div>
+  <div class="hook-row"><span class="hook-badge">IFR</span><span class="hook-text">Always on radio, always on ATC, always read back clearances. Never un-monitored.</span></div>
+  <div class="hook-row"><span class="hook-badge">ATIS</span><span class="hook-text">Get ATIS <em>first</em> — then call ATC. State the ATIS letter in your initial call.</span></div>
+</div>
+
+</body>
+</html>

--- a/web-app/public/visuals/roc006-emergency-comms.html
+++ b/web-app/public/visuals/roc006-emergency-comms.html
@@ -7,9 +7,10 @@
 <title>ROC-006: Emergency Communications</title>
 <style>
   /* ── Squawk code tiles — data-encoding domain colours ─────────────────
-   * 7700 Emergency: red — immediate grave danger
-   * 7600 Lost comms: amber — impaired but not immediately lethal
-   * 7500 Hijacking: orange — unlawful interference
+   * 7500 Hijacking:  red   (#e05050) — unlawful interference
+   * 7600 Lost comms: white (#e4ecf5) — radio failure
+   * 7700 Emergency:  amber (#f0c040) — immediate grave danger
+   * Colours match roc-ref-emergency.html (merged PR #364).
    */
   .sq-grid {
     display: grid;
@@ -18,19 +19,19 @@
     margin-bottom: 32px;
   }
   .sq-card { border-radius: 8px; padding: 18px 14px; text-align: center; border: 2px solid; }
-  .sq-7700 { background: rgba(224,80,80,0.15); border-color: #e05050; }
-  .sq-7600 { background: rgba(240,192,64,0.12); border-color: #f0c040; }
-  .sq-7500 { background: rgba(224,140,40,0.15); border-color: #e08828; }
+  .sq-7700 { background: rgba(240,192,64,0.12); border-color: #f0c040; }
+  .sq-7600 { background: rgba(228,236,245,0.08); border-color: rgba(228,236,245,0.40); }
+  .sq-7500 { background: rgba(224,80,80,0.15); border-color: #e05050; }
 
   .sq-code { font-size: 32px; font-weight: 900; letter-spacing: 3px; display: block; line-height: 1; margin-bottom: 8px; font-variant-numeric: tabular-nums; }
-  .sq-7700 .sq-code { color: #e05050; }
-  .sq-7600 .sq-code { color: #f0c040; }
-  .sq-7500 .sq-code { color: #e08828; }
+  .sq-7700 .sq-code { color: #f0c040; }
+  .sq-7600 .sq-code { color: #e4ecf5; }
+  .sq-7500 .sq-code { color: #e05050; }
 
   .sq-name { font-size: 13px; font-weight: 700; display: block; margin-bottom: 6px; }
-  .sq-7700 .sq-name { color: #e05050; }
-  .sq-7600 .sq-name { color: #f0c040; }
-  .sq-7500 .sq-name { color: #e08828; }
+  .sq-7700 .sq-name { color: #f0c040; }
+  .sq-7600 .sq-name { color: #e4ecf5; }
+  .sq-7500 .sq-name { color: #e05050; }
 
   .sq-desc { font-size: 11px; color: var(--text-muted); line-height: 1.5; }
 
@@ -215,9 +216,9 @@
 
 <div class="hook-box">
   <h2>Memory Hook</h2>
-  <div class="hook-row"><span class="hook-badge" style="background:#3a0a0a;color:#e05050;border-color:#e05050;">7700</span><span class="hook-text"><strong>Emergency</strong> — immediate danger. Set on MAYDAY declaration.</span></div>
-  <div class="hook-row"><span class="hook-badge" style="background:#3a3000;color:#f0c040;border-color:#f0c040;">7600</span><span class="hook-text"><strong>Lost comms</strong> — radio failure. ATC provides light signals.</span></div>
-  <div class="hook-row"><span class="hook-badge" style="background:#3a1e00;color:#e08828;border-color:#e08828;">7500</span><span class="hook-text"><strong>Hijacking</strong> — unlawful interference. Do not confirm verbally.</span></div>
+  <div class="hook-row"><span class="hook-badge" style="background:#3a3000;color:#f0c040;border-color:#f0c040;">7700</span><span class="hook-text"><strong>Emergency</strong> — immediate danger. Set on MAYDAY declaration.</span></div>
+  <div class="hook-row"><span class="hook-badge" style="background:rgba(228,236,245,0.08);color:#e4ecf5;border-color:rgba(228,236,245,0.40);">7600</span><span class="hook-text"><strong>Lost comms</strong> — radio failure. ATC provides light signals.</span></div>
+  <div class="hook-row"><span class="hook-badge" style="background:#3a0a0a;color:#e05050;border-color:#e05050;">7500</span><span class="hook-text"><strong>Hijacking</strong> — unlawful interference. Do not confirm verbally.</span></div>
   <div class="hook-row"><span class="hook-badge">MAYDAY</span><span class="hook-text">= imminent danger &nbsp;|&nbsp; PAN PAN = urgency. Give: position · nature · intentions · souls · fuel.</span></div>
   <div class="hook-row"><span class="hook-badge">121.5</span><span class="hook-text">Emergency frequency — always try this if working frequency fails.</span></div>
 </div>

--- a/web-app/public/visuals/roc006-emergency-comms.html
+++ b/web-app/public/visuals/roc006-emergency-comms.html
@@ -1,0 +1,226 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<link rel="stylesheet" href="/visuals/_common.css">
+<title>ROC-006: Emergency Communications</title>
+<style>
+  /* ── Squawk code tiles — data-encoding domain colours ─────────────────
+   * 7700 Emergency: red — immediate grave danger
+   * 7600 Lost comms: amber — impaired but not immediately lethal
+   * 7500 Hijacking: orange — unlawful interference
+   */
+  .sq-grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 12px;
+    margin-bottom: 32px;
+  }
+  .sq-card { border-radius: 8px; padding: 18px 14px; text-align: center; border: 2px solid; }
+  .sq-7700 { background: rgba(224,80,80,0.15); border-color: #e05050; }
+  .sq-7600 { background: rgba(240,192,64,0.12); border-color: #f0c040; }
+  .sq-7500 { background: rgba(224,140,40,0.15); border-color: #e08828; }
+
+  .sq-code { font-size: 32px; font-weight: 900; letter-spacing: 3px; display: block; line-height: 1; margin-bottom: 8px; font-variant-numeric: tabular-nums; }
+  .sq-7700 .sq-code { color: #e05050; }
+  .sq-7600 .sq-code { color: #f0c040; }
+  .sq-7500 .sq-code { color: #e08828; }
+
+  .sq-name { font-size: 13px; font-weight: 700; display: block; margin-bottom: 6px; }
+  .sq-7700 .sq-name { color: #e05050; }
+  .sq-7600 .sq-name { color: #f0c040; }
+  .sq-7500 .sq-name { color: #e08828; }
+
+  .sq-desc { font-size: 11px; color: var(--text-muted); line-height: 1.5; }
+
+  /* ── MAYDAY/PAN PAN comparison ──────────────────────────────────────── */
+  .distress-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 12px;
+    margin-bottom: 32px;
+  }
+  .d-card { border-radius: 8px; padding: 16px; border: 1.5px solid; }
+  /* data-encoding: red = immediate danger; amber = urgency/caution */
+  .d-mayday { background: rgba(224,80,80,0.08); border-color: rgba(224,80,80,0.4); }
+  .d-panpan { background: rgba(240,192,64,0.08); border-color: rgba(240,192,64,0.4); }
+  .d-mayday h3 { color: #e05050; font-size: 14px; font-weight: 800; margin-bottom: 8px; }
+  .d-panpan h3 { color: #f0c040; font-size: 14px; font-weight: 800; margin-bottom: 8px; }
+  .d-card p  { font-size: 12px; color: var(--text); line-height: 1.6; margin: 0 0 6px; }
+  .d-card ul { padding-left: 16px; margin: 0; }
+  .d-card li { font-size: 12px; color: var(--text-muted); line-height: 1.65; }
+
+  /* ── Signal flow ────────────────────────────────────────────────────── */
+  .flow {
+    display: flex;
+    flex-direction: column;
+    border-radius: 8px;
+    overflow: hidden;
+    border: 1.5px solid var(--border);
+    margin-bottom: 32px;
+  }
+  .flow-step {
+    display: flex;
+    align-items: flex-start;
+    gap: 14px;
+    padding: 14px 16px;
+    background: var(--surface);
+    border-bottom: 1px solid rgba(255,255,255,0.05);
+  }
+  .flow-step:last-child { border-bottom: none; }
+  .flow-icon {
+    width: 30px;
+    height: 30px;
+    min-width: 30px;
+    border-radius: 50%;
+    text-align: center;
+    line-height: 30px;
+    font-size: 14px;
+    font-weight: 800;
+    flex-shrink: 0;
+  }
+  /* data-encoding: red = danger/action; green = safe/proceed; blue = comms */
+  .icon-emg  { background: rgba(224,80,80,0.2); color: #e05050; border: 1.5px solid #e05050; }
+  .icon-freq { background: rgba(91,155,213,0.15); color: #5b9bd5; border: 1.5px solid #5b9bd5; }
+  .icon-xpdr { background: rgba(224,80,80,0.12); color: #e05050; border: 1.5px solid rgba(224,80,80,0.5); }
+  .icon-ok   { background: rgba(76,175,125,0.15); color: #4caf7d; border: 1.5px solid #4caf7d; }
+  .icon-sar  { background: rgba(91,155,213,0.12); color: #5b9bd5; border: 1.5px solid rgba(91,155,213,0.5); }
+
+  .flow-label   { font-size: 10px; color: var(--text-muted); text-transform: uppercase; letter-spacing: 0.8px; margin-bottom: 2px; }
+  .flow-main    { font-size: 13px; font-weight: 600; color: var(--text); line-height: 1.4; }
+  .flow-detail  { font-size: 12px; color: var(--text-muted); margin-top: 4px; line-height: 1.5; }
+  .flow-quote   { font-size: 12px; color: var(--accent); font-style: italic; margin-top: 4px; }
+
+  @media (max-width: 560px) {
+    .sq-grid { grid-template-columns: 1fr; }
+    .distress-grid { grid-template-columns: 1fr; }
+  }
+</style>
+</head>
+<body>
+  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:#f0c040;border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
+  <style>.container{padding-top:56px!important;}@media(max-width:480px){.container{padding-top:60px!important;}}</style>
+
+<h1>ROC-006 — Emergency Communications</h1>
+<p class="subtitle">AIM COM 4.3 · CARs 602.135–602.138 · ICAO Annex 10 · ROC-A Written Exam</p>
+
+<!-- ── Squawk codes ───────────────────────────────────────────────────── -->
+<div class="section-label">Emergency Transponder Codes</div>
+<div class="sq-grid">
+  <div class="sq-card sq-7700" role="region" aria-label="Squawk 7700 Emergency">
+    <span class="sq-code">7700</span>
+    <span class="sq-name">Emergency</span>
+    <span class="sq-desc">Grave and imminent danger — immediate assistance required. Set immediately on declaring MAYDAY.</span>
+  </div>
+  <div class="sq-card sq-7600" role="region" aria-label="Squawk 7600 Lost Communications">
+    <span class="sq-code">7600</span>
+    <span class="sq-name">Lost Comms</span>
+    <span class="sq-desc">Radio failure — cannot transmit or receive. ATC will provide light signals. Squawk 7700 if also in distress.</span>
+  </div>
+  <div class="sq-card sq-7500" role="region" aria-label="Squawk 7500 Hijacking">
+    <span class="sq-code">7500</span>
+    <span class="sq-name">Hijacking</span>
+    <span class="sq-desc">Unlawful interference in progress. Do not confirm verbally unless safe. ATC initiates response immediately.</span>
+  </div>
+</div>
+
+<!-- ── MAYDAY vs PAN PAN ─────────────────────────────────────────────── -->
+<div class="section-label">MAYDAY vs PAN PAN</div>
+<div class="distress-grid">
+  <div class="d-card d-mayday">
+    <h3>&#9888; MAYDAY (×3)</h3>
+    <p><strong>Grave and imminent danger</strong> — immediate assistance required.</p>
+    <ul>
+      <li>Engine failure, fire, loss of control, incapacitating medical</li>
+      <li>Squawk <strong>7700</strong></li>
+      <li>Transmit on <strong>121.5 MHz</strong> if possible</li>
+      <li>ATC provides priority; may activate SAR</li>
+    </ul>
+  </div>
+  <div class="d-card d-panpan">
+    <h3>&#9998; PAN PAN (×3)</h3>
+    <p><strong>Urgency condition</strong> — not immediately life-threatening, but safety is at risk.</p>
+    <ul>
+      <li>Fuel concern, minor medical, uncertain of position, system fault</li>
+      <li>Squawk <strong>7700</strong> or as ATC directs</li>
+      <li>Maintain working frequency; 121.5 if no response</li>
+      <li>Can be upgraded to MAYDAY if situation worsens</li>
+    </ul>
+  </div>
+</div>
+
+<!-- ── MAYDAY signal flow ─────────────────────────────────────────────── -->
+<div class="section-label">MAYDAY — Signal Flow (MAYDAY → GMDSS/SAR)</div>
+<div class="flow">
+  <div class="flow-step">
+    <div class="flow-icon icon-emg">!</div>
+    <div>
+      <div class="flow-label">Step 1 — Declare</div>
+      <div class="flow-main">Transmit MAYDAY three times on working frequency</div>
+      <div class="flow-quote">"MAYDAY MAYDAY MAYDAY — [callsign], [nature of emergency], [position], [altitude], [intentions], [souls on board], [fuel endurance]"</div>
+    </div>
+  </div>
+  <div class="flow-step">
+    <div class="flow-icon icon-freq">▶</div>
+    <div>
+      <div class="flow-label">Step 2 — Guard Frequency</div>
+      <div class="flow-main">Switch to 121.5 MHz if working frequency raises no response</div>
+      <div class="flow-detail">121.5 MHz is the international distress frequency — monitored continuously by all ATC facilities, SAR units, and most airliners.</div>
+    </div>
+  </div>
+  <div class="flow-step">
+    <div class="flow-icon icon-xpdr">T</div>
+    <div>
+      <div class="flow-label">Step 3 — Squawk</div>
+      <div class="flow-main">Select squawk <strong style="color:#e05050;">7700</strong> on transponder</div>
+      <div class="flow-detail">Squawk 7700 alerts all radar-equipped facilities immediately and enables ATC to vector SAR assets to your return.</div>
+    </div>
+  </div>
+  <div class="flow-step">
+    <div class="flow-icon icon-ok">&#10003;</div>
+    <div>
+      <div class="flow-label">Step 4 — Communicate</div>
+      <div class="flow-main">Maintain frequency; respond to ATC; update position continuously</div>
+      <div class="flow-detail">ATC will clear traffic and offer vectors to nearest suitable aerodrome. Continue transmitting position updates as situation evolves.</div>
+    </div>
+  </div>
+  <div class="flow-step">
+    <div class="flow-icon icon-sar">&#9992;</div>
+    <div>
+      <div class="flow-label">Step 5 — GMDSS / SAR Activation</div>
+      <div class="flow-main">ATC notifies JRCC — Search and Rescue activated</div>
+      <div class="flow-detail">Joint Rescue Coordination Centre (JRCC) dispatches SAR assets. ELT activates automatically on impact (121.5 MHz analogue + 406 MHz digital COSPAS-SARSAT). Souls on board and fuel endurance determine initial SAR resource dispatch.</div>
+    </div>
+  </div>
+</div>
+
+<div class="section-label">Emergency Locator Transmitter (ELT)</div>
+<table>
+  <thead>
+    <tr><th>Activation</th><th>Frequencies</th><th>System</th></tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Automatic (G-force impact ~5g) or manual</td>
+      <td>121.5 MHz (analogue) + 406 MHz (digital)</td>
+      <td>406 MHz received by COSPAS-SARSAT satellite — global coverage</td>
+    </tr>
+  </tbody>
+</table>
+
+<div class="note-box">
+  <strong>Cancel the MAYDAY:</strong> Once the emergency is resolved, cancel on the same frequency and on 121.5 MHz to prevent unnecessary SAR activation. Say: <em>"All stations, [callsign], cancel MAYDAY, [reason]."</em> (AIM COM 4.3.2)
+</div>
+
+<div class="hook-box">
+  <h2>Memory Hook</h2>
+  <div class="hook-row"><span class="hook-badge" style="background:#3a0a0a;color:#e05050;border-color:#e05050;">7700</span><span class="hook-text"><strong>Emergency</strong> — immediate danger. Set on MAYDAY declaration.</span></div>
+  <div class="hook-row"><span class="hook-badge" style="background:#3a3000;color:#f0c040;border-color:#f0c040;">7600</span><span class="hook-text"><strong>Lost comms</strong> — radio failure. ATC provides light signals.</span></div>
+  <div class="hook-row"><span class="hook-badge" style="background:#3a1e00;color:#e08828;border-color:#e08828;">7500</span><span class="hook-text"><strong>Hijacking</strong> — unlawful interference. Do not confirm verbally.</span></div>
+  <div class="hook-row"><span class="hook-badge">MAYDAY</span><span class="hook-text">= imminent danger &nbsp;|&nbsp; PAN PAN = urgency. Give: position · nature · intentions · souls · fuel.</span></div>
+  <div class="hook-row"><span class="hook-badge">121.5</span><span class="hook-text">Emergency frequency — always try this if working frequency fails.</span></div>
+</div>
+
+</body>
+</html>

--- a/web-app/public/visuals/roc007-light-signals.html
+++ b/web-app/public/visuals/roc007-light-signals.html
@@ -1,0 +1,182 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<link rel="stylesheet" href="/visuals/_common.css">
+<title>ROC-007: Light Gun Signals</title>
+<style>
+  /* ── Light signal colour dots — data-encoding domain colours ──────────
+   * Steady green   = cleared / safe to proceed       (#4caf7d)
+   * Flashing green = conditional clearance           (#4caf7d, semi-opaque)
+   * Steady red     = stop / do not land              (#e05050)
+   * Flashing red   = danger / clear area             (#e05050, semi-opaque)
+   * Flashing white = administrative / return         (#e4ecf5, semi-opaque)
+   * Alt red+green  = extreme caution                 (split)
+   */
+  .sig-dot {
+    display: inline-block;
+    width: 22px;
+    height: 22px;
+    min-width: 22px;
+    border-radius: 50%;
+    vertical-align: middle;
+    flex-shrink: 0;
+    border: 1px solid rgba(255,255,255,0.10);
+  }
+  .sig-green-s { background: #4caf7d; }
+  .sig-green-f { background: #4caf7d; opacity: 0.55; }
+  .sig-red-s   { background: #e05050; }
+  .sig-red-f   { background: #e05050; opacity: 0.55; }
+  .sig-white-f { background: #e4ecf5; opacity: 0.65; }
+  .sig-alt     { background: linear-gradient(135deg, #e05050 50%, #4caf7d 50%); }
+
+  .sig-cell {
+    display: flex;
+    align-items: center;
+    gap: 9px;
+    white-space: nowrap;
+  }
+  .sig-name { font-size: 12px; color: var(--text); }
+  .flash-indicator { font-size: 10px; color: var(--text-muted); letter-spacing: 1px; }
+
+  /* Meaning colour coding — data-encoding */
+  .m-safe    { color: #4caf7d; font-weight: 700; }
+  .m-caution { color: #f0c040; font-weight: 700; }
+  .m-stop    { color: #e05050; font-weight: 700; }
+  .m-danger  { color: #e08828; font-weight: 700; }
+  .m-admin   { color: var(--text-muted); font-weight: 600; }
+</style>
+</head>
+<body>
+  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:#f0c040;border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
+  <style>.container{padding-top:56px!important;}@media(max-width:480px){.container{padding-top:60px!important;}}</style>
+
+<h1>ROC-007 — Light Gun Signals</h1>
+<p class="subtitle">CARs 602.101 · AIM RAC 4.5.5 · ICAO Annex 2 · ROC-A Written Exam</p>
+
+<div class="note-box" style="margin-bottom:24px;">
+  Light signals are used when radio communication is unavailable or impractical. The tower light gun is authoritative — obey even if you have radio contact. Colour is the primary cue; steadiness indicates immediacy vs. conditionality. (CARs 602.101)
+</div>
+
+<!-- ── Tower → Aircraft in flight ────────────────────────────────────── -->
+<div class="section-label">Tower → Aircraft in Flight</div>
+<div class="wide-table">
+  <table>
+    <thead>
+      <tr><th style="width:180px;">Signal</th><th>Type</th><th>Meaning</th></tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><div class="sig-cell"><span class="sig-dot sig-green-s" aria-label="Steady green"></span><span class="sig-name">Steady Green</span></div></td>
+        <td>Continuous green</td>
+        <td><span class="m-safe">Cleared to land</span></td>
+      </tr>
+      <tr>
+        <td><div class="sig-cell"><span class="sig-dot sig-green-f" aria-label="Flashing green"></span><span class="sig-name">Flashing Green <span class="flash-indicator">●●●</span></span></div></td>
+        <td>Flashing green</td>
+        <td><span class="m-caution">Return for landing</span> (landing clearance to follow)</td>
+      </tr>
+      <tr>
+        <td><div class="sig-cell"><span class="sig-dot sig-red-s" aria-label="Steady red"></span><span class="sig-name">Steady Red</span></div></td>
+        <td>Continuous red</td>
+        <td><span class="m-stop">Give way to other aircraft; continue circling</span></td>
+      </tr>
+      <tr>
+        <td><div class="sig-cell"><span class="sig-dot sig-red-f" aria-label="Flashing red"></span><span class="sig-name">Flashing Red <span class="flash-indicator">●●●</span></span></div></td>
+        <td>Flashing red</td>
+        <td><span class="m-danger">Aerodrome unsafe — do not land</span></td>
+      </tr>
+      <tr>
+        <td><div class="sig-cell"><span class="sig-dot sig-white-f" aria-label="Flashing white"></span><span class="sig-name">Flashing White <span class="flash-indicator">●●●</span></span></div></td>
+        <td>Flashing white</td>
+        <td><span class="m-admin">Not used for aircraft in flight</span></td>
+      </tr>
+      <tr>
+        <td><div class="sig-cell"><span class="sig-dot sig-alt" aria-label="Alternating red and green"></span><span class="sig-name">Alternating Red/Green</span></div></td>
+        <td>Alternating</td>
+        <td><span class="m-caution">Exercise extreme caution</span></td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+
+<!-- ── Tower → Aircraft on ground ────────────────────────────────────── -->
+<div class="section-label">Tower → Aircraft on Ground</div>
+<div class="wide-table">
+  <table>
+    <thead>
+      <tr><th style="width:180px;">Signal</th><th>Type</th><th>Meaning</th></tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><div class="sig-cell"><span class="sig-dot sig-green-s" aria-label="Steady green"></span><span class="sig-name">Steady Green</span></div></td>
+        <td>Continuous green</td>
+        <td><span class="m-safe">Cleared for take-off</span></td>
+      </tr>
+      <tr>
+        <td><div class="sig-cell"><span class="sig-dot sig-green-f" aria-label="Flashing green"></span><span class="sig-name">Flashing Green <span class="flash-indicator">●●●</span></span></div></td>
+        <td>Flashing green</td>
+        <td><span class="m-safe">Cleared to taxi</span></td>
+      </tr>
+      <tr>
+        <td><div class="sig-cell"><span class="sig-dot sig-red-s" aria-label="Steady red"></span><span class="sig-name">Steady Red</span></div></td>
+        <td>Continuous red</td>
+        <td><span class="m-stop">Stop</span></td>
+      </tr>
+      <tr>
+        <td><div class="sig-cell"><span class="sig-dot sig-red-f" aria-label="Flashing red"></span><span class="sig-name">Flashing Red <span class="flash-indicator">●●●</span></span></div></td>
+        <td>Flashing red</td>
+        <td><span class="m-danger">Taxi clear of runway in use</span></td>
+      </tr>
+      <tr>
+        <td><div class="sig-cell"><span class="sig-dot sig-white-f" aria-label="Flashing white"></span><span class="sig-name">Flashing White <span class="flash-indicator">●●●</span></span></div></td>
+        <td>Flashing white</td>
+        <td><span class="m-admin">Return to starting point on aerodrome</span></td>
+      </tr>
+      <tr>
+        <td><div class="sig-cell"><span class="sig-dot sig-alt" aria-label="Alternating red and green"></span><span class="sig-name">Alternating Red/Green</span></div></td>
+        <td>Alternating</td>
+        <td><span class="m-caution">Exercise extreme caution</span></td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+
+<!-- ── Aircraft → Tower acknowledgement ─────────────────────────────── -->
+<div class="section-label">Aircraft → Tower — Acknowledgement Signals</div>
+<table>
+  <thead>
+    <tr><th>Condition</th><th>In flight (day)</th><th>In flight (night)</th><th>On ground (day)</th><th>On ground (night)</th></tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Acknowledge light signal received</td>
+      <td>Rock wings</td>
+      <td>Flash landing lights on/off twice</td>
+      <td>Move ailerons or rudder</td>
+      <td>Flash navigation lights on/off twice</td>
+    </tr>
+  </tbody>
+</table>
+
+<div class="note-box" style="margin-top:24px;">
+  <strong>Colour is the primary cue:</strong>
+  <span style="color:#4caf7d;font-weight:700;">Green = go/proceed</span> ·
+  <span style="color:#e05050;font-weight:700;">Red = stop/danger</span> ·
+  <span style="color:#e4ecf5;font-weight:600;">White = administrative (ground only)</span>.
+  Steady = immediate action. Flashing = conditional or upcoming action. Alternating red/green = extreme caution regardless of phase.
+</div>
+
+<div class="hook-box">
+  <h2>Memory Hook — 6 Signals × 2 Phases</h2>
+  <div class="hook-row"><span class="hook-badge" style="background:rgba(76,175,125,0.2);color:#4caf7d;border-color:#4caf7d;">Steady G</span><span class="hook-text">In flight: <strong>cleared to land</strong> · On ground: <strong>cleared take-off</strong></span></div>
+  <div class="hook-row"><span class="hook-badge" style="background:rgba(76,175,125,0.1);color:#80c880;border-color:#4caf7d;">Flash G</span><span class="hook-text">In flight: <strong>return for landing</strong> · On ground: <strong>cleared to taxi</strong></span></div>
+  <div class="hook-row"><span class="hook-badge" style="background:rgba(224,80,80,0.2);color:#e05050;border-color:#e05050;">Steady R</span><span class="hook-text">In flight: <strong>give way, keep circling</strong> · On ground: <strong>stop</strong></span></div>
+  <div class="hook-row"><span class="hook-badge" style="background:rgba(224,80,80,0.1);color:#f08080;border-color:#e05050;">Flash R</span><span class="hook-text">In flight: <strong>aerodrome unsafe, don't land</strong> · On ground: <strong>clear runway</strong></span></div>
+  <div class="hook-row"><span class="hook-badge" style="background:rgba(228,236,245,0.1);color:#b0bfcc;border-color:#6070808;">Flash W</span><span class="hook-text">In flight: N/A · On ground: <strong>return to start</strong></span></div>
+  <div class="hook-row"><span class="hook-badge" style="background:linear-gradient(135deg,rgba(224,80,80,0.2) 50%,rgba(76,175,125,0.2) 50%);color:var(--text);border-color:var(--border-hi);">Alt R/G</span><span class="hook-text"><strong>Extreme caution</strong> — both phases</span></div>
+</div>
+
+</body>
+</html>

--- a/web-app/public/visuals/roc007-light-signals.html
+++ b/web-app/public/visuals/roc007-light-signals.html
@@ -11,7 +11,7 @@
    * Flashing green = conditional clearance           (#4caf7d, semi-opaque)
    * Steady red     = stop / do not land              (#e05050)
    * Flashing red   = danger / clear area             (#e05050, semi-opaque)
-   * Flashing white = administrative / return         (#e4ecf5, semi-opaque)
+   * Flashing white = return to starting point        (#e4ecf5, semi-opaque)
    * Alt red+green  = extreme caution                 (split)
    */
   .sig-dot {
@@ -90,7 +90,7 @@
       <tr>
         <td><div class="sig-cell"><span class="sig-dot sig-white-f" aria-label="Flashing white"></span><span class="sig-name">Flashing White <span class="flash-indicator">●●●</span></span></div></td>
         <td>Flashing white</td>
-        <td><span class="m-admin">Not used for aircraft in flight</span></td>
+        <td><span class="m-admin">Return to starting point on the aerodrome</span></td>
       </tr>
       <tr>
         <td><div class="sig-cell"><span class="sig-dot sig-alt" aria-label="Alternating red and green"></span><span class="sig-name">Alternating Red/Green</span></div></td>
@@ -164,7 +164,7 @@
   <strong>Colour is the primary cue:</strong>
   <span style="color:#4caf7d;font-weight:700;">Green = go/proceed</span> ·
   <span style="color:#e05050;font-weight:700;">Red = stop/danger</span> ·
-  <span style="color:#e4ecf5;font-weight:600;">White = administrative (ground only)</span>.
+  <span style="color:#e4ecf5;font-weight:600;">White = administrative (return to starting point)</span>.
   Steady = immediate action. Flashing = conditional or upcoming action. Alternating red/green = extreme caution regardless of phase.
 </div>
 
@@ -174,7 +174,7 @@
   <div class="hook-row"><span class="hook-badge" style="background:rgba(76,175,125,0.1);color:#80c880;border-color:#4caf7d;">Flash G</span><span class="hook-text">In flight: <strong>return for landing</strong> · On ground: <strong>cleared to taxi</strong></span></div>
   <div class="hook-row"><span class="hook-badge" style="background:rgba(224,80,80,0.2);color:#e05050;border-color:#e05050;">Steady R</span><span class="hook-text">In flight: <strong>give way, keep circling</strong> · On ground: <strong>stop</strong></span></div>
   <div class="hook-row"><span class="hook-badge" style="background:rgba(224,80,80,0.1);color:#f08080;border-color:#e05050;">Flash R</span><span class="hook-text">In flight: <strong>aerodrome unsafe, don't land</strong> · On ground: <strong>clear runway</strong></span></div>
-  <div class="hook-row"><span class="hook-badge" style="background:rgba(228,236,245,0.1);color:#b0bfcc;border-color:#6070808;">Flash W</span><span class="hook-text">In flight: N/A · On ground: <strong>return to start</strong></span></div>
+  <div class="hook-row"><span class="hook-badge" style="background:rgba(228,236,245,0.1);color:#b0bfcc;border-color:#607080;">Flash W</span><span class="hook-text">In flight: <strong>return to starting point</strong> · On ground: <strong>return to starting point</strong></span></div>
   <div class="hook-row"><span class="hook-badge" style="background:linear-gradient(135deg,rgba(224,80,80,0.2) 50%,rgba(76,175,125,0.2) 50%);color:var(--text);border-color:var(--border-hi);">Alt R/G</span><span class="hook-text"><strong>Extreme caution</strong> — both phases</span></div>
 </div>
 

--- a/web-app/public/visuals/roc008-regulatory-framework.html
+++ b/web-app/public/visuals/roc008-regulatory-framework.html
@@ -1,0 +1,134 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<link rel="stylesheet" href="/visuals/_common.css">
+<title>ROC-008: Radio Regulatory Framework</title>
+<style>
+  .reg-card {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 16px 18px;
+    margin-bottom: 14px;
+  }
+  .reg-card h3 { font-size: 13px; font-weight: 700; color: var(--accent); margin-bottom: 6px; }
+  .reg-card p  { font-size: 12px; color: var(--text); line-height: 1.6; margin: 0; }
+  .reg-card ul { padding-left: 16px; margin: 6px 0 0; }
+  .reg-card li { font-size: 12px; color: var(--text-muted); line-height: 1.7; }
+
+  .org-tag {
+    display: inline-block;
+    border-radius: 4px;
+    padding: 2px 8px;
+    font-size: 10px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    margin-left: 6px;
+    vertical-align: middle;
+  }
+  .org-ised { background: rgba(91,155,213,0.15); color: #5b9bd5; border: 1px solid rgba(91,155,213,0.3); }
+  .org-tc   { background: rgba(76,175,125,0.12); color: #4caf7d; border: 1px solid rgba(76,175,125,0.3); }
+  .org-icao { background: rgba(240,192,64,0.12); color: var(--accent); border: 1px solid rgba(240,192,64,0.3); }
+</style>
+</head>
+<body>
+  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:#f0c040;border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
+  <style>.container{padding-top:56px!important;}@media(max-width:480px){.container{padding-top:60px!important;}}</style>
+
+<h1>ROC-008 — Radio Regulatory Framework</h1>
+<p class="subtitle">Radiocommunication Act · ISED RIC-21 · ICAO Annex 10 · ROC-A Written Exam</p>
+
+<div class="section-label">Regulatory Pillars</div>
+
+<div class="reg-card">
+  <h3>Radiocommunication Act (Canada) <span class="org-tag org-ised">ISED</span></h3>
+  <p>Federal statute administered by Innovation, Science and Economic Development Canada (ISED). Governs all radio transmitters in Canada, including aircraft.</p>
+  <ul>
+    <li>Prohibits operating a radio transmitter without a valid licence or authorization</li>
+    <li>Aeronautical radio operators must hold a <strong>Restricted Operator Certificate — Aeronautical</strong> (ROC-A)</li>
+    <li>Aircraft must carry an <strong>Aeronautical Station Licence</strong> (issued by ISED)</li>
+    <li>The ROC-A is an ISED certificate — separate from Transport Canada pilot licensing</li>
+  </ul>
+</div>
+
+<div class="reg-card">
+  <h3>Restricted Operator Certificate — Aeronautical (ROC-A) <span class="org-tag org-ised">ISED</span></h3>
+  <p>The individual certificate required by any person who operates an aeronautical mobile radio station (the aircraft radio).</p>
+  <ul>
+    <li>Examined and issued by ISED-accredited examiners</li>
+    <li>Tests: radio operation, phonetic alphabet, distress procedures, frequencies, regulations</li>
+    <li>Valid for life once issued — no renewal required</li>
+    <li>Not the same as a pilot licence — a non-pilot ground operator also needs one</li>
+    <li>A student pilot must operate under supervision of a ROC-A holder until they obtain one</li>
+  </ul>
+</div>
+
+<div class="reg-card">
+  <h3>Aeronautical Station Licence <span class="org-tag org-ised">ISED</span></h3>
+  <p>The station (aircraft) licence for radio equipment installed in the aircraft.</p>
+  <ul>
+    <li>Required for Canadian-registered aircraft; must be carried on board</li>
+    <li>The pilot certificate + station licence satisfy ROC-A operational requirements</li>
+  </ul>
+</div>
+
+<div class="reg-card">
+  <h3>Canadian Aviation Regulations (CARs) <span class="org-tag org-tc">TC</span></h3>
+  <p>Transport Canada regulations governing aviation operations, including when radio use is required per airspace class.</p>
+  <ul>
+    <li>CARs Part VI sets radio requirements per airspace class (see ROC-005)</li>
+    <li>Phraseology standards in AIM supplement the CARs</li>
+    <li>TC enforces CARs; ISED enforces Radiocommunication Act — they are separate agencies</li>
+  </ul>
+</div>
+
+<div class="reg-card">
+  <h3>ICAO Annex 10 — Aeronautical Telecommunications <span class="org-tag org-icao">ICAO</span></h3>
+  <p>International standards adopted by Canada. Sets phonetic alphabet, distress phraseology, and frequency allocations globally.</p>
+  <ul>
+    <li>Annex 10 Vol. II covers communication procedures</li>
+    <li>Canada's domestic rules must meet or exceed ICAO standards</li>
+  </ul>
+</div>
+
+<div class="section-label">Station Log Requirements</div>
+<table>
+  <thead>
+    <tr><th>Operation</th><th>Log required?</th><th>Notes</th></tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Commercial air operations (CAR 702/703/704/705)</td>
+      <td class="yes">Required</td>
+      <td>Distress and urgency comms must be logged; operational comms per ops spec</td>
+    </tr>
+    <tr>
+      <td>Private pilot VFR (CAR 401)</td>
+      <td class="no">Not required</td>
+      <td>No station log required for private non-commercial operations</td>
+    </tr>
+    <tr>
+      <td>Any distress / MAYDAY communications</td>
+      <td class="yes">Required</td>
+      <td>Record in any available log; preserve for investigation</td>
+    </tr>
+  </tbody>
+</table>
+
+<div class="note-box">
+  <strong>ROC-A vs Pilot Licence — two separate credentials:</strong> ISED issues the ROC-A (operator cert) and the Aeronautical Station Licence (aircraft licence). Transport Canada issues the pilot licence. You need both to legally operate an aircraft radio in Canada. (Radiocommunication Act s. 13)
+</div>
+
+<div class="hook-box">
+  <h2>Memory Hook</h2>
+  <div class="hook-row"><span class="hook-badge org-ised">ISED</span><span class="hook-text">Issues ROC-A (operator certificate) and Aeronautical Station Licence (aircraft licence)</span></div>
+  <div class="hook-row"><span class="hook-badge org-tc">TC</span><span class="hook-text">Issues pilot licence — separate department, separate rules</span></div>
+  <div class="hook-row"><span class="hook-badge">LOG</span><span class="hook-text">Log required for commercial ops and <strong>all</strong> distress communications</span></div>
+  <div class="hook-row"><span class="hook-badge">ROC-A</span><span class="hook-text">ISED exam — not TC. Tests radio, not flying. Valid for life. Needed before flying solo.</span></div>
+</div>
+
+</body>
+</html>

--- a/web-app/public/visuals/roc009-radio-etiquette.html
+++ b/web-app/public/visuals/roc009-radio-etiquette.html
@@ -1,0 +1,169 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<link rel="stylesheet" href="/visuals/_common.css">
+<title>ROC-009: Radio Etiquette</title>
+<style>
+  .rule-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 10px;
+    margin-bottom: 32px;
+  }
+  .rule-card {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 7px;
+    padding: 13px 15px;
+  }
+  .rule-num   { font-size: 10px; font-weight: 800; color: var(--accent); text-transform: uppercase; letter-spacing: 1px; margin-bottom: 5px; }
+  .rule-card h3 { font-size: 13px; font-weight: 700; color: var(--text); margin-bottom: 5px; }
+  .rule-card p  { font-size: 12px; color: var(--text-muted); line-height: 1.6; margin: 0; }
+
+  .do-dont {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 14px;
+    margin-bottom: 32px;
+  }
+  /* data-encoding: green = do (safe), red = don't (danger) */
+  .do-col   { border-top: 3px solid #4caf7d; }
+  .dont-col { border-top: 3px solid #e05050; }
+  .dd-block {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 0 0 7px 7px;
+    padding: 15px;
+  }
+  .dd-block h3 { font-size: 13px; font-weight: 700; margin-bottom: 10px; }
+  .do-col   h3 { color: #4caf7d; }
+  .dont-col h3 { color: #e05050; }
+  .dd-block ul { padding-left: 16px; margin: 0; }
+  .dd-block li { font-size: 12px; color: var(--text); line-height: 1.7; margin-bottom: 3px; }
+  .dd-eg { font-size: 11px; color: var(--accent); font-style: italic; display: block; margin-top: 1px; padding-left: 10px; }
+
+  @media (max-width: 560px) {
+    .rule-grid { grid-template-columns: 1fr; }
+    .do-dont   { grid-template-columns: 1fr; }
+  }
+</style>
+</head>
+<body>
+  <button data-backlink="true" onclick="if(window.history.length<=1){window.close();}else{window.history.back();}" style="position:fixed;top:12px;left:12px;z-index:9999;background:rgba(13,27,42,0.9);color:#f0c040;border:1.5px solid rgba(240,192,64,0.4);border-radius:6px;padding:10px 14px;font-size:14px;font-family:inherit;cursor:pointer;min-width:44px;min-height:44px;line-height:1.2;backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);" aria-label="Back to lesson">&#8592; Back to lesson</button>
+  <style>.container{padding-top:56px!important;}@media(max-width:480px){.container{padding-top:60px!important;}}</style>
+
+<h1>ROC-009 — Radio Etiquette</h1>
+<p class="subtitle">ISED RIC-21 · AIM COM 4.0 · ICAO Annex 10 Vol. II · ROC-A Written Exam</p>
+
+<div class="section-label">Core Rules</div>
+<div class="rule-grid">
+  <div class="rule-card">
+    <div class="rule-num">Rule 1</div>
+    <h3>Listen before transmitting</h3>
+    <p>Monitor the frequency for at least 5 seconds before pressing PTT. Transmitting over someone causes both transmissions to be lost ("stepped on").</p>
+  </div>
+  <div class="rule-card">
+    <div class="rule-num">Rule 2</div>
+    <h3>Keep transmissions brief</h3>
+    <p>Plan what you will say before keying PTT. Avoid fillers, mid-transmission pauses, and unnecessary repetition. State who, where, what — then release.</p>
+  </div>
+  <div class="rule-card">
+    <div class="rule-num">Rule 3</div>
+    <h3>Use standard phraseology</h3>
+    <p>ICAO standard words carry precise meaning. Plain language is permitted when standard phrases don't fit, but standard phrases reduce ambiguity and speed exchanges.</p>
+  </div>
+  <div class="rule-card">
+    <div class="rule-num">Rule 4</div>
+    <h3>Speak at a moderate pace</h3>
+    <p>Conversational speed — not fast (hard to write down), not slow (wastes airtime). Slow slightly for alphanumeric strings (frequencies, squawk codes, clearances).</p>
+  </div>
+  <div class="rule-card">
+    <div class="rule-num">Rule 5</div>
+    <h3>Correct microphone technique</h3>
+    <p>Hold mic 2–5 cm from mouth. Press PTT, pause 1 second, then speak. Release PTT only after finishing. Avoid breathing directly into the mic.</p>
+  </div>
+  <div class="rule-card">
+    <div class="rule-num">Rule 6</div>
+    <h3>Read back mandatory items</h3>
+    <p>Always read back: runway, clearance, heading, altitude, altimeter, squawk code, frequency change. Omitting a readback signals non-receipt to ATC.</p>
+  </div>
+  <div class="rule-card">
+    <div class="rule-num">Rule 7</div>
+    <h3>Callsign every transmission</h3>
+    <p>End every transmission with your callsign (abbreviated after first contact). This identifies who transmitted — critical on busy tower frequencies.</p>
+  </div>
+  <div class="rule-card">
+    <div class="rule-num">Rule 8</div>
+    <h3>"Standby" buys you time</h3>
+    <p>If you cannot respond immediately, say "Standby, [callsign]." ATC will wait. Never leave ATC unanswered — a missed call may trigger a radio-failure assumption.</p>
+  </div>
+</div>
+
+<div class="section-label">Do vs Don't</div>
+<div class="do-dont">
+  <div class="do-col">
+    <div class="dd-block">
+      <h3>&#10003; Do</h3>
+      <ul>
+        <li>Use phonetic alphabet for all letters<span class="dd-eg">"Golf Charlie Delta Foxtrot" not "G-C-D-F"</span></li>
+        <li>Say "say again" to request a repeat<span class="dd-eg">"Say again altitude, C-GCDF"</span></li>
+        <li>Say "Correction" then re-transmit on errors</li>
+        <li>Use "Affirmative" / "Negative" for yes / no</li>
+        <li>Say "Wilco" when you intend to comply<span class="dd-eg">Means "understood, will comply"</span></li>
+        <li>Cancel VFR flight plan on safely landing</li>
+        <li>Monitor 121.5 MHz on second radio when possible</li>
+      </ul>
+    </div>
+  </div>
+  <div class="dont-col">
+    <div class="dd-block">
+      <h3>&#10007; Don't</h3>
+      <ul>
+        <li>Say "repeat" — say <em>say again</em> (repeat = artillery)</li>
+        <li>Transmit personal info, profanity, or music</li>
+        <li>Say "Over and out" — pick one or the other</li>
+        <li>Use "Roger" when you mean "Wilco" — Roger = received only</li>
+        <li>Transmit routine calls on 121.5 MHz guard</li>
+        <li>Key PTT without speaking — blocks the frequency</li>
+        <li>Abbreviate callsign before ATC does so first</li>
+      </ul>
+    </div>
+  </div>
+</div>
+
+<div class="section-label">Blocked / Jammed Frequency</div>
+<table>
+  <thead>
+    <tr><th>Symptom</th><th>Likely cause</th><th>Action</th></tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Continuous carrier noise, no voice</td>
+      <td>Stuck PTT somewhere on frequency</td>
+      <td>Try alternate frequency or 121.5 MHz; report the block</td>
+    </tr>
+    <tr>
+      <td>Squealing / heterodyne tone</td>
+      <td>Two stations transmitting simultaneously</td>
+      <td>Listen; wait for squeal to clear; transmit again</td>
+    </tr>
+    <tr>
+      <td>No ATC response after two calls</td>
+      <td>Congestion, weak signal, or radio failure</td>
+      <td>Try alternate ATC frequency; try 121.5; squawk 7600 if radio failure confirmed</td>
+    </tr>
+  </tbody>
+</table>
+
+<div class="hook-box">
+  <h2>Memory Hook</h2>
+  <div class="hook-row"><span class="hook-badge">FLOW</span><span class="hook-text">Listen → Think → Transmit → Identify (callsign last)</span></div>
+  <div class="hook-row"><span class="hook-badge">!</span><span class="hook-text">Never say <strong>"repeat"</strong> — say <em>say again</em>. "Repeat" has a different meaning in other radio contexts.</span></div>
+  <div class="hook-row"><span class="hook-badge">!</span><span class="hook-text"><strong>"Roger"</strong> = received. <strong>"Wilco"</strong> = will comply. They are not the same word.</span></div>
+  <div class="hook-row"><span class="hook-badge">121.5</span><span class="hook-text">Monitor on second radio whenever possible. Emergency frequency — keep it clear of routine calls.</span></div>
+</div>
+
+</body>
+</html>


### PR DESCRIPTION
Closes #342

## Changes

- **9 new visual HTML files** in `web-app/public/visuals/` (`roc001` through `roc009`), each:
  - links `/visuals/_common.css` for shared tokens and component styles
  - includes canonical `data-backlink="true"` fixed back-to-lesson button
  - uses `var(--token)` for all chrome colours; hardcodes only data-encoding domain colours (signal/severity)
  - no external resources (`<script src>`, CDN fonts, remote images)
  - dark scheme only
- **ROC-001** — full NATO phonetic alphabet A–Z grid + digit pronunciation card (Tree/Fife/Niner) + altitude/frequency conventions table
- **ROC-006** — MAYDAY→GMDSS 5-step signal flow diagram; squawk 7500/7600/7700 colour-coded tiles (`#e05050` emergency · `#f0c040` lost-comms · `#e08828` hijack); MAYDAY vs PAN-PAN comparison; ELT table
- **ROC-007** — full light-signal reference table for tower→flight and tower→ground (steady green/red, flashing green/red/white, alternating red/green); aircraft acknowledgement signals; colour-coded meaning cells
- **ROC-002/003/004/005/008/009** — standard-format reference visuals per lesson topic
- **9 lesson frontmatter updates** — `visual:` field in `lessons/radio/NNN-*.md` now points to `/visuals/roc00N-{slug}.html`

## Test Plan

- [ ] Open each of the 9 HTML files in a browser; confirm dark-aviation styling renders correctly
- [ ] Confirm `data-backlink="true"` back-to-lesson button appears fixed top-left on every file
- [ ] Verify no `<script src>`, CDN fonts, or remote images exist in any file
- [ ] Confirm `visual:` in each `lessons/radio/NNN-*.md` points to the correct path
- [ ] `npm run build` in `web-app/` passes (verified locally: ✓ built in ~2.6s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)