### PR TITLE
[PPL-381] Fix mobile responsiveness of audio player

### DIFF
--- a/web-app/src/components/AudioPlayer.tsx
+++ b/web-app/src/components/AudioPlayer.tsx
@@ -150,7 +150,7 @@ export default function AudioPlayer({ src, title, topic, lessonId }: AudioPlayer
   }
 
   return (
-    <Box tabIndex={0} onKeyDown={handleKeyDown} sx={{ my: 2, outline: 'none' }}>
+    <Box tabIndex={0} onKeyDown={handleKeyDown} sx={{ my: 2, outline: 'none', overflow: 'hidden' }}>
       <Box
         sx={{
           display: 'flex',
@@ -203,8 +203,8 @@ export default function AudioPlayer({ src, title, topic, lessonId }: AudioPlayer
           ))}
         </Select>
       </Box>
-      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-        <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: { xs: 0.5, sm: 1 } }}>
+        <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', flexShrink: 0 }}>
           <IconButton
             onClick={handleSkipBack}
             aria-label="Skip back 15 seconds"
@@ -212,7 +212,7 @@ export default function AudioPlayer({ src, title, topic, lessonId }: AudioPlayer
           >
             <FastRewindIcon />
           </IconButton>
-          <Typography variant="caption" color="text.secondary" sx={{ fontSize: 10, lineHeight: 1 }}>
+          <Typography variant="caption" color="text.secondary" sx={{ fontSize: 10, lineHeight: 1, display: { xs: 'none', sm: 'block' } }}>
             −15s
           </Typography>
         </Box>
@@ -222,12 +222,12 @@ export default function AudioPlayer({ src, title, topic, lessonId }: AudioPlayer
           preload="none"
           onLoadedMetadata={handleLoaded}
           onKeyDown={handleKeyDown}
-          style={{ flex: 1, display: 'block', minWidth: 0 }}
+          style={{ flex: 1, display: 'block', minWidth: 0, width: '100%' }}
         >
           <source src={src} type="audio/mp4" />
           Your browser does not support the audio element.
         </audio>
-        <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
+        <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', flexShrink: 0 }}>
           <IconButton
             onClick={handleSkipForward}
             aria-label="Skip forward 15 seconds"
@@ -235,7 +235,7 @@ export default function AudioPlayer({ src, title, topic, lessonId }: AudioPlayer
           >
             <FastForwardIcon />
           </IconButton>
-          <Typography variant="caption" color="text.secondary" sx={{ fontSize: 10, lineHeight: 1 }}>
+          <Typography variant="caption" color="text.secondary" sx={{ fontSize: 10, lineHeight: 1, display: { xs: 'none', sm: 'block' } }}>
             +15s
           </Typography>
         </Box>

--- a/web-app/src/components/PlaylistPlayer.tsx
+++ b/web-app/src/components/PlaylistPlayer.tsx
@@ -255,7 +255,7 @@ export default function PlaylistPlayer({ lessons }: PlaylistPlayerProps) {
           ))}
         </Select>
       </Box>
-      <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 1, mb: 1 }}>
+      <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 1, mb: 1, justifyContent: { xs: 'center', sm: 'flex-start' } }}>
         <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
           <IconButton
             onClick={handleSkipBack}
@@ -264,7 +264,7 @@ export default function PlaylistPlayer({ lessons }: PlaylistPlayerProps) {
           >
             <FastRewindIcon />
           </IconButton>
-          <Typography variant="caption" color="text.secondary" sx={{ fontSize: 10, lineHeight: 1 }}>
+          <Typography variant="caption" color="text.secondary" sx={{ fontSize: 10, lineHeight: 1, display: { xs: 'none', sm: 'block' } }}>
             −15s
           </Typography>
         </Box>
@@ -276,7 +276,7 @@ export default function PlaylistPlayer({ lessons }: PlaylistPlayerProps) {
           >
             {isPlaying ? <PauseIcon /> : <PlayArrowIcon />}
           </IconButton>
-          <Typography variant="caption" color="text.secondary" sx={{ fontSize: 10, lineHeight: 1 }}>
+          <Typography variant="caption" color="text.secondary" sx={{ fontSize: 10, lineHeight: 1, display: { xs: 'none', sm: 'block' } }}>
             {isPlaying ? 'Pause' : 'Play'}
           </Typography>
         </Box>
@@ -288,7 +288,7 @@ export default function PlaylistPlayer({ lessons }: PlaylistPlayerProps) {
           >
             <FastForwardIcon />
           </IconButton>
-          <Typography variant="caption" color="text.secondary" sx={{ fontSize: 10, lineHeight: 1 }}>
+          <Typography variant="caption" color="text.secondary" sx={{ fontSize: 10, lineHeight: 1, display: { xs: 'none', sm: 'block' } }}>
             +15s
           </Typography>
         </Box>

--- a/web-app/src/components/StickyPlayerBar.tsx
+++ b/web-app/src/components/StickyPlayerBar.tsx
@@ -296,7 +296,7 @@ export default function StickyPlayerBar() {
       <Box
         sx={{
           overflow: 'hidden',
-          maxHeight: isExpanded ? 480 : 0,
+          maxHeight: isExpanded ? 'min(480px, 55vh)' : 0,
           transition: 'max-height 200ms ease-out',
           borderTop: isExpanded ? '1px solid' : 'none',
           borderColor: 'divider',

--- a/web-app/src/components/player/PlaylistQueue.tsx
+++ b/web-app/src/components/player/PlaylistQueue.tsx
@@ -50,7 +50,7 @@ export default function PlaylistQueue({
         borderColor: 'divider',
         borderRadius: '4px',
         overflow: 'hidden',
-        maxHeight: 320,
+        maxHeight: { xs: 220, sm: 320 },
         overflowY: 'auto',
       }}
     >


### PR DESCRIPTION
## Summary

- **AudioPlayer**: add `overflow:hidden` to outer container, shrink gap on xs, hide `−15s`/`+15s` labels on xs so native `<audio controls>` has more horizontal room, add `flexShrink:0` to skip button wrappers
- **PlaylistPlayer**: center transport controls (skip/play/skip) on xs; hide text labels below the buttons on xs to reduce vertical clutter
- **StickyPlayerBar**: cap expanded-panel max-height to `min(480px, 55vh)` — prevents the panel overflowing the viewport on short phones (e.g. iPhone SE, 568 px viewport)
- **PlaylistQueue**: reduce `maxHeight` from fixed `320` to `{ xs: 220, sm: 320 }` so the queue fits comfortably within the constrained panel on mobile

Closes #381

## Test plan

- [ ] Open a lesson with audio on a 360 px wide mobile viewport (Chrome DevTools)
- [ ] Verify `AudioPlayer` controls row (skip − audio − skip) does not cause horizontal overflow
- [ ] Open the playlist player on a topic page at 360 px; confirm transport buttons are centered and no text labels appear below them
- [ ] Open StickyPlayerBar, expand it on an iPhone SE (568 px tall); confirm expanded panel does not overflow the visible viewport
- [ ] Scroll the PlaylistQueue on mobile; confirm it does not consume the full screen height

🤖 Generated with [Claude Code](https://claude.com/claude-code)