### PR TITLE
[PPL-381] Fix 360px mobile layout for audio book player

### DIFF
--- a/web-app/src/components/PlaylistPlayer.tsx
+++ b/web-app/src/components/PlaylistPlayer.tsx
@@ -179,7 +179,7 @@ export default function PlaylistPlayer({ lessons }: PlaylistPlayerProps) {
   }
 
   return (
-    <Box tabIndex={0} onKeyDown={handleKeyDown} sx={{ my: 2, width: '100%', outline: 'none' }}>
+    <Box tabIndex={0} onKeyDown={handleKeyDown} sx={{ my: 2, width: '100%', outline: 'none', overflow: 'hidden' }}>
       <Typography
         variant="caption"
         color="text.secondary"
@@ -209,6 +209,7 @@ export default function PlaylistPlayer({ lessons }: PlaylistPlayerProps) {
           disabled={currentIndex === 0}
           aria-label="Previous lesson"
           size="small"
+          sx={{ minWidth: 48, minHeight: 48 }}
         >
           <SkipPreviousIcon />
         </IconButton>
@@ -220,6 +221,7 @@ export default function PlaylistPlayer({ lessons }: PlaylistPlayerProps) {
           disabled={currentIndex === playlist.length - 1}
           aria-label="Next lesson"
           size="small"
+          sx={{ minWidth: 48, minHeight: 48 }}
         >
           <SkipNextIcon />
         </IconButton>

--- a/web-app/src/components/StickyPlayerBar.tsx
+++ b/web-app/src/components/StickyPlayerBar.tsx
@@ -310,6 +310,7 @@ export default function StickyPlayerBar() {
               disabled={currentIndex === 0}
               aria-label="Previous lesson"
               size="small"
+              sx={{ minWidth: 48, minHeight: 48 }}
             >
               <SkipPreviousIcon />
             </IconButton>
@@ -325,6 +326,7 @@ export default function StickyPlayerBar() {
               disabled={currentIndex === playlist.length - 1}
               aria-label="Next lesson"
               size="small"
+              sx={{ minWidth: 48, minHeight: 48 }}
             >
               <SkipNextIcon />
             </IconButton>

--- a/web-app/src/components/player/PlaylistQueue.tsx
+++ b/web-app/src/components/player/PlaylistQueue.tsx
@@ -74,8 +74,8 @@ export default function PlaylistQueue({
             sx={{
               display: 'flex',
               alignItems: 'center',
-              gap: 1.5,
-              px: 2,
+              gap: { xs: 1, sm: 1.5 },
+              px: { xs: 1, sm: 2 },
               minHeight: 48,
               cursor: 'pointer',
               borderLeft: '3px solid',

--- a/web-app/src/components/player/SleepTimer.tsx
+++ b/web-app/src/components/player/SleepTimer.tsx
@@ -126,6 +126,7 @@ export default function SleepTimer({ audioRef }: SleepTimerProps) {
       {isActive && (
         <Typography
           sx={{
+            display: { xs: 'none', sm: 'block' },
             fontFamily: MONO,
             fontSize: 11,
             fontWeight: 500,


### PR DESCRIPTION
## Summary

Fixes mobile (360 px) layout issues in the audio book player components.

- **PlaylistPlayer**: SkipPrevious/SkipNext gained `minWidth/minHeight: 48px` (WCAG 2.5.5); outer container gets `overflow: hidden` to prevent horizontal scroll
- **StickyPlayerBar** expanded panel: same 48 px tap-target fix on SkipPrevious/SkipNext
- **PlaylistQueue** rows: `px`/`gap` made responsive `{xs:1,sm:2}` / `{xs:1,sm:1.5}` so rows have horizontal breathing room on narrow viewports
- **SleepTimer**: countdown Typography hidden on `xs` (`display:{xs:'none',sm:'block'}`); icon colour still signals active state — prevents "sleep in MM:SS" widening controls row 1 past 360 px

All changes use MUI responsive object syntax and `theme.palette.*` / semantic colour props — no hardcoded hex added. `npm run build` passes clean.

Closes #381