### PR TITLE
[PPL-387] Filter playlist index by active track

### DIFF
--- a/web-app/src/lib/exam-tracks.ts
+++ b/web-app/src/lib/exam-tracks.ts
@@ -1,4 +1,5 @@
-import type { Lesson } from './types';
+import type { Lesson, Topic } from './types';
+import { TOPICS } from './curriculum';
 
 export type TrackStatus = 'active' | 'coming-soon' | 'locked';
 
@@ -15,6 +16,10 @@ export interface ExamTrack {
   unlockHint?: string;
   /** Returns true for lessons that belong to this track */
   lessonFilter: (l: Lesson) => boolean;
+  /** Topics shown on the playlist index for this track */
+  playlistTopics: readonly Topic[];
+  /** Heading shown on the playlist index page */
+  playlistHeading: string;
 }
 
 const noLessons = (_l: Lesson) => false;
@@ -27,6 +32,8 @@ export const EXAM_TRACKS: ExamTrack[] = [
     tagline: 'Transport Canada Private Pilot Licence (Aeroplane)',
     status: 'active',
     lessonFilter: () => true,
+    playlistTopics: TOPICS,
+    playlistHeading: 'Study Playlist',
   },
   {
     id: 'pstar',
@@ -35,6 +42,8 @@ export const EXAM_TRACKS: ExamTrack[] = [
     tagline: 'Pre-Solo Standard Test of Air Regulations',
     status: 'active',
     lessonFilter: (l) => l.topic === 'air-law',
+    playlistTopics: ['air-law'] as const,
+    playlistHeading: 'PSTAR Playlist',
   },
   {
     id: 'rroe',
@@ -43,6 +52,8 @@ export const EXAM_TRACKS: ExamTrack[] = [
     tagline: 'Restricted Radiotelephone Operator Certificate (Aeronautical)',
     status: 'active',
     lessonFilter: (l) => l.topic === 'radio',
+    playlistTopics: ['radio'] as const,
+    playlistHeading: 'RROE Playlist',
   },
   {
     id: 'ppl-h',
@@ -51,6 +62,8 @@ export const EXAM_TRACKS: ExamTrack[] = [
     tagline: 'Transport Canada Private Pilot Licence (Helicopter)',
     status: 'coming-soon',
     lessonFilter: noLessons,
+    playlistTopics: TOPICS,
+    playlistHeading: 'PPL-H Playlist',
   },
   {
     id: 'cpl-a',
@@ -59,6 +72,8 @@ export const EXAM_TRACKS: ExamTrack[] = [
     tagline: 'Transport Canada Commercial Pilot Licence (Aeroplane)',
     status: 'coming-soon',
     lessonFilter: noLessons,
+    playlistTopics: TOPICS,
+    playlistHeading: 'CPL-A Playlist',
   },
   {
     id: 'ifr',
@@ -67,6 +82,8 @@ export const EXAM_TRACKS: ExamTrack[] = [
     tagline: 'Transport Canada Instrument Rating',
     status: 'coming-soon',
     lessonFilter: noLessons,
+    playlistTopics: TOPICS,
+    playlistHeading: 'IFR Playlist',
   },
   {
     id: 'instructor',
@@ -76,6 +93,8 @@ export const EXAM_TRACKS: ExamTrack[] = [
     status: 'locked',
     unlockHint: 'Complete PPL-A and CPL-A first',
     lessonFilter: noLessons,
+    playlistTopics: TOPICS,
+    playlistHeading: 'FI Playlist',
   },
 ];
 

--- a/web-app/src/pages/Playlist.tsx
+++ b/web-app/src/pages/Playlist.tsx
@@ -7,7 +7,8 @@ import Typography from '@mui/material/Typography';
 import { useTheme } from '@mui/material/styles';
 import PlaylistPlayer from '../components/PlaylistPlayer';
 import { getAllLessons, getLessonsByTopic } from '../lib/lesson-loader';
-import { TOPICS, TOPIC_LABELS, CURRICULUM } from '../lib/curriculum';
+import { TOPIC_LABELS, CURRICULUM } from '../lib/curriculum';
+import { useExamTrack } from '../context/ExamTrackContext';
 import type { Lesson } from '../lib/types';
 import { CURATED_PLAYLISTS } from '../data/curated-playlists';
 import { getUserPlaylists } from '../lib/user-playlists';
@@ -409,8 +410,10 @@ function NewPlaylistCard() {
 // ── Library index (no topic param) ────────────────────────────────────────
 
 function PlaylistLibrary() {
+  const { activeTrack } = useExamTrack();
+
   // Section 1: Topic playlists
-  const topicEntries: CardEntry[] = TOPICS.map((t) => {
+  const topicEntries: CardEntry[] = activeTrack.playlistTopics.map((t) => {
     const count = CURRICULUM.filter((s) => s.topic === t).length;
     return {
       id: t,
@@ -488,7 +491,7 @@ function PlaylistLibrary() {
           letterSpacing: '-0.015em',
         }}
       >
-        Playlist Library
+        {activeTrack.playlistHeading}
       </Typography>
       <Typography variant="body2" color="text.secondary" sx={{ mb: 0 }}>
         Study by topic, follow a curated path, or build your own.


### PR DESCRIPTION
Closes #387

## Changes

- **`web-app/src/lib/exam-tracks.ts`**: Added `playlistTopics: readonly Topic[]` and `playlistHeading: string` to the `ExamTrack` interface. Each track now declares which topics appear on the playlist index and what heading to show:
  - `ppl-a`: `TOPICS` (all), `'Study Playlist'`
  - `pstar`: `['air-law']`, `'PSTAR Playlist'`
  - `rroe`: `['radio']`, `'RROE Playlist'`
  - Coming-soon/locked tracks: `TOPICS`, generic headings
- **`web-app/src/pages/Playlist.tsx`**: `PlaylistLibrary` now reads `activeTrack` from `useExamTrack()` and uses `activeTrack.playlistTopics.map(...)` instead of the hard-coded `TOPICS` array, and renders `activeTrack.playlistHeading` as the page title.

## Test Plan

- [ ] Default PPL-A track: playlist index shows all 5 topic cards, heading reads "Study Playlist"
- [ ] Switch to PSTAR track: playlist index shows only the Air Law card, heading reads "PSTAR Playlist"
- [ ] Individual `/playlist/topic/:topic` view is unchanged
- [ ] No TypeScript errors (`tsc --noEmit` passes)