### PR TITLE
[PPL-391] track-aware exam heading

### DIFF
--- a/web-app/src/lib/exam-tracks.ts
+++ b/web-app/src/lib/exam-tracks.ts
@@ -10,6 +10,8 @@ export interface ExamTrack {
   name: string;
   /** One-line description shown in the dropdown */
   tagline: string;
+  /** Heading shown on the Exam practice page */
+  examHeading: string;
   status: TrackStatus;
   /** Hint shown on locked tracks explaining how to unlock */
   unlockHint?: string;
@@ -25,6 +27,7 @@ export const EXAM_TRACKS: ExamTrack[] = [
     code: 'PPL-A',
     name: 'Private Pilot · Aeroplane',
     tagline: 'Transport Canada Private Pilot Licence (Aeroplane)',
+    examHeading: 'Practice Quiz',
     status: 'active',
     lessonFilter: () => true,
   },
@@ -33,6 +36,7 @@ export const EXAM_TRACKS: ExamTrack[] = [
     code: 'PSTAR',
     name: 'Pre-Solo Standards',
     tagline: 'Pre-Solo Standard Test of Air Regulations',
+    examHeading: 'PSTAR Practice',
     status: 'active',
     lessonFilter: (l) => l.topic === 'air-law',
   },
@@ -41,6 +45,7 @@ export const EXAM_TRACKS: ExamTrack[] = [
     code: 'RROE',
     name: 'Radio Operator',
     tagline: 'Restricted Radiotelephone Operator Certificate (Aeronautical)',
+    examHeading: 'ROC-A Practice',
     status: 'active',
     lessonFilter: (l) => l.topic === 'radio',
   },
@@ -49,6 +54,7 @@ export const EXAM_TRACKS: ExamTrack[] = [
     code: 'PPL-H',
     name: 'Private Pilot · Helicopter',
     tagline: 'Transport Canada Private Pilot Licence (Helicopter)',
+    examHeading: 'Practice Quiz',
     status: 'coming-soon',
     lessonFilter: noLessons,
   },
@@ -57,6 +63,7 @@ export const EXAM_TRACKS: ExamTrack[] = [
     code: 'CPL-A',
     name: 'Commercial Pilot · Aeroplane',
     tagline: 'Transport Canada Commercial Pilot Licence (Aeroplane)',
+    examHeading: 'Practice Quiz',
     status: 'coming-soon',
     lessonFilter: noLessons,
   },
@@ -65,6 +72,7 @@ export const EXAM_TRACKS: ExamTrack[] = [
     code: 'IFR',
     name: 'Instrument Rating',
     tagline: 'Transport Canada Instrument Rating',
+    examHeading: 'Practice Quiz',
     status: 'coming-soon',
     lessonFilter: noLessons,
   },
@@ -73,6 +81,7 @@ export const EXAM_TRACKS: ExamTrack[] = [
     code: 'FI',
     name: 'Flight Instructor',
     tagline: 'Transport Canada Flight Instructor Rating',
+    examHeading: 'Practice Quiz',
     status: 'locked',
     unlockHint: 'Complete PPL-A and CPL-A first',
     lessonFilter: noLessons,

--- a/web-app/src/pages/Exam.tsx
+++ b/web-app/src/pages/Exam.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { Link as RouterLink, useSearchParams } from 'react-router-dom';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
@@ -42,12 +42,18 @@ function deriveOptionState(
 export default function Exam() {
   const theme = useTheme();
   const [searchParams] = useSearchParams();
-  const { store: activeStore } = useExamTrack();
+  const { store: activeStore, activeTrack } = useExamTrack();
   const { progress, store } = useProgress(activeStore);
 
   const lessons = getAllLessons().filter((l) => l.questions.length > 0);
 
-  const [topicFilter, setTopicFilter] = useState<TopicFilter>('all');
+  const [topicFilter, setTopicFilter] = useState<TopicFilter>(() =>
+    activeTrack.id === 'pstar' ? 'air-law' : 'all',
+  );
+
+  useEffect(() => {
+    setTopicFilter(activeTrack.id === 'pstar' ? 'air-law' : 'all');
+  }, [activeTrack.id]);
   const [selectedLessonId, setSelectedLessonId] = useState<string>(() => {
     const fromUrl = searchParams.get('lesson');
     if (fromUrl && lessons.some((l) => l.id === fromUrl)) return fromUrl;
@@ -118,7 +124,7 @@ export default function Exam() {
     return (
       <Container id="main-content" tabIndex={-1} maxWidth="md" sx={{ py: 4 }}>
         <Typography variant="h4" sx={{ mb: 3 }}>
-          Practice Quiz
+          {activeTrack.examHeading}
         </Typography>
         <Box
           sx={{
@@ -139,7 +145,7 @@ export default function Exam() {
   return (
     <Container id="main-content" tabIndex={-1} maxWidth="md" sx={{ py: 4 }}>
       <Typography variant="h4" sx={{ mb: 3 }}>
-        Practice Quiz
+        {activeTrack.examHeading}
       </Typography>
 
       {/* Inline confirm — replaces MUI Dialog */}


### PR DESCRIPTION
Closes #391

## Changes
- Added `examHeading` field to `ExamTrack` interface in `exam-tracks.ts`
- Populated `examHeading` for all tracks: `'Practice Quiz'` for ppl-a, `'PSTAR Practice'` for pstar, `'ROC-A Practice'` for rroe, `'Practice Quiz'` for coming-soon/locked tracks
- Updated `Exam.tsx` to import `activeTrack` from `useExamTrack()` and use `activeTrack.examHeading` in both heading locations (empty-state and main render)
- Default topic filter is now `'air-law'` when the active track is `pstar`; resets to `'all'` on track change; user can still switch to any topic

## Test Plan
- [ ] Switch to PPL-A track → Exam page heading shows "Practice Quiz", topic filter defaults to "All"
- [ ] Switch to PSTAR track → Exam page heading shows "PSTAR Practice", topic filter defaults to "Air Law"
- [ ] With PSTAR active, manually change topic filter to another topic — filter change works normally
- [ ] Switch back to PPL-A from PSTAR → heading and topic filter both reset correctly