### PR TITLE
[PPL-390] Home.tsx: track-aware hero heading and subtitle

### DIFF
--- a/web-app/src/lib/exam-tracks.ts
+++ b/web-app/src/lib/exam-tracks.ts
@@ -13,6 +13,14 @@ export interface ExamTrack {
   status: TrackStatus;
   /** Hint shown on locked tracks explaining how to unlock */
   unlockHint?: string;
+  /** Small monospace label above the hero heading */
+  byline: string;
+  /** Main hero heading text */
+  heroHeading: string;
+  /** Hero subtitle / description paragraph */
+  heroSubtitle: string;
+  /** Short credibility tag shown below the subtitle */
+  credibilityTag: string;
   /** Returns true for lessons that belong to this track */
   lessonFilter: (l: Lesson) => boolean;
 }
@@ -26,6 +34,10 @@ export const EXAM_TRACKS: ExamTrack[] = [
     name: 'Private Pilot · Aeroplane',
     tagline: 'Transport Canada Private Pilot Licence (Aeroplane)',
     status: 'active',
+    byline: 'Pre-Flight Briefing · 20 Min / Day',
+    heroHeading: 'Pass the PPL written exam. Twenty minutes a day.',
+    heroSubtitle: 'Structured lessons covering PSTAR and the full Transport Canada syllabus. Audio-first, exam-weighted.',
+    credibilityTag: 'Covers PSTAR & PPL written exam',
     lessonFilter: () => true,
   },
   {
@@ -34,6 +46,10 @@ export const EXAM_TRACKS: ExamTrack[] = [
     name: 'Pre-Solo Standards',
     tagline: 'Pre-Solo Standard Test of Air Regulations',
     status: 'active',
+    byline: 'Pre-Solo Air Law · 20 Min / Day',
+    heroHeading: 'Ace the PSTAR exam. Twenty minutes a day.',
+    heroSubtitle: 'Focused Air Law lessons covering the Pre-Solo Standard Test of Air Regulations. Audio-first, exam-weighted.',
+    credibilityTag: 'Covers PSTAR Air Law · 90% pass mark',
     lessonFilter: (l) => l.topic === 'air-law',
   },
   {
@@ -42,6 +58,10 @@ export const EXAM_TRACKS: ExamTrack[] = [
     name: 'Radio Operator',
     tagline: 'Restricted Radiotelephone Operator Certificate (Aeronautical)',
     status: 'active',
+    byline: 'Radio Operator Certificate · 20 Min / Day',
+    heroHeading: 'Pass the RROE exam. Twenty minutes a day.',
+    heroSubtitle: 'Focused radio operator lessons covering the Restricted Radiotelephone Operator Certificate (Aeronautical).',
+    credibilityTag: 'Covers aeronautical radio operator topics',
     lessonFilter: (l) => l.topic === 'radio',
   },
   {
@@ -50,6 +70,10 @@ export const EXAM_TRACKS: ExamTrack[] = [
     name: 'Private Pilot · Helicopter',
     tagline: 'Transport Canada Private Pilot Licence (Helicopter)',
     status: 'coming-soon',
+    byline: 'Coming Soon · 20 Min / Day',
+    heroHeading: 'PPL Helicopter. Coming soon.',
+    heroSubtitle: 'Structured lessons for the Transport Canada Private Pilot Licence (Helicopter). Audio-first, exam-weighted.',
+    credibilityTag: 'Covers TC PPL-H written exam',
     lessonFilter: noLessons,
   },
   {
@@ -58,6 +82,10 @@ export const EXAM_TRACKS: ExamTrack[] = [
     name: 'Commercial Pilot · Aeroplane',
     tagline: 'Transport Canada Commercial Pilot Licence (Aeroplane)',
     status: 'coming-soon',
+    byline: 'Coming Soon · 20 Min / Day',
+    heroHeading: 'CPL Aeroplane. Coming soon.',
+    heroSubtitle: 'Structured lessons for the Transport Canada Commercial Pilot Licence (Aeroplane). Audio-first, exam-weighted.',
+    credibilityTag: 'Covers TC CPL-A written exam',
     lessonFilter: noLessons,
   },
   {
@@ -66,6 +94,10 @@ export const EXAM_TRACKS: ExamTrack[] = [
     name: 'Instrument Rating',
     tagline: 'Transport Canada Instrument Rating',
     status: 'coming-soon',
+    byline: 'Coming Soon · 20 Min / Day',
+    heroHeading: 'Instrument Rating. Coming soon.',
+    heroSubtitle: 'Structured lessons for the Transport Canada Instrument Rating. Audio-first, exam-weighted.',
+    credibilityTag: 'Covers TC IFR written exam',
     lessonFilter: noLessons,
   },
   {
@@ -75,6 +107,10 @@ export const EXAM_TRACKS: ExamTrack[] = [
     tagline: 'Transport Canada Flight Instructor Rating',
     status: 'locked',
     unlockHint: 'Complete PPL-A and CPL-A first',
+    byline: 'Locked · Complete Prerequisites First',
+    heroHeading: 'Flight Instructor Rating. Unlock after PPL-A and CPL-A.',
+    heroSubtitle: 'Structured lessons for the Transport Canada Flight Instructor Rating.',
+    credibilityTag: 'Covers TC Flight Instructor Rating',
     lessonFilter: noLessons,
   },
 ];

--- a/web-app/src/lib/exam-tracks.ts
+++ b/web-app/src/lib/exam-tracks.ts
@@ -17,6 +17,8 @@ export interface ExamTrack {
   byline: string;
   /** Main hero heading text */
   heroHeading: string;
+  /** Optional phrase within heroHeading to render in primary.main amber; a <br /> is inserted after it */
+  heroHeadingAccent?: string;
   /** Hero subtitle / description paragraph */
   heroSubtitle: string;
   /** Short credibility tag shown below the subtitle */
@@ -36,6 +38,7 @@ export const EXAM_TRACKS: ExamTrack[] = [
     status: 'active',
     byline: 'Pre-Flight Briefing · 20 Min / Day',
     heroHeading: 'Pass the PPL written exam. Twenty minutes a day.',
+    heroHeadingAccent: 'PPL written',
     heroSubtitle: 'Structured lessons covering PSTAR and the full Transport Canada syllabus. Audio-first, exam-weighted.',
     credibilityTag: 'Covers PSTAR & PPL written exam',
     lessonFilter: () => true,

--- a/web-app/src/pages/Home.tsx
+++ b/web-app/src/pages/Home.tsx
@@ -133,21 +133,21 @@ export default function Home() {
         <Box sx={{ display: 'grid', gridTemplateColumns: { xs: '1fr', md: '1.5fr 1fr' }, gap: 4, alignItems: 'center', mb: '36px' }}>
           <Box>
             <Box sx={{ fontFamily: MONO, fontSize: '11px', color: 'primary.main', letterSpacing: '0.15em', mb: '14px', textTransform: 'uppercase' }}>
-              Pre-Flight Briefing · 20 Min / Day
+              {activeTrack.byline}
             </Box>
             <Typography
               variant="h1"
               component="h1"
               sx={{ mb: '14px' }}
             >
-              Pass the{' '}
-              <Box component="span" sx={{ color: 'primary.main' }}>PPL written</Box>
-              <br />
-              exam. Twenty minutes a day.
+              {activeTrack.heroHeading}
             </Typography>
-            <Typography variant="body1" color="text.secondary" sx={{ mb: 2.5, maxWidth: 460 }}>
-              Structured lessons covering PSTAR and the full Transport Canada syllabus. Audio-first, exam-weighted.
+            <Typography variant="body1" color="text.secondary" sx={{ mb: 1.5, maxWidth: 460 }}>
+              {activeTrack.heroSubtitle}
             </Typography>
+            <Box sx={{ fontFamily: MONO, fontSize: '11px', color: 'text.secondary', letterSpacing: '0.12em', mb: 2, textTransform: 'uppercase' }}>
+              {activeTrack.credibilityTag}
+            </Box>
             <Box
               component={RouterLink}
               to={ctaTo}

--- a/web-app/src/pages/Home.tsx
+++ b/web-app/src/pages/Home.tsx
@@ -18,6 +18,21 @@ import { useSRSStore } from '../hooks/useSRSStore';
 
 const MONO = typographyTokens.fontFamily.mono;
 
+function renderAccentedHeading(heading: string, accent: string) {
+  const idx = heading.indexOf(accent);
+  if (idx === -1) return heading;
+  const before = heading.slice(0, idx);
+  const after = heading.slice(idx + accent.length);
+  return (
+    <>
+      {before}
+      <Box component="span" sx={{ color: 'primary.main' }}>{accent}</Box>
+      <br />
+      {after}
+    </>
+  );
+}
+
 const TOPIC_CONFIG = [
   { key: 'air-law' as const, code: 'AL', label: 'Air Law', weight: 0.30 },
   { key: 'navigation' as const, code: 'NAV', label: 'Navigation', weight: 0.25 },
@@ -140,9 +155,11 @@ export default function Home() {
               component="h1"
               sx={{ mb: '14px' }}
             >
-              {activeTrack.heroHeading}
+              {activeTrack.heroHeadingAccent
+                ? renderAccentedHeading(activeTrack.heroHeading, activeTrack.heroHeadingAccent)
+                : activeTrack.heroHeading}
             </Typography>
-            <Typography variant="body1" color="text.secondary" sx={{ mb: 1.5, maxWidth: 460 }}>
+            <Typography variant="body1" color="text.secondary" sx={{ mb: 2.5, maxWidth: 460 }}>
               {activeTrack.heroSubtitle}
             </Typography>
             <Box sx={{ fontFamily: MONO, fontSize: '11px', color: 'text.secondary', letterSpacing: '0.12em', mb: 2, textTransform: 'uppercase' }}>


### PR DESCRIPTION
## Summary

- Adds `byline`, `heroHeading`, `heroSubtitle`, and `credibilityTag` fields to the `ExamTrack` interface in `exam-tracks.ts`
- Populates all 7 tracks with appropriate values; `ppl-a` values exactly match the previously hardcoded strings to avoid visual regression
- Replaces the four hardcoded hero strings in `Home.tsx` with `activeTrack.byline`, `activeTrack.heroHeading`, `activeTrack.heroSubtitle`, and `activeTrack.credibilityTag`
- CTA, progress section, lesson cards, and TrackSwitcher are untouched

Closes #390

## Test plan

- [ ] Switch between PPL-A, PSTAR, and RROE tracks — hero heading, subtitle, byline, and credibility tag should change per track
- [ ] PPL-A default: heading reads "Pass the PPL written exam. Twenty minutes a day.", subtitle and byline match prior hardcoded strings
- [ ] No regressions in CTA button, ReadinessGauge, TopicCoverageGrid, or NextActionCard

🤖 Generated with [Claude Code](https://claude.com/claude-code)