### PR TITLE
[PPL-398] Split QA workflow from deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,48 @@
+name: Deploy to Firebase Hosting
+
+# Deploys the web-app to Firebase Hosting (live channel) whenever main is
+# updated, or on manual dispatch. Build artifacts are produced fresh from
+# main so the deployed version always matches the merged state.
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v4
+        with:
+          ref: main
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: web-app/package-lock.json
+
+      - name: Install (main)
+        working-directory: web-app
+        run: npm ci
+
+      - name: Build (main)
+        working-directory: web-app
+        run: npm run build
+
+      - name: Deploy to Firebase Hosting
+        # No repoToken: we deploy to `live` channel only — no PR preview comment
+        # needed. Avoids the "Resource not accessible by integration" failure
+        # that happens when the action tries to write a check/comment using
+        # GITHUB_TOKEN after the PR is already merged.
+        uses: FirebaseExtended/action-hosting-deploy@v0
+        with:
+          firebaseServiceAccount: '${{ secrets.FIREBASE_SERVICE_ACCOUNT_SUPRUN_CA }}'
+          channelId: live
+          projectId: suprun-ca

--- a/.github/workflows/qa-build-test.yml
+++ b/.github/workflows/qa-build-test.yml
@@ -1,10 +1,11 @@
-name: QA build test merge deploy
+name: QA build and test
 
-# Single end-to-end pipeline: when a reviewer labels the PR `ready-for-qa`,
-# we build + test, then merge the PR, then deploy main to Firebase Hosting —
-# all in one workflow run. No PAT needed, no cross-workflow chaining.
+# QA-only pipeline: when a reviewer labels the PR `ready-for-qa`,
+# we build + test. On success, we swap labels (ready-for-qa → qa-pass)
+# so the merge-handler can proceed. Deployment is handled separately by
+# deploy.yml, which triggers on push to main.
 #
-# Fails fast: if build/test fails, we label qa-fail and skip merge + deploy.
+# Fails fast: if build/test fails, we label qa-fail and stop.
 
 on:
   pull_request:
@@ -12,13 +13,12 @@ on:
 
 permissions:
   pull-requests: write
-  contents: write
+  contents: read
   checks: write
-  deployments: write
   statuses: write
 
 jobs:
-  qa-merge-deploy:
+  qa:
     if: github.event.label.name == 'ready-for-qa'
     runs-on: ubuntu-latest
     steps:
@@ -60,37 +60,13 @@ jobs:
             --repo ${{ github.repository }} \
             --body "QA build/test failed. See [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for details."
 
-      # --- On success: squash-merge ---
-      - name: Merge PR
+      # --- On success: swap labels (ready-for-qa → qa-pass) ---
+      - name: Apply qa-pass
+        if: success()
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh pr merge ${{ github.event.pull_request.number }} \
+          gh pr edit ${{ github.event.pull_request.number }} \
             --repo ${{ github.repository }} \
-            --squash \
-            --delete-branch
-
-      # --- Then deploy from main (in same workflow — no cross-trigger needed) ---
-      - name: Checkout main (post-merge)
-        uses: actions/checkout@v4
-        with:
-          ref: main
-
-      - name: Install (main)
-        working-directory: web-app
-        run: npm ci
-
-      - name: Build (main)
-        working-directory: web-app
-        run: npm run build
-
-      - name: Deploy to Firebase Hosting
-        # No repoToken: we deploy to `live` channel only — no PR preview comment
-        # needed. Avoids the "Resource not accessible by integration" failure
-        # that happens when the action tries to write a check/comment using
-        # GITHUB_TOKEN after the PR is already merged.
-        uses: FirebaseExtended/action-hosting-deploy@v0
-        with:
-          firebaseServiceAccount: '${{ secrets.FIREBASE_SERVICE_ACCOUNT_SUPRUN_CA }}'
-          channelId: live
-          projectId: suprun-ca
+            --remove-label ready-for-qa \
+            --add-label qa-pass


### PR DESCRIPTION
## Summary

- `qa-build-test.yml`: removed `gh pr merge` step and all post-merge/deploy steps; added `qa-pass` label-swap on QA success; updated name/comment to QA-only scope; dropped `deployments` permission.
- `deploy.yml`: new workflow triggered on `push` to `main` and `workflow_dispatch`; ports Firebase deploy steps verbatim (same action versions, secrets, target site).
- `qa-fail` behavior is unchanged.

Closes #398

## Test plan

- [ ] Label a PR `ready-for-qa` → verify `qa-build-test.yml` runs build+test only, then swaps to `qa-pass` (no merge, no deploy)
- [ ] Verify `qa-fail` still applied when build/test fails
- [ ] Merge a PR to `main` → verify `deploy.yml` triggers and deploys to Firebase live channel
- [ ] Trigger `deploy.yml` via `workflow_dispatch` → verify it deploys successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)