### PR TITLE
[PPL-400] Hide radio topic from ppl-a playlist until audio exists

### DIFF
--- a/web-app/src/lib/exam-tracks.ts
+++ b/web-app/src/lib/exam-tracks.ts
@@ -1,5 +1,12 @@
 import type { Lesson, Topic } from './types';
-import { TOPICS } from './curriculum';
+import { TOPICS, CURRICULUM } from './curriculum';
+
+/** Returns only topics that have at least one lesson with a non-null audio URL. */
+function topicsWithAudio(topics: readonly Topic[]): readonly Topic[] {
+  return topics.filter((topic) =>
+    CURRICULUM.some((slot) => slot.topic === topic && slot.audio !== null),
+  );
+}
 
 export interface Track {
   slug: string;
@@ -83,7 +90,7 @@ export const EXAM_TRACKS: ExamTrack[] = [
     heroSubtitle: 'Structured lessons covering PSTAR and the full Transport Canada syllabus. Audio-first, exam-weighted.',
     credibilityTag: 'Covers PSTAR & PPL written exam',
     lessonFilter: () => true,
-    playlistTopics: TOPICS,
+    playlistTopics: topicsWithAudio(TOPICS),
     playlistHeading: 'Study Playlist',
   },
   {


### PR DESCRIPTION
## Summary

- Filters `playlistTopics` for the `ppl-a` track to only include topics that have at least one lesson with a non-null `audio` field
- Radio (ROC-A) lessons all have `audio: null` in `curriculum.ts`, so the topic is excluded from the playlist until audio files are added
- Other topics (`air-law`, `navigation`, `meteorology`, `general-knowledge`) have `audio: undefined` (field absent), which passes the `!== null` check and remain visible
- The fix is generalised via `topicsWithAudio()` — any future topic with all-null audio will automatically be hidden

Closes #400

## Test plan

- [ ] Visit `/playlist` on the `ppl-a` track — Radio topic should not appear
- [ ] Confirm Air Law, Navigation, Meteorology, and General Knowledge topics still appear
- [ ] Visit the RROE track playlist — Radio topic should still appear there (unaffected)
- [ ] When ROC-A audio is eventually added to `curriculum.ts`, Radio automatically reappears in ppl-a playlist without further code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)