### PR TITLE
[PPL-401] Make topic coverage / exam weight stat rows clickable

### DIFF
--- a/web-app/src/components/home/ReadinessGauge.tsx
+++ b/web-app/src/components/home/ReadinessGauge.tsx
@@ -1,7 +1,9 @@
 import Box from '@mui/material/Box';
 import { useTheme } from '@mui/material/styles';
 import { alpha } from '@mui/material/styles';
+import { Link as RouterLink } from 'react-router-dom';
 import { typographyTokens } from '../../tokens';
+import { getLessonsByTopic } from '../../lib/lesson-loader';
 
 const MONO = typographyTokens.fontFamily.mono;
 const R = 48;
@@ -10,6 +12,7 @@ const CIRCUMFERENCE = 2 * Math.PI * R;
 export interface TopicStat {
   code: string;
   label: string;
+  topic: string;
   weight: number;
   pct: number;
   done: number;
@@ -101,26 +104,54 @@ export default function ReadinessGauge({ weightedPct, topicStats }: Props) {
           </Box>
           <Box sx={{ fontFamily: MONO, fontSize: '11px', color: 'text.secondary', lineHeight: 1.9, mt: 0.75 }}>
             <Box>
-              {row1.map((s, i) => (
-                <Box key={s.code} component="span">
-                  {s.code}{' '}
-                  <Box component="span" sx={{ color: s.pct >= 70 ? 'success.main' : 'primary.main' }}>
-                    {s.pct}%
+              {row1.map((s, i) => {
+                const firstLesson = getLessonsByTopic(s.topic)[0];
+                const to = firstLesson ? `/lessons/${s.topic}/${firstLesson.slug}` : '/lessons';
+                return (
+                  <Box key={s.code} component="span">
+                    <Box
+                      component={RouterLink}
+                      to={to}
+                      sx={{
+                        color: 'inherit',
+                        textDecoration: 'none',
+                        '&:hover': { textDecoration: 'underline', color: 'primary.main' },
+                      }}
+                    >
+                      {s.code}{' '}
+                      <Box component="span" sx={{ color: s.pct >= 70 ? 'success.main' : 'primary.main' }}>
+                        {s.pct}%
+                      </Box>
+                    </Box>
+                    {i < row1.length - 1 && <Box component="span"> · </Box>}
                   </Box>
-                  {i < row1.length - 1 && <Box component="span"> · </Box>}
-                </Box>
-              ))}
+                );
+              })}
             </Box>
             <Box>
-              {row2.map((s, i) => (
-                <Box key={s.code} component="span">
-                  {s.code}{' '}
-                  <Box component="span" sx={{ color: s.pct >= 70 ? 'success.main' : 'primary.main' }}>
-                    {s.pct}%
+              {row2.map((s, i) => {
+                const firstLesson = getLessonsByTopic(s.topic)[0];
+                const to = firstLesson ? `/lessons/${s.topic}/${firstLesson.slug}` : '/lessons';
+                return (
+                  <Box key={s.code} component="span">
+                    <Box
+                      component={RouterLink}
+                      to={to}
+                      sx={{
+                        color: 'inherit',
+                        textDecoration: 'none',
+                        '&:hover': { textDecoration: 'underline', color: 'primary.main' },
+                      }}
+                    >
+                      {s.code}{' '}
+                      <Box component="span" sx={{ color: s.pct >= 70 ? 'success.main' : 'primary.main' }}>
+                        {s.pct}%
+                      </Box>
+                    </Box>
+                    {i < row2.length - 1 && <Box component="span"> · </Box>}
                   </Box>
-                  {i < row2.length - 1 && <Box component="span"> · </Box>}
-                </Box>
-              ))}
+                );
+              })}
             </Box>
             <Box sx={{ mt: '6px', color: delta >= 0 ? 'success.main' : 'primary.main' }}>
               Target 80 — Delta {delta >= 0 ? '+' : ''}{delta}

--- a/web-app/src/components/home/TopicCoverageGrid.tsx
+++ b/web-app/src/components/home/TopicCoverageGrid.tsx
@@ -1,6 +1,8 @@
 import Box from '@mui/material/Box';
+import { Link as RouterLink } from 'react-router-dom';
 import { typographyTokens } from '../../tokens';
 import type { TopicStat } from './ReadinessGauge';
+import { getLessonsByTopic } from '../../lib/lesson-loader';
 
 const MONO = typographyTokens.fontFamily.mono;
 
@@ -17,15 +19,25 @@ export default function TopicCoverageGrid({ stats }: Props) {
         gap: '14px',
       }}
     >
-      {stats.map((s) => (
+      {stats.map((s) => {
+        const firstLesson = getLessonsByTopic(s.topic)[0];
+        const to = firstLesson ? `/lessons/${s.topic}/${firstLesson.slug}` : '/lessons';
+        return (
         <Box
           key={s.code}
+          component={RouterLink}
+          to={to}
           sx={{
+            display: 'block',
             bgcolor: 'background.paper',
             border: '1px solid',
             borderColor: 'divider',
             borderRadius: 1,
             p: 2,
+            textDecoration: 'none',
+            color: 'text.primary',
+            transition: 'border-color 0.15s',
+            '&:hover': { borderColor: 'primary.main' },
           }}
         >
           <Box sx={{ fontFamily: MONO, fontSize: '10px', color: 'text.secondary', letterSpacing: '0.1em' }}>
@@ -58,7 +70,8 @@ export default function TopicCoverageGrid({ stats }: Props) {
             <Box component="strong" sx={{ color: 'primary.main', fontWeight: 500 }}>{s.pct}%</Box>
           </Box>
         </Box>
-      ))}
+        );
+      })}
     </Box>
   );
 }

--- a/web-app/src/pages/Home.tsx
+++ b/web-app/src/pages/Home.tsx
@@ -95,7 +95,7 @@ export default function Home() {
       const slots = CURRICULUM.filter((s) => s.topic === key);
       const done = slots.filter((s) => trackProgress.completed.includes(s.id)).length;
       const pct = slots.length > 0 ? Math.round((done / slots.length) * 100) : 0;
-      return { code, label, weight: weight / totalWeight, pct, done, total: slots.length };
+      return { code, label, topic: key, weight: weight / totalWeight, pct, done, total: slots.length };
     });
   }, [activeTopicConfig, trackProgress.completed]);
 


### PR DESCRIPTION
## Summary

- Added `topic: string` field to `TopicStat` interface so components know the URL-safe topic key
- `TopicCoverageGrid`: each card is now a `RouterLink` navigating to the first lesson of that topic; border highlights on hover matching the existing card navigation pattern
- `ReadinessGauge`: each inline stat entry (e.g. `AL 85%`, `NAV 42%`) is now a link to the first lesson of that topic; underline + primary color on hover

Closes #401

## Test plan

- [ ] Navigate to home page; hover over each topic card in the Topic Coverage grid — border should highlight
- [ ] Click a topic card — should land on the first lesson of that topic
- [ ] Hover over `AL`, `NAV`, `MET`, `GK` entries in the Readiness Gauge — should show underline + primary color
- [ ] Click each gauge stat entry — should navigate to first lesson of that topic
- [ ] Verify fallback: if a topic somehow has no lessons, link falls back to `/lessons`

🤖 Generated with [Claude Code](https://claude.com/claude-code)