### PR TITLE
[PPL-405] Add playlist audio smoke test

### DIFF
--- a/web-app/package.json
+++ b/web-app/package.json
@@ -22,7 +22,8 @@
   "scripts": {
     "start": "vite",
     "build": "tsc -b && vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "node scripts/validate-playlist-audio.mjs"
   },
   "devDependencies": {
     "@types/js-yaml": "^4.0.9",

--- a/web-app/scripts/validate-playlist-audio.mjs
+++ b/web-app/scripts/validate-playlist-audio.mjs
@@ -1,0 +1,64 @@
+/**
+ * Playlist audio smoke test — prevents the regression where a topic card
+ * appears in the playlist with zero audio lessons (Apr 2026 topicsWithAudio bug).
+ *
+ * Reads all lesson markdown frontmatter under lessons/, groups by topic, and
+ * exits 1 if any topic has zero lessons with a real audio URL.
+ */
+
+import { readFileSync, readdirSync, statSync } from 'fs';
+import { join, resolve } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
+const lessonsDir = resolve(__dirname, '../../lessons');
+
+function walkMd(dir) {
+  const results = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      results.push(...walkMd(full));
+    } else if (entry.endsWith('.md')) {
+      results.push(full);
+    }
+  }
+  return results;
+}
+
+const files = walkMd(lessonsDir);
+
+// topic -> { total, withAudio }
+const topics = {};
+
+for (const file of files) {
+  const raw = readFileSync(file, 'utf8');
+  const fm = raw.match(/^---\n([\s\S]*?)\n---/)?.[1] ?? '';
+  const topic = fm.match(/^topic:\s*(.+)$/m)?.[1]?.trim();
+  const audioLine = fm.match(/^audio:\s*(.+)$/m)?.[1]?.trim();
+  const hasAudio = audioLine && audioLine !== 'null' && audioLine !== '~' && audioLine !== '';
+
+  if (!topic) continue;
+
+  if (!topics[topic]) topics[topic] = { total: 0, withAudio: 0 };
+  topics[topic].total += 1;
+  if (hasAudio) topics[topic].withAudio += 1;
+}
+
+let failed = false;
+
+for (const [topic, { total, withAudio }] of Object.entries(topics).sort()) {
+  if (withAudio === 0) {
+    console.log(`✗ ${topic}: ${total} lessons, 0 with audio  ← FAIL`);
+    failed = true;
+  } else {
+    console.log(`✓ ${topic}: ${total} lessons, ${withAudio} with audio`);
+  }
+}
+
+if (failed) {
+  console.error('\nValidation failed: one or more topics have no audio lessons.');
+  process.exit(1);
+}
+
+console.log('\nAll topics have at least one audio lesson. ✓');


### PR DESCRIPTION
Closes #405

## Changes

- **`web-app/scripts/validate-playlist-audio.mjs`** (new): Dependency-free ESM script that walks all `lessons/**/*.md` files, parses YAML frontmatter via regex, groups lessons by `topic`, and exits 1 if any topic has zero lessons with a non-null/non-empty `audio:` URL. Documents the Apr 2026 topicsWithAudio regression it guards against.
- **`web-app/package.json`**: Added `"test": "node scripts/validate-playlist-audio.mjs"` so the existing CI step `npm test --if-present` picks it up automatically.

Script output against current repo (all pass):
```
✓ air-law: 18 lessons, 18 with audio
✓ general-knowledge: 14 lessons, 14 with audio
✓ meteorology: 14 lessons, 14 with audio
✓ navigation: 14 lessons, 14 with audio
✓ radio: 9 lessons, 9 with audio

All topics have at least one audio lesson. ✓
```

## Test Plan

- [ ] Run `node scripts/validate-playlist-audio.mjs` from `web-app/` — exits 0 with checkmarks for all topics
- [ ] Manually set an `audio:` field to `null` in any lesson file and re-run — script should exit 1 and flag the topic
- [ ] CI run on this PR should pass (qa-build-test workflow runs `npm test --if-present`)