### PR TITLE
[PPL-406] Update README — document current feature set

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,25 +1,40 @@
-# PPL Study — Canadian Pilot License Exam Prep
+# PPL Study — Canadian Pilot Licence Exam Prep
+
+> **Live site:** [https://ppl.suprun.ca](https://ppl.suprun.ca)
 
 A structured, audio-first curriculum for Transport Canada PPL (Aeroplane) written exam preparation. Each lesson is a 20-minute audio module with practice questions and linked regulatory sources.
 
 **Target:** Transport Canada PPL written exam (passing grade 60%, target 80%+)  
-**Audience:** Student pilots preparing for the Canadian pilot license  
+**Audience:** Student pilots preparing for the Canadian pilot licence  
 **Format:** Audio-first lessons with visual support and practice questions
 
-## Features
+---
 
-- **20-minute audio lessons** — Kokoro-narrated, scientifically paced for retention
-- **Audio-first design** — Study while driving, flying, or commuting
-- **Regulatory references** — Every fact linked to TP (Transport Publications) or CARs (Canadian Aviation Regulations)
-- **Practice questions** — 3–5 multi-choice questions per lesson with explanations
-- **Web app** — React SPA for lesson playback and practice tests
-- **Lessons by topic:**
-  - Air Law
-  - Human Performance & Limitations
-  - Meteorology
-  - Navigation
-  - Aircraft Technical Knowledge
-  - Flight Planning & Performance
+## Features at a Glance
+
+- **Lesson library** — 64 lessons across four PPL-A topics plus a Radio/ROC-A track:
+  - Air Law (13 lessons — audio available)
+  - Navigation (14 lessons — 2 with audio, rest in production)
+  - Meteorology (14 lessons — audio in production)
+  - General Knowledge (14 lessons — audio in production)
+  - Radio / ROC-A (9 lessons — audio in production)
+
+- **Audio playlist** — Continuous playback with per-lesson progress tracking; study while commuting or flying
+
+- **Track switcher** — Switch between three exam tracks in the app header:
+  - **PPL-A** — full Transport Canada PPL syllabus
+  - **PSTAR** — Pre-Solo Standard Test of Air Regulations subset
+  - **RROE** — Radio/ROC-A (Restricted Operator Certificate with Aeronautical Qualification)
+
+- **PSTAR path** — Dedicated study track for the mandatory pre-solo air regulations test
+
+- **SRS review queue** — Spaced-repetition scheduling surfaces lessons due for review so knowledge stays fresh
+
+- **Practice quiz** — 3–5 multiple-choice questions per lesson with explanations, taken right after the audio
+
+- **Final exam mode** — Timed, randomised exam simulation covering the full syllabus
+
+---
 
 ## Quick Start
 
@@ -33,74 +48,51 @@ npm run dev
 
 The web app will be available at `http://localhost:5173`.
 
+### Deploy
+
+```bash
+firebase deploy --only hosting
+```
+
 ### Project Structure
 
 ```
 ppl-study/
-├── lessons/              # Lesson content (Markdown + audio)
+├── lessons/          # Lesson content (Markdown)
 │   ├── air-law/
-│   ├── human-performance/
+│   ├── navigation/
 │   ├── meteorology/
-│   └── ...
-├── web-app/             # React + Vite + TypeScript web application
-├── docs/                # Guides and schema documentation
-│   ├── lesson-schema.md # Lesson format specification
-│   └── curriculum-plan.md
-└── scripts/             # Build & deployment scripts
+│   └── general-knowledge/
+├── audio/            # Generated narration files per lesson
+├── web-app/          # React + Vite + TypeScript web application
+├── docs/             # Reference docs, design system, audio standards
+└── scripts/          # Utility scripts
 ```
 
-## Contributing
-
-Want to add lessons, fix content, or improve the web app? See [CONTRIBUTING.md](./CONTRIBUTING.md).
-
-### Lesson Format
-
-Lessons follow a strict schema:
-
-```yaml
 ---
-id: AL-001
-topic: air-law
-order: 1
-slug: airspace-classifications
-title: "Airspace Classifications"
-duration_min: 20
-status: published
-audio: https://media.suprun.workers.dev/ppl/lessons/air-law/001-airspace-classifications.m4a
-visual: null
-sources:
-  - CARs Part I, Section 101.01
-  - TP 12880E "Pilot's Handbook of Aeronautical Knowledge"
-questions:
-  - id: q1
-    prompt: "Class B airspace requires..."
-    choices: [...]
-```
-
-See [docs/lesson-schema.md](./docs/lesson-schema.md) for the full schema.
-
-### Factual Accuracy Rules
-
-- **Every regulation reference must cite a source:** TP number (Transport Publications) or CARs section
-- **No unsourced claims:** If you can't cite Transport Canada, CAA, or peer-reviewed aviation publications, don't include it
-- **Canadian focus:** This is PPL (Canada), not FAA. Use Transport Canada materials exclusively
 
 ## Tech Stack
 
 - **Web App:** React 18 + TypeScript + Vite 6 + MUI 7
-- **Narration:** Kokoro TTS (ai-echo voice profile)
+- **Narration:** Kokoro TTS (echo voice, speed 1.1)
 - **Media Storage:** Cloudflare R2
+- **Hosting:** Firebase Hosting
 - **CI/CD:** GitHub Actions
+
+---
+
+## Factual Accuracy
+
+- Every regulation reference cites a Transport Canada source: TP number or CARs section
+- Canadian PPL only — regulations differ significantly from FAA; do not mix sources
+
+---
 
 ## License
 
 [MIT](./LICENSE) — Educational content. Contributed lessons remain the copyright of their authors unless transferred.
 
-## Questions?
-
-Open an [issue](https://github.com/svv2014/ppl-study/issues) or check [docs/](./docs) for guidance.
-
 ---
 
-**Made by:** Vadym Suprun & contributors  
-**Updated:** 2026-04-20
+**Live site:** [https://ppl.suprun.ca](https://ppl.suprun.ca)  
+**Made by:** Vadym Suprun & contributors


### PR DESCRIPTION
Closes #406

## Changes

Rewrote `README.md` to accurately reflect the current web app feature set:

- Added prominent live site link (`https://ppl.suprun.ca`) at the top and bottom
- Added **"Features at a Glance"** section listing all major features:
  - Lesson library with accurate lesson counts per topic (Air Law 13, Navigation 14, Meteorology 14, General Knowledge 14, Radio/ROC-A 9)
  - Audio playlist
  - Track switcher (PPL-A / PSTAR / RROE) with descriptions of each track
  - PSTAR path
  - SRS review queue
  - Practice quiz per lesson
  - Final exam mode
- Updated local dev section to include `firebase deploy --only hosting`
- Updated project structure to match actual directories (`audio/`, corrected topic folders)
- Removed stale contributing guide reference (no CONTRIBUTING.md exists) and outdated lesson schema YAML block
- Removed outdated topic list (Human Performance, Aircraft Technical Knowledge, Flight Planning) that no longer matches the syllabus

## Test Plan

- Verify all links resolve: live site URL, GitHub issues link, LICENSE
- Confirm lesson counts match the app (Air Law 13, Navigation 14, Meteorology 14, General Knowledge 14, Radio/ROC-A 9)
- Confirm local dev steps work: `cd web-app && npm install && npm run dev`