### PR TITLE
[PPL-409] Fix TrackSwitcher to use ExamTrackContext

### DIFF
--- a/web-app/src/components/TrackSwitcher.tsx
+++ b/web-app/src/components/TrackSwitcher.tsx
@@ -1,7 +1,7 @@
 import Box from '@mui/material/Box';
 import Tooltip from '@mui/material/Tooltip';
-import { useTrack } from '../context/TrackContext';
-import { TRACKS } from '../lib/exam-tracks';
+import { useExamTrack } from '../context/ExamTrackContext';
+import { EXAM_TRACKS } from '../lib/exam-tracks';
 
 const CHIP_BASE = {
   display: 'inline-flex',
@@ -22,7 +22,7 @@ const CHIP_BASE = {
 } as const;
 
 export default function TrackSwitcher() {
-  const { activeTrack, setActiveTrack } = useTrack();
+  const { activeTrack, setActiveTrack } = useExamTrack();
 
   return (
     <Box
@@ -30,15 +30,20 @@ export default function TrackSwitcher() {
       aria-label="Exam track"
       sx={{ display: 'flex', flexWrap: 'wrap', gap: '6px', minWidth: 0 }}
     >
-      {TRACKS.map((track) => {
-        const isActive = track.slug === activeTrack.slug;
-        const isComingSoon = track.status === 'coming-soon';
+      {EXAM_TRACKS.map((track) => {
+        const isActive = track.id === activeTrack.id;
+        const isDisabled = track.status !== 'active';
 
-        if (isComingSoon) {
+        if (isDisabled) {
+          const tooltipTitle =
+            track.status === 'locked' && track.unlockHint
+              ? `${track.name} — ${track.unlockHint}`
+              : `${track.name} — coming soon`;
+
           return (
             <Tooltip
-              key={track.slug}
-              title={`${track.label} — coming soon`}
+              key={track.id}
+              title={tooltipTitle}
               placement="bottom"
             >
               {/* span wrapper required: Tooltip doesn't receive events on disabled buttons */}
@@ -46,7 +51,7 @@ export default function TrackSwitcher() {
                 <Box
                   component="button"
                   disabled
-                  aria-label={`${track.label} — coming soon`}
+                  aria-label={tooltipTitle}
                   sx={(theme) => ({
                     ...CHIP_BASE,
                     cursor: 'default',
@@ -55,7 +60,7 @@ export default function TrackSwitcher() {
                     color: theme.palette.text.disabled,
                   })}
                 >
-                  {track.shortLabel}
+                  {track.code}
                 </Box>
               </span>
             </Tooltip>
@@ -64,11 +69,11 @@ export default function TrackSwitcher() {
 
         return (
           <Box
-            key={track.slug}
+            key={track.id}
             component="button"
-            onClick={() => setActiveTrack(track.slug)}
+            onClick={() => setActiveTrack(track.id)}
             aria-pressed={isActive}
-            aria-label={track.label}
+            aria-label={track.name}
             sx={(theme) => ({
               ...CHIP_BASE,
               cursor: 'pointer',
@@ -90,7 +95,7 @@ export default function TrackSwitcher() {
                   }),
             })}
           >
-            {track.shortLabel}
+            {track.code}
           </Box>
         );
       })}


### PR DESCRIPTION
Closes #409

## Changes

Replaced `useTrack` / `TRACKS` with `useExamTrack` / `EXAM_TRACKS` in `TrackSwitcher.tsx`:

- **Same-tab propagation fixed**: The switcher now calls `setActiveTrack` from `ExamTrackContext`, which is the same context all content pages (`Playlist`, `LessonsIndex`, `Exam`, `Home`) read from. Clicking a track pill immediately updates content without a page reload.
- **RROE now visible**: `EXAM_TRACKS` includes `rroe`; the old `TRACKS` array only had `ppl-a` and `pstar`.
- **`track.id` used as key/comparator** instead of `track.slug` (which doesn't exist on `ExamTrack`).
- **`track.code` used as pill label** (e.g. `PPL-A`, `PSTAR`, `RROE`) instead of `track.shortLabel`.
- **Both `coming-soon` and `locked` tracks render as disabled pills**; locked tracks show the `unlockHint` in the tooltip.
- `TrackContext.tsx` and `ExamTrackContext.tsx` are untouched.

## Test Plan

- Open the app; verify PPL-A, PSTAR, and RROE pills appear in the switcher
- Click PSTAR → playlist shows only Air Law topics, no page reload needed
- Click RROE → playlist shows only radio topics
- Click PPL-A → playlist shows all audio-available topics
- Verify PPL-H, CPL-A, IFR, FI pills appear as disabled (greyed out, non-clickable)
- Hover over a coming-soon pill → tooltip shows "coming soon"; hover FI → shows unlock hint
- `npm run build` passes with no TypeScript errors