### PR TITLE
Draft: [PPL-413] Fix Radio playlist broken when RROE track selected

### DIFF
--- a/web-app/src/lib/curriculum.ts
+++ b/web-app/src/lib/curriculum.ts
@@ -80,15 +80,15 @@ export const CURRICULUM: CurriculumSlot[] = [
   { id: 'GK-014', slug: 'preflight-inspection', title: 'Pre-Flight Inspection and Maintenance', topic: 'general-knowledge', order: 14 },
 
   // Radio (ROC-A) (9)
-  { id: 'ROC-001', slug: 'phonetic-alphabet-numbers', title: 'Phonetic Alphabet and Numbers', topic: 'radio', order: 1, audio: null, visual: '' },
-  { id: 'ROC-002', slug: 'standard-phraseology-readback', title: 'Standard Phraseology and Readback', topic: 'radio', order: 2, audio: null, visual: '' },
-  { id: 'ROC-003', slug: 'frequencies-reference', title: 'Frequencies Reference', topic: 'radio', order: 3, audio: null, visual: '' },
-  { id: 'ROC-004', slug: 'position-reporting', title: 'Position Reporting', topic: 'radio', order: 4, audio: null, visual: '' },
-  { id: 'ROC-005', slug: 'vfr-ifr-comms-overview', title: 'VFR/IFR Communications Overview', topic: 'radio', order: 5, audio: null, visual: '' },
-  { id: 'ROC-006', slug: 'emergency-comms', title: 'Emergency Communications', topic: 'radio', order: 6, audio: null, visual: '' },
-  { id: 'ROC-007', slug: 'light-signals', title: 'Light Signals', topic: 'radio', order: 7, audio: null, visual: '' },
-  { id: 'ROC-008', slug: 'regulatory-framework', title: 'Regulatory Framework', topic: 'radio', order: 8, audio: null, visual: '' },
-  { id: 'ROC-009', slug: 'radio-etiquette', title: 'Radio Etiquette', topic: 'radio', order: 9, audio: null, visual: '' },
+  { id: 'ROC-001', slug: 'phonetic-alphabet-numbers', title: 'Phonetic Alphabet and Numbers', topic: 'radio', order: 1, audio: 'https://media.suprun.workers.dev/ppl/lessons/radio/001-phonetic-alphabet-numbers.m4a', visual: '' },
+  { id: 'ROC-002', slug: 'standard-phraseology-readback', title: 'Standard Phraseology and Readback', topic: 'radio', order: 2, audio: 'https://media.suprun.workers.dev/ppl/lessons/radio/002-standard-phraseology-readback.m4a', visual: '' },
+  { id: 'ROC-003', slug: 'frequencies-reference', title: 'Frequencies Reference', topic: 'radio', order: 3, audio: 'https://media.suprun.workers.dev/ppl/lessons/radio/003-frequencies-reference.m4a', visual: '' },
+  { id: 'ROC-004', slug: 'position-reporting', title: 'Position Reporting', topic: 'radio', order: 4, audio: 'https://media.suprun.workers.dev/ppl/lessons/radio/004-position-reporting.m4a', visual: '' },
+  { id: 'ROC-005', slug: 'vfr-ifr-comms-overview', title: 'VFR/IFR Communications Overview', topic: 'radio', order: 5, audio: 'https://media.suprun.workers.dev/ppl/lessons/radio/005-vfr-ifr-comms-overview.m4a', visual: '' },
+  { id: 'ROC-006', slug: 'emergency-comms', title: 'Emergency Communications', topic: 'radio', order: 6, audio: 'https://media.suprun.workers.dev/ppl/lessons/radio/006-emergency-comms.m4a', visual: '' },
+  { id: 'ROC-007', slug: 'light-signals', title: 'Light Signals', topic: 'radio', order: 7, audio: 'https://media.suprun.workers.dev/ppl/lessons/radio/007-light-signals.m4a', visual: '' },
+  { id: 'ROC-008', slug: 'regulatory-framework', title: 'Regulatory Framework', topic: 'radio', order: 8, audio: 'https://media.suprun.workers.dev/ppl/lessons/radio/008-regulatory-framework.m4a', visual: '' },
+  { id: 'ROC-009', slug: 'radio-etiquette', title: 'Radio Etiquette', topic: 'radio', order: 9, audio: 'https://media.suprun.workers.dev/ppl/lessons/radio/009-radio-etiquette.m4a', visual: '' },
 ];
 
 export const TOPIC_LABELS: Record<string, string> = {

--- a/web-app/src/lib/exam-tracks.ts
+++ b/web-app/src/lib/exam-tracks.ts
@@ -90,7 +90,7 @@ export const EXAM_TRACKS: ExamTrack[] = [
     heroSubtitle: 'Structured lessons covering PSTAR and the full Transport Canada syllabus. Audio-first, exam-weighted.',
     credibilityTag: 'Covers PSTAR & PPL written exam',
     lessonFilter: () => true,
-    playlistTopics: topicsWithAudio(TOPICS),
+    playlistTopics: topicsWithAudio(TOPICS.filter((t) => t !== 'radio')),
     playlistHeading: 'Study Playlist',
   },
   {


### PR DESCRIPTION
Closes #413

## Changes

- **`web-app/src/lib/curriculum.ts`**: Updated all 9 ROC-001–ROC-009 entries from `audio: null` to real R2 audio URLs (copied from markdown frontmatter in `lessons/radio/*.md`). This fixes the root cause: `topicsWithAudio()` reads CURRICULUM, so `null` entries caused radio to appear as having no audio.

- **`web-app/src/lib/exam-tracks.ts`**: Changed PPL-A `playlistTopics` from `topicsWithAudio(TOPICS)` to `topicsWithAudio(TOPICS.filter((t) => t !== radio))`. Since radio now has real audio URLs, it would otherwise appear in PPL-A's playlist — this explicit exclusion preserves the original PPL-A behavior.

## Test Plan
- Switch to RROE track: all 9 radio lessons should appear in the playlist with working audio playback
- Switch to PPL-A track: radio topic should NOT appear in the playlist
- Switch between PPL-A and RROE: no cross-bleed (each track shows correct topics)
- PSTAR track: unaffected (uses hardcoded `["air-law"]`)
- `npm run build` passes with no TypeScript errors