### PR TITLE
Draft: [PPL-416] Scope Study Plan to active exam track

### DIFF
--- a/web-app/src/pages/Plan.tsx
+++ b/web-app/src/pages/Plan.tsx
@@ -21,10 +21,11 @@ import { CURRICULUM, TOPIC_LABELS, TOPICS } from '../lib/curriculum';
 import { getAllLessons } from '../lib/lesson-loader';
 import { useProgress } from '../lib/progress';
 import { useExamTrack } from '../context/ExamTrackContext';
+import type { Lesson } from '../lib/types';
 
 export default function Plan() {
   const [resetOpen, setResetOpen] = useState(false);
-  const { store } = useExamTrack();
+  const { store, activeTrack } = useExamTrack();
   const { progress, markComplete, markIncomplete, isComplete, reset } = useProgress(store);
 
   const { authoredIds, lessonTitleMap } = useMemo(() => {
@@ -35,8 +36,17 @@ export default function Plan() {
     };
   }, []);
 
-  const totalLessons = CURRICULUM.length;
-  const completedCount = CURRICULUM.filter((s) => isComplete(s.id)).length;
+  const filteredCurriculum = useMemo(
+    () => CURRICULUM.filter((slot) => activeTrack.lessonFilter({ topic: slot.topic } as Lesson)),
+    [activeTrack],
+  );
+  const filteredTopics = useMemo(
+    () => TOPICS.filter((t) => filteredCurriculum.some((s) => s.topic === t)),
+    [filteredCurriculum],
+  );
+
+  const totalLessons = filteredCurriculum.length;
+  const completedCount = filteredCurriculum.filter((s) => isComplete(s.id)).length;
   const overallPercent = totalLessons > 0 ? Math.round((completedCount / totalLessons) * 100) : 0;
 
   function handleToggle(lessonId: string) {
@@ -78,8 +88,8 @@ export default function Plan() {
       </Box>
 
       {/* ── Topic sections ── */}
-      {TOPICS.map((topic) => {
-        const slots = CURRICULUM.filter((s) => s.topic === topic);
+      {filteredTopics.map((topic) => {
+        const slots = filteredCurriculum.filter((s) => s.topic === topic);
         const topicDone = slots.filter((s) => isComplete(s.id)).length;
 
         return (


### PR DESCRIPTION
Closes #416

## Changes

- `web-app/src/pages/Plan.tsx`: Added `activeTrack` to the `useExamTrack()` destructure
- Derived `filteredCurriculum` via `useMemo` using `activeTrack.lessonFilter` — same cast pattern (`{ topic: slot.topic } as Lesson`) described in the issue
- Derived `filteredTopics` from `filteredCurriculum` so only topics with at least one slot in the active track are rendered
- Replaced bare `CURRICULUM`/`TOPICS` references in the stats and render section with `filteredCurriculum`/`filteredTopics`
- Imported `Lesson` type from `'../lib/types'` to satisfy the cast

The completion counter (`X / Y lessons complete`) and overall progress bar now reflect only the active track's lessons.

## Test Plan

- Switch to **PSTAR**: Study Plan should show only Air Law section (~18 slots); completion counter denominator should be 18
- Switch to **RROE**: Study Plan should show only Radio section (~9 slots); completion counter denominator should be 9
- Switch to **PPL-A**: Study Plan should show all 5 topic sections (69 total slots)
- Toggle back and forth: per-track progress must be preserved (marking a PSTAR lesson complete must not affect PPL-A progress)