### PR TITLE
Draft: [PPL-422] CPL-A lesson taxonomy: curriculum doc and 18 lesson files

### DIFF
--- a/docs/curriculum-cpl-a.md
+++ b/docs/curriculum-cpl-a.md
@@ -1,0 +1,115 @@
+# CPL-A Curriculum — Subject Areas and Lesson Titles
+
+**Exam:** Transport Canada Commercial Pilot Licence — Aeroplane (CPL-A) Written Exam  
+**Prerequisite:** PPL-A (or equivalent flight hours and qualifications)  
+**Passing grade:** 60% minimum; recommend targeting 80%+  
+**Format:** Multiple choice, ~100 questions  
+**Last updated:** 2026-04-28
+
+---
+
+## Authoritative Sources
+
+| Source | Description |
+|--------|-------------|
+| CARs Part IV | Personnel Licensing and Training — pilot licence requirements |
+| CARs Part VI | General Operating and Flight Rules |
+| CARs Part VII | Commercial Air Services — AOC, duty times, operations |
+| CARs Part VIII | Aerial Work — specialty commercial operations |
+| TP 12880E | Aeroplane Flight Training Manual |
+| TP 1102 Vol. 5 | Air Pilot's Manual — Advanced Meteorology |
+| TC CPL-A PTS | Transport Canada CPL-A Pilot Training Standards |
+
+---
+
+## CPL-A vs PPL-A: Scope
+
+CPL-A builds on PPL-A foundations. Topics that map directly to existing PPL-A lessons are **not duplicated** — the skeleton file references the foundation lesson instead. New CPL-A content covers commercial operations law, advanced meteorology for commercial IFR-adjacent operations, and higher-stakes performance calculations.
+
+---
+
+## Subject 1: Commercial Air Law
+
+**Exam weight:** Highest (~35–40% of CPL-A written exam)  
+**Lesson ID prefix:** CAL  
+**Status:** 5 lessons authored; 2 skeletons pending
+
+| File | ID | Title | Status | PPL-A Foundation |
+|------|----|-------|--------|-----------------|
+| `001-cpl-licence-requirements.md` | CAL-001 | CPL-A Licence Requirements and Privileges | complete | — |
+| `002-commercial-air-services.md` | CAL-002 | Commercial Air Services and Air Operator Certificates | complete | — |
+| `003-duty-times-rest.md` | CAL-003 | Flight Crew Duty Times and Rest Requirements | complete | — |
+| `004-pic-authority-responsibilities.md` | CAL-004 | Pilot-in-Command Authority and Responsibilities | complete | — |
+| `005-commercial-vfr-operations.md` | CAL-005 | Commercial VFR and Special Operations | complete | — |
+| `006-dangerous-goods.md` | CAL-006 | Dangerous Goods in Air Transport | draft | — |
+| `007-passenger-safety.md` | CAL-007 | Passenger Safety Briefings and Emergency Equipment | draft | — |
+
+---
+
+## Subject 2: Advanced Meteorology
+
+**Exam weight:** ~20–25%  
+**Lesson ID prefix:** CAM  
+**Status:** Skeletons only — content pending
+
+Where marked, the PPL-A lesson provides the foundation; the CPL-A lesson extends to commercial decision-making and higher-altitude weather considerations.
+
+| File | ID | Title | Status | PPL-A Foundation |
+|------|----|-------|--------|-----------------|
+| `008-adverse-wx-commercial.md` | CAM-001 | Adverse Weather Decision-Making for Commercial Operations | draft | MET-014 (wx-decision-making) |
+| `009-high-altitude-wx.md` | CAM-002 | High-Altitude Weather and Jet Stream Effects | draft | — |
+| `010-icing-advanced.md` | CAM-003 | Structural Icing — Advanced Recognition and Avoidance | draft | MET-010 (icing) |
+| `011-sigmets-airmets.md` | CAM-004 | SIGMETs, AIRMETs, and Volcanic Ash Advisories | draft | — |
+
+---
+
+## Subject 3: Advanced Navigation
+
+**Exam weight:** ~20–25%  
+**Lesson ID prefix:** CAN  
+**Status:** Skeletons only — content pending
+
+| File | ID | Title | Status | PPL-A Foundation |
+|------|----|-------|--------|-----------------|
+| `012-advanced-nav-planning.md` | CAN-001 | Advanced Cross-Country Planning for Commercial Ops | draft | NAV-008 (cross-country-planning) |
+| `013-navigation-systems.md` | CAN-002 | Navigation Systems — VOR, NDB, GPS, and RNAV | draft | NAV-010 (vor-navigation), NAV-011 (gps-basics) |
+| `014-airways-ifr-procedures.md` | CAN-003 | Airways and IFR Procedures Overview | draft | — |
+
+---
+
+## Subject 4: Aerodynamics and Engines
+
+**Exam weight:** ~10–15%  
+**Lesson ID prefix:** CAE  
+**Status:** Skeletons only — content pending
+
+| File | ID | Title | Status | PPL-A Foundation |
+|------|----|-------|--------|-----------------|
+| `015-advanced-aerodynamics.md` | CAE-001 | Advanced Aerodynamics — Stability, Mach Effects, V-speeds | draft | GK-002 (four-forces), GK-012 (stalls-spins) |
+| `016-advanced-engines.md` | CAE-002 | Advanced Engine Systems — Fuel-Injected, Turbo, and Complex | draft | GK-003 (piston-engines) |
+
+---
+
+## Subject 5: Performance and Limitations
+
+**Exam weight:** ~10–15%  
+**Lesson ID prefix:** CAP  
+**Status:** Skeletons only — content pending
+
+| File | ID | Title | Status | PPL-A Foundation |
+|------|----|-------|--------|-----------------|
+| `017-performance-commercial.md` | CAP-001 | Performance Calculations for Commercial Operations | draft | GK-010 (performance-charts), GK-011 (takeoff-landing-perf) |
+| `018-weight-balance-commercial.md` | CAP-002 | Weight and Balance — Multi-Seat and Multi-Leg Operations | draft | GK-009 (weight-and-balance) |
+
+---
+
+## Lesson Counts
+
+| Subject | Authored | Skeletons | Total |
+|---------|---------|-----------|-------|
+| Commercial Air Law | 5 | 2 | 7 |
+| Advanced Meteorology | 0 | 4 | 4 |
+| Advanced Navigation | 0 | 3 | 3 |
+| Aerodynamics & Engines | 0 | 2 | 2 |
+| Performance & Limitations | 0 | 2 | 2 |
+| **Total** | **5** | **13** | **18** |

--- a/lessons/cpl-a/001-cpl-licence-requirements.md
+++ b/lessons/cpl-a/001-cpl-licence-requirements.md
@@ -1,0 +1,170 @@
+---
+id: CAL-001
+topic: cpl-a
+order: 1
+slug: cpl-licence-requirements
+title: "CPL-A Licence Requirements and Privileges"
+duration_min: 20
+status: complete
+audio: null
+visual: null
+sources:
+  - CARs Part IV
+  - CARs 401.17
+  - TP 12880E
+  - TC CPL-A PTS
+questions:
+  - id: q1
+    prompt: "Under CARs 401.17, what is the minimum total flight time required to qualify for a Commercial Pilot Licence — Aeroplane?"
+    choices:
+      A: "150 hours"
+      B: "200 hours"
+      C: "250 hours"
+      D: "300 hours"
+    answer: B
+    explanation: "CARs 401.17 requires a minimum of 200 hours total flight time for the CPL-A. This is in addition to specific requirements for PIC time, cross-country PIC, night, and instrument hours. Source: CARs 401.17."
+  - id: q2
+    prompt: "A CPL-A applicant must hold a minimum of which Transport Canada medical category?"
+    choices:
+      A: "Category 3 (Third-Class equivalent)"
+      B: "Category 2"
+      C: "Category 1"
+      D: "Aviation Medical Certificate, any class"
+    answer: C
+    explanation: "A Commercial Pilot Licence requires a Category 1 Medical Certificate issued by a Transport Canada Civil Aviation Medical Examiner (CAME). Category 3 is the minimum for PPL; the higher standard of Category 1 applies to commercial operations. Source: CARs 404.04, CARs 401.17."
+  - id: q3
+    prompt: "What is the minimum age to be issued a Commercial Pilot Licence — Aeroplane in Canada?"
+    choices:
+      A: "17 years"
+      B: "18 years"
+      C: "19 years"
+      D: "21 years"
+    answer: B
+    explanation: "CARs 401.17 sets the minimum age for a CPL-A at 18 years. This differs from the PPL, which may be issued at 17. Source: CARs 401.17."
+  - id: q4
+    prompt: "Which of the following privileges does a CPL-A add that a PPL does NOT grant?"
+    choices:
+      A: "Act as PIC of an aircraft in VFR flight"
+      B: "Carry passengers for hire or reward"
+      C: "Fly at night with a night rating"
+      D: "Conduct cross-country flights"
+    answer: B
+    explanation: "A PPL authorizes acting as PIC for personal, non-remunerated VFR flight. The CPL-A adds the privilege of carrying passengers or cargo for hire or reward — which is the defining commercial privilege. Source: CARs 401.17, CARs 401.05."
+  - id: q5
+    prompt: "Under CARs 401.17, what minimum PIC cross-country flight time is required for a CPL-A?"
+    choices:
+      A: "10 hours"
+      B: "15 hours"
+      C: "20 hours"
+      D: "25 hours"
+    answer: C
+    explanation: "CARs 401.17 requires at least 20 hours of PIC cross-country flight time. Cross-country flight for this purpose means a flight that includes a landing at a point more than 25 nautical miles from the departure aerodrome. Source: CARs 401.17."
+---
+
+# Lesson CAL-001: CPL-A Licence Requirements and Privileges
+
+**Subject:** Commercial Air Law  
+**Lesson number:** 001  
+**Estimated time:** 20 minutes  
+**Sources:** CARs Part IV, CARs 401.17, TP 12880E, TC CPL-A PTS
+
+---
+
+## Narration Script
+
+Welcome to the first lesson of the CPL-A Commercial Air Law series. This lesson covers the regulatory foundation for the Commercial Pilot Licence — Aeroplane in Canada. Every CPL-A candidate should know these requirements cold before sitting the written exam.
+
+---
+
+### What the CPL-A Is
+
+The Commercial Pilot Licence — Aeroplane (CPL-A) is a Transport Canada licence that authorizes a pilot to act as PIC of an aeroplane in commercial air service operations. The defining privilege it adds — over and above the PPL — is the right to carry passengers or cargo **for hire or reward**. Without a CPL-A, accepting payment for flight services is not permitted under Canadian law.
+
+The regulatory foundation is **CARs Part IV — Personnel Licensing and Training**, specifically **CARs 401.17**, which sets out all requirements for initial issue of the CPL-A.
+
+---
+
+### Age and Medical Requirements
+
+You must meet two administrative thresholds before any flight time requirements apply:
+
+**Minimum age:** 18 years. You cannot be issued a CPL-A if you are under 18, regardless of flight experience.
+
+**Medical certificate:** Category 1. The PPL requires a Category 3 medical. The CPL-A steps up to a Category 1 Medical Certificate, issued by a Transport Canada Civil Aviation Medical Examiner (CAME). Category 1 standards are stricter — particularly for vision, cardiovascular health, and certain neurological conditions. If you currently hold a PPL with a Category 3 medical, you must upgrade to Category 1 before the CPL-A can be issued. Source: CARs 404.04 read in conjunction with CARs 401.17.
+
+---
+
+### Flight Time Requirements
+
+CARs 401.17 specifies minimum hours. These are floors, not targets — most candidates need more time to reach the required proficiency.
+
+| Requirement | Minimum Hours |
+|-------------|---------------|
+| Total flight time | 200 hours |
+| PIC time | 100 hours |
+| PIC cross-country | 20 hours |
+| Night flight (PIC, with night rating) | 5 hours |
+| Instrument flight time (actual or simulated) | 5 hours |
+| Instrument ground time | 10 hours |
+
+**Total time (200 hours):** This is time logged as pilot-in-command or as dual instruction. Hours under Part IV training count fully. Military equivalencies may apply under certain conditions — but for the civilian path, 200 total is the number.
+
+**PIC time (100 hours):** At least half your total time must be as pilot-in-command. This incentivizes building PIC time early in training rather than accumulating dual instruction hours right to the limit.
+
+**PIC cross-country (20 hours):** Cross-country for this purpose means a flight including a landing at a point more than 25 nautical miles from the departure aerodrome. This must be PIC time — dual instruction cross-country does not count toward this 20-hour sub-requirement.
+
+**Night and instrument:** You must already hold, or complete the requirements for, a night rating. The 5 hours instrument and 10 hours instrument ground time ensure you have basic exposure to IFR technique — even though a CPL-A alone does not authorize instrument flight.
+
+---
+
+### Knowledge and Skill Requirements
+
+**Written exam:** You must pass the Transport Canada CPL-A written exam. The exam tests all commercial air law topics, advanced meteorology, advanced navigation, aerodynamics, and aircraft performance. Passing grade is 60%. You must book and pass this exam before the flight test.
+
+**Flight test:** You must demonstrate the competencies in the **TC CPL-A Pilot Training Standards (PTS)**. The flight test is conducted by a Transport Canada-authorized pilot examiner. The PTS document lists required exercises, performance criteria, and common failure points.
+
+**Language:** You must demonstrate adequate English or French proficiency for aviation communication. This is assessed during training and affirmed by the endorsement of your instructor.
+
+---
+
+### CPL-A Privileges
+
+Once issued, a CPL-A allows you to:
+
+- Act as PIC of an aeroplane in any operation for which an Airline Transport Pilot Licence (ATPL) is not specifically required
+- Carry passengers and cargo **for hire or reward**
+- Act as a flight crew member in commercial air services (e.g., charter, air taxi)
+- Provide flight instruction only if you additionally hold a Flight Instructor Rating
+
+**What the CPL-A does NOT authorize without additional ratings:**
+- Instrument flight (requires an Instrument Rating)
+- Multi-engine operations (requires a Multi-Engine Class Rating)
+- Airline transport operations as PIC (requires an ATPL)
+
+---
+
+### Key Distinctions from PPL
+
+| Requirement | PPL-A | CPL-A |
+|-------------|-------|-------|
+| Minimum age | 17 | 18 |
+| Medical | Category 3 | Category 1 |
+| Total flight time | 45 hours | 200 hours |
+| Commercial hire privilege | No | Yes |
+| Instrument hours required | No | Yes (5 + 10 ground) |
+
+The medical upgrade is the most common overlooked requirement. Start your Category 1 medical exam early — if a condition is borderline, the assessment process can take weeks.
+
+---
+
+## Key Points
+
+1. **CARs 401.17** is the governing section — know it by reference
+2. Minimum age: **18**, minimum medical: **Category 1**
+3. 200 total hours, 100 PIC, 20 PIC cross-country, 5 night, 5 instrument, 10 instrument ground
+4. Written exam first, then flight test
+5. The core new privilege: carrying passengers/cargo **for hire or reward**
+
+---
+
+*End of Lesson CAL-001.*

--- a/lessons/cpl-a/002-commercial-air-services.md
+++ b/lessons/cpl-a/002-commercial-air-services.md
@@ -1,0 +1,174 @@
+---
+id: CAL-002
+topic: cpl-a
+order: 2
+slug: commercial-air-services
+title: "Commercial Air Services and Air Operator Certificates"
+duration_min: 20
+status: complete
+audio: null
+visual: null
+sources:
+  - CARs Part VII
+  - CARs 700.02
+  - CARs 703
+  - CARs 704
+  - CARs 705
+  - TP 4711
+questions:
+  - id: q1
+    prompt: "Under CARs Part VII, which document authorizes a company to operate a commercial air service in Canada?"
+    choices:
+      A: "Certificate of Airworthiness"
+      B: "Air Operator Certificate (AOC)"
+      C: "Operating Permit issued by Transport Canada"
+      D: "Certificate of Registration"
+    answer: B
+    explanation: "An Air Operator Certificate (AOC) is the document issued by Transport Canada under CARs Part VII that authorizes a company to conduct commercial air services. Without an AOC, operating a commercial air service is prohibited. Source: CARs 700.02, CARs 703.07."
+  - id: q2
+    prompt: "CARs Subpart 3 (703) applies to which category of commercial operation?"
+    choices:
+      A: "Airline operations using aircraft with more than 19 passenger seats"
+      B: "Air taxi operations using aircraft with a MCTOW of 25,000 kg or less"
+      C: "Aerial work operations including crop-dusting and pipeline patrol"
+      D: "Commuter operations using aircraft certificated for 10–19 passenger seats"
+    answer: B
+    explanation: "CARs Subpart 703 (Air Taxi) covers commercial operations with aeroplanes having a MCTOW of 25,000 kg or less. This is the most common CPL-A operational environment — charter flights, air taxi, and similar on-demand commercial work. Source: CARs 703.01."
+  - id: q3
+    prompt: "A pilot acting as PIC on a CARs 703 (Air Taxi) operation must hold, at minimum:"
+    choices:
+      A: "A Private Pilot Licence with 500 hours total time"
+      B: "A Commercial Pilot Licence — Aeroplane (CPL-A)"
+      C: "An Airline Transport Pilot Licence (ATPL)"
+      D: "A CPL-A and an Instrument Rating, regardless of conditions"
+    answer: B
+    explanation: "CARs 703 requires the PIC to hold a CPL-A. An ATPL is not required for 703 operations. An Instrument Rating is required only when flying IFR; VFR air taxi operations with a CPL-A are permitted. Source: CARs 703.88."
+  - id: q4
+    prompt: "An air operator must have an Operations Manual that is approved by Transport Canada. Under CARs, the Operations Manual must be:"
+    choices:
+      A: "Carried on board every flight"
+      B: "Available to all flight crew at their base of operations"
+      C: "Memorized by every pilot — no physical copy is required"
+      D: "Filed with Transport Canada annually and not required on the aircraft"
+    answer: A
+    explanation: "CARs Part VII requires that the Operations Manual (or relevant portions of it) be carried on board every flight. Flight crew must be familiar with its contents. It is a controlled document — changes require TC acceptance. Source: CARs 703.108."
+  - id: q5
+    prompt: "Which of the following best describes a 'commercial air service' as defined in CARs 700.02?"
+    choices:
+      A: "Any flight where the aircraft is rented from a flying school"
+      B: "Any use of an aircraft for hire or reward"
+      C: "Any flight that crosses an international boundary"
+      D: "Any flight conducted by a company that owns more than 5 aircraft"
+    answer: B
+    explanation: "CARs 700.02 defines a commercial air service as any use of an aircraft for hire or reward. The key element is remuneration — if money (or any consideration of value) is exchanged for the flight, it is a commercial operation and requires an AOC. Source: CARs 700.02."
+---
+
+# Lesson CAL-002: Commercial Air Services and Air Operator Certificates
+
+**Subject:** Commercial Air Law  
+**Lesson number:** 002  
+**Estimated time:** 20 minutes  
+**Sources:** CARs Part VII, CARs 700.02, CARs 703, CARs 704, CARs 705, TP 4711
+
+---
+
+## Narration Script
+
+Lesson CAL-002 covers the commercial operations regulatory framework — specifically what makes a flight "commercial," who needs an Air Operator Certificate, and how CARs Part VII divides commercial operations into categories. This material appears heavily on the CPL-A written exam.
+
+---
+
+### What Makes a Flight "Commercial"?
+
+The definition is simple and broad. Under **CARs 700.02**, a **commercial air service** is *any use of an aircraft for hire or reward*. "Hire or reward" means any payment of money or transfer of anything of value in exchange for carrying passengers, cargo, or performing aerial work.
+
+Examples that are commercial:
+- Flying a paying passenger from point A to point B (air taxi)
+- Carrying freight for a shipping company
+- Aerial photography for a client
+- Pipeline patrol under contract
+
+Examples that are NOT commercial:
+- Flying friends for pleasure, splitting fuel costs equally
+- A pilot flying their own aircraft for personal transportation
+- Flying a club aircraft with no compensation involved
+
+The bright line is remuneration. If someone pays you — or your employer — for the flight, it is a commercial air service.
+
+---
+
+### The Air Operator Certificate (AOC)
+
+No company may operate a commercial air service in Canada without an **Air Operator Certificate (AOC)** issued by Transport Canada under **CARs Part VII**. The AOC specifies:
+
+- The operations the holder is authorized to conduct
+- The aircraft types authorized
+- The areas of operation (domestic, international)
+- Special authorizations or limitations
+
+An individual pilot does not hold an AOC — the **operator** (company) does. As a CPL-A holder, you may fly for an AOC holder, but you cannot personally operate a commercial air service without either being the operator or working for one.
+
+---
+
+### CARs Part VII — Four Commercial Subparts
+
+Transport Canada divides commercial operations into four subparts based on operation type and aircraft size:
+
+**CARs Subpart 702 — Aerial Work**  
+Covers specialty operations: aerial photography, pipeline patrol, crop-dusting, fire-fighting, survey. These operations do not carry passengers for hire in the conventional sense — they carry equipment or perform a task. A separate subpart (CARs Part VIII) also addresses aerial work, with Part VII focusing on the operational certification requirements.
+
+**CARs Subpart 703 — Air Taxi**  
+The most common CPL-A environment. Air taxi covers on-demand charter operations using aeroplanes with a **Maximum Certified Take-Off Weight (MCTOW) of 25,000 kg or less**. Single-engine and light twin aircraft used for charter flights fall under 703. The PIC must hold a CPL-A; an ATPL is not required.
+
+**CARs Subpart 704 — Commuter Operations**  
+Commuter covers scheduled or non-scheduled operations using multi-engine turbine-powered aircraft *certificated for 10 to 19 passenger seats*, or operations with 10–19 passenger seats using piston aircraft. This is the stepping stone between air taxi and airline operations.
+
+**CARs Subpart 705 — Airline Operations**  
+Airline operations use aircraft certificated for 20 or more passenger seats. CARs 705 applies to major carriers and requires PICs to hold an ATPL. These are the most heavily regulated operations.
+
+| Subpart | Type | Aircraft/Seats | PIC Licence |
+|---------|------|----------------|-------------|
+| 702 | Aerial work | Varies | CPL-A |
+| 703 | Air taxi | MCTOW ≤ 25,000 kg | CPL-A |
+| 704 | Commuter | 10–19 seats (turbine) | CPL-A or ATPL |
+| 705 | Airline | 20+ seats | ATPL |
+
+---
+
+### The Operations Manual
+
+Every AOC holder must maintain an **Operations Manual** — a controlled document that describes how the operator conducts all aspects of flight operations. Key points:
+
+- The Operations Manual requires Transport Canada acceptance
+- It must be carried on board every flight (or the relevant portions)
+- Flight crew must be familiar with all applicable sections
+- Changes to the manual must be submitted to and accepted by TC before implementation
+
+As a line pilot on a 703 charter, you are responsible for knowing the sections of the Operations Manual that apply to your role — not just the aircraft manual (POH/AFM), but also the operator's procedures for dispatch, weather minimums, fuelling, and emergency response.
+
+---
+
+### Practical Significance for CPL-A Candidates
+
+The written exam tests whether you understand:
+
+1. The legal definition of a commercial air service
+2. Which subpart governs a described operation
+3. What certificate the operator (not the pilot) must hold
+4. Minimum pilot qualifications for each subpart
+
+Know that **703 (Air Taxi)** is where most new commercial pilots work. Know the **MCTOW 25,000 kg** threshold that separates 703 from 704. Know that an AOC is an operator document, not a personal licence.
+
+---
+
+## Key Points
+
+1. **Commercial air service:** any use of an aircraft for hire or reward — CARs 700.02
+2. The operator needs an **AOC**; the pilot needs a **CPL-A** (or ATPL for 705 PIC)
+3. CARs 703 (Air Taxi): MCTOW ≤ 25,000 kg, CPL-A PIC — the most common new-commercial environment
+4. CARs 705 (Airline): 20+ seats, ATPL required as PIC
+5. Operations Manual must be on board every flight
+
+---
+
+*End of Lesson CAL-002.*

--- a/lessons/cpl-a/003-duty-times-rest.md
+++ b/lessons/cpl-a/003-duty-times-rest.md
@@ -1,0 +1,169 @@
+---
+id: CAL-003
+topic: cpl-a
+order: 3
+slug: duty-times-rest
+title: "Flight Crew Duty Times and Rest Requirements"
+duration_min: 20
+status: complete
+audio: null
+visual: null
+sources:
+  - CARs Part VII
+  - CARs 700.14
+  - CARs 700.15
+  - CARs 700.16
+  - CARs 700.17
+  - TP 14371
+questions:
+  - id: q1
+    prompt: "Under CARs Part VII, what is the maximum flight time a commercial pilot may log in a single calendar year?"
+    choices:
+      A: "900 hours"
+      B: "1,000 hours"
+      C: "1,200 hours"
+      D: "1,400 hours"
+    answer: C
+    explanation: "CARs 700.15 limits a flight crew member to a maximum of 1,200 hours of flight time in any consecutive 12-month period. This is an absolute ceiling regardless of operator or accumulated rest. Source: CARs 700.15."
+  - id: q2
+    prompt: "Under CARs 700.15, the maximum flight time in any 90 consecutive days is:"
+    choices:
+      A: "200 hours"
+      B: "300 hours"
+      C: "400 hours"
+      D: "450 hours"
+    answer: B
+    explanation: "In addition to the annual limit, CARs 700.15 sets a rolling 300-hour limit in any 90 consecutive days. This prevents pilots from front-loading all annual hours into a short burst. Source: CARs 700.15."
+  - id: q3
+    prompt: "A commercial pilot finishes a flight duty period at 2300. Under CARs Part VII, the minimum rest period before the next flight duty period begins is:"
+    choices:
+      A: "8 hours free from duty"
+      B: "8 continuous hours of sleep opportunity"
+      C: "The equivalent of the flight duty period just completed"
+      D: "The time needed to provide 8 hours of rest at the next base"
+    answer: B
+    explanation: "CARs 700.16 requires a minimum rest period that provides at least 8 continuous hours of sleep opportunity. The rest period must be long enough that, accounting for personal hygiene, meals, and transport to accommodation, the pilot can get 8 hours of sleep. Source: CARs 700.16."
+  - id: q4
+    prompt: "Who is responsible for determining whether a flight crew member is fit for duty before a flight?"
+    choices:
+      A: "The air operator's dispatch department"
+      B: "Transport Canada's duty-time monitoring system"
+      C: "The flight crew member themselves"
+      D: "The chief pilot only"
+    answer: C
+    explanation: "Under CARs 700.14, the flight crew member is personally responsible for presenting themselves for duty only when fit. Even if the duty-time limits have not been exceeded, a pilot must not commence a flight if they are impaired by fatigue, illness, or any other factor. Source: CARs 700.14."
+  - id: q5
+    prompt: "Which of the following correctly describes 'flight time' as it applies to CARs Part VII duty-time limits?"
+    choices:
+      A: "Time from engine start to engine shutdown"
+      B: "Time from when the aircraft moves under its own power until it comes to rest at the end of a flight"
+      C: "Time from the pilot's report for duty to completion of post-flight duties"
+      D: "Block time as entered in the journey log, including taxi"
+    answer: B
+    explanation: "For duty-time purposes, 'flight time' means the time from when the aircraft first moves under its own power for the purpose of taking off until it comes to rest at the end of that flight. This is consistent with the definition used throughout CARs and the journey log requirements. Source: CARs 101.01 definition of 'flight time', applied through CARs 700.15."
+---
+
+# Lesson CAL-003: Flight Crew Duty Times and Rest Requirements
+
+**Subject:** Commercial Air Law  
+**Lesson number:** 003  
+**Estimated time:** 20 minutes  
+**Sources:** CARs Part VII, CARs 700.14–700.17, TP 14371
+
+---
+
+## Narration Script
+
+Duty times and rest requirements are a recurring topic on the CPL-A written exam — and even more important in real-world commercial operations. Fatigue is a documented cause of aviation accidents. Transport Canada's rules in CARs Part VII set hard limits that cannot be waived by the operator or the pilot.
+
+---
+
+### Why Duty-Time Rules Exist
+
+Pilot fatigue degrades decision-making, reaction time, and situational awareness in ways that parallel alcohol impairment — but are often less obvious to the impaired person. CARs Part VII addresses fatigue through three mechanisms:
+
+1. **Absolute flight-time ceilings** — hard limits on hours flown
+2. **Rest requirements** — mandatory rest before new duty periods
+3. **Personal fitness responsibility** — the pilot's own duty to refuse duty when unfit
+
+---
+
+### Maximum Flight Time Limits (CARs 700.15)
+
+These are the cumulative ceilings — rolling totals, not reset on January 1:
+
+| Period | Maximum Flight Time |
+|--------|---------------------|
+| 24 consecutive hours | Operator determined (within flight duty period limits) |
+| 7 consecutive days | Operator determined |
+| 90 consecutive days | 300 hours |
+| 12 consecutive months | 1,200 hours |
+
+The **300 hours / 90 days** limit prevents pilots from clustering hours into bursts. The **1,200 hours / 12-month** ceiling is absolute — exceeding it requires Transport Canada authorization, which is essentially never granted.
+
+These limits apply regardless of how many operators you fly for. If you fly for two different air taxi companies simultaneously, your combined hours count toward the limits.
+
+---
+
+### Rest Requirements (CARs 700.16)
+
+Before commencing a flight duty period, a flight crew member must have had a rest period that provides at least **8 continuous hours of sleep opportunity**. The rest period must be long enough that — after accounting for personal hygiene, meals, and transport to accommodation — the pilot can realistically get 8 hours of sleep.
+
+This is different from simply "8 hours off duty." An operator cannot schedule a pilot with a 9-hour rest that includes 90 minutes of transport each way, leaving only 6 hours of actual sleep opportunity.
+
+Extended rest may be required when:
+- The preceding flight duty period was unusually long
+- The pilot will be crossing multiple time zones
+- The operator's Operations Manual specifies greater rest for certain routes
+
+---
+
+### Personal Fitness Responsibility (CARs 700.14)
+
+This section is one of the most important — and most commonly tested. CARs 700.14 imposes a **personal duty** on each flight crew member to:
+
+- Not commence a flight if their ability is impaired by fatigue, illness, injury, medication, or any other cause
+- Report for duty only when fit to perform their assigned functions
+- Declare themselves unfit if circumstances change between reporting and departure
+
+The key point: **compliance with the duty-time numbers does not automatically make you fit to fly.** A pilot who has been legally on rest but spent that time moving house and sleeping only 3 hours is not fit to fly — even if the hours-of-rest box is technically checked. The pilot bears personal responsibility for this judgment.
+
+Operators cannot pressure a pilot to fly when the pilot has declared themselves unfit. CARs protects a pilot's right to make this call without adverse employment consequences — though the practical dynamics of commercial operations mean this requires professional backbone.
+
+---
+
+### Operator Obligations
+
+The air operator also has duties under CARs Part VII:
+
+- Must not schedule a crew member beyond the flight-time limits
+- Must provide adequate rest facilities at bases where overnight stays are required
+- Must maintain records of flight crew duty times
+- Must have a fatigue management program described in their Operations Manual
+
+Under a **Fatigue Risk Management System (FRMS)**, operators may apply for alternative duty-time schemes if they can demonstrate equivalent safety through data. FRMS is an advanced topic beyond the CPL-A written exam scope.
+
+---
+
+### Key Numbers to Remember
+
+| Limit | Value |
+|-------|-------|
+| Maximum flight time — 90 days | 300 hours |
+| Maximum flight time — 12 months | 1,200 hours |
+| Minimum rest before duty | 8 hours sleep opportunity |
+| Personal responsibility section | CARs 700.14 |
+
+---
+
+## Key Points
+
+1. **1,200 hours** maximum in any 12 consecutive months — CARs 700.15
+2. **300 hours** maximum in any 90 consecutive days — CARs 700.15
+3. Rest must provide **8 continuous hours of sleep opportunity** — not just 8 hours off — CARs 700.16
+4. **The pilot bears personal responsibility** for fitness for duty under CARs 700.14
+5. Complying with the numbers does not override a pilot's personal fitness obligation
+
+---
+
+*End of Lesson CAL-003.*

--- a/lessons/cpl-a/004-pic-authority-responsibilities.md
+++ b/lessons/cpl-a/004-pic-authority-responsibilities.md
@@ -1,0 +1,178 @@
+---
+id: CAL-004
+topic: cpl-a
+order: 4
+slug: pic-authority-responsibilities
+title: "Pilot-in-Command Authority and Responsibilities"
+duration_min: 20
+status: complete
+audio: null
+visual: null
+sources:
+  - CARs Part I
+  - CARs 101.01
+  - CARs Part VI
+  - CARs 602.01
+  - CARs 700.14
+  - TP 12880E
+questions:
+  - id: q1
+    prompt: "Under CARs 602.01, the pilot-in-command is responsible for:"
+    choices:
+      A: "The safety of the aircraft only — passengers are the operator's responsibility"
+      B: "The safe conduct of the flight and the safety of all persons and property on board"
+      C: "Following ATC instructions at all times, with no authority to deviate"
+      D: "Completing post-flight paperwork and reporting to the operator within 24 hours"
+    answer: B
+    explanation: "CARs 602.01 establishes that the pilot-in-command is responsible for the safe conduct of the flight and the safety of all persons and property on board the aircraft. This is an overriding authority that supersedes other considerations in an emergency. Source: CARs 602.01."
+  - id: q2
+    prompt: "A PIC declares an emergency and deviates from an ATC clearance to avoid a collision. After the flight, the PIC:"
+    choices:
+      A: "Must file a Criminal Code report with Transport Canada within 24 hours"
+      B: "Must submit a written report to Transport Canada if requested"
+      C: "Faces automatic suspension pending investigation"
+      D: "Is exempt from all reporting requirements for emergency deviations"
+    answer: B
+    explanation: "CARs 602.01 allows the PIC to deviate from any rule or clearance to the extent necessary in an emergency. If a deviation occurs, the PIC must submit a written report to Transport Canada if TC requests one. There is no automatic suspension — the deviation authority is a recognized PIC right. Source: CARs 602.01."
+  - id: q3
+    prompt: "During boarding, a passenger refuses to fasten their seatbelt and becomes verbally abusive. The PIC may:"
+    choices:
+      A: "Do nothing — passenger management is the flight attendant's responsibility"
+      B: "Refuse to allow the passenger to continue the flight"
+      C: "Depart only after notifying ATC of an unruly passenger"
+      D: "Issue a verbal warning but cannot deny boarding once the passenger is seated"
+    answer: B
+    explanation: "The PIC has authority under CARs 602.01 and the Aeronautics Act to refuse to transport any person whose presence would be a hazard to the safety of the flight. Refusing to wear a seatbelt, or being abusive in a way that threatens flight safety, is sufficient grounds for removal. Source: CARs 602.03, Aeronautics Act s.8.7."
+  - id: q4
+    prompt: "A co-pilot believes the PIC is making an unsafe decision and expresses concern. The co-pilot's CARs obligation is:"
+    choices:
+      A: "To assume control of the aircraft immediately"
+      B: "To comply with the PIC's decision — crew resource management concerns are not a CARs matter"
+      C: "To notify ATC of the disagreement"
+      D: "To raise the concern clearly but ultimately defer to the PIC unless the PIC is incapacitated"
+    answer: D
+    explanation: "CARs establishes a clear chain of command. The PIC has final authority. A co-pilot's duty is to communicate concerns clearly (CRM), but actual authority rests with the PIC unless the PIC is unable to perform their duties (incapacitation), at which point the co-pilot assumes command. Source: CARs 602.01, TP 12880E."
+  - id: q5
+    prompt: "Under CARs, a PIC may deviate from a prescribed rule in an emergency. What must be true for this authority to apply?"
+    choices:
+      A: "The deviation must be pre-approved by the operator's chief pilot"
+      B: "The emergency must be declared on guard frequency (121.5 MHz)"
+      C: "The deviation must be necessary to meet the emergency and no greater than required"
+      D: "The PIC must have at least 1,000 hours PIC time before this authority applies"
+    answer: C
+    explanation: "PIC emergency authority under CARs 602.01 permits deviation from any rule or clearance to the extent necessary in an emergency. The key qualifier is necessity — the deviation must be required to meet the emergency and no greater than the emergency demands. No pre-approval or guard frequency call is legally required. Source: CARs 602.01."
+---
+
+# Lesson CAL-004: Pilot-in-Command Authority and Responsibilities
+
+**Subject:** Commercial Air Law  
+**Lesson number:** 004  
+**Estimated time:** 20 minutes  
+**Sources:** CARs Part I (101.01), CARs 602.01, CARs 602.03, CARs 700.14, TP 12880E
+
+---
+
+## Narration Script
+
+Lesson CAL-004 addresses one of the most fundamental legal concepts in commercial aviation: what the Pilot-in-Command actually is, what authority the role carries, and what obligations come with it. This applies whether you fly a Cessna 172 on a charter or a transport-category aircraft on an airline — the legal framework is the same.
+
+---
+
+### Defining the PIC
+
+Under **CARs 101.01**, the Pilot-in-Command (PIC) means "the pilot responsible for the operation and safety of an aircraft during flight time." Two words matter here: **responsible** and **operation**.
+
+- **Responsible** means liability, not just capability. The PIC is accountable for what happens.
+- **Operation** means more than just flying — it includes the decision to depart, the decision to divert, the management of the flight environment, and the safety of everyone on board.
+
+On a multi-crew aircraft, the PIC is designated before the flight — not determined by who happens to have their hands on the controls. The PIC may delegate tasks but cannot delegate accountability.
+
+---
+
+### PIC Authority (CARs 602.01)
+
+CARs 602.01 establishes the scope of PIC authority and responsibility:
+
+**Core responsibility:** The PIC is responsible for the safe conduct of the flight and the safety of all persons and property on board.
+
+**Emergency deviation authority:** The PIC may deviate from any rule or ATC clearance to the extent necessary in an emergency. This is broad — it covers deviating from an altitude restriction to avoid a TCAS RA, busting a TFR to avoid a thunderstorm, or landing at an unauthorized aerodrome in an engine-out situation.
+
+**Condition:** The deviation must be necessary — not more than required, and not used as a convenient excuse. After the emergency, the PIC must comply with any reporting requested by Transport Canada.
+
+**Passenger authority:** The PIC may refuse to transport any person or cargo that would pose a hazard to flight safety. This includes removing a disruptive passenger before departure.
+
+---
+
+### Specific PIC Duties
+
+CARs spreads PIC duties across multiple sections. The CPL-A exam focuses on these key obligations:
+
+**Before flight:**
+- Determine that the aircraft is airworthy (CARs 602.02)
+- Review all available weather information
+- Determine that adequate fuel is on board
+- Ensure the aircraft weight does not exceed limits and the CG is within the envelope
+
+**During flight:**
+- Maintain continuous vigilance over the flight
+- Comply with ATC instructions (unless safety requires otherwise)
+- Manage crew duties and delegate tasks appropriately
+- Declare emergencies when safety requires it
+
+**After flight:**
+- Complete the journey log and record defects
+- Report incidents and accidents as required by CARs Part V
+
+---
+
+### PIC Fitness and Authority Limits
+
+The PIC's authority is significant, but it operates within constraints:
+
+**Fitness:** Under CARs 700.14, the PIC must not commence a flight when impaired by fatigue, illness, or any other factor. The PIC's authority to fly does not exist if the PIC is unfit. No operator instruction overrides this personal responsibility.
+
+**Rules of the air:** The PIC must comply with CARs Part VI (General Operating and Flight Rules) and the applicable operating rules (Part VII Subparts 702–705). Emergency deviation authority exists but is not a license for routine rule-breaking.
+
+**ATC:** ATC clearances are binding unless safety requires deviation. Deviating from an ATC clearance for non-emergency convenience (e.g., wanting a more scenic route) is not permitted under PIC emergency authority.
+
+---
+
+### Multi-Crew Operations: PIC vs. SIC
+
+When two pilots are on the flight deck:
+
+- The **PIC** (Captain) is designated before departure — it is a specific assigned role
+- The **Second-in-Command (SIC)** (First Officer) assists and monitors
+- If the PIC becomes incapacitated, the SIC assumes PIC responsibility immediately
+- The SIC's duty is to communicate concerns clearly; the PIC has final authority unless incapacitated
+
+In CRM (Crew Resource Management) terms, a co-pilot who identifies a safety issue has a **duty to communicate it firmly** — but CARs does not authorize the co-pilot to override a competent, fit PIC. The SIC's tool is assertive communication, not unilateral control.
+
+---
+
+### The Journey Log
+
+One practical PIC duty worth noting: the journey log. CARs 605.97 requires the PIC to ensure the journey log is completed for every flight, including:
+
+- Aircraft registration and type
+- Date of flight
+- Name of PIC
+- Departure and arrival aerodrome
+- Total flight time
+- Defects noted
+
+Entries are made immediately after each flight. Defects noted in the journey log must be assessed by an AME before the aircraft is declared airworthy for the next flight.
+
+---
+
+## Key Points
+
+1. **PIC = responsible for safe conduct of the flight and all persons/property on board** — CARs 602.01
+2. Emergency deviation authority: may deviate from any rule to the extent necessary — TC may request a report
+3. PIC may refuse to transport passengers or cargo that pose a safety hazard
+4. Personal fitness responsibility applies — CARs 700.14 — operators cannot override this
+5. In multi-crew: SIC communicates concerns, but PIC has final authority unless incapacitated
+
+---
+
+*End of Lesson CAL-004.*

--- a/lessons/cpl-a/005-commercial-vfr-operations.md
+++ b/lessons/cpl-a/005-commercial-vfr-operations.md
@@ -1,0 +1,181 @@
+---
+id: CAL-005
+topic: cpl-a
+order: 5
+slug: commercial-vfr-operations
+title: "Commercial VFR and Special Operations"
+duration_min: 20
+status: complete
+audio: null
+visual: null
+sources:
+  - CARs Part VI
+  - CARs 602.115
+  - CARs 602.117
+  - CARs 602.120
+  - CARs Part VII
+  - CARs 703.29
+  - TP 12880E
+questions:
+  - id: q1
+    prompt: "VFR OTT (Over The Top) flight is defined as VFR flight above a cloud layer. Under CARs 602.117, what is required before conducting VFR OTT?"
+    choices:
+      A: "An Instrument Rating — VFR OTT requires IFR currency"
+      B: "A VFR OTT authorization in the aircraft's Certificate of Airworthiness"
+      C: "The pilot must hold a VFR OTT rating endorsement"
+      D: "The pilot must have weather information ensuring VMC exists at the destination and alternates"
+    answer: D
+    explanation: "VFR OTT is conducted under VFR — no instrument rating or special endorsement is required on the pilot's licence. However, CARs 602.117 requires the pilot to have current weather information indicating that VMC (Visual Meteorological Conditions) will exist at the destination and alternates throughout the planned route. Source: CARs 602.117."
+  - id: q2
+    prompt: "Under CARs 703.29, a commercial pilot conducting a VFR flight for hire at night must meet which minimum weather requirement?"
+    choices:
+      A: "3 statute miles visibility and 1,000 feet ceiling"
+      B: "5 statute miles visibility and 1,000 feet ceiling"
+      C: "3 statute miles visibility and clear of cloud"
+      D: "5 statute miles visibility and 2,000 feet ceiling"
+    answer: B
+    explanation: "CARs 703.29 imposes stricter VFR weather minimums for commercial night operations than the basic VFR standards. The minimum is 5 statute miles flight visibility and a ceiling of at least 1,000 feet. This is higher than the day VFR minimum of 3 miles in controlled airspace, reflecting the added hazard of night commercial flight. Source: CARs 703.29."
+  - id: q3
+    prompt: "Special VFR (SVFR) allows a VFR pilot to enter or operate in a control zone when weather is below standard VFR minimums. Which of the following is a limitation of Special VFR?"
+    choices:
+      A: "SVFR can only be used at uncontrolled aerodromes"
+      B: "SVFR requires an instrument rating if the flight is at night"
+      C: "SVFR is not available to aircraft flying above 10,000 feet ASL"
+      D: "SVFR authorization requires filing an IFR flight plan"
+    answer: B
+    explanation: "Special VFR is available to VFR pilots in daylight, but at night, SVFR requires the pilot to hold an Instrument Rating and the aircraft to be IFR-equipped. This is because night SVFR in low-visibility conditions demands instrument capability. Source: CARs 602.120."
+  - id: q4
+    prompt: "A commercial pilot is operating a VFR charter under CARs 703. The weather at the destination drops to 2 statute miles visibility en route. The pilot should:"
+    choices:
+      A: "Continue — 3 miles is the minimum, and 2 miles is adequate with caution"
+      B: "Divert to the alternate, as 3 statute miles is the minimum VFR visibility in controlled airspace"
+      C: "Declare an emergency and request a special VFR clearance from ATC"
+      D: "Descend below cloud to maintain VFR and continue"
+    answer: B
+    explanation: "The minimum VFR flight visibility in controlled airspace is 3 statute miles during the day (CARs 602.115). When destination weather drops to 2 miles, the pilot must divert — continuing would be a CARs violation. SVFR is an option only in a control zone, requires ATC clearance, and is not the first-line response to deteriorating destination weather. Source: CARs 602.115, 703.29."
+  - id: q5
+    prompt: "Under CARs Part VI, a VFR pilot flying in Class E airspace at 5,500 feet ASL must maintain what minimum distance from cloud?"
+    choices:
+      A: "Clear of cloud — no distance required"
+      B: "500 feet below, 1,000 feet above, 1,000 feet horizontal"
+      C: "500 feet below, 1,000 feet above, 2,000 feet horizontal"
+      D: "1,000 feet below, 1,000 feet above, 1 statute mile horizontal"
+    answer: C
+    explanation: "In Class E controlled airspace (and all controlled airspace classes C, D, and E), the VFR cloud clearance is: 500 feet below, 1,000 feet above, and 2,000 feet horizontally. These minimums are identical across all controlled airspace classes in Canada. Source: CARs 602.115."
+---
+
+# Lesson CAL-005: Commercial VFR and Special Operations
+
+**Subject:** Commercial Air Law  
+**Lesson number:** 005  
+**Estimated time:** 20 minutes  
+**Sources:** CARs 602.115, 602.117, 602.120, CARs 703.29, TP 12880E
+
+---
+
+## Narration Script
+
+Lesson CAL-005 covers VFR weather rules as they apply specifically to commercial operations, plus two special VFR concepts: VFR OTT (Over The Top) and Special VFR (SVFR). Commercial VFR rules are stricter than the private pilot minimums you learned for PPL-A — and the exam will test whether you know the difference.
+
+---
+
+### Baseline VFR Minimums (Review)
+
+From PPL-A, you know the standard VFR minimums under CARs 602.115:
+
+**Controlled airspace (Class C, D, E) — Day:**
+- 3 statute miles flight visibility
+- 500 feet below / 1,000 feet above / 2,000 feet horizontal from cloud
+
+**Class G — Day, at and below 1,000 feet AGL:**
+- 2 statute miles visibility
+- Clear of cloud
+
+These minimums are floors for *all* VFR flight. Commercial operations often impose **higher minimums** than these.
+
+---
+
+### Commercial Night VFR (CARs 703.29)
+
+Operating commercially at night is higher risk — even with a night rating, the absence of visual horizon and terrain references means weather minimums must be stricter.
+
+Under **CARs 703.29**, a CARs 703 (Air Taxi) operator conducting VFR night flights must apply:
+
+- **Flight visibility:** 5 statute miles (versus 3 miles day minimum)
+- **Ceiling:** At least 1,000 feet
+
+These are the **operator minimums** — individual operators may set even higher company minimums in their Operations Manual, but they cannot go below the CARs 703.29 floor.
+
+The practical implication: a VFR night charter that departs in acceptable conditions may not be able to continue if the ceiling drops below 1,000 feet at the destination. Dispatch planning must account for this.
+
+---
+
+### VFR Over The Top (CARs 602.117)
+
+VFR OTT means flying VFR above a cloud layer. The flight is entirely under VFR rules — no instrument rating, no IFR equipment requirement, no ATC IFR clearance.
+
+**Requirements under CARs 602.117:**
+- The pilot must have current weather information confirming that VMC will exist at the planned destination and alternates during the planned arrival period
+- The pilot must be able to descend through the cloud layer to the destination (or alternate) in VMC — not through IFR conditions
+- The aircraft must be equipped for VFR flight (standard VFR equipment)
+
+**The risk:** VFR OTT can become a trap. If destination weather deteriorates and you cannot descend in VMC, you are trapped above cloud with no IFR capability. Transport Canada strongly recommends having an alternate route or alternate that can be reached in VMC before committing to VFR OTT.
+
+VFR OTT is not available at night. At night, if you are above cloud, you need an Instrument Rating and appropriate clearance.
+
+---
+
+### Special VFR (CARs 602.120)
+
+Special VFR (SVFR) allows a VFR aircraft to operate within a **control zone** when weather is below standard VFR minimums — but only if ATC issues an SVFR clearance and the visibility is at least 1 statute mile (in some contexts, as defined by the ATC unit).
+
+**Day SVFR:**
+- No instrument rating required
+- Need ATC clearance
+- Must remain clear of cloud
+- Minimum visibility as directed by ATC
+
+**Night SVFR:**
+- Requires an **Instrument Rating**
+- Aircraft must be IFR-equipped
+- ATC clearance required
+
+**Important:** SVFR is only available within a **control zone** — the small cylinder of controlled airspace around a towered airport. It is not a blank authorization to fly below VFR minimums anywhere; it is a local dispensation granted by ATC for arrivals and departures at a specific aerodrome when weather is marginal.
+
+---
+
+### Operator-Imposed Minimums
+
+Air operators under CARs Part VII are permitted — and often required — to set weather minimums that are **higher** than the CARs regulatory floors. These appear in the operator's Operations Manual.
+
+Example: A 703 operator might specify company minimums of:
+- Day: 5 miles visibility and 1,500 feet ceiling (higher than the 3-mile CARs minimum)
+- Night: 5 miles and 1,500 feet (higher than 703.29's 1,000-foot ceiling minimum)
+
+As a line pilot, you must comply with **whichever is more restrictive** — the CARs minimum or the company minimum. You cannot use the CARs minimum as justification to depart below company minimums.
+
+---
+
+### Decision-Making Framework for VFR Commercial Ops
+
+Apply this hierarchy when evaluating departure and en-route decisions:
+
+1. **Can I legally go?** — Is weather at or above CARs minimums (602.115, 703.29)?
+2. **Can I legally go by company standards?** — Do I meet the Operations Manual minimums?
+3. **Should I go?** — Is the trip safe given actual conditions, trends, and pilot capability?
+
+Step 3 is a personal judgment. PIC authority includes the right to refuse a commercial flight that is legal on paper but unsafe in practice.
+
+---
+
+## Key Points
+
+1. **Commercial night VFR (CARs 703.29):** 5 miles visibility, 1,000-foot ceiling minimum
+2. **VFR OTT (CARs 602.117):** Legal without instrument rating if VMC confirmed at destination/alternates; not available at night
+3. **Special VFR (CARs 602.120):** Control zone only; no instrument rating needed by day; instrument rating required at night
+4. Company minimums may be stricter than CARs — comply with the **more restrictive** standard
+5. Day VFR cloud clearance in controlled airspace: **500 below / 1,000 above / 2,000 horizontal** — CARs 602.115
+
+---
+
+*End of Lesson CAL-005.*

--- a/lessons/cpl-a/006-dangerous-goods.md
+++ b/lessons/cpl-a/006-dangerous-goods.md
@@ -1,0 +1,25 @@
+---
+id: CAL-006
+topic: cpl-a
+order: 6
+slug: dangerous-goods
+title: "Dangerous Goods in Air Transport"
+duration_min: 20
+status: draft
+audio: null
+visual: null
+sources:
+  - CARs Part XII
+  - ICAO Technical Instructions for the Safe Transport of Dangerous Goods by Air (Doc 9284)
+  - TC TP 14563
+questions: []
+---
+
+# Lesson CAL-006: Dangerous Goods in Air Transport
+
+**Subject:** Commercial Air Law  
+**Status:** Draft — content pending
+
+This lesson will cover the classification, packaging, labelling, and documentation requirements for dangerous goods carried by air under CARs Part XII and the ICAO Technical Instructions. Topics include: the nine UN hazard classes, operator and shipper responsibilities, the PIC's right to refuse dangerous goods, and the accident/incident reporting obligations for dangerous goods occurrences.
+
+Content to author: body narration, 5 quiz questions, source citations.

--- a/lessons/cpl-a/007-passenger-safety.md
+++ b/lessons/cpl-a/007-passenger-safety.md
@@ -1,0 +1,27 @@
+---
+id: CAL-007
+topic: cpl-a
+order: 7
+slug: passenger-safety
+title: "Passenger Safety Briefings and Emergency Equipment"
+duration_min: 20
+status: draft
+audio: null
+visual: null
+sources:
+  - CARs Part VI
+  - CARs 602.89
+  - CARs 605.30
+  - CARs Part VII
+  - CARs 703.69
+questions: []
+---
+
+# Lesson CAL-007: Passenger Safety Briefings and Emergency Equipment
+
+**Subject:** Commercial Air Law  
+**Status:** Draft — content pending
+
+This lesson will cover the mandatory passenger safety briefing requirements for commercial operations under CARs 703.69 and 602.89, including: what must be covered in a pre-takeoff briefing, emergency equipment requirements by aircraft category, life jackets and ditching procedures, the use of portable electronic devices, and seatbelt/shoulder harness obligations. Includes differences between private and commercial briefing standards.
+
+Content to author: body narration, 5 quiz questions, source citations.

--- a/lessons/cpl-a/008-adverse-wx-commercial.md
+++ b/lessons/cpl-a/008-adverse-wx-commercial.md
@@ -1,0 +1,28 @@
+---
+id: CAM-001
+topic: cpl-a
+order: 8
+slug: adverse-wx-commercial
+title: "Adverse Weather Decision-Making for Commercial Operations"
+duration_min: 20
+status: draft
+audio: null
+visual: null
+sources:
+  - CARs Part VI
+  - CARs Part VII
+  - TP 1102 Vol. 5
+  - TC Safety Publication SP 12/2019
+questions: []
+---
+
+# Lesson CAM-001: Adverse Weather Decision-Making for Commercial Operations
+
+**Subject:** Advanced Meteorology  
+**Status:** Draft — content pending
+
+**PPL-A Foundation:** PPL-A lesson MET-014 (weather-decision-making) covers the go/no-go framework for personal VFR flight. This CPL-A lesson extends that foundation to commercial operations: operator minimums, dispatch authority, crew communication during deteriorating conditions, and the legal and professional consequences of continuing into adverse weather.
+
+New content beyond PPL-A MET-014: commercial operator obligations under CARs Part VII, the role of meteorological dispatch, in-flight weather reassessment obligations, and case studies from TC safety publications.
+
+Content to author: body narration, 5 quiz questions, source citations.

--- a/lessons/cpl-a/009-high-altitude-wx.md
+++ b/lessons/cpl-a/009-high-altitude-wx.md
@@ -1,0 +1,25 @@
+---
+id: CAM-002
+topic: cpl-a
+order: 9
+slug: high-altitude-wx
+title: "High-Altitude Weather and Jet Stream Effects"
+duration_min: 20
+status: draft
+audio: null
+visual: null
+sources:
+  - TP 1102 Vol. 5
+  - TC AIM MET section
+  - NOAA/NAV CANADA upper winds forecasts
+questions: []
+---
+
+# Lesson CAM-002: High-Altitude Weather and Jet Stream Effects
+
+**Subject:** Advanced Meteorology  
+**Status:** Draft — content pending
+
+This lesson covers weather phenomena relevant to higher-altitude commercial VFR and IFR-adjacent operations: jet stream position and effects, clear-air turbulence (CAT), mountain wave activity, upper wind forecasts (UA forms), and the practical use of NAV CANADA's graphical upper wind charts. Distinct from PPL-A meteorology in its focus on flight levels and higher-altitude planning rather than low-level VFR.
+
+Content to author: body narration, 5 quiz questions, source citations.

--- a/lessons/cpl-a/010-icing-advanced.md
+++ b/lessons/cpl-a/010-icing-advanced.md
@@ -1,0 +1,25 @@
+---
+id: CAM-003
+topic: cpl-a
+order: 10
+slug: icing-advanced
+title: "Structural Icing — Advanced Recognition and Avoidance"
+duration_min: 20
+status: draft
+audio: null
+visual: null
+sources:
+  - TP 1102 Vol. 5
+  - CARs 602.11
+  - TC AIM MET 3.12
+questions: []
+---
+
+# Lesson CAM-003: Structural Icing — Advanced Recognition and Avoidance
+
+**Subject:** Advanced Meteorology  
+**Status:** Draft — content pending
+
+**PPL-A Foundation:** PPL-A lesson MET-010 (icing) covers icing types, conditions, and basic avoidance. This CPL-A lesson extends to: supercooled large droplets (SLD), freezing level forecasts and their limitations, anti-ice vs. de-ice systems on complex aircraft, icing certification standards (FAR/CS 25 Appendix C), and the regulatory requirements under CARs 602.11 for flight into known icing conditions without appropriate certification.
+
+Content to author: body narration, 5 quiz questions, source citations.

--- a/lessons/cpl-a/011-sigmets-airmets.md
+++ b/lessons/cpl-a/011-sigmets-airmets.md
@@ -1,0 +1,25 @@
+---
+id: CAM-004
+topic: cpl-a
+order: 11
+slug: sigmets-airmets
+title: "SIGMETs, AIRMETs, and Volcanic Ash Advisories"
+duration_min: 20
+status: draft
+audio: null
+visual: null
+sources:
+  - TC AIM MET section
+  - NAV CANADA flight planning documentation
+  - ICAO Annex 3
+questions: []
+---
+
+# Lesson CAM-004: SIGMETs, AIRMETs, and Volcanic Ash Advisories
+
+**Subject:** Advanced Meteorology  
+**Status:** Draft — content pending
+
+This lesson covers significant meteorological information products beyond the GFA: SIGMETs (Significant Meteorological Information) for severe turbulence, icing, and volcanic ash; AIRMETs for less severe but significant conditions; and Volcanic Ash Advisories (VAA) from the Volcanic Ash Advisory Centers (VAACs). Focus on decoding, geographic applicability, and the pilot's obligation to obtain and use these products in commercial flight planning.
+
+Content to author: body narration, 5 quiz questions, source citations.

--- a/lessons/cpl-a/012-advanced-nav-planning.md
+++ b/lessons/cpl-a/012-advanced-nav-planning.md
@@ -1,0 +1,25 @@
+---
+id: CAN-001
+topic: cpl-a
+order: 12
+slug: advanced-nav-planning
+title: "Advanced Cross-Country Planning for Commercial Operations"
+duration_min: 20
+status: draft
+audio: null
+visual: null
+sources:
+  - CARs Part VI
+  - CARs 602.73
+  - TP 12880E
+questions: []
+---
+
+# Lesson CAN-001: Advanced Cross-Country Planning for Commercial Operations
+
+**Subject:** Advanced Navigation  
+**Status:** Draft — content pending
+
+**PPL-A Foundation:** PPL-A lesson NAV-008 (cross-country-planning) covers the fundamental leg-by-leg planning process. This CPL-A lesson extends to: fuel planning for commercial operations (IFR reserves, alternate fuel requirements under CARs 602.73), flight release and dispatch requirements, NOTAMs for commercial operators, and multi-leg trip planning with passenger/cargo loading considerations.
+
+Content to author: body narration, 5 quiz questions, source citations.

--- a/lessons/cpl-a/013-navigation-systems.md
+++ b/lessons/cpl-a/013-navigation-systems.md
@@ -1,0 +1,25 @@
+---
+id: CAN-002
+topic: cpl-a
+order: 13
+slug: navigation-systems
+title: "Navigation Systems — VOR, NDB, GPS, and RNAV"
+duration_min: 20
+status: draft
+audio: null
+visual: null
+sources:
+  - TC AIM RAC section
+  - TP 1102 Vol. 4
+  - TC GPS RNAV guidance
+questions: []
+---
+
+# Lesson CAN-002: Navigation Systems — VOR, NDB, GPS, and RNAV
+
+**Subject:** Advanced Navigation  
+**Status:** Draft — content pending
+
+**PPL-A Foundation:** PPL-A lessons NAV-010 (vor-navigation) and NAV-011 (gps-basics) cover the fundamentals. This CPL-A lesson extends to: NDB/ADF systems (not covered in PPL-A), area navigation (RNAV) concepts, RNP (Required Navigation Performance), database currency requirements for GPS/RNAV, and how these systems are used in commercial IFR-adjacent operations. Also covers system failure recognition and cross-checking multiple navigation sources.
+
+Content to author: body narration, 5 quiz questions, source citations.

--- a/lessons/cpl-a/014-airways-ifr-procedures.md
+++ b/lessons/cpl-a/014-airways-ifr-procedures.md
@@ -1,0 +1,25 @@
+---
+id: CAN-003
+topic: cpl-a
+order: 14
+slug: airways-ifr-procedures
+title: "Airways and IFR Procedures Overview"
+duration_min: 20
+status: draft
+audio: null
+visual: null
+sources:
+  - TC AIM RAC 4.0
+  - CARs Part VI
+  - NAV CANADA FLIP documents
+questions: []
+---
+
+# Lesson CAN-003: Airways and IFR Procedures Overview
+
+**Subject:** Advanced Navigation  
+**Status:** Draft — content pending
+
+This lesson introduces the IFR en-route structure relevant to CPL-A candidates: low-level airways (Victor routes / LF airways) and high-level airways (Jet routes / UH airways) in Canadian airspace, how airways are depicted on IFR En-Route Charts, MEA (Minimum En-Route Altitude), MORA (Minimum Off-Route Altitude), and the conceptual framework for IFR departure and arrival procedures. Scope is awareness-level — full IFR operations require an Instrument Rating beyond the CPL-A.
+
+Content to author: body narration, 5 quiz questions, source citations.

--- a/lessons/cpl-a/015-advanced-aerodynamics.md
+++ b/lessons/cpl-a/015-advanced-aerodynamics.md
@@ -1,0 +1,25 @@
+---
+id: CAE-001
+topic: cpl-a
+order: 15
+slug: advanced-aerodynamics
+title: "Advanced Aerodynamics — Stability, Mach Effects, and V-speeds"
+duration_min: 20
+status: draft
+audio: null
+visual: null
+sources:
+  - TP 12880E
+  - TP 1102 Vol. 2
+  - TC CPL-A PTS
+questions: []
+---
+
+# Lesson CAE-001: Advanced Aerodynamics — Stability, Mach Effects, and V-speeds
+
+**Subject:** Aerodynamics and Engines  
+**Status:** Draft — content pending
+
+**PPL-A Foundation:** PPL-A lessons GK-002 (four-forces), GK-012 (stalls-spins), and GK-013 (load-factor) cover fundamental aerodynamics. This CPL-A lesson extends to: static vs. dynamic stability, longitudinal/lateral/directional stability, the critical engine concept in multi-engine aircraft (Vmca), V-speed definitions required at CPL level (Vmc, Vsse, Vxse, Vyse), and introductory Mach effects (Mach tuck, coffin corner) relevant for pressurized aircraft awareness.
+
+Content to author: body narration, 5 quiz questions, source citations.

--- a/lessons/cpl-a/016-advanced-engines.md
+++ b/lessons/cpl-a/016-advanced-engines.md
@@ -1,0 +1,25 @@
+---
+id: CAE-002
+topic: cpl-a
+order: 16
+slug: advanced-engines
+title: "Advanced Engine Systems — Fuel-Injected, Turbo, and Complex Aircraft"
+duration_min: 20
+status: draft
+audio: null
+visual: null
+sources:
+  - TP 12880E
+  - TP 1102 Vol. 2
+  - POH/AFM for complex aircraft types
+questions: []
+---
+
+# Lesson CAE-002: Advanced Engine Systems — Fuel-Injected, Turbo, and Complex Aircraft
+
+**Subject:** Aerodynamics and Engines  
+**Status:** Draft — content pending
+
+**PPL-A Foundation:** PPL-A lesson GK-003 (piston-engines) covers the four-stroke cycle, magnetos, carb heat, and mixture. This CPL-A lesson extends to: fuel injection systems (no carb ice, but vapour lock concerns), turbocharging and turbonormalizing (density altitude compensation, critical altitude, bootstrapping), constant-speed propellers (governor operation, manifold pressure vs RPM relationship), and complex aircraft systems definition under CARs (retractable gear + controllable pitch prop + flaps).
+
+Content to author: body narration, 5 quiz questions, source citations.

--- a/lessons/cpl-a/017-performance-commercial.md
+++ b/lessons/cpl-a/017-performance-commercial.md
@@ -1,0 +1,26 @@
+---
+id: CAP-001
+topic: cpl-a
+order: 17
+slug: performance-commercial
+title: "Performance Calculations for Commercial Operations"
+duration_min: 20
+status: draft
+audio: null
+visual: null
+sources:
+  - TP 12880E
+  - CARs 605.92
+  - TC CPL-A PTS
+  - POH/AFM performance sections
+questions: []
+---
+
+# Lesson CAP-001: Performance Calculations for Commercial Operations
+
+**Subject:** Performance and Limitations  
+**Status:** Draft — content pending
+
+**PPL-A Foundation:** PPL-A lessons GK-010 (performance-charts) and GK-011 (takeoff-landing-perf) cover POH/AFM chart interpretation and basic density altitude corrections. This CPL-A lesson extends to: obstacle clearance gradient calculations, accelerate-stop distance, accelerate-go (engine failure on takeoff) distance, landing field length requirements with contaminated runways, performance factoring requirements under CARs 605.92, and the regulatory requirement to use approved data rather than conservative estimates.
+
+Content to author: body narration, 5 quiz questions, source citations.

--- a/lessons/cpl-a/018-weight-balance-commercial.md
+++ b/lessons/cpl-a/018-weight-balance-commercial.md
@@ -1,0 +1,26 @@
+---
+id: CAP-002
+topic: cpl-a
+order: 18
+slug: weight-balance-commercial
+title: "Weight and Balance — Multi-Seat and Multi-Leg Operations"
+duration_min: 20
+status: draft
+audio: null
+visual: null
+sources:
+  - TP 12880E
+  - CARs 605.92
+  - TC CPL-A PTS
+  - POH/AFM weight and balance sections
+questions: []
+---
+
+# Lesson CAP-002: Weight and Balance — Multi-Seat and Multi-Leg Operations
+
+**Subject:** Performance and Limitations  
+**Status:** Draft — content pending
+
+**PPL-A Foundation:** PPL-A lesson GK-009 (weight-and-balance) covers CG concepts, moment calculations, and the loading envelope. This CPL-A lesson extends to: multi-passenger loading optimization, fuel burn and CG shift during a multi-leg flight (forward/aft CG migration), freight loading and floor loading limits, the use of loading manifests required for commercial flights, and the PIC's legal responsibility to confirm compliance before each departure regardless of dispatch-provided loading data.
+
+Content to author: body narration, 5 quiz questions, source citations.

--- a/scripts/validate-lesson-schema.sh
+++ b/scripts/validate-lesson-schema.sh
@@ -26,7 +26,7 @@ REQUIRED_FIELDS = [
     "duration_min", "status", "audio", "visual",
     "sources", "questions",
 ]
-VALID_TOPICS = {"air-law", "navigation", "meteorology", "general-knowledge"}
+VALID_TOPICS = {"air-law", "navigation", "meteorology", "general-knowledge", "radio", "cpl-a"}
 REQUIRED_QUESTION_FIELDS = {"id", "prompt", "choices", "answer", "explanation"}
 
 def fail(path, msg):
@@ -79,15 +79,18 @@ def main():
     if topic not in VALID_TOPICS:
         fail(path, f"invalid topic {topic!r}; must be one of {sorted(VALID_TOPICS)}")
 
-    # ── 5. questions must have exactly 5 entries ──────────────────────────────
+    # ── 5. questions must have exactly 5 entries (0 allowed for draft/planning) ─
     questions = fm.get("questions")
     if not isinstance(questions, list):
         fail(path, "questions must be a YAML list")
-    if len(questions) != 5:
+    status = fm.get("status", "")
+    if len(questions) == 0 and status not in ("draft", "planning"):
+        fail(path, f"questions list is empty; 5 required unless status is draft or planning")
+    if len(questions) not in (0, 5):
         fail(path, f"questions must have exactly 5 entries (found {len(questions)})")
 
     # ── 6. Each question's answer key must exist in its choices map ───────────
-    for i, q in enumerate(questions, start=1):
+    for i, q in enumerate(questions, start=1):  # skipped when questions is []
         if not isinstance(q, dict):
             fail(path, f"question {i} is not a YAML mapping")
         for qf in REQUIRED_QUESTION_FIELDS:


### PR DESCRIPTION
Closes #422

## Changes

### docs/curriculum-cpl-a.md (new)
Full taxonomy document listing all 5 CPL-A subject areas with lesson titles, IDs, status, and PPL-A foundation cross-references. Covers: Commercial Air Law (7 lessons), Advanced Meteorology (4), Advanced Navigation (3), Aerodynamics & Engines (2), Performance & Limitations (2).

### lessons/cpl-a/ (new directory, 18 files)

**5 fully authored Commercial Air Law lessons** (CAL-001 through CAL-005), each with:
- Complete frontmatter (id, topic, order, slug, title, duration_min, status: complete, audio: null, visual: null, sources, 5 quiz questions)
- Full ~20-minute narration script body
- TC-sourced CARs citations throughout (CARs 401.17, 700.02, 700.14–700.17, 602.01, 602.115, 602.117, 602.120, 703.29)

Topics covered:
- CAL-001: CPL-A Licence Requirements (age, medical Cat 1, 200hr total, PIC cross-country, instrument time)
- CAL-002: Commercial Air Services and AOC (CARs Part VII, 702/703/704/705 subpart breakdown)
- CAL-003: Duty Times and Rest (1,200hr/year, 300hr/90 days, 8hr sleep opportunity)
- CAL-004: PIC Authority and Responsibilities (CARs 602.01, emergency deviation, journey log)
- CAL-005: Commercial VFR and Special Operations (commercial night VFR, VFR OTT, SVFR)

**13 skeleton draft lessons** (status: draft, questions: []) for:
- CAL-006 (Dangerous Goods), CAL-007 (Passenger Safety)
- CAM-001–004 (Advanced Meteorology)
- CAN-001–003 (Advanced Navigation)
- CAE-001–002 (Aerodynamics & Engines)
- CAP-001–002 (Performance & Limitations)

PPL-A lessons that map 1-to-1 are noted in skeleton body text (e.g., CAM-001 references MET-014, CAP-001 references GK-010/GK-011) — no content duplication.

### scripts/validate-lesson-schema.sh (updated)
- Added `cpl-a` (and `radio`) to VALID_TOPICS — these were already supported in web-app/src/lib/types.ts but missing from the validator
- Allow `questions: []` for lessons with `status: draft` or `planning` (enables skeleton files without requiring placeholder questions)

## Test Plan
- [x] `npm run build` passes (verified after `npm install`)
- [x] `scripts/validate-lesson-schema.sh` — all 18 CPL-A lessons pass; pre-existing failures in navigation/radio lessons are unchanged (out of scope)
- [ ] Content review: verify CARs section numbers against Transport Canada source documents
- [ ] Verify skeleton PPL-A cross-references match actual lesson slugs in lessons/