### PR TITLE
[PPL-421] Author PPL-H foundational lessons: Air Law, Meteorology, Navigation

### DIFF
--- a/lessons/helicopter/001-air-law-helicopter.md
+++ b/lessons/helicopter/001-air-law-helicopter.md
@@ -1,0 +1,195 @@
+---
+id: HEL-001
+topic: helicopter
+order: 1
+slug: air-law-helicopter
+title: "Air Law for Helicopter Operations"
+duration_min: 20
+status: draft
+audio: null
+sources:
+  - "CARs Part VI (General Operating and Flight Rules)"
+  - "CARs Part VI, Subpart 2 (Visual Flight Rules)"
+  - "CARs 602.114 – 602.116 (VFR Weather Minimums)"
+  - "CARs 602.78 – 602.101 (Flight Plans and Itineraries)"
+  - "TP 12880E (Aeroplane Flight Training Manual) – referenced for comparison"
+  - "AIM RAC 2.0 (Airspace)"
+questions:
+  - id: q1
+    prompt: "A helicopter operating VFR at 500 feet AGL in Class G airspace during the day requires a minimum flight visibility of:"
+    choices:
+      A: "1 statute mile, clear of cloud"
+      B: "2 statute miles, clear of cloud"
+      C: "3 statute miles with cloud clearance of 500/1,000/2,000"
+      D: "Half a statute mile, clear of cloud"
+    answer: B
+    explanation: "In Class G airspace at and below 1,000 feet AGL during the day, both aeroplanes and helicopters require 2 statute miles visibility and clear of cloud. CARs 602.115."
+  - id: q2
+    prompt: "Which of the following statements about helicopter VFR weather minimums in Class C airspace is correct?"
+    choices:
+      A: "Helicopters require lower visibility than fixed-wing in Class C"
+      B: "Helicopters apply the same minimums as fixed-wing: 3 SM visibility with 500/1,000/2,000 cloud clearance"
+      C: "Helicopters may operate clear of cloud with 1 SM visibility in Class C"
+      D: "Helicopters do not require ATC clearance to enter Class C"
+    answer: B
+    explanation: "In controlled airspace (Class C, D, E), VFR weather minimums are the same for helicopters and aeroplanes: 3 statute miles visibility, 500 feet below / 1,000 feet above / 2,000 feet horizontally from cloud. CARs 602.114."
+  - id: q3
+    prompt: "A helicopter pilot operating under VFR in uncontrolled airspace at night must carry:"
+    choices:
+      A: "No additional equipment beyond what is required for day VFR"
+      B: "A functioning ELT only"
+      C: "Navigation lights and an anti-collision light"
+      D: "A VHF radio capable of reaching the nearest ATC facility"
+    answer: C
+    explanation: "Night VFR requires navigation lights (position lights — red, green, white) and an anti-collision light. CARs 605.16 and 605.17. Night VFR weather minimums and equipment requirements apply equally to helicopters."
+  - id: q4
+    prompt: "When is a helicopter pilot in Canada required to file a flight plan for a cross-country flight conducted under VFR?"
+    choices:
+      A: "Only when the flight crosses an international boundary"
+      B: "Any time the flight will be conducted in controlled airspace"
+      C: "When the flight will be conducted outside of 25 NM from the departure aerodrome"
+      D: "When the flight is conducted in uncontrolled airspace only"
+    answer: C
+    explanation: "A flight plan or flight itinerary is required for VFR flights that depart beyond 25 NM from the departure aerodrome. This rule applies to helicopters and aeroplanes alike. CARs 602.73."
+  - id: q5
+    prompt: "A helicopter approaches an aerodrome where fixed-wing traffic is also operating in the circuit. Who has right of way?"
+    choices:
+      A: "The helicopter, because rotary-wing aircraft always have priority"
+      B: "The fixed-wing aeroplane, because helicopters must give way to all fixed-wing traffic"
+      C: "The aircraft on final approach, regardless of type"
+      D: "The aircraft that is lower and slower has priority"
+    answer: C
+    explanation: "Right-of-way rules are based on situation, not aircraft type. An aircraft on final approach generally has priority over aircraft joining the circuit. CARs 602.19 sets out right-of-way rules for aircraft in flight — type is not the determining factor."
+---
+
+# Lesson HEL-001: Air Law for Helicopter Operations
+
+**Section:** Helicopter — Foundational  
+**Lesson number:** 001  
+**Estimated time:** 20 minutes  
+**Sources:** CARs Part VI; AIM RAC 2.0; TP 12880E (for comparison)
+
+---
+
+## Narration Script
+
+Welcome to the first helicopter module. This lesson covers Canadian Aviation Regulations as they apply to helicopter operations — with special attention to where helicopter rules align with fixed-wing rules and where they diverge. On the PPL-H written exam, examiners will test both your knowledge of the rules and your ability to spot helicopter-specific differences.
+
+---
+
+### The Regulatory Framework
+
+Canadian aviation is governed by the *Aeronautics Act* and the *Canadian Aviation Regulations*, known as the CARs. For pilots, the most important parts are found in **CARs Part VI — General Operating and Flight Rules**. Part VI applies to all aircraft operating in Canadian airspace, including helicopters.
+
+The key point: most of Part VI is aircraft-neutral. The airspace classification rules, VFR weather minimums for controlled airspace, right-of-way requirements, and flight plan rules apply identically to helicopters and aeroplanes — unless a specific regulation says otherwise.
+
+Where helicopters have distinct rules, the CARs call them out explicitly. We will flag those exceptions throughout this lesson.
+
+---
+
+### Airspace Classifications — Identical for Helicopters
+
+Canada uses the ICAO letter classification system: Class A through G. These rules do not change based on aircraft type. A helicopter entering Class C airspace faces the same requirements as a Cessna 172:
+
+- **Class A** (18,000 ft ASL and above): IFR only, ATC clearance required. Helicopters rarely operate here.
+- **Class B** (12,500 ft ASL to 18,000 ft): IFR only, clearance required.
+- **Class C** (around major airports): VFR permitted with ATC clearance and two-way radio contact.
+- **Class D** (towered airports): Two-way radio contact required before entry; no formal clearance needed.
+- **Class E** (controlled airspace, no tower): VFR without ATC contact if you meet weather minimums.
+- **Class F**: Special use — F(R) is restricted (permission required), F(A) is advisory (hazard warning only).
+- **Class G**: Uncontrolled airspace — the primary environment for most helicopter low-level and off-aerodrome work. No clearance, no radio contact required, but you must meet VFR weather minimums.
+
+**Source:** CARs 601.01 through 601.15; AIM RAC 2.0.
+
+---
+
+### VFR Weather Minimums — Where Helicopters Differ
+
+This is one area where helicopters *do* have a specific provision. Let's separate the cases:
+
+**In controlled airspace (Class C, D, E) — same as fixed-wing:**  
+3 statute miles visibility, 500 feet below cloud, 1,000 feet above cloud, 2,000 feet horizontal from cloud.  
+**Source:** CARs 602.114.
+
+**In uncontrolled airspace (Class G), day, at and below 1,000 ft AGL — same as fixed-wing:**  
+2 statute miles visibility, clear of cloud.  
+**Source:** CARs 602.115.
+
+**In uncontrolled airspace (Class G), day, above 1,000 ft AGL — same as fixed-wing:**  
+1 statute mile visibility, clear of cloud.  
+**Source:** CARs 602.115.
+
+**Where helicopters gain a special reduced minimum:**  
+Under CARs 602.116, helicopters operating at speeds that allow the pilot to see and avoid obstacles and other aircraft — typically slow, low-level operations — *may* operate with reduced visibility in Class G airspace if the conditions meet the criteria in the regulation. This provision exists because a helicopter hovering or flying at very low speed can safely operate in conditions that would be unsafe for a fixed-wing aircraft. In practice, this is a narrow exception and exam questions will test your understanding that the *general* Class G minimums apply unless the specific conditions of 602.116 are met.
+
+**Key exam point:** Do not assume helicopters always have lower weather minimums. In controlled airspace, they do not. The relaxed minimums apply only in Class G, at low speeds, under specific conditions.
+
+---
+
+### Flight Plans and Itineraries
+
+Flight plans are required when:
+- Departing beyond **25 NM** from the departure aerodrome (CARs 602.73).
+- Crossing international borders (always file).
+- Operating IFR.
+
+A flight itinerary (a simpler form, filed with a responsible person) is an alternative when the 25 NM threshold is crossed but a full flight plan isn't mandatory. The itinerary tells someone where you're going and when to call search and rescue.
+
+For helicopters doing remote off-aerodrome work — a common real-world scenario — the itinerary requirement becomes especially important. If you're landing in a remote field and no one knows where you are, the consequences of an accident are far worse.
+
+**Source:** CARs 602.73 through 602.78.
+
+---
+
+### Right-of-Way Rules
+
+CARs 602.19 establishes right-of-way. The key principles:
+
+1. **Aircraft in distress** have right of way over all other aircraft.
+2. **Gliders** have right of way over powered aircraft.
+3. **Airships** have right of way over aeroplanes and helicopters.
+4. **Aeroplanes** have right of way over helicopters — yes, this is the rule. CARs 602.19(c) explicitly places aeroplanes above helicopters in the priority order.
+5. **When on approach:** The aircraft lower and on final approach generally has priority.
+6. **Head-on:** Both aircraft turn right.
+7. **Converging:** The aircraft with the other on its right gives way.
+
+The exam will test right-of-way in mixed traffic. Remember: in a conflict between an aeroplane and a helicopter, the helicopter gives way.
+
+**Source:** CARs 602.19.
+
+---
+
+### Circuit Procedures at Uncontrolled Aerodromes
+
+Helicopters operating at uncontrolled aerodromes should follow the published circuit direction and altitude where one is established. Where the aerodrome has a mix of fixed-wing and rotary-wing traffic, helicopters are expected to remain clear of the fixed-wing circuit when possible — operating at lower altitudes or using routes that don't conflict with the aeroplane pattern.
+
+At uncontrolled aerodromes, position reports on the MF (Mandatory Frequency) or ATF (Aerodrome Traffic Frequency) are required. Helicopters must broadcast their position and intentions just as aeroplanes do.
+
+**Source:** CARs 602.96 through 602.101; AIM RAC 4.5.
+
+---
+
+### Night VFR
+
+Night VFR requires:
+- Navigation lights (red port, green starboard, white tail) — CARs 605.16.
+- Anti-collision light — CARs 605.17.
+- Weather minimums of 3 SM visibility and standard cloud clearances in controlled airspace; in Class G at night, 2 SM and 500/1,000/2,000 cloud clearance (the Class G day minimums relax for low-altitude but night rules do not).
+
+Helicopters must also carry the standard emergency equipment — ELT, life-saving equipment for overwater or remote operations, and survival equipment appropriate to the geography.
+
+---
+
+### Key Numbers to Remember
+
+| Rule | Value | Source |
+|------|-------|--------|
+| Flight plan required beyond | 25 NM from departure | CARs 602.73 |
+| Controlled airspace VFR visibility | 3 SM | CARs 602.114 |
+| Class G day, ≤1,000 ft AGL visibility | 2 SM, clear of cloud | CARs 602.115 |
+| Class A lower limit | 18,000 ft ASL | CARs 601.01 |
+| Right of way: aeroplane vs. helicopter | Aeroplane has priority | CARs 602.19 |
+
+---
+
+*End of Lesson HEL-001.*

--- a/lessons/helicopter/002-meteorology-helicopter.md
+++ b/lessons/helicopter/002-meteorology-helicopter.md
@@ -1,0 +1,230 @@
+---
+id: HEL-002
+topic: helicopter
+order: 2
+slug: meteorology-helicopter
+title: "Meteorology for Helicopter Operations"
+duration_min: 20
+status: draft
+audio: null
+sources:
+  - "TP 12880E (Aeroplane Flight Training Manual) – Meteorology chapters"
+  - "TC AIM MET section"
+  - "CARs 602.114–602.116 (VFR Weather Minimums)"
+  - "NAV CANADA – METAR, TAF, GFA product descriptions"
+questions:
+  - id: q1
+    prompt: "Density altitude is best defined as:"
+    choices:
+      A: "The altitude shown on the altimeter when set to 29.92 inHg"
+      B: "Pressure altitude corrected for non-standard temperature"
+      C: "The height above sea level as measured by GPS"
+      D: "The altitude at which the helicopter achieves its maximum hover ceiling"
+    answer: B
+    explanation: "Density altitude is pressure altitude corrected for non-standard temperature. High temperature, high humidity, and high elevation all increase density altitude, degrading helicopter performance. TP 12880E, Chapter on Aircraft Performance."
+  - id: q2
+    prompt: "A helicopter is hovering in ground effect (IGE) at a high-altitude airport on a hot, humid summer day. The pilot attempts to transition to out-of-ground-effect (OGE) hover. What is the primary risk?"
+    choices:
+      A: "Retreating blade stall caused by the high humidity"
+      B: "The helicopter may not have sufficient power to maintain OGE hover due to high density altitude"
+      C: "The tail rotor loses effectiveness due to hot air reducing tail rotor thrust"
+      D: "The carburetor will ice in the moist air, causing engine failure"
+    answer: B
+    explanation: "At high density altitudes, rotor efficiency decreases significantly. A helicopter that can hover IGE may lack the excess power margin needed for OGE hover, creating a dangerous situation during takeoff or if an obstacle forces the pilot higher."
+  - id: q3
+    prompt: "Surface winds are especially critical to helicopter pilots because:"
+    choices:
+      A: "Helicopters require a minimum headwind for takeoff on all surfaces"
+      B: "Helicopters cannot operate in crosswinds exceeding 10 knots"
+      C: "Wind provides translational lift and affects performance during takeoff, landing, and hover"
+      D: "Wind changes the direction of gyroscopic precession in the rotor system"
+    answer: C
+    explanation: "Wind — particularly headwind — provides translational lift that significantly improves helicopter performance during takeoff and landing. Calm winds mean the helicopter must produce all lift from rotor thrust alone, increasing power demand. Crosswinds and tailwinds also affect tail rotor effectiveness and directional control."
+  - id: q4
+    prompt: "A METAR reports: CYYZ 151900Z 28008KT 15SM FEW030 BKN090 OVC250 18/11 A2992. What does OVC250 indicate?"
+    choices:
+      A: "Overcast cloud layer at 2,500 feet above sea level"
+      B: "Overcast cloud layer at 25,000 feet AGL"
+      C: "Occasional vertical cloud to 2,500 feet"
+      D: "Overcast ceiling at 2,500 feet AGL"
+    answer: B
+    explanation: "Cloud heights in METARs are reported in hundreds of feet AGL. OVC250 = overcast at 25,000 feet AGL. The lowest layer that is BKN or OVC defines the ceiling — in this METAR it is BKN090 (broken at 9,000 ft AGL), which is the ceiling."
+  - id: q5
+    prompt: "Which weather product provides a forecast for a specific aerodrome covering a 24-hour period, including expected wind, visibility, weather, and cloud?"
+    choices:
+      A: "METAR"
+      B: "GFA"
+      C: "SIGMET"
+      D: "TAF"
+    answer: D
+    explanation: "A TAF (Terminal Aerodrome Forecast) provides a 24-hour aerodrome forecast (sometimes up to 30 hours) covering wind, visibility, weather, and cloud. A METAR is an observation, not a forecast. A GFA covers a large region, not a single aerodrome. Source: NAV CANADA weather products guide."
+---
+
+# Lesson HEL-002: Meteorology for Helicopter Operations
+
+**Section:** Helicopter — Foundational  
+**Lesson number:** 002  
+**Estimated time:** 20 minutes  
+**Sources:** TP 12880E (Meteorology); TC AIM MET; NAV CANADA weather products
+
+---
+
+## Narration Script
+
+Welcome to the meteorology lesson for helicopter pilots. Weather is critical for all aviation, but helicopters have a set of unique vulnerabilities that make certain weather phenomena especially dangerous. In this lesson we cover the standard weather products you must know for the PPL-H written exam — METAR, TAF, and GFA — and then focus on the weather hazards that are disproportionately dangerous for low-level, low-speed rotary-wing operations.
+
+---
+
+### Standard Weather Products
+
+**METAR — Aviation Routine Weather Report**
+
+A METAR is a weather observation taken at a reporting station (usually an aerodrome). It is a snapshot of actual conditions at the time of observation, not a forecast. METARs are issued at 20 and 50 minutes past the hour (routine), or whenever conditions change significantly (SPECI — Special METAR).
+
+A METAR reads left to right in a fixed format:
+
+`CYYZ 151900Z 28008KT 15SM FEW030 BKN090 OVC250 18/11 A2992`
+
+- `CYYZ` — ICAO station identifier (Toronto Pearson)
+- `151900Z` — day 15, time 1900 Zulu (UTC)
+- `28008KT` — wind from 280° at 8 knots
+- `15SM` — visibility 15 statute miles
+- `FEW030` — few clouds at 3,000 feet AGL
+- `BKN090` — broken cloud at 9,000 feet AGL (this is the ceiling)
+- `OVC250` — overcast at 25,000 feet AGL
+- `18/11` — temperature 18°C, dew point 11°C
+- `A2992` — altimeter setting 29.92 inHg
+
+Cloud amounts use: SKC (sky clear), FEW (1–2 oktas), SCT (3–4 oktas), BKN (5–7 oktas), OVC (8 oktas). The **ceiling** is the lowest layer that is BKN or OVC.
+
+**Source:** NAV CANADA METAR documentation; TP 12880E.
+
+---
+
+**TAF — Terminal Aerodrome Forecast**
+
+A TAF is a forecast for conditions at a specific aerodrome, valid for 24 hours (some TAFs extend to 30 hours). TAFs use the same format elements as METARs. Change indicators signal expected shifts: BECMG (becoming), TEMPO (temporary, lasting less than an hour at a time), FM (from a specific time), PROB (probability — PROB30 or PROB40).
+
+TAFs are issued by meteorological centres, not by the aerodrome itself. Before flight, the helicopter pilot checks the TAF for the destination and any alternates.
+
+**Source:** NAV CANADA weather products guide.
+
+---
+
+**GFA — Graphical Forecast for Aviation**
+
+The GFA (Graphical Forecast for Aviation) replaced the FA (Area Forecast) in Canada. It provides a depiction of weather for large geographic regions, showing forecast cloud, icing, turbulence, and freezing levels on a map. GFAs are issued every 6 hours and cover 6-hour intervals.
+
+For helicopter pilots operating at low altitudes over large areas — pipelines, powerline inspections, survey work — the GFA provides regional weather context that point forecasts (TAFs) cannot provide.
+
+**Source:** NAV CANADA GFA documentation.
+
+---
+
+**SIGMETs and AIRMETs**
+
+A SIGMET (Significant Meteorological Information) is an advisory of significant weather affecting a large area: severe icing, severe turbulence, volcanic ash, tropical cyclones. SIGMETs are mandatory avoidance items on exam questions.
+
+An AIRMET (Airmen's Meteorological Information) covers less severe but still significant conditions affecting light aircraft: moderate icing, moderate turbulence, widespread reduced visibility.
+
+---
+
+### Density Altitude — Critical for Helicopters
+
+Density altitude is the most important performance concept for helicopter pilots operating in any condition other than sea level on a standard day.
+
+**Definition:** Density altitude is pressure altitude corrected for non-standard temperature. It represents the altitude at which the air has the same density as the current conditions — and it is the altitude the helicopter "thinks" it is at in terms of engine and rotor performance.
+
+**Standard atmosphere:** 15°C at sea level, decreasing at 2°C per 1,000 feet (approximately). Pressure 29.92 inHg at sea level.
+
+**What raises density altitude:**
+- **High temperature** — warm air is less dense
+- **High elevation** — less air pressure above you
+- **High humidity** — water vapour is less dense than dry air (this is often underestimated)
+
+**Formula approximation:** Density Altitude ≈ Pressure Altitude + (100 × (OAT − ISA Temperature at that altitude))
+
+**Helicopter performance impact:**
+
+Rotor blades are airfoils. Rotor lift is directly proportional to air density. In low-density (high density altitude) conditions:
+
+1. **Main rotor produces less lift** for the same RPM and blade angle — the pilot must increase collective to compensate.
+2. **Engine produces less power** — internal combustion engines and turbines both lose power in thinner air. Turbine engines are especially sensitive.
+3. **Tail rotor produces less thrust** — anti-torque effectiveness decreases, potentially causing loss of directional control at high power settings.
+
+The practical result: at high density altitudes, a helicopter may be able to hover in ground effect (IGE) but unable to hover out of ground effect (OGE). The hover in ground effect (IGE) benefits from the ground cushion — air compressed between the rotor and the ground that reduces power demand. When the helicopter rises above approximately one rotor diameter, it loses the ground effect and power demand jumps.
+
+This is not academic. A helicopter that can hover IGE at high elevation on a hot day may not be able to climb above an obstacle, transition to forward flight, or carry the intended load. The pilot must consult the helicopter's Pilot Operating Handbook (POH) performance charts before flight to verify OGE hover capability given the current density altitude and aircraft weight.
+
+**Source:** TP 12880E (Aircraft Performance chapters).
+
+---
+
+### Surface Winds and Low-Level Hazards
+
+**Translational Lift**
+
+As a helicopter accelerates from a hover into forward flight, it transitions from hovering flight to translational lift — a state where the rotor moves through undisturbed air and generates significantly more lift for the same power input. Translational lift becomes effective at approximately 15–24 knots of airspeed (varies by helicopter).
+
+This means a headwind of 15 knots dramatically reduces the power needed for takeoff — the helicopter gains translational lift at a much lower ground speed. A tailwind of 15 knots means the helicopter must accelerate further and use more power to reach translational lift. Never take off into a strong tailwind unless operationally required and within performance limits.
+
+**Low-Level Wind Shear and Turbulence**
+
+Helicopters operating at low altitude spend more time in the boundary layer where wind shear, gusts, and mechanical turbulence caused by terrain and obstacles are most severe. Key hazards:
+
+- **Mechanical turbulence** around buildings, ridges, and tree lines at low level
+- **Valley winds and channeling** — terrain forces wind to accelerate through valleys
+- **Wake turbulence** — horizontal vortices shed by the tips of rotor blades persist longer than wingtip vortices from aeroplanes; if operating near other helicopters or heavy aircraft, avoid flying through their wake
+
+**Rotor Downwash Interaction**
+
+Helicopter downwash — the column of air forced downward by the rotor system — creates unique hazards:
+- **Ground resonance** can be induced if the downwash interacts with unsuitable surfaces (not strictly a weather issue, but surface condition matters)
+- **Downwash over water** creates spray and can obscure visual reference
+- **Brownout / whiteout** — in dusty or snowy conditions, rotor downwash can completely obscure ground references during landing, causing spatial disorientation. These are among the leading causes of helicopter accidents.
+
+**Source:** TP 12880E; Transport Canada helicopter safety resources.
+
+---
+
+### Fog and Low Visibility
+
+Fog is especially dangerous for helicopter operations because helicopters frequently operate without filed instrument flight plans, at low altitude, without the terrain clearance margins built into IFR procedures. Types of fog relevant to pilots:
+
+- **Radiation fog** — forms on calm, clear nights as the ground cools; typically burns off by mid-morning; worst in valleys and low-lying areas
+- **Advection fog** — forms when warm moist air moves over a cold surface; can persist all day and cover large areas (coastal regions, Great Lakes)
+- **Upslope fog** — moist air forced up terrain cools and condenses; common in mountainous areas
+
+For helicopter pilots, radiation fog is a frequent early-morning hazard. If the destination fog hasn't lifted by your intended arrival, you may be unable to land. Always check the forecast fog burn-off time and have a fuel margin or an alternate plan.
+
+---
+
+### Icing
+
+Helicopters are susceptible to rotor icing, which is distinct from airframe icing on fixed-wing aircraft. Rotor icing is particularly hazardous because:
+
+- Ice on rotor blades changes the blade profile and reduces lift
+- Ice on leading edges is uneven, causing vibration
+- Ice shedding from rotor blades is asymmetric, causing severe vibration and potential structural damage
+
+Conditions conducive to icing: visible moisture (cloud, precipitation) + temperatures at or slightly below 0°C at flight altitude.
+
+The standard icing avoidance guidance applies: if the OAT at altitude is between −10°C and +2°C and you are in visible moisture, you are in potential icing conditions. Most small helicopters used for PPL-H training are not certified for flight into known icing (FIKI) — know your aircraft's limitations.
+
+**Source:** TP 12880E (Icing chapter).
+
+---
+
+### Key Weather Numbers
+
+| Item | Value | Source |
+|------|-------|--------|
+| ISA sea-level temperature | 15°C | ICAO standard |
+| ISA temperature lapse rate | 2°C per 1,000 ft (approx.) | ICAO standard |
+| Translational lift onset (approx.) | 15–24 knots | TP 12880E |
+| Potential icing zone temperature | −10°C to +2°C in visible moisture | TP 12880E |
+| GFA valid period | 6-hour intervals | NAV CANADA |
+
+---
+
+*End of Lesson HEL-002.*

--- a/lessons/helicopter/003-navigation-helicopter.md
+++ b/lessons/helicopter/003-navigation-helicopter.md
@@ -1,0 +1,246 @@
+---
+id: HEL-003
+topic: helicopter
+order: 3
+slug: navigation-helicopter
+title: "Navigation for Helicopter Operations"
+duration_min: 20
+status: draft
+audio: null
+sources:
+  - "TP 12880E (Aeroplane Flight Training Manual) – Navigation chapters"
+  - "TC AIM MAP section"
+  - "CARs 602.114–602.116 (VFR Weather Minimums)"
+  - "CARs 602.35 (Cruising Altitudes and Levels)"
+  - "Transport Canada – VNC (VFR Navigation Chart) and VTA documentation"
+questions:
+  - id: q1
+    prompt: "A helicopter is flying a true course of 090° with a wind from 360° at 20 knots and an airspeed of 100 knots. The wind correction angle (WCA) is approximately:"
+    choices:
+      A: "11° left"
+      B: "11° right"
+      C: "20° left"
+      D: "No correction needed — the wind is perpendicular and has no effect"
+    answer: A
+    explanation: "Wind from 360° on a course of 090° is a 90° crosswind from the left (north wind pushing the aircraft southward). To correct, the pilot must point the nose into the wind (left), producing a left WCA. Using the 1-in-60 approximation: WCA ≈ 20/100 × 60 ≈ 12°, close to 11°. The exact answer is about 11.5°."
+  - id: q2
+    prompt: "On a VFR Navigation Chart (VNC), the scale is:"
+    choices:
+      A: "1:50,000"
+      B: "1:250,000"
+      C: "1:500,000"
+      D: "1:1,000,000"
+    answer: C
+    explanation: "The VFR Navigation Chart (VNC) used for cross-country navigation in Canada has a scale of 1:500,000 (1 cm = 5 km). The VTA (Visual Terminal Area) chart has a scale of 1:250,000 for terminal area navigation. Source: TC AIM MAP 2.0."
+  - id: q3
+    prompt: "A helicopter pilot departing a remote off-aerodrome site must assess the landing site. Which of the following is NOT a primary factor in an off-aerodrome site assessment?"
+    choices:
+      A: "Slope of the ground relative to the rotor disk"
+      B: "Availability of a published instrument approach"
+      C: "Surface texture and suitability for brownout/whiteout"
+      D: "Obstacles on approach and departure paths"
+    answer: B
+    explanation: "Off-aerodrome landing site assessment covers: slope (rotor disk clearance from terrain), surface condition, obstacle clearance on approach/departure, and wind direction. The availability of an instrument approach is irrelevant — off-aerodrome sites have no published approaches by definition."
+  - id: q4
+    prompt: "Dead reckoning navigation uses which of the following inputs to estimate position?"
+    choices:
+      A: "VOR radial and DME distance"
+      B: "Known departure point, true airspeed, magnetic heading, and elapsed time"
+      C: "GPS track and groundspeed only"
+      D: "Nearest NDB bearing and estimated wind drift"
+    answer: B
+    explanation: "Dead reckoning (DR) uses a known starting point, true airspeed corrected for wind to get groundspeed, a magnetic heading corrected for variation and deviation, and elapsed time to estimate the current position. It is the foundational navigation technique that all other methods build on. Source: TP 12880E Navigation chapter."
+  - id: q5
+    prompt: "When planning a VFR cross-country flight in a helicopter, the minimum fuel reserve at destination should be:"
+    choices:
+      A: "20 minutes at normal cruise"
+      B: "30 minutes at normal cruise"
+      C: "45 minutes at normal cruise"
+      D: "60 minutes at normal cruise"
+    answer: B
+    explanation: "CARs 602.88 requires a VFR flight to carry fuel for the flight to the destination plus 30 minutes of cruise flight (day VFR). Night VFF requires 45 minutes. This applies equally to helicopters."
+---
+
+# Lesson HEL-003: Navigation for Helicopter Operations
+
+**Section:** Helicopter — Foundational  
+**Lesson number:** 003  
+**Estimated time:** 20 minutes  
+**Sources:** TP 12880E (Navigation); TC AIM MAP; CARs 602
+
+---
+
+## Narration Script
+
+Welcome to the navigation lesson. Navigation for helicopter pilots covers the same foundational concepts as fixed-wing navigation — charts, dead reckoning, wind correction, fuel planning — but applies them in a low-altitude, variable-route environment where flexibility and site assessment are essential. This lesson prepares you for both the PPL-H written exam and the practical realities of helicopter cross-country flight.
+
+---
+
+### Canadian VFR Charts
+
+**VNC — VFR Navigation Chart (1:500,000)**
+
+The VNC is the primary chart for cross-country VFR navigation. Scale of 1:500,000 means 1 centimetre on the chart equals 5 kilometres on the ground (or about 2.7 nautical miles). The VNC shows:
+
+- Airspace boundaries (class, altitude limits)
+- Terrain and prominent landmarks
+- Aerodromes (with identifiers, elevation, and services)
+- Obstructions (towers, antenna farms) above 200 feet AGL
+- Navigational aids (VORs, NDBs)
+- Routes and airways
+- Restricted and danger areas (Class F)
+
+Contour lines on the VNC are critical for terrain clearance planning, particularly in mountainous regions. Contour interval is typically 500 feet.
+
+**VTA — Visual Terminal Area Chart (1:250,000)**
+
+The VTA is used near busy terminal areas where detail at 1:500,000 scale is insufficient. It provides more detail about the airspace structure around major airports and their vicinity. Use the VTA when operating in or near terminal areas; switch to the VNC for en-route navigation.
+
+**WAC — World Aeronautical Chart (1:1,000,000)**
+
+The WAC provides small-scale coverage of large areas. It is less useful for low-level VFR navigation but can be used for long-distance planning.
+
+**Source:** TC AIM MAP 2.0.
+
+---
+
+### Dead Reckoning — The Foundation
+
+Dead reckoning (DR) is the calculation of your estimated position using:
+
+1. **Known departure point** — a fix (aerodrome, VOR, prominent landmark)
+2. **True course** — the direction to your destination on the chart
+3. **True airspeed (TAS)** — the actual speed through the air (calibrated airspeed corrected for altitude and temperature)
+4. **Wind** — direction and velocity, from the forecast or actual observation
+5. **Wind correction angle (WCA)** — the offset applied to the true course to maintain the desired track over the ground
+6. **Magnetic variation** — the local difference between magnetic north and true north
+7. **Compass deviation** — the instrument error in your specific aircraft
+8. **Elapsed time** — time since last fix
+
+**The navigation triangle:**
+
+The wind correction angle offsets your heading into the wind so that your ground track follows the intended course. The groundspeed is the result — the speed at which you actually travel over the ground. Groundspeed = TAS adjusted for headwind/tailwind component.
+
+Groundspeed drives your time calculation: Time = Distance ÷ Groundspeed. Fuel required = Time × Fuel burn rate.
+
+**Why DR matters for helicopter pilots:**
+
+Helicopters frequently operate off published airways and in areas without GPS coverage (remote northern Canada, mountainous terrain). A pilot who cannot navigate by DR alone is dependent on a single point of failure. The PPL-H exam will test your ability to apply wind correction, calculate groundspeed, and estimate arrival time.
+
+**Source:** TP 12880E, Navigation chapter.
+
+---
+
+### Magnetic Variation and Compass Deviation
+
+**Magnetic Variation (Var):** The angle between magnetic north (where the compass points) and true north (geographic north pole). In Canada, magnetic variation is significant — it ranges from about 20° West in eastern Canada to 30° East in the western Arctic. Variation is printed on VNCs as isogonic lines (lines of equal variation).
+
+To convert: True course ± Variation = Magnetic course  
+Mnemonic: "Variation East, Magnetic least; Variation West, Magnetic best"  
+(East variation: subtract to get magnetic. West variation: add to get magnetic.)
+
+**Compass Deviation (Dev):** Every aircraft compass is slightly affected by the metal, wiring, and instruments around it. Deviation is listed on the aircraft's compass correction card. It is typically small (within a few degrees) but must be applied.
+
+Magnetic heading ± Deviation = Compass heading
+
+**Source:** TP 12880E, Navigation chapter.
+
+---
+
+### GPS Navigation
+
+GPS is standard equipment in most modern helicopters and dramatically simplifies cross-country navigation. However:
+
+- GPS must not replace understanding of DR — equipment can fail, satellite signal can be degraded (RAIM alerts), and database currency matters.
+- For PPL-H, GPS is a supplement to, not a replacement for, fundamental navigation skills.
+- Always verify GPS track against visual landmarks. A GPS that is showing the wrong destination, an old database, or a route to an incorrect waypoint will lead you astray quietly.
+
+When using GPS:
+- Set the correct datum (WGS-84 is standard)
+- Confirm the destination waypoint identifier matches the intended destination
+- Monitor groundspeed and crosscheck against fuel plan
+- Know the nearest aerodromes along the route for emergency planning
+
+**Source:** TP 12880E, Navigation chapter.
+
+---
+
+### Altitude Selection and Cruising Levels
+
+For VFR flights in Canada at and above 3,000 feet AGL:
+- **Magnetic track 0° to 179°:** Odd thousands + 500 feet (3,500 / 5,500 / 7,500 ft)
+- **Magnetic track 180° to 359°:** Even thousands + 500 feet (4,500 / 6,500 / 8,500 ft)
+
+**Source:** CARs 602.35.
+
+Helicopters frequently cruise below 3,000 feet AGL where this rule does not apply. At low altitudes, the pilot selects a height appropriate for terrain clearance and obstacle avoidance. Common practice is to maintain at least 500 feet above the highest obstacle within 5 nautical miles of the route (following CARs 602.14 for over populated areas or controlled routes; CARs 602.15 for other airspace).
+
+---
+
+### Off-Aerodrome Landing Site Assessment
+
+One of the most distinctive aspects of helicopter navigation is the ability — and frequent requirement — to operate from unprepared sites. A systematic approach to landing site assessment is essential for safety.
+
+**The SOCA check (a common helicopter approach mnemonic):**
+
+**S — Size:** Is the site large enough for the helicopter rotor diameter plus margins? The site must accommodate the rotor disk (main rotor diameter, typically 10–12 metres for a Robinson R44) plus a buffer. Obstacles at the edge of the rotor disk are a hazard.
+
+**O — Obstacles:** What is on the approach path? The departure path? Trees, wires, poles, and fences are common hazards. Power lines are particularly dangerous because they are often invisible against cluttered backgrounds. Conduct an elevated reconnaissance before committing to a landing if wires are suspected.
+
+**C — Configuration / Slope:** Helicopters can land on slopes, but the rotor disk limits the maximum safe slope. Most small training helicopters have a maximum slope tolerance of approximately 5°–8° depending on the type. On a slope, the rotor tip on the upslope side will be closest to the terrain. Always land and take off heading upslope wherever possible. Check the POH for slope limitations.
+
+**A — Altitude / Air:** Density altitude at the site? Is there sufficient power margin for OGE hover if needed? What is the surface condition — dust, snow, loose material that could cause brownout or whiteout? What is the wind direction? Plan the approach into the wind when possible.
+
+**Source:** Transport Canada helicopter training publications; TP 12880E (performance chapters for density altitude).
+
+---
+
+### Low-Level Flight Planning
+
+Helicopter low-level flight planning differs from fixed-wing cross-country planning in several respects:
+
+**Terrain clearance:** The CARs minimum altitude over populated areas is 1,000 feet AGL; over sparse areas it is 500 feet AGL (CARs 602.14 and 602.15). However, helicopters operating for legitimate purposes (pipeline patrol, agricultural, search and rescue, medivac) may legally operate below these altitudes. Know the regulatory basis for any low-level operation.
+
+**Checkpoint frequency:** At low altitude, landmarks pass quickly and the horizon is compressed. Plan more frequent checkpoints — every 3–5 minutes of flight, not every 10–15 minutes as might be appropriate at altitude.
+
+**Fuel planning:** Helicopters have high fuel burn at low altitude (more induced drag, often higher power settings). Use low-altitude fuel burn figures from the POH, not cruise altitude figures.
+
+**Emergency landing sites:** Identify potential landing sites every few minutes along the route. In the event of a power failure, a helicopter enters autorotation — a controlled descent using rotor inertia — and has a very limited glide range (roughly 1–2 nautical miles from 1,000 feet AGL for a light helicopter). Routes over dense forest, water, or urban areas with no landing options require extra risk consideration.
+
+**Fuel reserve:** CARs 602.88 requires 30 minutes fuel reserve at cruise power for day VFR; 45 minutes for night VFR. Plan to land with this reserve intact.
+
+**Source:** CARs 602.14, 602.15, 602.88; TP 12880E.
+
+---
+
+### Pre-Flight Navigation Checklist
+
+Before any cross-country helicopter flight:
+
+1. Obtain weather briefing (METAR, TAF at destination and alternates, GFA for en-route)
+2. Calculate density altitude at origin and destination
+3. Plot route on VNC, identify checkpoints, measure distances and magnetic tracks
+4. Calculate TAS, apply wind for groundspeed and WCA, calculate ETAs
+5. Calculate fuel required (with reserve), confirm aircraft fuel load
+6. File flight plan or flight itinerary (if beyond 25 NM — CARs 602.73)
+7. Identify emergency landing sites along the route
+8. Confirm aircraft performance — verify OGE hover capability at departure and destination density altitude
+
+---
+
+### Key Navigation Numbers
+
+| Item | Value | Source |
+|------|-------|--------|
+| VNC scale | 1:500,000 | TC AIM MAP |
+| VTA scale | 1:250,000 | TC AIM MAP |
+| Day VFR fuel reserve | 30 minutes at cruise | CARs 602.88 |
+| Night VFR fuel reserve | 45 minutes at cruise | CARs 602.88 |
+| Flight plan required beyond | 25 NM from departure | CARs 602.73 |
+| Cruising altitude rule applies at | ≥ 3,000 ft AGL | CARs 602.35 |
+| Min altitude over populated areas | 1,000 ft AGL | CARs 602.14 |
+| Min altitude over sparse areas | 500 ft AGL | CARs 602.15 |
+
+---
+
+*End of Lesson HEL-003.*


### PR DESCRIPTION
Closes #421

> **Note:** This PR depends on #428 ([PPL-418]) which creates `lessons/helicopter/`. The base branch should be changed to `feat/issue-418-ppl-h-track` before merging, or both can be merged to main in order (418 first, then this PR).

## Changes

Added full lesson body content for three helicopter foundational lessons:

**`lessons/helicopter/001-air-law-helicopter.md` (HEL-001)**
- CARs Part VI framework — which rules are aircraft-neutral vs. helicopter-specific
- Airspace classifications A–G (identical requirements for helicopters)
- VFR weather minimums: controlled airspace same as fixed-wing; Class G reduced minimum per CARs 602.116 explained with caveats
- Right-of-way rules including aeroplane > helicopter priority (CARs 602.19)
- Flight plan/itinerary requirements (CARs 602.73)
- Circuit procedures at uncontrolled aerodromes and MF/ATF requirements
- Night VFR equipment requirements
- 5 quiz questions

**`lessons/helicopter/002-meteorology-helicopter.md` (HEL-002)**
- METAR, TAF, GFA, SIGMET/AIRMET product descriptions with Canadian sources
- Density altitude: definition, what raises it, performance impact on main rotor / engine / tail rotor, IGE vs. OGE hover margin concept
- Surface winds and translational lift — headwind vs. tailwind effect on performance
- Rotor downwash hazards: brownout, whiteout, spray
- Fog types and relevance to low-level helicopter ops
- Rotor icing hazards distinct from airframe icing
- 5 quiz questions

**`lessons/helicopter/003-navigation-helicopter.md` (HEL-003)**
- VNC (1:500,000), VTA (1:250,000), WAC chart types and uses
- Dead reckoning: full calculation chain including TAS, WCA, groundspeed, ETA
- Magnetic variation and compass deviation with mnemonic
- GPS as supplement — limitations and verification discipline
- Cruising altitude rule (CARs 602.35) and low-altitude exception for helicopters
- Off-aerodrome site assessment (SOCA: Size, Obstacles, Configuration/Slope, Altitude/Air)
- Low-level flight planning: terrain clearance rules, checkpoint frequency, autorotation range, fuel reserve
- 5 quiz questions

All lessons: `status: draft`, `duration_min: 20`, CARs section or TP number cited for every rule.

## Test Plan
- [ ] Each file parses as valid YAML frontmatter (id, topic, order, slug, title, duration_min, status, audio, sources, questions)
- [ ] Each lesson has exactly 5 quiz questions with id, prompt, choices (A–D), answer, explanation
- [ ] No regulations cited without CARs section or TP number
- [ ] No FAA-specific rules (all content is Transport Canada / Canadian CARs)
- [ ] Helicopter-specific differences from fixed-wing are clearly flagged
- [ ] Density altitude section covers the performance chart concept (POH reference)