### PR TITLE
Fix /playlist blank screen on RROE track + add app-wide ErrorBoundary

### DIFF
--- a/web-app/src/App.tsx
+++ b/web-app/src/App.tsx
@@ -5,6 +5,7 @@ import { buildTheme } from './theme';
 import { useThemeMode } from './context/ThemeModeContext';
 import { useStickyPlayer } from './context/StickyPlayerContext';
 import { TrackProvider } from './context/TrackContext';
+import AppErrorBoundary from './components/AppErrorBoundary';
 import Nav from './components/Nav';
 import StickyPlayerBar from './components/StickyPlayerBar';
 import Home from './pages/Home';
@@ -109,6 +110,7 @@ export default function App() {
               }),
             }}
           >
+            <AppErrorBoundary>
             <Routes>
               <Route path="/" element={<Home />} />
               <Route path="/lessons" element={<LessonsIndex />} />
@@ -129,6 +131,7 @@ export default function App() {
               <Route path="/pstar" element={<PSTARPath />} />
               <Route path="/srs" element={<SRSQueue />} />
             </Routes>
+            </AppErrorBoundary>
           </Box>
           <StickyPlayerBar />
         </Box>

--- a/web-app/src/components/AppErrorBoundary.tsx
+++ b/web-app/src/components/AppErrorBoundary.tsx
@@ -1,0 +1,51 @@
+import { Component } from 'react';
+import type { ReactNode, ErrorInfo } from 'react';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Container from '@mui/material/Container';
+import Typography from '@mui/material/Typography';
+
+interface Props {
+  children: ReactNode;
+}
+
+interface State {
+  hasError: boolean;
+  message: string;
+}
+
+export default class AppErrorBoundary extends Component<Props, State> {
+  state: State = { hasError: false, message: '' };
+
+  static getDerivedStateFromError(error: unknown): State {
+    const message = error instanceof Error ? error.message : String(error);
+    return { hasError: true, message };
+  }
+
+  componentDidCatch(error: unknown, info: ErrorInfo) {
+    console.error('[AppErrorBoundary]', error, info.componentStack);
+  }
+
+  render() {
+    if (!this.state.hasError) return this.props.children;
+
+    return (
+      <Container maxWidth="sm" sx={{ py: 8, textAlign: 'center' }}>
+        <Typography variant="h4" component="h1" sx={{ fontWeight: 700, mb: 2 }}>
+          Something went wrong
+        </Typography>
+        <Typography variant="body1" color="text.secondary" sx={{ mb: 4 }}>
+          An unexpected error occurred. Try going back or returning to the home page.
+        </Typography>
+        <Box sx={{ display: 'flex', gap: 2, justifyContent: 'center', flexWrap: 'wrap' }}>
+          <Button variant="outlined" onClick={() => window.history.back()}>
+            Go Back
+          </Button>
+          <Button variant="contained" href="/">
+            Back to Home
+          </Button>
+        </Box>
+      </Container>
+    );
+  }
+}

--- a/web-app/src/components/PlaylistPlayer.tsx
+++ b/web-app/src/components/PlaylistPlayer.tsx
@@ -178,6 +178,16 @@ export default function PlaylistPlayer({ lessons }: PlaylistPlayerProps) {
     writeSpeed(val);
   }
 
+  if (playlist.length === 0 || !current) {
+    return (
+      <Box sx={{ py: 4, textAlign: 'center' }}>
+        <Typography variant="body2" color="text.secondary">
+          No audio lessons available for this playlist yet.
+        </Typography>
+      </Box>
+    );
+  }
+
   return (
     <Box tabIndex={0} onKeyDown={handleKeyDown} sx={{ my: 2, width: '100%', outline: 'none', overflow: 'hidden' }}>
       <Typography

--- a/web-app/src/lib/exam-tracks.ts
+++ b/web-app/src/lib/exam-tracks.ts
@@ -167,7 +167,7 @@ export const EXAM_TRACKS: ExamTrack[] = [
     heroSubtitle: 'Structured lessons for the Transport Canada Instrument Rating. Audio-first, exam-weighted.',
     credibilityTag: 'Covers TC IFR written exam',
     lessonFilter: noLessons,
-    playlistTopics: TOPICS,
+    playlistTopics: [] as const,
     playlistHeading: 'IFR Playlist',
   },
   {
@@ -183,7 +183,7 @@ export const EXAM_TRACKS: ExamTrack[] = [
     heroSubtitle: 'Structured lessons for the Transport Canada Flight Instructor Rating.',
     credibilityTag: 'Covers TC Flight Instructor Rating',
     lessonFilter: noLessons,
-    playlistTopics: TOPICS,
+    playlistTopics: [] as const,
     playlistHeading: 'FI Playlist',
   },
 ];

--- a/web-app/src/pages/Playlist.tsx
+++ b/web-app/src/pages/Playlist.tsx
@@ -506,13 +506,19 @@ function PlaylistLibrary() {
       {/* §1 — Topic playlists */}
       <SectionHeader
         title="Topic Playlists"
-        meta={`${topicEntries.length} PLAYLISTS`}
+        meta={topicEntries.length > 0 ? `${topicEntries.length} PLAYLISTS` : undefined}
       />
-      <CardGrid>
-        {topicEntries.map((entry) => (
-          <PlaylistCard key={entry.id} entry={entry} />
-        ))}
-      </CardGrid>
+      {topicEntries.length === 0 ? (
+        <EmptyState
+          message={`No audio playlists for ${activeTrack.code} yet — lessons are still being recorded.`}
+        />
+      ) : (
+        <CardGrid>
+          {topicEntries.map((entry) => (
+            <PlaylistCard key={entry.id} entry={entry} />
+          ))}
+        </CardGrid>
+      )}
 
       {/* §2 — Curated playlists */}
       <SectionHeader


### PR DESCRIPTION
Closes #434

## Changes

1. **`web-app/src/components/AppErrorBoundary.tsx`** (new) — React class-based `ErrorBoundary` with `getDerivedStateFromError` / `componentDidCatch`. Fallback renders a centered MUI layout with heading, description, and "Go Back" / "Back to Home" buttons. No hardcoded hex.

2. **`web-app/src/App.tsx`** — Import and wrap `<Routes>` with `<AppErrorBoundary>`. `<Nav>` remains a sibling above the boundary so it stays visible on any render error.

3. **`web-app/src/pages/Playlist.tsx`** — In `PlaylistLibrary`, when `topicEntries.length === 0`, render the existing `<EmptyState>` component with a track-code-aware message ("No audio playlists for RROE yet — lessons are still being recorded.") instead of an empty card grid. All other sections (Curated, Your Playlists, Smart) continue to render regardless.

4. **`web-app/src/components/PlaylistPlayer.tsx`** — Early-return a friendly empty state when `playlist.length === 0` or `current` is undefined, before any access to `current.topic` / `current.title`.

5. **`web-app/src/lib/exam-tracks.ts`** — Set `playlistTopics: [] as const` on `ifr` and `instructor` tracks. `rroe`, `ppl-h`, and `cpl-a` keep their current `playlistTopics` and hit the new empty state naturally.

## Verification

| Track | `/playlist` result |
|---|---|
| PPL-A | Topic cards (Air Law, Nav, Met, GK) — unchanged |
| PSTAR | Air Law topic card — unchanged |
| RROE | Empty state: "No audio playlists for RROE yet…" |
| PPL-H | Empty state: "No audio playlists for PPL-H yet…" |
| CPL-A | Empty state: "No audio playlists for CPL-A yet…" |
| IFR | Empty state: "No audio playlists for IFR yet…" |
| Instructor (FI) | Empty state: "No audio playlists for FI yet…" |

Build: `npm run build` passes (TypeScript + Vite, 0 errors).