### PR TITLE
[PPL-434] Fault-tolerant playlist + app-wide ErrorBoundary

### DIFF
--- a/web-app/src/App.tsx
+++ b/web-app/src/App.tsx
@@ -7,6 +7,7 @@ import { useStickyPlayer } from './context/StickyPlayerContext';
 import { TrackProvider } from './context/TrackContext';
 import Nav from './components/Nav';
 import StickyPlayerBar from './components/StickyPlayerBar';
+import AppErrorBoundary from './components/AppErrorBoundary';
 import Home from './pages/Home';
 import LessonsIndex from './pages/LessonsIndex';
 import LessonDetail from './pages/LessonDetail';
@@ -109,6 +110,7 @@ export default function App() {
               }),
             }}
           >
+            <AppErrorBoundary>
             <Routes>
               <Route path="/" element={<Home />} />
               <Route path="/lessons" element={<LessonsIndex />} />
@@ -129,6 +131,7 @@ export default function App() {
               <Route path="/pstar" element={<PSTARPath />} />
               <Route path="/srs" element={<SRSQueue />} />
             </Routes>
+            </AppErrorBoundary>
           </Box>
           <StickyPlayerBar />
         </Box>

--- a/web-app/src/components/AppErrorBoundary.tsx
+++ b/web-app/src/components/AppErrorBoundary.tsx
@@ -1,0 +1,64 @@
+import { Component, type ErrorInfo, type ReactNode } from 'react';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Typography from '@mui/material/Typography';
+
+interface Props {
+  children: ReactNode;
+}
+
+interface State {
+  hasError: boolean;
+}
+
+export default class AppErrorBoundary extends Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError(): State {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    console.error('[AppErrorBoundary]', error, info.componentStack);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <Box
+          id="main-content"
+          sx={{
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+            justifyContent: 'center',
+            minHeight: '60vh',
+            px: 3,
+            textAlign: 'center',
+            gap: 2,
+          }}
+        >
+          <Typography variant="h5" component="h1" sx={{ fontWeight: 700 }}>
+            Something went wrong
+          </Typography>
+          <Typography variant="body2" color="text.secondary" sx={{ maxWidth: 400 }}>
+            An unexpected error occurred. Your study progress is safe — use the button below to return to the home screen.
+          </Typography>
+          <Button
+            variant="contained"
+            color="primary"
+            href="/"
+            sx={{ mt: 1, borderRadius: 1 }}
+          >
+            Back to Home
+          </Button>
+        </Box>
+      );
+    }
+
+    return this.props.children;
+  }
+}

--- a/web-app/src/components/PlaylistPlayer.tsx
+++ b/web-app/src/components/PlaylistPlayer.tsx
@@ -178,6 +178,16 @@ export default function PlaylistPlayer({ lessons }: PlaylistPlayerProps) {
     writeSpeed(val);
   }
 
+  if (playlist.length === 0) {
+    return (
+      <Box sx={{ py: 4, textAlign: 'center' }}>
+        <Typography variant="body2" color="text.secondary">
+          No audio lessons available for this playlist yet.
+        </Typography>
+      </Box>
+    );
+  }
+
   return (
     <Box tabIndex={0} onKeyDown={handleKeyDown} sx={{ my: 2, width: '100%', outline: 'none', overflow: 'hidden' }}>
       <Typography

--- a/web-app/src/lib/exam-tracks.ts
+++ b/web-app/src/lib/exam-tracks.ts
@@ -167,7 +167,7 @@ export const EXAM_TRACKS: ExamTrack[] = [
     heroSubtitle: 'Structured lessons for the Transport Canada Instrument Rating. Audio-first, exam-weighted.',
     credibilityTag: 'Covers TC IFR written exam',
     lessonFilter: noLessons,
-    playlistTopics: TOPICS,
+    playlistTopics: [] as const,
     playlistHeading: 'IFR Playlist',
   },
   {
@@ -183,7 +183,7 @@ export const EXAM_TRACKS: ExamTrack[] = [
     heroSubtitle: 'Structured lessons for the Transport Canada Flight Instructor Rating.',
     credibilityTag: 'Covers TC Flight Instructor Rating',
     lessonFilter: noLessons,
-    playlistTopics: TOPICS,
+    playlistTopics: [] as const,
     playlistHeading: 'FI Playlist',
   },
 ];

--- a/web-app/src/pages/Playlist.tsx
+++ b/web-app/src/pages/Playlist.tsx
@@ -506,13 +506,21 @@ function PlaylistLibrary() {
       {/* §1 — Topic playlists */}
       <SectionHeader
         title="Topic Playlists"
-        meta={`${topicEntries.length} PLAYLISTS`}
+        meta={topicEntries.length > 0 ? `${topicEntries.length} PLAYLISTS` : undefined}
       />
-      <CardGrid>
-        {topicEntries.map((entry) => (
-          <PlaylistCard key={entry.id} entry={entry} />
-        ))}
-      </CardGrid>
+      {topicEntries.length === 0 ? (
+        <Box sx={{ py: 4, textAlign: 'center' }}>
+          <Typography variant="h6" color="text.secondary">
+            No audio playlists for {activeTrack.code} yet — lessons are still being recorded.
+          </Typography>
+        </Box>
+      ) : (
+        <CardGrid>
+          {topicEntries.map((entry) => (
+            <PlaylistCard key={entry.id} entry={entry} />
+          ))}
+        </CardGrid>
+      )}
 
       {/* §2 — Curated playlists */}
       <SectionHeader


### PR DESCRIPTION
Closes #434

## Changes

- **`web-app/src/components/AppErrorBoundary.tsx`** (new) — React class-based `ErrorBoundary` using `getDerivedStateFromError` / `componentDidCatch`. Renders a centred fallback with a heading, description, and "Back to Home" button. Uses `theme.palette.*` tokens, no hardcoded hex, `borderRadius: 1` (8px).
- **`web-app/src/App.tsx`** — Wraps `<Routes>` in `<AppErrorBoundary>`. `<Nav>` remains a sibling above the boundary so it stays mounted on error.
- **`web-app/src/pages/Playlist.tsx`** — `PlaylistLibrary` now renders a track-aware empty-state `<Box>`+`<Typography>` when `topicEntries.length === 0` (e.g. "No audio playlists for RROE yet — lessons are still being recorded."). Curated / Your Playlists / Smart sections render regardless.
- **`web-app/src/components/PlaylistPlayer.tsx`** — Added early-return empty state when `playlist.length === 0` (post-filter), preventing a crash on `current.topic` / `current.title` when passed an all-null or empty lesson list.
- **`web-app/src/lib/exam-tracks.ts`** — `ifr` and `instructor` tracks now have `playlistTopics: [] as const`, so they correctly hit the empty-state path. `rroe`, `ppl-h`, and `cpl-a` keep their current values.

## Test Plan

- [ ] Switch active track to **RROE** → visit `/playlist` → page shows "No audio playlists for RROE yet…" with Nav and all other sections (Curated, Your Playlists, Smart) still present.
- [ ] Switch to **PPL-H**, **CPL-A**, **IFR**, or **Instructor** → visit `/playlist` → same friendly empty-state, no blank screen.
- [ ] Add a temporary `throw new Error('boom')` in any child component → app shows fallback heading + "Back to Home" button; Nav remains visible.
- [ ] `/playlist/topic/<unknown-slug>`, `/playlist/curated/<unknown-slug>`, `/playlist/user/<unknown-slug>` → friendly fallback (verify existing behaviour preserved).
- [ ] Switch to **PPL-A** or **PSTAR** → topic playlists render normally (regression check).