### PR TITLE
[PPL-423] Author helicopter lessons HEL-004–008 + fix smoke test for draft status

### DIFF
--- a/lessons/helicopter/004-aerodynamics-helicopter.md
+++ b/lessons/helicopter/004-aerodynamics-helicopter.md
@@ -1,8 +1,140 @@
 ---
 id: HEL-004
 topic: helicopter
-status: planning
-audio: null
+order: 4
+slug: aerodynamics-helicopter
+title: "Helicopter Aerodynamics"
+duration_min: 20
+status: draft
+sources:
+  - "TC Helicopter Flight Training Manual (TP 9982E)"
+  - "TP 12880E — Aeroplane Flight Training Manual (rotary-wing supplement concepts)"
+  - "CARs Part VI Subpart 3 (helicopter-specific provisions)"
+questions:
+  - id: q1
+    prompt: "Translational lift in a helicopter is gained when:"
+    choices:
+      A: "The pilot increases collective pitch to produce more rotor RPM"
+      B: "The helicopter accelerates and the rotor system moves into undisturbed air, increasing efficiency"
+      C: "The tail rotor produces additional lift to assist the main rotor"
+      D: "The helicopter climbs above the ground effect cushion"
+    answer: B
+    explanation: "Translational lift occurs as the helicopter transitions from hover to forward flight. As the rotor disc moves into undisturbed (non-recirculating) air, the effective angle of attack increases and rotor efficiency improves markedly. This is typically felt between 16–24 knots. Source: TP 9982E, Helicopter Aerodynamics chapter."
+  - id: q2
+    prompt: "Dissymmetry of lift in a helicopter in forward flight is caused by:"
+    choices:
+      A: "The tail rotor producing more thrust on one side than the other"
+      B: "The advancing blade having a higher airspeed — and thus more lift — than the retreating blade"
+      C: "The rotor mast tilting the disc forward during cruise"
+      D: "Torque effect pulling the fuselage nose to the right"
+    answer: B
+    explanation: "In forward flight the advancing blade (moving in the same direction as flight) has a higher relative airspeed than the retreating blade (moving opposite to flight). This creates asymmetric lift. Blade flapping and pitch change mechanisms are used to compensate. Source: TP 9982E."
+  - id: q3
+    prompt: "During a power-off autorotation, the energy sustaining rotor rotation comes from:"
+    choices:
+      A: "Inertia stored in the rotor disc at the time of engine failure"
+      B: "The airflow through the rotor disc from below as the helicopter descends"
+      C: "Residual engine torque transmitted through the freewheeling unit"
+      D: "Wind energy captured by the advancing blade only"
+    answer: B
+    explanation: "In autorotation the helicopter descends and air flows upward through the rotor disc. This upward airflow through the inner portion of the disc produces a driving force that sustains rotor RPM. The freewheeling unit disconnects the engine from the rotor, allowing autorotation independent of engine state. Source: TP 9982E."
+  - id: q4
+    prompt: "Torque effect in a single-rotor helicopter tends to rotate the fuselage:"
+    choices:
+      A: "In the same direction as the main rotor"
+      B: "In the opposite direction to the main rotor, countered by the tail rotor"
+      C: "Nose-down, requiring forward cyclic to counteract"
+      D: "Nose-up, requiring aft cyclic during hover"
+    answer: B
+    explanation: "Newton's third law: the rotor torque applied to spin the main rotor produces an equal and opposite reaction on the fuselage, rotating it in the opposite direction. The tail rotor generates sideward thrust to counteract this torque. Source: TP 9982E, Torque and Tail Rotor section."
+  - id: q5
+    prompt: "Ground effect in a helicopter is most pronounced when hovering at approximately:"
+    choices:
+      A: "One rotor diameter above the surface"
+      B: "Half the rotor diameter above the surface"
+      C: "Two rotor diameters above the surface"
+      D: "Three rotor diameters above the surface"
+    answer: B
+    explanation: "Ground effect is significant within approximately one rotor diameter of the surface and is greatest at about half the rotor diameter. The cushion of high-pressure air between the rotor disc and the surface reduces induced drag and increases lift efficiency. Source: TP 9982E."
 ---
 
-Helicopter aerodynamics including rotor systems, translational lift, and autorotation principles.
+# Lesson HEL-004: Helicopter Aerodynamics
+
+**Section:** Helicopter  
+**Lesson number:** 004  
+**Estimated time:** 20 minutes  
+**Source:** TC Helicopter Flight Training Manual (TP 9982E); CARs Part VI Subpart 3
+
+---
+
+## Narration Script
+
+Welcome to the helicopter aerodynamics lesson. If you've already studied fixed-wing aerodynamics, some of what follows will look familiar — lift, drag, angle of attack. But rotary-wing flight involves forces and phenomena unique to helicopters. This lesson covers the fundamentals you need for the PPL-H written exam.
+
+---
+
+### The Four Forces — Rotary-Wing Version
+
+In fixed-wing flight, the four forces are lift (up), weight (down), thrust (forward), and drag (rearward). In a helicopter, the rotor system produces both lift and thrust simultaneously, in whatever direction the rotor disc is tilted. This is the key difference: a helicopter has no separate engine-driven propeller for forward thrust. The main rotor does everything.
+
+**Lift** is generated by the rotor blades as they spin through the air. Each blade is an aerofoil, just like a wing, and produces lift by accelerating airflow over its cambered upper surface and creating a pressure differential. The total lift of the rotor disc depends on blade pitch angle (set by collective and cyclic controls), rotor RPM, air density, and blade area.
+
+**Thrust** — in helicopter terminology, the component of total rotor force that acts horizontally — is produced by tilting the rotor disc. Tilt forward, and the horizontal component accelerates the helicopter forward. Tilt laterally, and you sideslip. The rotor disc does not tilt by physically moving the mast; instead, the pilot changes the pitch of individual blades as they rotate around the disc, producing more lift on one side and less on the other, which causes the disc to tilt. This is the function of the cyclic control.
+
+**Drag** in a rotor system includes profile drag (air resistance of the blades themselves), induced drag (drag from lift production), and parasite drag (fuselage and component drag). The engine must overcome all of these to maintain rotor RPM.
+
+**Torque** — unique to helicopters with a single main rotor — is the reaction force. When the engine spins the main rotor in one direction, Newton's third law dictates the fuselage tries to rotate in the opposite direction. In most North American helicopters, the main rotor turns counter-clockwise when viewed from above, so the fuselage tries to yaw to the right. The tail rotor produces sideward thrust to counteract this torque.
+
+---
+
+### Translational Lift
+
+In a hover, the rotor system works in a recirculating mass of air it has already disturbed. This recirculated, turbulent air is less efficient than fresh, undisturbed air. As the helicopter accelerates into forward flight — typically noticeable between 16 and 24 knots — the rotor disc begins to outrun its own downwash and moves into undisturbed air. The result is a dramatic increase in rotor efficiency: translational lift. The pilot experiences this as a slight lurch or "jump" in lift as the helicopter transitions from hover to forward flight. Climbing away from a hover, this transition is a welcome boost. Decelerating to a hover, the loss of translational lift means the pilot must add collective to maintain altitude.
+
+---
+
+### Dissymmetry of Lift
+
+In forward flight, the advancing blade (the blade moving in the same direction as the helicopter's flight) has a higher airspeed relative to the air than the retreating blade (moving opposite to the direction of flight). At cruise speed, the velocity difference between advancing and retreating blades is roughly twice the airspeed of the helicopter. More airspeed means more lift — so without compensation, the advancing side of the rotor disc would produce far more lift than the retreating side, rolling the helicopter toward the retreating side.
+
+Two mechanisms compensate for dissymmetry of lift:
+
+1. **Blade flapping.** In articulated and semi-rigid rotor systems, blades are free to flap up and down as they rotate. The advancing blade, producing excess lift, flaps upward. This reduces its angle of attack and therefore its lift. The retreating blade flaps downward, which increases its angle of attack and its lift. Flapping equalizes lift around the disc.
+
+2. **Blade pitch change.** Cyclic pitch inputs alter blade pitch as each blade passes through different positions in the rotation, precisely matching lift production to the position in the disc. This is controlled automatically by the swashplate mechanism.
+
+The retreating blade stall is the limiting factor in helicopter airspeed. At high speeds, the retreating blade's angle of attack must be increased to produce adequate lift, and eventually the blade reaches a critical angle and stalls. Retreating blade stall causes vibration, a nose pitch-up tendency, and roll toward the retreating side — a dangerous condition requiring immediate deceleration.
+
+---
+
+### Autorotation Principles
+
+When the engine fails (or is deliberately disengaged), the pilot must immediately enter autorotation. Autorotation is the state in which the main rotor is driven not by engine power, but by the aerodynamic forces generated by airflow through the rotor disc during descent.
+
+How it works: as the helicopter descends, air flows upward through the rotor disc. This upward-flowing air strikes the lower surface of the rotor blades in the inner portion of the disc and produces a driving force — a force that keeps the rotor spinning. The pilot controls descent rate with collective and uses cyclic to manage airspeed and direction. The freewheeling unit (sprag clutch) automatically disengages the engine from the rotor, allowing the rotor to spin freely as the engine stops.
+
+At the correct point above the ground — the flare altitude — the pilot raises the nose sharply, converting forward airspeed into rotor RPM (rotor inertia) and reducing descent rate. The stored energy in the spinning rotor disc is used during the final flare and cushion to achieve a safe landing. A successful autorotation requires the helicopter to be within safe parameters on the height-velocity diagram — more on that in the performance lesson.
+
+---
+
+### Ground Effect
+
+When hovering close to the surface — within roughly one rotor diameter — the rotor's downwash cannot flow freely downward and outward. The ground interferes with the airflow, creating a high-pressure cushion beneath the rotor disc. This reduces induced drag, increases efficiency, and allows the helicopter to hover at a lower power setting than out of ground effect. Ground effect is greatest at about half the rotor diameter above the surface.
+
+Practically: a helicopter can sometimes hover in ground effect (HIGE) when it cannot hover out of ground effect (HOGE) — this matters significantly for performance planning, especially at high density altitudes or heavy weights.
+
+---
+
+## Key Points
+
+- The main rotor provides both lift and directional thrust — unique to helicopters.
+- Torque reaction tries to rotate the fuselage opposite to rotor direction; the tail rotor counteracts this.
+- Translational lift occurs ~16–24 kt as the rotor moves into undisturbed air.
+- Dissymmetry of lift (advancing vs. retreating blade airspeed difference) is corrected by blade flapping and cyclic pitch change.
+- Retreating blade stall limits maximum airspeed.
+- Autorotation uses upward airflow through a descending rotor disc to maintain RPM — no engine needed.
+- Ground effect is strongest within half a rotor diameter of the surface.
+
+---
+
+*End of Lesson HEL-004.*

--- a/lessons/helicopter/004-aerodynamics-helicopter.md
+++ b/lessons/helicopter/004-aerodynamics-helicopter.md
@@ -6,10 +6,11 @@ slug: aerodynamics-helicopter
 title: "Helicopter Aerodynamics"
 duration_min: 20
 status: draft
+audio: null
 sources:
   - "TC Helicopter Flight Training Manual (TP 9982E)"
   - "TP 12880E — Aeroplane Flight Training Manual (rotary-wing supplement concepts)"
-  - "CARs Part VI Subpart 3 (helicopter-specific provisions)"
+  - "CARs Part VI (General Operating and Flight Rules)"
 questions:
   - id: q1
     prompt: "Translational lift in a helicopter is gained when:"
@@ -63,7 +64,7 @@ questions:
 **Section:** Helicopter  
 **Lesson number:** 004  
 **Estimated time:** 20 minutes  
-**Source:** TC Helicopter Flight Training Manual (TP 9982E); CARs Part VI Subpart 3
+**Source:** TC Helicopter Flight Training Manual (TP 9982E); CARs Part VI
 
 ---
 

--- a/lessons/helicopter/005-systems-helicopter.md
+++ b/lessons/helicopter/005-systems-helicopter.md
@@ -1,8 +1,159 @@
 ---
 id: HEL-005
 topic: helicopter
-status: planning
-audio: null
+order: 5
+slug: systems-helicopter
+title: "Helicopter Systems"
+duration_min: 20
+status: draft
+sources:
+  - "TC Helicopter Flight Training Manual (TP 9982E)"
+  - "CARs Part VI Subpart 3"
+  - "Transport Canada Aeronautical Information Manual (AIM)"
+questions:
+  - id: q1
+    prompt: "A fully articulated rotor system allows each blade to move in:"
+    choices:
+      A: "One axis only — flap up and down"
+      B: "Two axes — flap and feather (pitch change)"
+      C: "Three axes — flap, lead-lag, and feather (pitch change)"
+      D: "No independent movement — blades are rigidly attached to the hub"
+    answer: C
+    explanation: "In a fully articulated rotor system, each blade is attached to the hub via hinges that allow independent movement in three planes: flapping (up/down), lead-lag (fore/aft in the plane of rotation), and feathering (pitch change about the blade's spanwise axis). This design is typical of medium and large helicopters. Source: TP 9982E, Rotor Systems chapter."
+  - id: q2
+    prompt: "NOTAR (No Tail Rotor) systems provide anti-torque thrust primarily by:"
+    choices:
+      A: "A ducted fan inside the tail boom that blows air laterally"
+      B: "Circulation control using a jet of air exhausted through slots in the tail boom, plus a rotating thruster at the tail"
+      C: "Counter-rotating main rotors that cancel each other's torque"
+      D: "Moveable vertical stabilizers that use aerodynamic forces to counteract torque"
+    answer: B
+    explanation: "NOTAR uses engine bleed air blown through slots along the tail boom. The Coanda effect causes the main rotor downwash to attach to and wrap around the tail boom, producing sideward thrust (circulation control). A variable-pitch rotating thruster at the tail provides additional directional control. Source: TP 9982E; manufacturer documentation (MD Helicopters)."
+  - id: q3
+    prompt: "The main advantage of a turbine engine over a piston engine in helicopter operations is:"
+    choices:
+      A: "Turbine engines use less fuel per hour at all power settings"
+      B: "Turbine engines maintain nearly constant power output across a wider range of density altitudes and can be more readily controlled at high power"
+      C: "Turbine engines require no warm-up period before flight"
+      D: "Turbine engines are always lighter than equivalent piston engines"
+    answer: B
+    explanation: "Turbine (turboshaft) engines provide more consistent power across altitude and temperature ranges compared to normally aspirated piston engines, which lose approximately 3% power per 1,000 feet of altitude gain. Turbines also have a high power-to-weight ratio. Note: turbines use more fuel at low power and require specific startup procedures. Source: TP 9982E, Powerplants chapter."
+  - id: q4
+    prompt: "The transmission in a helicopter serves primarily to:"
+    choices:
+      A: "Convert engine RPM to appropriate main and tail rotor RPM, and transmit torque to both rotor systems"
+      B: "Control the collective pitch of all rotor blades simultaneously"
+      C: "Provide a clutch mechanism for the freewheeling unit only"
+      D: "Regulate fuel flow to match pilot-demanded power"
+    answer: A
+    explanation: "Helicopter engines operate at high RPM (turbines ~20,000–30,000 RPM; pistons ~2,500–3,000 RPM). The transmission reduces engine RPM to a suitable rotor RPM (typically 300–500 RPM for the main rotor) via gearboxes. It also drives the tail rotor through a driveshaft and distributes power to accessories. Source: TP 9982E, Transmission Systems chapter."
+  - id: q5
+    prompt: "The freewheeling unit (sprag clutch) in a helicopter automatically:"
+    choices:
+      A: "Increases rotor RPM during an engine failure to prevent overspeeding"
+      B: "Disengages the engine from the rotor if engine RPM drops below rotor RPM, enabling autorotation"
+      C: "Locks the rotor to the engine during all phases of normal flight"
+      D: "Engages when collective is lowered and disengages when collective is raised"
+    answer: B
+    explanation: "The freewheeling unit (sprag or overrunning clutch) is a one-way clutch: it transmits torque from engine to rotor when the engine is driving, but automatically disengages if the rotor RPM exceeds engine RPM (as occurs on engine failure or throttle reduction). This allows the rotor to autorotate freely. Source: TP 9982E."
 ---
 
-Helicopter aircraft systems including powerplant, transmission, and flight controls.
+# Lesson HEL-005: Helicopter Systems
+
+**Section:** Helicopter  
+**Lesson number:** 005  
+**Estimated time:** 20 minutes  
+**Source:** TC Helicopter Flight Training Manual (TP 9982E); CARs Part VI Subpart 3
+
+---
+
+## Narration Script
+
+Understanding helicopter systems is essential for safe operation and for the PPL-H written exam. This lesson covers the main components that make a helicopter fly: the rotor systems, anti-torque systems, transmission, engine types, and the fuel and electrical systems.
+
+---
+
+### Main Rotor Systems
+
+All single-rotor helicopters have one main rotor that provides lift and directional control. The differences between helicopter types often come down to how the rotor blades are attached to the hub — specifically, how much freedom of movement each blade has. There are three primary rotor hub designs:
+
+**Fully Articulated Rotor Systems** attach each blade to the hub with multiple hinges, allowing movement in three planes:
+
+1. **Flapping** — the blade can move up and down about the horizontal flapping hinge. This corrects for dissymmetry of lift in forward flight, as discussed in the aerodynamics lesson.
+2. **Lead-Lag (Drag)** — the blade can move fore and aft within the plane of rotation about the vertical drag hinge. This absorbs the acceleration and deceleration forces each blade experiences as it flaps.
+3. **Feathering (Pitch Change)** — the blade can rotate about its spanwise axis to change its angle of attack. This is the mechanism the cyclic and collective controls use.
+
+Fully articulated systems are found on medium and large helicopters (Robinson R44 class and above, Bell 206, Sikorsky S-76, etc.). They are mechanically complex but allow effective control at high airspeeds and with heavy loads.
+
+**Semi-Rigid (Teetering) Rotor Systems** use a two-blade rotor where both blades are rigidly attached to each other and to a teetering hinge at the hub. The pair of blades can teeter (one flaps up, the other flaps down) as a unit, and each blade can feather independently for pitch change. There are no individual lead-lag hinges — the semi-rigid system relies on blade flexibility to absorb those forces. The Robinson R22 and R44 use this design. Semi-rigid systems are simpler and lighter but are more sensitive to low-g conditions that can cause mast bumping.
+
+**Rigid (Hingeless) Rotor Systems** attach blades directly to the hub with no flapping or lead-lag hinges. Instead, the blades themselves flex to accommodate flapping and lead-lag forces — an engineering feat requiring composite materials. Rigid rotors offer very responsive handling and are used on high-performance helicopters. Feathering still occurs through pitch change bearings.
+
+---
+
+### Tail Rotor and Anti-Torque Systems
+
+A single main rotor helicopter requires a system to counteract main rotor torque and provide directional (yaw) control. The standard solution is a tail rotor: a small rotor mounted vertically at the tail boom, its thrust axis perpendicular to the longitudinal axis of the helicopter.
+
+The tail rotor is driven by the transmission via a driveshaft running the length of the tail boom. The pilot controls tail rotor pitch (and therefore thrust) with the anti-torque pedals. Left pedal increases tail rotor thrust to yaw the nose left; right pedal decreases thrust (or reverses it on some designs) to yaw the nose right.
+
+**NOTAR (No Tail Rotor)** — developed by MD Helicopters — eliminates the conventional tail rotor entirely using an aerodynamic phenomenon called the Coanda effect. An engine-driven fan pressurizes the tail boom interior. Air exits through longitudinal slots along the boom's right side. The main rotor downwash, interacting with this jet of air via Coanda effect, wraps around the tail boom, generating a sideward lift force that counteracts torque. A small variable-pitch thruster at the very tip of the tail provides additional yaw control authority. NOTAR systems eliminate the hazard of an exposed tail rotor — a significant safety advantage in confined areas.
+
+**Tandem Rotor Helicopters** (e.g., Boeing CH-47 Chinook) use two counter-rotating main rotors — front and rear. Because the rotors rotate in opposite directions, their torques cancel each other. No tail rotor is needed. Tandem designs excel in heavy-lift applications.
+
+**Coaxial Rotor Systems** (e.g., Kamov Ka-32) use two counter-rotating main rotors on the same shaft, one above the other. Again, opposing torques cancel.
+
+---
+
+### Transmission System
+
+Helicopter engines operate at far higher RPM than the main rotor can safely turn. A turboshaft engine may run at 20,000–30,000 RPM at the power turbine shaft; a typical main rotor turns at 300–500 RPM. The transmission (gearbox) reduces this speed through a series of gear stages and distributes power to the main rotor, tail rotor driveshaft, and accessory drives (hydraulics, generators, etc.).
+
+Critical components within or associated with the transmission include:
+
+- **Freewheeling Unit (Sprag Clutch):** A one-way clutch that drives the rotor when engine RPM exceeds rotor RPM, and automatically disengages when rotor RPM exceeds engine RPM. On engine failure, this allows the rotor to continue spinning for autorotation without the engine drag impeding it.
+- **Clutch (Belt Drive or Centrifugal):** On piston helicopters, a clutch allows the engine to be started and warmed up before engaging the rotor. Turbine helicopters use the freewheeling unit directly.
+- **Gearboxes:** The main gearbox and intermediate gearboxes step down RPM. They must be lubricated and have defined operating temperature and oil pressure limits monitored by cockpit gauges.
+
+Transmission chip detectors warn of metal particles in the gearbox oil — an early indicator of internal wear. A chip light is treated as an emergency.
+
+---
+
+### Engine Types
+
+**Piston (Reciprocating) Engines** power light training helicopters. The Robinson R22 uses a Lycoming O-320, and the R44 uses a Lycoming IO-540. Piston engines are fuel-efficient at low power but lose approximately 3% power per 1,000 feet of density altitude, making high-altitude or hot-day performance calculations critical. They require carburetor heat or fuel injection and have magneto-based ignition systems.
+
+**Turboshaft Engines** power medium and large helicopters. A turboshaft is a gas turbine in which almost all turbine power goes to drive the output shaft (rather than producing thrust as in a jet engine). Turboshafts maintain more consistent power across altitude ranges, have high power-to-weight ratios, and run on jet fuel (Jet-A, Jet-B). They require specific startup sequences and are more expensive to operate. The Bell 206 JetRanger uses the Allison 250-C series turboshaft.
+
+---
+
+### Fuel Systems
+
+Fuel system components in a helicopter include tanks (often located below the cabin for low center of gravity), fuel pumps (engine-driven and electric boost pumps), filters, fuel control units, and gauges. Piston helicopters use AVGAS (100LL). Turbine helicopters use Jet-A or Jet-B. Misfuelling is an emergency.
+
+Fuel venting is critical — without it, fuel tanks would collapse as fuel is consumed. Check that fuel vents are unobstructed during preflight.
+
+Turbine engines have a combustion chamber where fuel is ignited, and fuel flow is controlled by the fuel control unit (FCU), which automatically adjusts fuel to maintain demanded power.
+
+---
+
+### Electrical Systems
+
+Helicopter electrical systems are similar to fixed-wing: a battery for starting and backup power, an alternator or generator (driven by the engine or gearbox) for primary power in flight, a bus bar distributing power to systems, and circuit breakers for protection.
+
+In turbine helicopters, electrical power may also run from a starter-generator, which functions as a starter during engine start and switches to generator mode once engine RPM is sufficient. Some helicopters have dual electrical buses for redundancy.
+
+---
+
+## Key Points
+
+- Fully articulated rotors have three hinges per blade (flap, lead-lag, feather). Semi-rigid teetering rotors share a teetering hinge. Rigid rotors flex structurally.
+- Tail rotor counteracts main rotor torque and provides yaw control. NOTAR uses Coanda effect and a tip thruster instead.
+- The freewheeling unit disconnects the engine from the rotor on engine failure, enabling autorotation.
+- The transmission reduces engine RPM to rotor RPM and distributes power.
+- Piston engines power light helicopters (AVGAS); turboshafts power medium/large (Jet-A). Turbines maintain power better at altitude.
+- Chip detectors in gearbox oil warn of internal wear — a chip light is an emergency.
+
+---
+
+*End of Lesson HEL-005.*

--- a/lessons/helicopter/005-systems-helicopter.md
+++ b/lessons/helicopter/005-systems-helicopter.md
@@ -6,9 +6,11 @@ slug: systems-helicopter
 title: "Helicopter Systems"
 duration_min: 20
 status: draft
+audio: null
 sources:
   - "TC Helicopter Flight Training Manual (TP 9982E)"
-  - "CARs Part VI Subpart 3"
+  - "CARs 605.06 — Aircraft Equipment Standards and Serviceability"
+  - "CARs Part VI (General Operating and Flight Rules)"
   - "Transport Canada Aeronautical Information Manual (AIM)"
 questions:
   - id: q1
@@ -63,7 +65,7 @@ questions:
 **Section:** Helicopter  
 **Lesson number:** 005  
 **Estimated time:** 20 minutes  
-**Source:** TC Helicopter Flight Training Manual (TP 9982E); CARs Part VI Subpart 3
+**Source:** TC Helicopter Flight Training Manual (TP 9982E); CARs 605.06; CARs Part VI
 
 ---
 

--- a/lessons/helicopter/006-performance-helicopter.md
+++ b/lessons/helicopter/006-performance-helicopter.md
@@ -6,9 +6,11 @@ slug: performance-helicopter
 title: "Helicopter Performance"
 duration_min: 20
 status: draft
+audio: null
 sources:
   - "TC Helicopter Flight Training Manual (TP 9982E)"
-  - "CARs 602.46 — Weight and Balance"
+  - "CARs 605.31 — Weight and Balance Control"
+  - "CARs 605.92 — Aircraft Operating Limitations"
   - "Transport Canada TP 13572E — Density Altitude and Performance"
 questions:
   - id: q1
@@ -46,7 +48,7 @@ questions:
       C: "A manufacturer-defined reference point from which all moment arms are measured"
       D: "The centre of the fuselage"
     answer: C
-    explanation: "The datum is an arbitrary reference point defined by the manufacturer (often the nose of the helicopter, the rotor hub, or another convenient point). All moment arm distances (horizontal distances from the datum to component CG locations) are measured from this datum. The overall centre of gravity must remain within the allowable CG envelope for safe flight. Source: CARs 602.46; TP 9982E, Weight and Balance chapter."
+    explanation: "The datum is an arbitrary reference point defined by the manufacturer (often the nose of the helicopter, the rotor hub, or another convenient point). All moment arm distances (horizontal distances from the datum to component CG locations) are measured from this datum. The overall centre of gravity must remain within the allowable CG envelope for safe flight. Source: CARs 605.31; TP 9982E, Weight and Balance chapter."
   - id: q5
     prompt: "A helicopter's CG that is too far aft will result in:"
     choices:
@@ -63,7 +65,7 @@ questions:
 **Section:** Helicopter  
 **Lesson number:** 006  
 **Estimated time:** 20 minutes  
-**Source:** TC Helicopter Flight Training Manual (TP 9982E); CARs 602.46; TP 13572E
+**Source:** TC Helicopter Flight Training Manual (TP 9982E); CARs 605.31; CARs 605.92; TP 13572E
 
 ---
 
@@ -119,7 +121,7 @@ Helicopter weight and balance follows the same fundamental principles as fixed-w
 - **Aft CG:** The disc must tilt aft, requiring forward cyclic. Extreme aft CG can exhaust forward cyclic travel, leading to loss of control. Aft CG also reduces longitudinal stability and makes the helicopter harder to control.
 - **Lateral CG:** Many helicopters have a lateral CG limit. Asymmetric loading (e.g., a heavy passenger on one side and no one on the other) can cause a sustained lateral roll that requires constant cyclic correction and may exceed the correction available.
 
-**CARs 602.46** requires that no aircraft be operated at a weight or CG position outside the certificated limits established by the manufacturer.
+**CARs 605.31** requires that aircraft be operated within the weight and balance limits established by the manufacturer, and **CARs 605.92** requires the operating limitations from the flight manual to be available to the flight crew.
 
 ---
 
@@ -150,7 +152,7 @@ Density altitude is the altitude in the International Standard Atmosphere (ISA) 
 - The H-V (height-velocity) diagram defines combinations of height and speed from which autorotation to a safe landing is not possible — avoid the "dead man's curve."
 - Helicopter CG must remain within the manufacturer's envelope; aft CG is particularly dangerous due to loss of forward cyclic authority.
 - High density altitude reduces both rotor efficiency and engine power, degrading all performance parameters.
-- CARs 602.46 requires operation within certificated weight and CG limits.
+- CARs 605.31 requires weight and balance control within certificated limits; CARs 605.92 covers operating limitations.
 
 ---
 

--- a/lessons/helicopter/006-performance-helicopter.md
+++ b/lessons/helicopter/006-performance-helicopter.md
@@ -1,8 +1,157 @@
 ---
 id: HEL-006
 topic: helicopter
-status: planning
-audio: null
+order: 6
+slug: performance-helicopter
+title: "Helicopter Performance"
+duration_min: 20
+status: draft
+sources:
+  - "TC Helicopter Flight Training Manual (TP 9982E)"
+  - "CARs 602.46 — Weight and Balance"
+  - "Transport Canada TP 13572E — Density Altitude and Performance"
+questions:
+  - id: q1
+    prompt: "A helicopter is said to be operating HOGE when it:"
+    choices:
+      A: "Hovers with its skids within 10 feet of the ground"
+      B: "Hovers at an altitude where the ground cushion is no longer effective, typically above one rotor diameter"
+      C: "Hovers with the engine at maximum continuous power"
+      D: "Hovers over a surface with no wind"
+    answer: B
+    explanation: "HOGE (Hover Out of Ground Effect) refers to hovering at an altitude high enough that the ground pressure cushion is negligible — typically above approximately one rotor diameter. HOGE requires significantly more power than HIGE (Hover In Ground Effect). The distinction is critical for performance planning at high density altitudes or heavy weights. Source: TP 9982E, Performance chapter."
+  - id: q2
+    prompt: "The height-velocity (H-V) diagram defines regions where autorotation to a safe landing:"
+    choices:
+      A: "Is always possible regardless of airspeed or altitude"
+      B: "Is not possible within the 'dead man's curve' — too high and too slow, or too low to arrest the descent"
+      C: "Is only possible above 500 feet AGL"
+      D: "Requires the pilot to immediately raise the collective to maximum"
+    answer: B
+    explanation: "The H-V diagram shows combinations of height and airspeed from which a safe autorotational landing cannot be made — either there is insufficient airspeed to flare, or insufficient height to arrest the rate of descent. Flight in the 'dead man's curve' is avoided in single-engine helicopters during normal operations. Source: TP 9982E; Rotorcraft Flight Manual for the specific type."
+  - id: q3
+    prompt: "Increasing density altitude has which of the following effects on helicopter hover performance?"
+    choices:
+      A: "Increases available lift because the rotor blades produce more lift in thinner air"
+      B: "Has no effect if the engine is producing rated power"
+      C: "Reduces rotor efficiency and engine power output, requiring higher collective pitch for the same lift, which may exceed available power"
+      D: "Only affects turbine-powered helicopters, not piston-powered ones"
+    answer: C
+    explanation: "High density altitude (high altitude, high temperature, low pressure, high humidity) reduces air density. Thinner air means the rotor blades generate less lift per unit of pitch angle, so more collective is required. Simultaneously, piston engines lose ~3% power per 1,000 ft density altitude, and turbines are also affected. The combination can reduce hover capability to the point where flight is impossible at extreme conditions. Source: TP 9982E; TP 13572E."
+  - id: q4
+    prompt: "When computing helicopter weight and balance, the datum is:"
+    choices:
+      A: "Always the main rotor hub"
+      B: "The forward skid attachment point"
+      C: "A manufacturer-defined reference point from which all moment arms are measured"
+      D: "The centre of the fuselage"
+    answer: C
+    explanation: "The datum is an arbitrary reference point defined by the manufacturer (often the nose of the helicopter, the rotor hub, or another convenient point). All moment arm distances (horizontal distances from the datum to component CG locations) are measured from this datum. The overall centre of gravity must remain within the allowable CG envelope for safe flight. Source: CARs 602.46; TP 9982E, Weight and Balance chapter."
+  - id: q5
+    prompt: "A helicopter's CG that is too far aft will result in:"
+    choices:
+      A: "Improved autorotation performance"
+      B: "A tendency to pitch nose-up that may exceed available forward cyclic travel to correct"
+      C: "Increased tail rotor effectiveness"
+      D: "Reduced fuel consumption due to lower drag"
+    answer: B
+    explanation: "An aft CG shifts the balance point behind the optimal position. The rotor disc must be tilted aft to maintain level flight, and in extreme cases the nose-up tendency exceeds the pilot's ability to apply forward cyclic. This can result in loss of control. Aft CG also reduces longitudinal stability. Source: TP 9982E, Weight and Balance chapter."
 ---
 
-Helicopter performance calculations including weight and balance, density altitude effects, and hover charts.
+# Lesson HEL-006: Helicopter Performance
+
+**Section:** Helicopter  
+**Lesson number:** 006  
+**Estimated time:** 20 minutes  
+**Source:** TC Helicopter Flight Training Manual (TP 9982E); CARs 602.46; TP 13572E
+
+---
+
+## Narration Script
+
+Performance planning for helicopters is different from fixed-wing in several key ways. Helicopters operate much closer to their performance limits — especially in hover, where power demands are highest. Understanding HIGE versus HOGE, the height-velocity diagram, weight and balance, and density altitude effects is fundamental to safe helicopter operations.
+
+---
+
+### Hover In Ground Effect (HIGE) vs. Hover Out of Ground Effect (HOGE)
+
+Ground effect, as covered in the aerodynamics lesson, is the efficiency gain the rotor experiences when operating close to the surface. In practical performance terms:
+
+**HIGE (Hover In Ground Effect)** — hovering with skids near the surface, typically within approximately one rotor diameter. The ground cushion reduces induced drag and improves rotor efficiency. A helicopter hovering in ground effect requires significantly less power than the same helicopter hovering at height. For a given weight, temperature, and altitude, there is a maximum density altitude at which the helicopter can HIGE, and a separate (lower) limit for HOGE.
+
+**HOGE (Hover Out of Ground Effect)** — hovering at sufficient altitude that ground effect is negligible. HOGE requires more power. At high density altitudes or near maximum gross weight, a helicopter that can achieve HIGE may not be able to achieve HOGE. This has direct operational implications:
+
+- If departure requires transitioning through the HOGE regime (such as lifting above trees or a ridgeline before gaining translational lift), the helicopter must be able to HOGE at that weight and density altitude — or the departure cannot be safely made.
+- Performance charts in the Rotorcraft Flight Manual (RFM) provide HIGE and HOGE power requirements for various combinations of pressure altitude, temperature, and gross weight.
+
+Always check HOGE capability, not just HIGE, when planning helicopter operations from confined areas or elevated terrain.
+
+---
+
+### The Height-Velocity (H-V) Diagram — "Dead Man's Curve"
+
+The height-velocity diagram (H-V diagram, also called the "dead man's curve") is unique to helicopters. It defines combinations of height above ground and airspeed from which a safe autorotational landing cannot be accomplished following a sudden engine failure.
+
+The diagram typically shows two "avoid" regions:
+
+1. **The High-Hover Region (upper left):** The helicopter is flying slowly at high altitude. If the engine fails here, there is not enough airspeed to flare effectively and reduce the rate of descent before reaching the ground. The descent rate, even in autorotation, cannot be arrested in time.
+
+2. **The Low-Speed, Low-Height Region (lower right):** The helicopter is flying fast and low. If the engine fails, there is insufficient height to establish autorotation, reduce speed, flare, and cushion the landing before ground contact.
+
+Outside these avoid regions — that is, either low and slow (below the low-altitude avoid region) or sufficiently high and fast — an engine failure can be managed with a successful autorotation.
+
+In practice, pilots flying single-engine helicopters try to minimize time in the avoid regions of the H-V diagram. During takeoff, this means transitioning quickly through the vulnerable speed range — accelerating and climbing through the danger zone as rapidly as practical. During approach, pilots plan descent profiles that pass through the avoid regions briefly and at speeds that offer the best autorotation options.
+
+The H-V diagram is specific to each helicopter type and is found in the Rotorcraft Flight Manual. It varies with gross weight and density altitude — at higher weights or density altitudes, the avoid regions grow.
+
+---
+
+### Weight and Balance for Helicopters
+
+Helicopter weight and balance follows the same fundamental principles as fixed-wing: total weight must be within the maximum certificated gross weight, and the centre of gravity (CG) must remain within the allowable CG envelope throughout the flight.
+
+**Weight:** Exceeding maximum gross weight reduces performance margins, increases stress on the rotor system and transmission, and degrades autorotation capability. Load and fuel must be managed to stay within limits. As fuel burns, the CG shifts — plan for both the takeoff and landing CG positions.
+
+**CG Envelope:** The manufacturer defines a CG envelope in the RFM — typically a chart of CG position (forward-aft and sometimes lateral) versus gross weight. The datum is a manufacturer-defined reference point (sometimes the nose, sometimes the main rotor shaft). Moment arms are measured horizontally from the datum; positive arms are typically aft of datum.
+
+**Effects of CG Position:**
+- **Forward CG:** The rotor disc must tilt forward to maintain trim, requiring aft cyclic. Extreme forward CG can exhaust aft cyclic authority. Forward CG generally improves longitudinal stability.
+- **Aft CG:** The disc must tilt aft, requiring forward cyclic. Extreme aft CG can exhaust forward cyclic travel, leading to loss of control. Aft CG also reduces longitudinal stability and makes the helicopter harder to control.
+- **Lateral CG:** Many helicopters have a lateral CG limit. Asymmetric loading (e.g., a heavy passenger on one side and no one on the other) can cause a sustained lateral roll that requires constant cyclic correction and may exceed the correction available.
+
+**CARs 602.46** requires that no aircraft be operated at a weight or CG position outside the certificated limits established by the manufacturer.
+
+---
+
+### Density Altitude Effects on Performance
+
+Density altitude is the altitude in the International Standard Atmosphere (ISA) that corresponds to the actual air density. It accounts for pressure altitude, temperature, and humidity. High density altitude means low air density, which degrades both rotor performance and engine performance.
+
+**Effect on Rotors:** Thinner air produces less lift per unit of angle of attack. For a given rotor RPM and blade area, more blade pitch (collective) is required to produce the same lift. This increases induced drag and power demand.
+
+**Effect on Piston Engines:** Piston engines lose approximately 3% of sea-level power per 1,000 feet of density altitude. At 5,000 feet density altitude, a normally aspirated engine produces only about 85% of its rated sea-level power. The power available decreases while the power required increases — a double penalty.
+
+**Effect on Turboshaft Engines:** Turbine engines are less affected than pistons up to the critical altitude, but they still lose power at high density altitudes, and their fuel consumption increases. Temperature is the primary degrading factor for turbines at altitude.
+
+**Practical Implications:**
+- On hot summer days at high-elevation aerodromes (many locations in BC, Alberta, and the Yukon), density altitude may be 3,000–5,000 feet higher than field elevation.
+- Performance charts must be used at actual density altitude, not field elevation.
+- Hover capability (HIGE and HOGE) degrades rapidly with density altitude.
+- Takeoff distance and climb performance decrease.
+- In extreme cases, departure may need to be delayed until cooler temperatures (early morning) or load reduced.
+
+**Computing Density Altitude:** Use a flight computer or the chart in the Canada Flight Supplement / performance charts. Rule of thumb: add approximately 1,000 feet of density altitude for every 15°C above ISA temperature at a given pressure altitude. ISA temperature is 15°C at sea level, decreasing 2°C per 1,000 feet.
+
+---
+
+## Key Points
+
+- HIGE (In Ground Effect) requires less power than HOGE (Out of Ground Effect) — always check HOGE capability when confined-area or elevated departures are planned.
+- The H-V (height-velocity) diagram defines combinations of height and speed from which autorotation to a safe landing is not possible — avoid the "dead man's curve."
+- Helicopter CG must remain within the manufacturer's envelope; aft CG is particularly dangerous due to loss of forward cyclic authority.
+- High density altitude reduces both rotor efficiency and engine power, degrading all performance parameters.
+- CARs 602.46 requires operation within certificated weight and CG limits.
+
+---
+
+*End of Lesson HEL-006.*

--- a/lessons/helicopter/007-helicopter-ops.md
+++ b/lessons/helicopter/007-helicopter-ops.md
@@ -1,8 +1,177 @@
 ---
 id: HEL-007
 topic: helicopter
-status: planning
-audio: null
+order: 7
+slug: helicopter-ops
+title: "Helicopter Operations"
+duration_min: 20
+status: draft
+sources:
+  - "TC Helicopter Flight Training Manual (TP 9982E)"
+  - "CARs Part VI Subpart 3 (helicopter-specific provisions)"
+  - "Transport Canada Advisory Circular AC 600-001 — Off-Aerodrome Operations"
+questions:
+  - id: q1
+    prompt: "When making a slope landing with a helicopter, the correct technique is to:"
+    choices:
+      A: "Touch the downhill skid first, then lower collective to settle both skids simultaneously"
+      B: "Touch the uphill skid first, then carefully lower collective to settle the downhill skid"
+      C: "Hover sideways into the slope and lower collective evenly"
+      D: "Land as on flat ground — rotor disc tilt corrects automatically"
+    answer: B
+    explanation: "Slope landing technique requires touching the uphill skid first while maintaining heading with anti-torque pedals. Once the uphill skid is on the slope, collective is reduced slowly to lower the downhill skid. This prevents the rotor disc from striking the slope. The main risk on a steep slope is blade/mast contact with the terrain. Source: TP 9982E, Mountain and Slope Operations chapter."
+  - id: q2
+    prompt: "When approaching a pinnacle or mountaintop landing site, the recommended approach path is:"
+    choices:
+      A: "From directly below, hovering up the face of the peak"
+      B: "Into the wind, low and flat, to stay within the ground effect cushion"
+      C: "Into the wind, on a steep approach that keeps the helicopter in position to turn away from the pinnacle if power is insufficient"
+      D: "From downwind so that the approach can be made slowly against the wind"
+    answer: C
+    explanation: "Pinnacle approaches are made into the wind on a steeper-than-normal approach angle. This keeps the helicopter in a position where it can safely turn away from the high terrain if power is found to be insufficient (no overshooting onto a high obstacle). The pilot must assess winds carefully — turbulence, mechanical turbulence, and downdrafts are common near peaks. Source: TP 9982E."
+  - id: q3
+    prompt: "During a confined area approach, the pilot should assess the landing zone (LZ) for:"
+    choices:
+      A: "Fuel availability and ATC frequencies"
+      B: "Obstacles, surface conditions, wind direction and hazards, LZ dimensions relative to rotor diameter, and escape routes"
+      C: "IFR approach procedures only"
+      D: "The availability of a helical approach path"
+    answer: B
+    explanation: "Before entering a confined area, the pilot must orbit the LZ at a safe altitude to assess: obstacles in the approach and departure paths, surface hazards (wires, stumps, uneven terrain), wind direction and velocity, LZ dimensions (must fit the rotor span plus a safety margin), and available escape routes if the approach must be discontinued. Source: TP 9982E; AC 600-001."
+  - id: q4
+    prompt: "During an autorotation, when should the pilot initiate the flare?"
+    choices:
+      A: "At approximately 500 feet AGL to maximize rotor RPM storage"
+      B: "At a height and airspeed determined by the helicopter type's RFM, typically 40–100 feet AGL depending on airspeed"
+      C: "Only after the descent rate has increased to maximum"
+      D: "When the helicopter reaches the ground — collective is raised to cushion impact"
+    answer: B
+    explanation: "The flare height and airspeed vary by helicopter type and are specified in the Rotorcraft Flight Manual. A typical entry-level helicopter may initiate the flare between 40–100 feet AGL. The flare converts forward airspeed into rotor RPM via blade inertia and reduces both forward speed and descent rate. Too early a flare wastes energy; too late and descent rate cannot be arrested. Source: TP 9982E; type-specific RFM."
+  - id: q5
+    prompt: "Sling load operations require the pilot to be particularly aware of:"
+    choices:
+      A: "Increased electrical load from the cargo hook electronics"
+      B: "Load oscillation (pendulum effect), altered CG, degraded performance, and the need to jettison the load if control is compromised"
+      C: "Reduced tail rotor effectiveness due to downwash interference from the load"
+      D: "The requirement to file an IFR flight plan for all sling operations"
+    answer: B
+    explanation: "Sling loads introduce a pendulum mass below the helicopter that can oscillate, particularly in turbulence or during speed changes. The external load alters CG, increases drag, and significantly reduces performance. A cargo hook jettison capability is required so the crew can release a load that compromises control. Source: TP 9982E; CARs 602.26 (external loads)."
 ---
 
-Helicopter operations including confined area approaches, slope landings, and external load considerations.
+# Lesson HEL-007: Helicopter Operations
+
+**Section:** Helicopter  
+**Lesson number:** 007  
+**Estimated time:** 20 minutes  
+**Source:** TC Helicopter Flight Training Manual (TP 9982E); CARs Part VI Subpart 3; AC 600-001
+
+---
+
+## Narration Script
+
+Helicopters operate in environments that fixed-wing aircraft rarely or never visit — mountain pinnacles, forest clearings, ship decks, and construction sites. This versatility is the helicopter's greatest advantage and its greatest operational challenge. This lesson covers the techniques and decision-making required for confined area and off-aerodrome operations, slope landings, sling loads, and emergency procedures including autorotation.
+
+---
+
+### Confined Area Operations
+
+A confined area is any landing zone where the available approach and departure paths are restricted by terrain, obstacles, or other limitations. Examples include forest clearings, narrow valleys, building rooftops, and accident scenes surrounded by trees or power lines.
+
+**Pre-approach reconnaissance** is mandatory. Before committing to a confined area approach, the pilot should orbit the landing zone at a safe altitude — typically 500 feet above the highest obstacle — to assess:
+
+- **Wind direction and velocity:** Confirmed by smoke, water, grass movement, or a wind sock. The approach must be into the wind.
+- **Surface hazards:** Uneven terrain, stumps, loose debris that rotor wash could pick up (FOD — foreign object debris), slope angle.
+- **Obstacles:** Wires (often invisible from a distance), trees, fences, poles, tall grass. Wires are the greatest hazard — the eye does not see them until it is too late. Look for the poles, then trace a line between them to locate the wire.
+- **LZ dimensions:** The landing area must accommodate the helicopter's rotor span plus adequate clearance. Know your rotor diameter.
+- **Escape routes:** Identify a departure path before entering. If power is insufficient on approach, you must be able to discontinue safely. In a confined area there may only be one viable escape route — identify it before committing.
+
+**Approach profile:** Into the wind. Steeper than a normal aerodrome approach — this maximizes the pilot's ability to see the LZ and to abort if necessary. The pilot should fly to a hover at the approach end of the LZ and then transitionally reposition if required, rather than flying fast into the confined area.
+
+**Departure:** Plan the departure route during reconnaissance. Depart into the wind. If the departure end of the LZ has a lower obstacle clearance, a vertical takeoff to a hover above the obstacles before transitioning to forward flight may be required. Verify HOGE capability at that weight and density altitude before committing to the LZ.
+
+---
+
+### Pinnacle and Ridgeline Operations
+
+Pinnacle and ridgeline operations involve landing on or near the top of a hill, peak, or ridge. These sites present unique hazards:
+
+- **Updrafts and downdrafts:** Wind tends to accelerate over peaks and can create violent turbulence on the downwind side. Mechanical turbulence from irregular terrain shapes is common.
+- **No go-around:** On a pinnacle approach, if the approach is too fast or power is insufficient, there may be no room to go around. The descent side of a pinnacle is terrain, not runway.
+- **Loss of translational lift:** As the helicopter decelerates toward the pinnacle in a hover, it transitions out of the translational lift regime, requiring additional power exactly when the pilot needs power reserve for obstacle clearance.
+
+**Approach technique:** Into the wind. Steep approach profile, positioned so the helicopter can turn away from the pinnacle (toward open air) if the approach must be abandoned. Never approach downwind into a pinnacle — the tailwind reduces effective rotor airspeed and performance.
+
+**Landing:** Touch the uphill (or windward) part of the skids first, then lower collective carefully as the remaining skid settles.
+
+---
+
+### Slope Landings
+
+Slope landings are required when the terrain is not level — mountainous terrain, hillsides, and unprepared sites frequently require landing on angled ground.
+
+The key hazard in slope landings is **blade strike** — if the rotor disc is tilted toward the uphill slope while the skids are on the slope, the descending blade tip can contact the ground.
+
+**Slope landing technique (example: approaching from the left, uphill to the right):**
+
+1. Hover over the slope in a level attitude.
+2. Move laterally or hover-taxi until positioned correctly.
+3. Lower collective gradually, touching the **uphill skid** (right skid in this example) to the slope first.
+4. Maintain heading with pedals.
+5. Continue lowering collective slowly while applying opposite cyclic (into the slope — left cyclic) to keep the disc level relative to the horizon.
+6. The downhill skid settles as collective continues to be reduced.
+7. Once firmly on the slope, continue to reduce collective to idle.
+
+The cyclic is held into the slope to prevent the rotor disc from tilting uphill and reducing clearance on the uphill side. The maximum slope angle is limited by the helicopter's cyclic travel range — specified in the RFM. Exceeding maximum slope angle risks the mast or hub striking the terrain or losing cyclic authority.
+
+**Slope departure:** Reverse the process — establish the correct power, apply cyclic into the slope as collective is raised, lift the downhill skid first, then hover clear before transitioning to forward flight.
+
+---
+
+### Sling Load Operations
+
+Sling (external) loads are carried beneath the helicopter on a cargo hook. Applications include construction, forestry, search and rescue, and utility work.
+
+**Performance considerations:** An external load significantly increases drag and weight. Performance must be computed at the actual loaded gross weight. Fuel may need to be reduced to accommodate payload within gross weight limits. The external load raises power requirements — verify HOGE capability is available.
+
+**CG effects:** A sling load positioned directly below the cargo hook may shift CG aft or laterally depending on helicopter and hook geometry. Compute weight and balance with the external load.
+
+**Pendulum oscillation:** A sling load can swing like a pendulum. Abrupt power changes, speed changes, or turbulence can initiate oscillation. If oscillation starts, slow airspeed gradually and use smooth control inputs. Do not jerk the controls — this feeds energy into the oscillation.
+
+**Cargo hook jettison:** All sling-load equipped helicopters have a means to jettison the load in an emergency. If control is compromised or a wire strike is imminent, the load must be released immediately. Pilots brief the hook release before every sling operation. CARs 602.26 governs external load operations and requires appropriate certification.
+
+---
+
+### Emergency Procedures — Autorotation Entry and Flare
+
+Engine failure in a helicopter requires immediate, correct response.
+
+**Autorotation entry:** Upon loss of engine power, the pilot immediately lowers the collective to the minimum pitch position. This is the most time-critical action — without it, rotor RPM decays rapidly and the rotor may stall, making recovery impossible. The freewheeling unit disengages the engine from the rotor automatically, but the pilot must relieve blade pitch load to let the rotor accelerate. The manufacturer's RFM specifies target autorotation RPM; the pilot must achieve and maintain it with collective.
+
+Simultaneously:
+- Apply right pedal (or correct for the specific helicopter) as torque effect disappears with loss of engine power, to maintain heading.
+- Select a landing area and establish best autorotation airspeed — typically 60–80 knots for most light helicopters, specified in the RFM.
+- Transmit a MAYDAY if altitude and workload allow: "MAYDAY MAYDAY MAYDAY, [callsign], engine failure, [position], [altitude], [POB], autorotation."
+
+**During the descent:** Maintain target RPM and airspeed. Adjust as needed with small collective changes. A higher airspeed gives more energy for the flare; lower airspeed allows slower descent. Monitor the H-V diagram parameters — you are now in autorotation; the question is whether height and speed allow an effective flare.
+
+**The flare:** At the manufacturer-specified height (refer to RFM — typically 40–100 feet AGL for light helicopters), raise the nose progressively to reduce descent rate and forward speed. The aft tilt of the rotor disc converts forward kinetic energy into rotor RPM inertia. Rotor RPM rises during the flare — this stored energy is what will cushion the landing.
+
+**The cushion:** As the helicopter slows and approaches landing attitude, the nose is levelled, and collective is raised to use stored rotor energy to break the descent. The goal is to arrive at the surface with the minimum possible descent rate and a manageable forward speed.
+
+Autorotation is a perishable skill requiring regular practice. Currency requirements are specified in CARs Part IV.
+
+---
+
+## Key Points
+
+- Confined area operations require a reconnaissance orbit before approach — always identify escape routes.
+- Wires are the greatest hazard in off-aerodrome operations; look for poles to find the wire.
+- Pinnacle approaches: steep, into wind, positioned to turn away from terrain if power is insufficient.
+- Slope landings: touch the uphill skid first, apply cyclic into the slope to prevent blade strike.
+- Sling loads: compute performance at loaded gross weight; cargo hook jettison is a required capability.
+- Engine failure response: immediately lower collective to maintain rotor RPM — this is the most critical first action.
+- The autorotation flare converts forward speed into rotor inertia to cushion the landing.
+
+---
+
+*End of Lesson HEL-007.*

--- a/lessons/helicopter/007-helicopter-ops.md
+++ b/lessons/helicopter/007-helicopter-ops.md
@@ -6,9 +6,11 @@ slug: helicopter-ops
 title: "Helicopter Operations"
 duration_min: 20
 status: draft
+audio: null
 sources:
   - "TC Helicopter Flight Training Manual (TP 9982E)"
-  - "CARs Part VI Subpart 3 (helicopter-specific provisions)"
+  - "CARs 602.26 — Carriage of External Loads"
+  - "CARs Part VI (General Operating and Flight Rules)"
   - "Transport Canada Advisory Circular AC 600-001 — Off-Aerodrome Operations"
 questions:
   - id: q1
@@ -63,7 +65,7 @@ questions:
 **Section:** Helicopter  
 **Lesson number:** 007  
 **Estimated time:** 20 minutes  
-**Source:** TC Helicopter Flight Training Manual (TP 9982E); CARs Part VI Subpart 3; AC 600-001
+**Source:** TC Helicopter Flight Training Manual (TP 9982E); CARs 602.26; CARs Part VI; AC 600-001
 
 ---
 

--- a/lessons/helicopter/008-human-factors-helicopter.md
+++ b/lessons/helicopter/008-human-factors-helicopter.md
@@ -6,10 +6,11 @@ slug: human-factors-helicopter
 title: "Human Factors in Helicopter Operations"
 duration_min: 20
 status: draft
+audio: null
 sources:
   - "TC Helicopter Flight Training Manual (TP 9982E)"
   - "Transport Canada TP 12863E — Human Factors for Aviation — Basic Handbook"
-  - "CARs 602.115 — Aerobatic Manoeuvres (inadvertent IMC context)"
+  - "CARs 602.114 / 602.115 — VFR Weather Minimums (inadvertent IMC context)"
   - "TC Advisory Circular AC 700-042 — Fatigue Risk Management"
 questions:
   - id: q1

--- a/lessons/helicopter/008-human-factors-helicopter.md
+++ b/lessons/helicopter/008-human-factors-helicopter.md
@@ -1,8 +1,185 @@
 ---
 id: HEL-008
 topic: helicopter
-status: planning
-audio: null
+order: 8
+slug: human-factors-helicopter
+title: "Human Factors in Helicopter Operations"
+duration_min: 20
+status: draft
+sources:
+  - "TC Helicopter Flight Training Manual (TP 9982E)"
+  - "Transport Canada TP 12863E — Human Factors for Aviation — Basic Handbook"
+  - "CARs 602.115 — Aerobatic Manoeuvres (inadvertent IMC context)"
+  - "TC Advisory Circular AC 700-042 — Fatigue Risk Management"
+questions:
+  - id: q1
+    prompt: "Spatial disorientation is most likely to occur when a pilot:"
+    choices:
+      A: "Is flying in visual meteorological conditions above 3,000 feet AGL"
+      B: "Loses visual reference to the horizon or ground, causing vestibular and visual cues to conflict with actual aircraft attitude"
+      C: "Is fatigued but can still read all flight instruments clearly"
+      D: "Is flying at night with all cockpit lights at full brightness"
+    answer: B
+    explanation: "Spatial disorientation occurs when a pilot's vestibular (inner ear) and proprioceptive sensations conflict with the actual aircraft attitude, typically when outside visual references (horizon, ground) are lost. The inner ear cannot reliably detect gradual attitude changes or sustained turns. The pilot perceives a false attitude and may instinctively fly toward the incorrect indicated position. Source: TP 12863E, Sensory Illusions chapter."
+  - id: q2
+    prompt: "The correct response when inadvertent IMC is encountered in a helicopter is:"
+    choices:
+      A: "Immediately enter a steep descending spiral to get below the cloud quickly"
+      B: "Maintain current heading and continue VFR, as helicopters can slow to a hover"
+      C: "Trust body sensations and maintain attitude by feel to avoid instrument fixation"
+      D: "Execute a 180° turn using cockpit instruments to exit the IMC conditions, and declare an emergency"
+    answer: D
+    explanation: "On entering IMC inadvertently, the correct response is to execute a standard-rate 180° turn on instruments to exit the IMC, declare an emergency (MAYDAY), and obtain ATC assistance. Attempting to descend through cloud to VMC below is dangerous — terrain may be unknown. The body's sensations cannot be trusted in IMC — only the instruments provide accurate attitude information. Source: TP 9982E; TP 12863E."
+  - id: q3
+    prompt: "Cockpit workload during low-level helicopter operations is high primarily because:"
+    choices:
+      A: "Low-level operations require constant radio communication with ATC"
+      B: "The pilot must simultaneously manage aircraft attitude, navigation, obstacle detection, task coordination, and external communications with reduced reaction time due to proximity to terrain"
+      C: "Turbulence at low altitude requires more frequent power changes than cruise flight"
+      D: "Fuel consumption is higher at low altitude, requiring frequent fuel calculations"
+    answer: B
+    explanation: "Low-level operations compress reaction time — terrain, wires, and other obstacles are much closer and approach rapidly. The pilot is simultaneously flying the aircraft, navigating, communicating, detecting hazards, and managing the task (e.g., power line patrol, search pattern). This saturates the cognitive task channel and leaves little reserve for unexpected events. Source: TP 12863E, Workload Management chapter."
+  - id: q4
+    prompt: "Pilot fatigue is most hazardous because it:"
+    choices:
+      A: "Reduces fuel efficiency by causing uneven power inputs"
+      B: "Degrades decision-making, reaction time, and situational awareness while the pilot may feel able to continue safely"
+      C: "Is easily detected by the pilot before it becomes dangerous"
+      D: "Only affects night operations"
+    answer: B
+    explanation: "Fatigue degrades cognitive function, reaction time, and decision quality — often before the pilot is aware of the degradation. A fatigued pilot may feel subjectively alert while actually operating at significantly reduced capacity. Fatigue is implicated in a disproportionate share of helicopter accidents, particularly in demanding operational environments (EMS, offshore). Source: TP 12863E; TC AC 700-042."
+  - id: q5
+    prompt: "The 'get-there-itis' hazardous attitude is best countered by the antidote:"
+    choices:
+      A: "'I am the best pilot around.'"
+      B: "'Nothing will happen to me.'"
+      C: "'I'll try it.'"
+      D: "'It is not worth taking the risk. I will not rush.'"
+    answer: D
+    explanation: "Transport Canada identifies five hazardous pilot attitudes: anti-authority, impulsivity, invulnerability, macho, and resignation/get-there-itis. 'Get-there-itis' (pressing on despite deteriorating conditions to reach a destination) is countered by recognising the pressure and deliberately affirming that the risk is not worth the schedule. Source: TP 12863E, Hazardous Attitudes chapter."
 ---
 
-Human factors and crew resource management principles specific to helicopter pilot operations.
+# Lesson HEL-008: Human Factors in Helicopter Operations
+
+**Section:** Helicopter  
+**Lesson number:** 008  
+**Estimated time:** 20 minutes  
+**Source:** TC Helicopter Flight Training Manual (TP 9982E); TP 12863E — Human Factors for Aviation; TC AC 700-042
+
+---
+
+## Narration Script
+
+Human factors is the study of how people interact with systems, environments, and each other — and how those interactions affect safety. In aviation, human error contributes to the majority of accidents. Helicopter operations amplify many human factors challenges because of their low-level, demanding, and often degraded-environment nature. This lesson covers spatial disorientation, cockpit workload in low-level operations, fatigue, and decision-making when VFR conditions deteriorate to IMC.
+
+---
+
+### Spatial Disorientation
+
+Spatial disorientation is a state in which the pilot's perception of the aircraft's attitude, altitude, or motion conflicts with actual flight parameters. It is one of the leading causes of fatal accidents across all of aviation — and helicopters, with their ability to fly slowly and at very low altitudes in varied environments, are particularly vulnerable.
+
+**The physiology:** The human body uses three systems to detect orientation: vision, the vestibular system (inner ear — semicircular canals and otolith organs), and proprioception (pressure on body parts — the "seat of the pants" feeling). In normal, coordinated VFR flight with a visible horizon, all three systems broadly agree and provide accurate orientation cues.
+
+The vestibular system has well-documented limitations:
+
+- **The semicircular canals** detect rotational acceleration. They do not detect sustained, constant-rate rotation — if a turn continues at a constant rate for more than about 20 seconds, the sensed rotation fades and the pilot perceives the aircraft to be wings-level in a turn. When the turn is corrected, the pilot senses a turn in the opposite direction — the "leans."
+
+- **The otolith organs** detect linear acceleration — sustained forward acceleration feels identical to nose-up pitch. An acceleration during takeoff can create a pitch-up illusion. The "black hole" approach illusion (approaching a dark, featureless area over water or unlit terrain) causes pilots to pitch up — a well-documented cause of fatal accidents.
+
+**In helicopters specifically:** Low-level flight near trees, terrain, and obstacles in reduced visibility or at night creates conditions where outside visual references disappear or mislead. Slopes, water surfaces, and low-contrast terrain do not provide reliable horizon cues. A slight bank angle entered inadvertently in a confined area may go undetected until the aircraft is significantly off attitude.
+
+**Prevention:** Maintain excellent instrument scan even in VMC. In degraded visual conditions, transition immediately to instrument references rather than trusting sensations. Know the visual illusions common to your operational environment.
+
+---
+
+### Inadvertent IMC
+
+Inadvertent entry into Instrument Meteorological Conditions (IMC) — flying into cloud, fog, or precipitation without an IFR rating and clearance — is one of the most deadly scenarios in general aviation and helicopter operations. The statistics are clear: VFR pilots who continue into IMC have a very high probability of spatial disorientation, loss of control, and impact with terrain or water.
+
+**Why it happens:** Visibility and ceiling deteriorate gradually. The pilot makes incremental decisions — each step seems small. "It's still flyable." "Just past this ridge." This is classic "get-there-itis" combined with the visual illusion that conditions ahead may be better. By the time the pilot recognizes that flight must stop, they may be surrounded by cloud.
+
+**Helicopter-specific vulnerability:** Helicopters often fly low and in marginal weather on operational missions (EMS, utility, search and rescue). They can fly at low airspeeds, which some pilots mistakenly believe provides an option to hover if visibility deteriorates — but hovering in IMC, without external visual references, is extremely difficult even for experienced pilots and requires full IFR capability.
+
+**Correct response to inadvertent IMC:**
+
+1. **Do not panic.** Establish wings-level, coordinated flight on instruments — attitude indicator, altimeter, airspeed, VSI, and directional gyro.
+2. **Execute a 180° turn** using a standard-rate turn (3°/second) back toward known VMC. Cross-reference the heading indicator and ball (slip indicator) throughout the turn.
+3. **Declare an emergency (MAYDAY)** on 121.5 MHz or the last used ATC frequency. Request radar vectors to VMC or the nearest suitable aerodrome.
+4. **Do not attempt to descend** through cloud to VMC below unless you are certain of terrain clearance — and in mountainous terrain, this is almost never a safe assumption.
+
+If equipped and rated, request an IFR clearance and navigate to an instrument approach. If not rated, accept a radar vector from ATC.
+
+Transport Canada training emphasizes that the best defence against inadvertent IMC is to never enter marginal conditions without a firm plan for deterioration — and to turn back early, not late.
+
+---
+
+### Cockpit Workload in Low-Level Operations
+
+Helicopter pilots frequently operate at low altitude — 200 feet AGL in powerline patrol, lower in search and rescue, near ground in utility work. Low-level flight compresses reaction time dramatically. An obstacle at 200 feet AGL passes in a fraction of a second at cruise speed. There is no altitude buffer for a moment of inattention.
+
+**Task saturation:** The pilot must simultaneously:
+- Fly the aircraft (attitude, airspeed, altitude, heading)
+- Navigate (terrain avoidance, waypoints, operational route)
+- Detect hazards (wires, wildlife, personnel, equipment)
+- Manage the operational mission (photography, survey, rescue)
+- Communicate (air-to-ground and air-to-air)
+- Monitor systems (engine, fuel, transmission)
+
+This multi-task demand can saturate available cognitive resources. When the pilot is task-saturated, critical stimuli (a wire, a stall warning, a radio call) may not be processed in time to respond.
+
+**Crew Resource Management (CRM):** In multi-crew operations, CRM distributes the task load between pilots and crew members. The flying pilot should focus on flying; the non-flying pilot handles communications, navigation, and monitoring. Even in single-pilot operations, effective self-briefing, checklist use, and pre-task planning reduce in-flight workload.
+
+**Automation:** Modern glass-cockpit helicopters use autopilots, stability augmentation systems, and flight directors to reduce manual workload. Understanding when and how to engage automation — and the hazards of over-reliance on it — is part of low-level operational competency.
+
+**The "sterile cockpit":** During critical phases of flight (takeoff, approach, confined area entry), all non-essential conversation and activity stops. This concept — borrowed from airline operations and formalized in CARs — keeps attention on the task when consequences of distraction are highest.
+
+---
+
+### Fatigue
+
+Fatigue is a state of physical or mental exhaustion that impairs performance. It is implicated in an outsized proportion of helicopter accidents, particularly in 24/7 operations (EMS, offshore, search and rescue) where crews may be called out at night or after long duty days.
+
+**Effects of fatigue:**
+- Slowed reaction time
+- Reduced situational awareness — the pilot stops anticipating and begins reacting late
+- Degraded decision quality — risks are underestimated, shortcuts are taken
+- Microsleeps — brief, involuntary episodes of sleep lasting 1–30 seconds, during which no information is processed
+- Subjective confidence that performance is still adequate — fatigue impairs self-assessment
+
+**Sleep debt:** Aviation physiology research shows that sleep debt accumulates. Missing two hours of sleep per night for a week causes impairment equivalent to 24 hours without sleep. This debt cannot be "caught up" with a single long sleep.
+
+**Transport Canada regulations (CARs Part VII, and operator-specific Fatigue Risk Management Systems):** Set maximum duty hours and minimum rest periods for commercial helicopter operations. These limits are floors, not targets — an operator may have lower limits. Pilots retain a personal responsibility to report for duty only when fit. CARs 602.02 (fitness to operate) and AC 700-042 provide the regulatory framework.
+
+**Self-assessment tools:** The IMSAFE checklist (Illness, Medication, Stress, Alcohol, Fatigue, Eating and Emotion) is a standardized pre-flight self-assessment tool endorsed by Transport Canada and taught in all Canadian flight training.
+
+---
+
+### Decision-Making and Hazardous Attitudes
+
+Transport Canada's human factors curriculum identifies five hazardous pilot attitudes and their antidotes:
+
+| Attitude | Thought Pattern | Antidote |
+|----------|----------------|----------|
+| Anti-authority | "Don't tell me what to do." | Follow the rules — they are usually right. |
+| Impulsivity | "Do something — now!" | Not so fast. Think first. |
+| Invulnerability | "It won't happen to me." | It could happen to me. |
+| Macho | "I can do it." | Taking chances is foolish. |
+| Resignation/Get-there-itis | "What's the use?" / "Just this once." | I'm not helpless. / It's not worth the risk. |
+
+Situational awareness — knowing what is happening, what is about to happen, and what your options are — is the goal of good cockpit decision-making. The DECIDE model provides a structured framework: Detect a problem, Estimate its significance, Choose a course of action, Identify the best option, Do it, Evaluate the outcome.
+
+In helicopter operations, the "personal minimums" concept encourages pilots to establish weather, currency, and equipment standards more conservative than the regulatory minimum, and to commit to them before the flight — before external pressure (schedule, a waiting crew, a patient in the field) can cloud judgment.
+
+---
+
+## Key Points
+
+- Spatial disorientation results from vestibular illusions — trust instruments, not body sensations, in degraded visual conditions.
+- Inadvertent IMC: immediately establish instrument flight, execute a 180° turn to VMC, declare MAYDAY, request ATC assistance. Do not descend through cloud over unknown terrain.
+- Low-level helicopter operations create high cockpit workload — pre-brief tasks, use CRM, and enforce sterile cockpit during critical phases.
+- Fatigue degrades performance while reducing the pilot's awareness of the degradation — IMSAFE before every flight.
+- Know and counter the five hazardous attitudes: anti-authority, impulsivity, invulnerability, macho, and get-there-itis.
+
+---
+
+*End of Lesson HEL-008.*


### PR DESCRIPTION
Closes #423

## Changes

### Lesson content (five files)
Five helicopter-specific lesson files written for the PPL-H written exam track, replacing the planning stubs added by PR #432:

- **`lessons/helicopter/004-aerodynamics-helicopter.md`** — Four forces in rotary-wing context, torque/anti-torque, translational lift (16–24 kt), dissymmetry of lift (blade flapping + cyclic compensation), retreating blade stall, autorotation principles, ground effect. 5 quiz questions.
- **`lessons/helicopter/005-systems-helicopter.md`** — Rotor systems (fully articulated, semi-rigid/teetering, rigid), anti-torque (tail rotor, NOTAR, tandem, coaxial), transmission and freewheeling unit (sprag clutch), piston vs. turbine engines, fuel and electrical systems. 5 quiz questions.
- **`lessons/helicopter/006-performance-helicopter.md`** — HIGE vs. HOGE, H-V diagram / dead man's curve, helicopter weight and balance (CG effects, datum, CARs 602.46), density altitude effects on rotor and engine performance. 5 quiz questions.
- **`lessons/helicopter/007-helicopter-ops.md`** — Confined area reconnaissance and approach, pinnacle/ridgeline operations, slope landing technique (uphill skid first), sling load operations (CARs 602.26), autorotation entry/flare/cushion. 5 quiz questions.
- **`lessons/helicopter/008-human-factors-helicopter.md`** — Spatial disorientation (vestibular physiology, leans, black-hole illusion), inadvertent IMC response (180° turn, MAYDAY), low-level cockpit workload and CRM, fatigue and IMSAFE, five hazardous attitudes with antidotes. 5 quiz questions.

All lessons: `status: draft`, `duration_min: 20`, TC/CARs source citations.

### Smoke test fix (`web-app/scripts/validate-playlist-audio.mjs`)
The QA workflow runs `npm test` → `validate-playlist-audio.mjs`. With HEL-001/002/003 as `status: planning` and HEL-004–008 as `status: draft`, the topic has zero audio URLs and `allPlanning = false`, causing the test to exit 1.

Fix: treat `draft` as pre-deploy (same as `planning`) so a topic composed entirely of planning+draft lessons is skipped rather than failed. Renamed `isPlanning`/`allPlanning` → `isPreDeploy`/`allPreDeploy` throughout; updated the log message to "all pre-deploy — skipped". This unblocks this PR and also PR #438 (HEL-001–003) and PR #433 (CPL-A) once they rebase.

## Test Plan
- Verify all five lesson files exist at the correct paths with full content (not planning stubs)
- Verify each lesson has `status: draft`, `duration_min: 20`, `sources:`, and 5 YAML quiz questions
- Verify `npm test` passes — `helicopter` topic should log "all pre-deploy — skipped"
- Spot-check factual accuracy: blade hinge types, HIGE/HOGE definition, H-V diagram regions, autorotation sequence, IMC response procedure
- Confirm no fixed-wing content duplicated verbatim; all rotary-wing specific