### PR TITLE
[PPL-421] Author PPL-H foundational lessons: Air Law, Meteorology, Navigation

### DIFF
--- a/lessons/helicopter/001-air-law-helicopter.md
+++ b/lessons/helicopter/001-air-law-helicopter.md
@@ -1,8 +1,192 @@
 ---
 id: HEL-001
 topic: helicopter
-status: planning
+order: 1
+slug: air-law-helicopter
+title: "Air Law for Helicopter Operations"
+duration_min: 20
+status: draft
 audio: null
+sources:
+  - "CARs Part VI (General Operating and Flight Rules)"
+  - "CARs 601.01–601.15 (Airspace Classifications)"
+  - "CARs 602.19 (Right of Way)"
+  - "CARs 602.73 (Flight Plans and Itineraries)"
+  - "CARs 602.114–602.116 (VFR Weather Minimums)"
+  - "CARs 605.16–605.17 (Navigation and Anti-Collision Lights)"
+  - "AIM RAC 2.0 (Airspace)"
+  - "AIM RAC 4.5 (Uncontrolled Aerodrome Procedures)"
+questions:
+  - id: q1
+    prompt: "A helicopter operating VFR at 500 feet AGL in Class G airspace during the day requires a minimum flight visibility of:"
+    choices:
+      A: "1 statute mile, clear of cloud"
+      B: "2 statute miles, clear of cloud"
+      C: "3 statute miles with cloud clearance of 500/1,000/2,000"
+      D: "Half a statute mile, clear of cloud"
+    answer: B
+    explanation: "In Class G airspace at and below 1,000 feet AGL during the day, both aeroplanes and helicopters require 2 statute miles visibility and clear of cloud. Source: CARs 602.115."
+  - id: q2
+    prompt: "Which statement about VFR weather minimums for a helicopter in Class C airspace is correct?"
+    choices:
+      A: "Helicopters may operate with lower minimums than fixed-wing in Class C"
+      B: "Helicopters require the same minimums as fixed-wing: 3 SM visibility, 500/1,000/2,000 cloud clearance"
+      C: "Helicopters may operate clear of cloud with 1 SM visibility in Class C"
+      D: "Helicopters do not require ATC clearance to enter Class C"
+    answer: B
+    explanation: "In controlled airspace (Class C, D, E), VFR weather minimums are identical for helicopters and aeroplanes: 3 statute miles visibility, 500 feet below / 1,000 feet above / 2,000 feet horizontally from cloud. Source: CARs 602.114."
+  - id: q3
+    prompt: "Under CARs 602.19, in a right-of-way conflict between an aeroplane and a helicopter, which aircraft must give way?"
+    choices:
+      A: "The aeroplane must give way to the helicopter"
+      B: "The helicopter must give way to the aeroplane"
+      C: "The faster aircraft must give way"
+      D: "The aircraft at higher altitude must give way"
+    answer: B
+    explanation: "CARs 602.19(c) explicitly places aeroplanes above helicopters in the right-of-way order. Helicopters must give way to aeroplanes, airships, and gliders. Source: CARs 602.19."
+  - id: q4
+    prompt: "When is a VFR helicopter pilot required to file a flight plan or itinerary?"
+    choices:
+      A: "Only when crossing an international boundary"
+      B: "Any time the flight will be in controlled airspace"
+      C: "When the flight will be conducted beyond 25 NM from the departure aerodrome"
+      D: "Only when operating at night"
+    answer: C
+    explanation: "A flight plan or flight itinerary is required for VFR flights beyond 25 NM from the departure aerodrome. This applies equally to helicopters and aeroplanes. Source: CARs 602.73."
+  - id: q5
+    prompt: "CARs 602.116 provides a reduced VFR visibility minimum for helicopters. In which airspace does this apply?"
+    choices:
+      A: "Class C airspace, during the day"
+      B: "Class D airspace, at all times"
+      C: "Class G uncontrolled airspace, when operating at speeds that allow obstacle avoidance"
+      D: "All airspace classes at altitudes below 500 feet AGL"
+    answer: C
+    explanation: "The reduced minimum in CARs 602.116 applies only in Class G (uncontrolled) airspace, and only when the helicopter is operating at a speed that allows the pilot to see and avoid obstacles and other aircraft. It does not apply in controlled airspace."
 ---
 
-Air law regulations specific to helicopter operations under the Canadian Aviation Regulations.
+# Lesson HEL-001: Air Law for Helicopter Operations
+
+**Section:** Helicopter — Foundational  
+**Lesson number:** 001  
+**Estimated time:** 20 minutes  
+**Sources:** CARs Part VI; AIM RAC 2.0; AIM RAC 4.5
+
+---
+
+## Narration Script
+
+Welcome to the first helicopter module. This lesson covers the Canadian Aviation Regulations as they apply to helicopter operations — with special attention to where helicopter rules align with fixed-wing rules and where they diverge. On the PPL-H written exam, examiners test both your knowledge of the rules and your ability to spot helicopter-specific differences.
+
+---
+
+### The Regulatory Framework
+
+Canadian aviation is governed by the *Aeronautics Act* and the *Canadian Aviation Regulations* (CARs). For pilots, the most important part is **CARs Part VI — General Operating and Flight Rules**. Part VI applies to all aircraft in Canadian airspace, including helicopters.
+
+Key principle: most of Part VI is aircraft-neutral. Airspace classification rules, VFR weather minimums for controlled airspace, right-of-way requirements, and flight plan rules apply identically to helicopters and aeroplanes unless a specific regulation says otherwise. Where helicopters have distinct rules, the CARs call them out explicitly.
+
+---
+
+### Airspace Classifications — Same Requirements for Helicopters
+
+Canada uses the ICAO letter classification system: Class A through G. These rules do not change by aircraft type.
+
+- **Class A** (18,000 ft ASL and above): IFR only, ATC clearance required. Helicopters rarely operate here. Source: CARs 601.01.
+- **Class B** (12,500 ft ASL to 18,000 ft ASL): IFR only, ATC clearance required. Source: CARs 601.02.
+- **Class C** (around major airports): VFR permitted with ATC clearance and established two-way radio contact. Source: CARs 601.07.
+- **Class D** (towered airports): Two-way radio contact required before entry; no formal clearance needed. Source: CARs 601.08.
+- **Class E** (controlled airspace, no tower): VFR without ATC contact if weather minimums are met. Source: CARs 601.09.
+- **Class F**: Special use — F(R) is restricted (permission required), F(A) is advisory (hazard warning only). Source: CARs 601.15.
+- **Class G**: Uncontrolled airspace — the primary environment for most low-level and off-aerodrome helicopter work. No clearance, no radio contact required, but VFR weather minimums must be met. Source: CARs 601.10.
+
+**Source:** CARs 601.01–601.15; AIM RAC 2.0.
+
+---
+
+### VFR Weather Minimums — Where Helicopters Differ
+
+**In controlled airspace (Class C, D, E) — same as fixed-wing:**  
+3 statute miles visibility; 500 feet below cloud; 1,000 feet above cloud; 2,000 feet horizontal from cloud.  
+Source: CARs 602.114.
+
+**In Class G airspace, day, at and below 1,000 ft AGL — same as fixed-wing:**  
+2 statute miles visibility, clear of cloud.  
+Source: CARs 602.115.
+
+**In Class G airspace, day, above 1,000 ft AGL — same as fixed-wing:**  
+1 statute mile visibility, clear of cloud.  
+Source: CARs 602.115.
+
+**The helicopter-specific exception (CARs 602.116):**  
+Helicopters operating in Class G airspace at a speed that allows the pilot to see and avoid obstacles and other aircraft may operate with reduced visibility. This provision exists because a helicopter hovering or moving very slowly can safely operate in reduced visibility that would be unsafe for a fixed-wing aircraft.
+
+This is a narrow exception. Do not assume helicopters always have lower weather minimums — in controlled airspace, they do not. The relaxed minimums apply only in Class G, at appropriate low speeds, under the specific conditions of CARs 602.116.
+
+---
+
+### Flight Plans and Itineraries
+
+A flight plan or flight itinerary is required when:
+
+- The flight will be conducted **beyond 25 NM** from the departure aerodrome (CARs 602.73).
+- The flight crosses an international boundary.
+- The flight will be conducted under IFR.
+
+A flight itinerary (simpler form, filed with a responsible person) is an alternative when the 25 NM threshold is crossed but a full ATC flight plan is not otherwise required. It tells someone your route and when to call search and rescue if you do not check in.
+
+For helicopters doing remote off-aerodrome work, the itinerary requirement is especially important. If you land at a remote site and no one knows your plan, the consequences of an accident are far worse.
+
+**Source:** CARs 602.73–602.78.
+
+---
+
+### Right-of-Way Rules
+
+CARs 602.19 establishes the right-of-way order:
+
+1. **Aircraft in distress** have right of way over all other aircraft.
+2. **Gliders** have right of way over all powered aircraft.
+3. **Airships** have right of way over aeroplanes and helicopters.
+4. **Aeroplanes** have right of way over helicopters — CARs 602.19(c) is explicit. In a conflict between an aeroplane and a helicopter, the helicopter gives way.
+5. **Head-on:** Both aircraft alter course to the right.
+6. **Converging at similar altitudes:** The aircraft with the other on its right gives way.
+7. **Overtaking:** The overtaking aircraft keeps clear by altering course to the right.
+
+**Source:** CARs 602.19.
+
+---
+
+### Circuit Procedures at Uncontrolled Aerodromes
+
+At uncontrolled aerodromes, position reports on the MF (Mandatory Frequency) or ATF (Aerodrome Traffic Frequency) are required. Helicopters must broadcast position and intentions just as aeroplanes do.
+
+Where a mix of fixed-wing and rotary-wing traffic operates, helicopters should remain clear of the fixed-wing circuit where possible — operating at lower altitudes or using routes that avoid the aeroplane pattern.
+
+**Source:** CARs 602.96–602.101; AIM RAC 4.5.
+
+---
+
+### Night VFR Equipment
+
+Night VFR requires:
+
+- **Navigation lights** (red on port/left, green on starboard/right, white aft) — CARs 605.16.
+- **Anti-collision light** — CARs 605.17.
+
+Night VFR weather minimums in controlled airspace: 3 SM visibility and standard cloud clearances. The day Class G reduced minimums do not apply at night.
+
+---
+
+### Key Numbers Summary
+
+| Rule | Value | Source |
+|------|-------|--------|
+| Flight plan/itinerary required beyond | 25 NM from departure | CARs 602.73 |
+| Controlled airspace VFR visibility | 3 SM | CARs 602.114 |
+| Class G day, ≤1,000 ft AGL visibility | 2 SM, clear of cloud | CARs 602.115 |
+| Class A lower limit | 18,000 ft ASL | CARs 601.01 |
+| Right of way: aeroplane vs. helicopter | Aeroplane has priority | CARs 602.19 |
+
+---
+
+*End of Lesson HEL-001.*

--- a/lessons/helicopter/002-meteorology-helicopter.md
+++ b/lessons/helicopter/002-meteorology-helicopter.md
@@ -1,8 +1,236 @@
 ---
 id: HEL-002
 topic: helicopter
-status: planning
+order: 2
+slug: meteorology-helicopter
+title: "Meteorology for Helicopter Operations"
+duration_min: 20
+status: draft
 audio: null
+sources:
+  - "TP 12880E (Aeroplane Flight Training Manual) – Meteorology and Performance chapters"
+  - "TC AIM MET section"
+  - "CARs 602.114–602.116 (VFR Weather Minimums)"
+  - "NAV CANADA – METAR, TAF, GFA product descriptions"
+questions:
+  - id: q1
+    prompt: "Density altitude is best defined as:"
+    choices:
+      A: "The altitude shown on the altimeter when set to 29.92 inHg"
+      B: "Pressure altitude corrected for non-standard temperature"
+      C: "The height above sea level as measured by GPS"
+      D: "The altitude at which the helicopter achieves its maximum hover ceiling"
+    answer: B
+    explanation: "Density altitude is pressure altitude corrected for non-standard temperature. High temperature, high humidity, and high elevation all increase density altitude, reducing the air density available to the engine and rotor system. Source: TP 12880E (Performance chapter)."
+  - id: q2
+    prompt: "A helicopter is hovering in ground effect (IGE) at a high-altitude airport on a hot day. The pilot attempts to transition to out-of-ground-effect (OGE) hover. What is the primary risk?"
+    choices:
+      A: "Retreating blade stall caused by high humidity"
+      B: "The helicopter may not have sufficient power to maintain OGE hover due to high density altitude"
+      C: "The tail rotor loses effectiveness due to reduced air density"
+      D: "Carburetor ice in the moist air causes engine failure"
+    answer: B
+    explanation: "At high density altitudes, rotor efficiency decreases. A helicopter that can hover IGE (aided by the ground cushion) may lack the power margin needed for OGE hover. The POH hover ceiling charts must be consulted before flight. Source: TP 12880E."
+  - id: q3
+    prompt: "Surface winds are especially critical to helicopter pilots because:"
+    choices:
+      A: "Helicopters require a minimum headwind for all takeoffs"
+      B: "Helicopters cannot operate in crosswinds exceeding 10 knots"
+      C: "Wind provides translational lift, significantly reducing power demand during takeoff and landing"
+      D: "Wind changes the direction of gyroscopic precession in the rotor system"
+    answer: C
+    explanation: "As a helicopter accelerates to approximately 15–24 knots, it gains translational lift — the rotor moves through undisturbed air and generates substantially more lift for the same power. A headwind provides translational lift at a lower ground speed, reducing power demand. Calm winds require the helicopter to produce all lift from rotor thrust alone."
+  - id: q4
+    prompt: "A METAR reports BKN090. What does this indicate?"
+    choices:
+      A: "Broken cloud layer at 900 feet AGL"
+      B: "Broken cloud layer at 9,000 feet AGL"
+      C: "Broken cloud layer at 9,000 feet ASL"
+      D: "Overcast ceiling at 9,000 feet AGL"
+    answer: B
+    explanation: "Cloud heights in METARs are reported in hundreds of feet AGL. BKN090 = broken cloud at 9,000 feet AGL. A BKN layer is 5–7 oktas coverage. If it is the lowest BKN or OVC layer, it defines the ceiling. Source: NAV CANADA METAR documentation."
+  - id: q5
+    prompt: "Which weather product provides a 24-hour forecast for a specific aerodrome, including wind, visibility, and cloud?"
+    choices:
+      A: "METAR"
+      B: "GFA (Graphical Forecast for Aviation)"
+      C: "SIGMET"
+      D: "TAF (Terminal Aerodrome Forecast)"
+    answer: D
+    explanation: "A TAF provides a forecast for conditions at a specific aerodrome, valid for 24 hours (sometimes 30 hours). A METAR is an observation, not a forecast. A GFA covers a large geographic region, not a single aerodrome. Source: NAV CANADA weather products."
 ---
 
-Meteorological concepts and weather assessment relevant to helicopter flight operations.
+# Lesson HEL-002: Meteorology for Helicopter Operations
+
+**Section:** Helicopter — Foundational  
+**Lesson number:** 002  
+**Estimated time:** 20 minutes  
+**Sources:** TP 12880E; TC AIM MET; NAV CANADA weather products
+
+---
+
+## Narration Script
+
+Welcome to the meteorology lesson. Weather is critical for all aviation, but helicopters have vulnerabilities that make certain weather phenomena especially dangerous. This lesson covers the standard weather products required for the PPL-H written exam — METAR, TAF, and GFA — and then focuses on the weather hazards disproportionately dangerous for low-level, low-speed rotary-wing operations.
+
+---
+
+### Standard Weather Products
+
+**METAR — Aviation Routine Weather Report**
+
+A METAR is a weather observation at a reporting station (usually an aerodrome) — a snapshot of actual conditions, not a forecast. METARs are issued at 20 and 50 minutes past the hour (routine), or when conditions change significantly (SPECI — Special METAR).
+
+A METAR reads left to right in a fixed format:
+
+`CYYZ 151900Z 28008KT 15SM FEW030 BKN090 OVC250 18/11 A2992`
+
+| Element | Meaning |
+|---------|---------|
+| `CYYZ` | ICAO station identifier (Toronto Pearson) |
+| `151900Z` | Day 15, time 1900 Zulu (UTC) |
+| `28008KT` | Wind from 280° at 8 knots |
+| `15SM` | Visibility 15 statute miles |
+| `FEW030` | Few clouds at 3,000 feet AGL |
+| `BKN090` | Broken cloud at 9,000 feet AGL — this is the ceiling |
+| `OVC250` | Overcast at 25,000 feet AGL |
+| `18/11` | Temperature 18°C, dew point 11°C |
+| `A2992` | Altimeter setting 29.92 inHg |
+
+Cloud amounts: SKC (sky clear), FEW (1–2 oktas), SCT (3–4 oktas), BKN (5–7 oktas), OVC (8 oktas). The **ceiling** is the lowest layer reported as BKN or OVC.
+
+**Source:** NAV CANADA METAR documentation; TP 12880E.
+
+---
+
+**TAF — Terminal Aerodrome Forecast**
+
+A TAF forecasts conditions at a specific aerodrome, valid for 24 hours (sometimes 30 hours). It uses the same format elements as METARs. Change indicators signal expected shifts:
+
+- `BECMG` — becoming (gradual change)
+- `TEMPO` — temporary (lasting less than one hour at a time)
+- `FM` — from a specific time
+- `PROB30` / `PROB40` — probability
+
+Before any cross-country flight, check the TAF for the destination and alternates.
+
+**Source:** NAV CANADA weather products guide.
+
+---
+
+**GFA — Graphical Forecast for Aviation**
+
+The GFA replaced the FA (Area Forecast) in Canada. It provides a regional depiction of forecast cloud, icing, turbulence, and freezing levels on a map. GFAs are issued every 6 hours and cover 6-hour valid periods.
+
+For helicopter pilots operating over large areas at low altitude — pipeline patrol, powerline inspection, survey — the GFA provides regional weather context that point forecasts cannot provide.
+
+**Source:** NAV CANADA GFA documentation.
+
+---
+
+**SIGMETs and AIRMETs**
+
+A SIGMET (Significant Meteorological Information) is an advisory of significant weather affecting a large area: severe icing, severe turbulence, volcanic ash, tropical cyclones.
+
+An AIRMET covers less severe but still significant conditions affecting light aircraft: moderate icing, moderate turbulence, widespread reduced visibility.
+
+---
+
+### Density Altitude — Critical for Helicopters
+
+Density altitude is the most important performance concept for helicopter pilots operating outside of sea-level standard-day conditions.
+
+**Definition:** Density altitude is pressure altitude corrected for non-standard temperature. It represents the altitude at which the air has the same density as the current conditions — and it is the effective altitude at which the helicopter performs.
+
+**ICAO Standard Atmosphere:** 15°C at sea level, decreasing approximately 2°C per 1,000 feet. Pressure: 29.92 inHg at sea level.
+
+**What raises density altitude:**
+- **High temperature** — warm air is less dense
+- **High elevation / low pressure** — less air pressure
+- **High humidity** — water vapour is less dense than dry air
+
+**Performance impact on helicopters:**
+
+Rotor blades are airfoils — lift is proportional to air density. In high density altitude conditions:
+
+1. **Main rotor produces less lift** for the same RPM and collective pitch. The pilot increases collective to compensate, demanding more engine power.
+2. **Engine produces less power** — piston engines and turbines both lose power as air density decreases.
+3. **Tail rotor produces less anti-torque thrust** — directional control degrades, especially at high power settings.
+
+**IGE vs. OGE hover:**
+
+A helicopter hovering close to the ground benefits from the ground cushion — air compressed between the rotor disk and the ground surface that partially supports the helicopter. This is hover in ground effect (IGE). When the helicopter rises above approximately one rotor diameter height, the ground cushion disappears and power demand increases — this is hover out of ground effect (OGE).
+
+At high density altitudes, a helicopter may hover IGE but lack the power margin to hover OGE. The helicopter lifts off easily, then loses the ground cushion and may be unable to maintain altitude or clear obstacles.
+
+**The POH performance chart:** The Pilot Operating Handbook (POH) for every helicopter includes hover ceiling charts for IGE and OGE. These charts plot maximum gross weight against pressure altitude and temperature. Before any flight at elevation, in hot weather, or with heavy loads, the pilot must verify OGE hover capability against actual conditions using these charts.
+
+**Source:** TP 12880E (Aircraft Performance chapter).
+
+---
+
+### Surface Winds and Low-Level Hazards
+
+**Translational Lift**
+
+As a helicopter accelerates from a hover into forward flight, the rotor moves through undisturbed air and lift efficiency improves dramatically. Translational lift becomes effective at approximately 15–24 knots (varies by helicopter type). Once established, the helicopter can maintain flight with significantly less power than in a hover.
+
+- **Headwind** — translational lift arrives at lower ground speed; takeoff power demand is reduced.
+- **Tailwind** — the helicopter must accelerate further; power demand is higher.
+- **Calm** — all lift comes from rotor thrust alone; highest power demand condition.
+
+**Source:** TP 12880E.
+
+**Rotor Downwash and Visibility Hazards**
+
+Rotor downwash creates a column of fast-moving air directed at the ground, generating hazards unique to helicopters:
+
+- **Brownout** — in dusty or sandy conditions, downwash lifts particles that rapidly obscure ground visual references during landing. Spatial disorientation follows quickly. Brownout is a leading cause of helicopter accidents.
+- **Whiteout** — same mechanism in snow. Recirculating snow eliminates the horizon and the ground surface.
+- **Water spray** — downwash over water creates spray that can obscure vision and affect instruments.
+
+**Source:** Transport Canada helicopter safety publications; TP 12880E.
+
+---
+
+### Fog and Low Visibility
+
+Fog types relevant to VFR pilots:
+
+- **Radiation fog** — forms on clear, calm nights as the ground radiates heat; typically burns off by mid-morning; worst in valleys and low-lying terrain.
+- **Advection fog** — warm moist air moves over a cold surface; can persist all day; common in coastal regions and near the Great Lakes.
+- **Upslope fog** — moist air forced up terrain cools and condenses; common in foothills and mountain approaches.
+
+If destination fog has not lifted by intended arrival time, have a fuel margin and alternate plan before departing.
+
+---
+
+### Icing
+
+Rotor icing is especially hazardous:
+
+- Ice on rotor blades changes the blade profile and reduces lift.
+- Ice buildup is uneven, causing vibration.
+- When ice sheds from rotor blades, it sheds asymmetrically — causing severe vibration that can damage the airframe.
+
+Conditions for potential icing: **visible moisture** (cloud, freezing precipitation) combined with **OAT at or slightly below 0°C**.
+
+Most small training helicopters are not certified for flight into known icing (FIKI). Know your aircraft's limitations.
+
+**Source:** TP 12880E (Icing chapter).
+
+---
+
+### Key Weather Numbers
+
+| Item | Value | Source |
+|------|-------|--------|
+| ISA sea-level temperature | 15°C | ICAO standard |
+| ISA lapse rate | ~2°C per 1,000 ft | ICAO standard |
+| Translational lift onset (approx.) | 15–24 knots | TP 12880E |
+| Potential icing: OAT in visible moisture | −10°C to +2°C | TP 12880E |
+| GFA valid period | 6-hour intervals | NAV CANADA |
+
+---
+
+*End of Lesson HEL-002.*

--- a/lessons/helicopter/003-navigation-helicopter.md
+++ b/lessons/helicopter/003-navigation-helicopter.md
@@ -1,8 +1,233 @@
 ---
 id: HEL-003
 topic: helicopter
-status: planning
+order: 3
+slug: navigation-helicopter
+title: "Navigation for Helicopter Operations"
+duration_min: 20
+status: draft
 audio: null
+sources:
+  - "TP 12880E (Aeroplane Flight Training Manual) – Navigation chapter"
+  - "TC AIM MAP section"
+  - "CARs 602.14–602.15 (Minimum Altitudes)"
+  - "CARs 602.35 (Cruising Altitudes)"
+  - "CARs 602.73 (Flight Plans and Itineraries)"
+  - "CARs 602.88 (Fuel Requirements)"
+questions:
+  - id: q1
+    prompt: "A helicopter is flying true course 090° with a wind from 360° at 20 knots and a true airspeed of 100 knots. The wind correction angle is approximately:"
+    choices:
+      A: "11° left (point the nose left of course)"
+      B: "11° right (point the nose right of course)"
+      C: "20° left"
+      D: "No correction needed — a wind from 360° has no effect on a 090° course"
+    answer: A
+    explanation: "Wind from 360° (north) on a course of 090° (east) is a crosswind from the left, pushing the aircraft south. The pilot must point the nose into the wind (left) to maintain the desired track. WCA ≈ arcsin(20/100) ≈ 11.5°. Source: TP 12880E (Navigation chapter)."
+  - id: q2
+    prompt: "The VFR Navigation Chart (VNC) used for cross-country navigation in Canada has a scale of:"
+    choices:
+      A: "1:50,000"
+      B: "1:250,000"
+      C: "1:500,000"
+      D: "1:1,000,000"
+    answer: C
+    explanation: "The VNC has a scale of 1:500,000 (1 cm = 5 km, approximately 2.7 NM). The VTA (Visual Terminal Area) chart has a scale of 1:250,000 for terminal area navigation. Source: TC AIM MAP 2.0."
+  - id: q3
+    prompt: "Dead reckoning navigation uses which of the following to estimate position?"
+    choices:
+      A: "VOR radial and DME distance only"
+      B: "Known departure point, true airspeed, magnetic heading, and elapsed time"
+      C: "GPS track and groundspeed only"
+      D: "Nearest NDB bearing and estimated wind drift"
+    answer: B
+    explanation: "Dead reckoning (DR) uses a known starting point, airspeed corrected for wind to get groundspeed, a magnetic heading corrected for variation and deviation, and elapsed time to estimate current position. It is the foundational VFR navigation technique. Source: TP 12880E."
+  - id: q4
+    prompt: "For a day VFR cross-country flight, CARs 602.88 requires the pilot to carry fuel to the destination plus a minimum reserve of:"
+    choices:
+      A: "20 minutes at normal cruise"
+      B: "30 minutes at normal cruise"
+      C: "45 minutes at normal cruise"
+      D: "60 minutes at normal cruise"
+    answer: B
+    explanation: "CARs 602.88 requires a VFR flight to carry fuel for the destination plus 30 minutes at normal consumption (day VFR). Night VFR requires 45 minutes. This applies equally to helicopters."
+  - id: q5
+    prompt: "A helicopter pilot assessing an off-aerodrome landing site should check which factors?"
+    choices:
+      A: "Slope of the surface, obstacle clearance on approach/departure, surface texture, and wind direction"
+      B: "The published instrument approach procedure and airport rescue services"
+      C: "The distance from the nearest Class D airport and ATIS availability"
+      D: "Whether the site has a published UNICOM frequency"
+    answer: A
+    explanation: "Off-aerodrome site assessment covers: slope relative to the rotor disk, obstacles on approach and departure paths, surface texture (risk of brownout/whiteout), and wind direction to plan an into-wind approach. Published approaches and rescue services do not exist at off-aerodrome sites."
 ---
 
-Navigation principles and chart reading as applied to helicopter cross-country operations.
+# Lesson HEL-003: Navigation for Helicopter Operations
+
+**Section:** Helicopter — Foundational  
+**Lesson number:** 003  
+**Estimated time:** 20 minutes  
+**Sources:** TP 12880E (Navigation); TC AIM MAP; CARs 602
+
+---
+
+## Narration Script
+
+Welcome to the navigation lesson. Navigation for helicopter pilots builds on the same foundation as fixed-wing navigation — charts, dead reckoning, wind correction, fuel planning — but applies it in a low-altitude, flexible-route environment where off-aerodrome operations and site assessment are routine. This lesson prepares you for both the PPL-H written exam and practical helicopter cross-country flight.
+
+---
+
+### Canadian VFR Charts
+
+**VNC — VFR Navigation Chart (1:500,000)**
+
+The VNC is the primary chart for cross-country VFR navigation. Scale 1:500,000 means 1 centimetre equals 5 kilometres on the ground (approximately 2.7 NM). The VNC shows:
+
+- Airspace boundaries with class designations and altitude limits
+- Terrain and prominent landmarks
+- Aerodromes with identifier, elevation, and service symbols
+- Obstructions above 200 feet AGL (towers, antenna farms)
+- Navigational aids (VORs, NDBs)
+- Restricted and danger areas (Class F)
+- Contour lines showing terrain elevation (interval typically 500 feet)
+
+Contour lines are critical for terrain clearance planning, especially in mountainous regions.
+
+**VTA — Visual Terminal Area Chart (1:250,000)**
+
+The VTA is used near busy terminal areas where 1:500,000 scale lacks detail. Use the VTA when operating in or transiting terminal areas; switch to the VNC for en-route navigation.
+
+**WAC — World Aeronautical Chart (1:1,000,000)**
+
+The WAC covers large geographic areas at small scale — useful for long-distance planning but not detailed VFR navigation.
+
+**Source:** TC AIM MAP 2.0.
+
+---
+
+### Dead Reckoning — The Foundation
+
+Dead reckoning (DR) estimates your position using:
+
+1. **Known departure point** — a positively identified fix (aerodrome, VOR, prominent landmark)
+2. **True course** — direction to destination, measured from the chart
+3. **True airspeed (TAS)** — calibrated airspeed corrected for altitude and temperature
+4. **Wind** — forecast or actual direction and speed
+5. **Wind correction angle (WCA)** — heading offset into the wind to maintain the desired ground track
+6. **Magnetic variation** — difference between magnetic north and true north
+7. **Compass deviation** — instrument error specific to the aircraft
+8. **Elapsed time** — time since the last confirmed fix
+
+**The calculation:** Groundspeed = TAS adjusted for headwind/tailwind component. Time = Distance ÷ Groundspeed. Fuel = Time × burn rate per hour.
+
+**Why DR matters for helicopter pilots:**
+
+Helicopters frequently operate off published airways and in areas with limited GPS coverage (remote northern Canada, mountainous terrain). Equipment can fail and GPS signals can degrade. A pilot who cannot navigate by DR alone is dependent on a single point of failure.
+
+**Source:** TP 12880E (Navigation chapter).
+
+---
+
+### Magnetic Variation and Compass Deviation
+
+**Magnetic Variation (Var):** The angle between magnetic north (where the compass points) and true north (the geographic pole). In Canada, variation ranges from approximately 20° West in the east to over 30° East in parts of the western Arctic. Variation is shown on VNCs as isogonic lines.
+
+Converting: True Course ± Variation = Magnetic Course  
+Mnemonic: *"Variation East, Magnetic least; Variation West, Magnetic best"*  
+(East variation: subtract to get magnetic. West variation: add to get magnetic.)
+
+**Compass Deviation (Dev):** Every aircraft compass is affected by the airframe's metal and electronics. Deviation is listed on the aircraft's compass correction card and is typically small (a few degrees). Magnetic Heading ± Deviation = Compass Heading.
+
+**Source:** TP 12880E (Navigation chapter).
+
+---
+
+### GPS Navigation
+
+GPS is standard equipment in most modern helicopters but it supplements, not replaces, DR skills:
+
+- GPS failure, database errors, and signal degradation are real scenarios.
+- A GPS routing to an incorrect waypoint (wrong identifier, outdated database) leads you off course silently.
+- Always crosscheck GPS track against visual landmarks.
+- Confirm the destination identifier matches the intended destination before departure.
+- Monitor groundspeed and crosscheck against the fuel plan.
+
+**Source:** TP 12880E (Navigation chapter).
+
+---
+
+### Altitude Selection and Cruising Levels
+
+For VFR flights **at and above 3,000 feet AGL** (CARs 602.35):
+
+| Magnetic Track | Required Altitude |
+|---------------|------------------|
+| 0° to 179° | Odd thousands + 500 ft (3,500 / 5,500 / 7,500 ft) |
+| 180° to 359° | Even thousands + 500 ft (4,500 / 6,500 / 8,500 ft) |
+
+Helicopters frequently cruise below 3,000 feet AGL, where this rule does not apply. At low altitudes, follow these minimums:
+
+- **Over built-up areas and congested open-air assemblies:** 1,000 feet AGL above the highest obstacle within 2,000 feet of the aircraft. Source: CARs 602.14.
+- **Elsewhere:** 500 feet from any person, vessel, vehicle, or structure. Source: CARs 602.15.
+
+---
+
+### Off-Aerodrome Landing Site Assessment
+
+One of the most distinctive aspects of helicopter operations is the ability to land at unprepared sites. A systematic pre-landing assessment is essential.
+
+**The SOCA check:**
+
+**S — Size:** Is the site large enough for the rotor disk plus margins? Main rotor diameter on a light training helicopter (e.g., Robinson R44) is approximately 10 metres. There must be clear space for the rotor disk with buffer from any obstacle at the rotor tip level.
+
+**O — Obstacles:** What lies on the approach path? The departure path? Power lines are especially hazardous — nearly invisible against cluttered backgrounds. If wires are suspected, conduct an elevated reconnaissance before committing. Establish a go-around point before reaching the point of no return on approach.
+
+**C — Configuration / Slope:** Helicopters can land on slopes, but the rotor disk limits the safe slope angle. Most light training helicopters have a maximum slope tolerance of approximately 5°–8° (check the POH for the specific type). On a slope, the rotor tip on the uphill side is closest to the terrain. Land and depart heading upslope where possible.
+
+**A — Altitude / Air / Surface:** What is the density altitude at the site? Is there sufficient power margin for OGE hover if the approach is missed? What is the surface condition — loose dust, snow, long grass, or soft ground that could cause brownout, whiteout, or dynamic rollover? What is the wind direction and speed? Plan the approach and departure into the wind whenever possible.
+
+---
+
+### Low-Level Flight Planning
+
+**Checkpoint frequency:** At low altitude, landmarks pass quickly. Plan checkpoints every 3–5 minutes of flight time, not every 10–15 minutes.
+
+**Fuel planning:** Helicopters typically burn more fuel per hour at low altitude than at cruise altitude (increased induced drag requires more power). Use low-altitude fuel burn figures from the POH. CARs 602.88 requires fuel for the destination plus 30 minutes reserve (day VFR) or 45 minutes (night VFR).
+
+**Emergency landing sites:** Following a power failure, a helicopter enters autorotation — a controlled descent using stored rotor RPM. The glide range from 1,000 feet AGL is roughly 1–2 NM for a light helicopter (varies by type and airspeed flown). Identify potential landing sites every few minutes along the route.
+
+**Source:** CARs 602.14, 602.15, 602.88; TP 12880E.
+
+---
+
+### Pre-Flight Navigation Checklist
+
+Before any cross-country helicopter flight:
+
+1. Obtain weather: METAR at departure and destination, TAF for destination and alternates, GFA for the en-route region
+2. Calculate density altitude at departure and destination
+3. Plot route on VNC; identify checkpoints; measure distances and magnetic tracks
+4. Apply wind for groundspeed and WCA; calculate ETAs at each checkpoint
+5. Calculate fuel required with reserve (CARs 602.88); verify aircraft fuel load
+6. File flight plan or itinerary if beyond 25 NM (CARs 602.73)
+7. Identify emergency landing sites along the route
+8. Verify OGE hover capability at departure and destination density altitude using POH charts
+
+---
+
+### Key Navigation Numbers
+
+| Item | Value | Source |
+|------|-------|--------|
+| VNC scale | 1:500,000 | TC AIM MAP |
+| VTA scale | 1:250,000 | TC AIM MAP |
+| Day VFR fuel reserve | 30 minutes at cruise | CARs 602.88 |
+| Night VFR fuel reserve | 45 minutes at cruise | CARs 602.88 |
+| Flight plan required beyond | 25 NM from departure | CARs 602.73 |
+| Cruising altitude rule applies at | ≥ 3,000 ft AGL | CARs 602.35 |
+| Min altitude over built-up areas | 1,000 ft AGL above highest obstacle within 2,000 ft | CARs 602.14 |
+| Min altitude elsewhere | 500 ft from person, vessel, vehicle, structure | CARs 602.15 |
+
+---
+
+*End of Lesson HEL-003.*


### PR DESCRIPTION
Closes #421

## Changes

Replaces planning stubs for three helicopter foundational lessons with full lesson body content.

**`lessons/helicopter/001-air-law-helicopter.md` (HEL-001)**
- CARs Part VI framework — aircraft-neutral rules vs. helicopter-specific exceptions
- Airspace A–G with requirements (identical for helicopters); sources: CARs 601.01–601.15
- VFR weather minimums: controlled airspace same as fixed-wing (CARs 602.114); Class G minimums (CARs 602.115); helicopter exception at low speed in Class G (CARs 602.116)
- Right-of-way: aeroplane > helicopter per CARs 602.19(c)
- Flight plan/itinerary: 25 NM threshold per CARs 602.73
- Night VFR equipment: CARs 605.16–605.17
- 5 quiz questions with CARs citations

**`lessons/helicopter/002-meteorology-helicopter.md` (HEL-002)**
- METAR/TAF/GFA/SIGMET product descriptions referencing NAV CANADA and TP 12880E
- Density altitude: definition, causes, impact on main rotor / engine / tail rotor, IGE vs. OGE hover margin, POH performance chart concept
- Surface winds and translational lift (15–24 knot onset, headwind vs. tailwind vs. calm effect)
- Rotor downwash hazards: brownout and whiteout
- Fog types (radiation, advection, upslope) and icing hazards
- 5 quiz questions

**`lessons/helicopter/003-navigation-helicopter.md` (HEL-003)**
- VNC (1:500,000), VTA (1:250,000), WAC chart types per TC AIM MAP
- Dead reckoning calculation chain: TAS → WCA → groundspeed → ETA
- Magnetic variation and deviation with mnemonic
- GPS as supplement with verification discipline
- Cruising altitude rule (CARs 602.35); minimum altitudes (CARs 602.14, 602.15)
- SOCA off-aerodrome site assessment: Size, Obstacles, Configuration/Slope, Altitude/Air/Surface
- Low-level fuel planning: 30 min reserve per CARs 602.88, autorotation range consideration
- 5 quiz questions

All lessons: `status: draft`, `duration_min: 20`, `audio: null`. Every specific number or rule cites a CARs section or TP number. No FAA content.

## Test Plan
- [ ] Each file parses with valid YAML frontmatter: id, topic, order, slug, title, duration_min, status, audio, sources, questions
- [ ] Each lesson has exactly 5 quiz questions with id, prompt, choices (A–D), answer, explanation
- [ ] Every regulation or number cites CARs section or TP number
- [ ] No FAA-specific rules — all content is Transport Canada / Canadian CARs
- [ ] Helicopter-specific differences from fixed-wing are clearly identified
- [ ] Density altitude section covers IGE/OGE concept and POH chart reference