### PR TITLE
[PPL-422] CPL-A lesson taxonomy: curriculum doc, 18 lesson files, smoke-test fix

### DIFF
--- a/docs/curriculum-cpl-a.md
+++ b/docs/curriculum-cpl-a.md
@@ -1,0 +1,107 @@
+# CPL-A Curriculum — Commercial Pilot Licence (Aeroplane)
+
+Transport Canada CPL-A written exam preparation. All regulatory references are to current
+Canadian Aviation Regulations (CARs) and Transport Canada publications.
+
+## Subject Areas and Lesson Plan
+
+### 1. Commercial Air Law (CAL) — 5 lessons
+
+The highest-weight subject on the CPL-A written exam. Covers the regulatory framework
+governing commercial operations: licensing requirements, operator certificates, and the
+key provisions of CARs Part IV and Part VII that distinguish commercial from private flight.
+
+| # | File | ID | Title |
+|---|------|----|-------|
+| 1 | `lessons/cpl-a/001-cpl-licensing-requirements.md` | CAL-001 | CPL Licensing Requirements |
+| 2 | `lessons/cpl-a/002-commercial-air-services.md` | CAL-002 | Commercial Air Services and Operator Certificates |
+| 3 | `lessons/cpl-a/003-air-taxi-operations.md` | CAL-003 | Air Taxi Operations (CARs 703) |
+| 4 | `lessons/cpl-a/004-pic-authority-responsibilities.md` | CAL-004 | PIC Authority and Commercial Crew Responsibilities |
+| 5 | `lessons/cpl-a/005-commercial-vfr-night-regulations.md` | CAL-005 | Commercial VFR and Night Regulations |
+
+**Sources:** CARs Part IV (Personnel Licensing), CARs Part VII (Commercial Air Services),
+CARs 421.32, CARs 703, CARs 704, TP 12880E.
+
+---
+
+### 2. Advanced Meteorology (AMT) — 4 lessons
+
+Builds on PPL-A meteorology. Emphasises upper-level weather, icing, convective hazards,
+and the meteorological products used in commercial flight planning.
+
+| # | File | ID | Title |
+|---|------|----|-------|
+| 6 | `lessons/cpl-a/006-upper-level-charts-sigwx.md` | AMT-001 | Upper Level Charts and Significant Weather Forecasts |
+| 7 | `lessons/cpl-a/007-icing-types-avoidance.md` | AMT-002 | Icing — Causes, Types, and Avoidance |
+| 8 | `lessons/cpl-a/008-thunderstorm-hazards.md` | AMT-003 | Thunderstorm Structure and Aviation Hazards |
+| 9 | `lessons/cpl-a/009-mountain-wave-turbulence.md` | AMT-004 | Mountain Wave Turbulence and Orographic Effects |
+
+**Sources:** TP 1102 Vol. 5, EC aviation weather products, AIM MET chapter.
+
+---
+
+### 3. Advanced Navigation (ANV) — 3 lessons
+
+Extends PPL-A navigation to cross-country and high-altitude flight planning, including
+RNAV concepts and the computational skills required for commercial cross-country work.
+
+| # | File | ID | Title |
+|---|------|----|-------|
+| 10 | `lessons/cpl-a/010-rnav-high-level-navigation.md` | ANV-001 | RNAV and High-Level Navigation Concepts |
+| 11 | `lessons/cpl-a/011-time-distance-calculations.md` | ANV-002 | Time and Distance Calculations for Long-Range Flying |
+| 12 | `lessons/cpl-a/012-cross-country-commercial.md` | ANV-003 | Cross-Country Flight Planning — Commercial Standards |
+
+**Sources:** TP 12880E, CARs Part VI, AIM ENR.
+
+---
+
+### 4. Aerodynamics & Engines (ADE) — 3 lessons
+
+Advanced aerodynamics and propulsion topics that extend beyond the PPL-A syllabus:
+compressibility effects, high-altitude engine behaviour, and propeller theory.
+
+| # | File | ID | Title |
+|---|------|----|-------|
+| 13 | `lessons/cpl-a/013-high-speed-aerodynamics.md` | ADE-001 | High-Speed Aerodynamics and Compressibility Effects |
+| 14 | `lessons/cpl-a/014-advanced-engine-systems.md` | ADE-002 | Advanced Engine Systems and High-Altitude Performance |
+| 15 | `lessons/cpl-a/015-propeller-theory.md` | ADE-003 | Propeller Theory and Variable-Pitch Systems |
+
+**Sources:** TP 12880E Chapters 2–4, TP 1102 Vol. 4.
+
+---
+
+### 5. Performance & Limitations (PAL) — 3 lessons
+
+Commercial-standard performance planning: cruise computations, weight and balance for
+complex operations, and use of the aircraft flight manual to determine operating limits.
+
+| # | File | ID | Title |
+|---|------|----|-------|
+| 16 | `lessons/cpl-a/016-performance-charts-cruise.md` | PAL-001 | Performance Charts — Cruise and Range Computations |
+| 17 | `lessons/cpl-a/017-weight-balance-commercial.md` | PAL-002 | Weight and Balance for Commercial Operations |
+| 18 | `lessons/cpl-a/018-aircraft-limitations.md` | PAL-003 | Aircraft Limitations — Operating Envelope and Flight Manual |
+
+**Sources:** TP 12880E Chapters 5–6, CARs 605, aircraft AFM/POH.
+
+---
+
+## Relationship to PPL-A Foundation
+
+The following CPL-A lessons extend (rather than duplicate) PPL-A foundation lessons.
+Cross-references are provided in each skeleton for content authors.
+
+| CPL-A Lesson | Extends PPL-A Lesson |
+|-------------|---------------------|
+| AMT-002 Icing | `lessons/meteorology/` — icing and freezing level |
+| AMT-003 Thunderstorms | `lessons/meteorology/` — thunderstorm lesson |
+| ANV-002 Time & Distance | `lessons/navigation/` — dead reckoning |
+| PAL-002 W&B Commercial | `lessons/general-knowledge/` — weight and balance |
+
+---
+
+## Out of Scope (CPL-A)
+
+- IFR procedures and instrument flying
+- Multi-engine systems
+- Night rating content (covered in commercial night ops lesson)
+- Audio production (all lessons currently `draft`)

--- a/lessons/cpl-a/001-cpl-licensing-requirements.md
+++ b/lessons/cpl-a/001-cpl-licensing-requirements.md
@@ -1,0 +1,176 @@
+---
+id: CAL-001
+topic: cpl-a
+order: 1
+slug: cpl-licensing-requirements
+title: "CPL Licensing Requirements"
+duration_min: 20
+status: draft
+audio: null
+visual: null
+sources:
+  - "CARs Part IV (Personnel Licensing)"
+  - "CARs 421.32 (Commercial Pilot Licence — Aeroplane)"
+  - "CARs 404.04 (Medical Certificate Categories)"
+  - "TP 12880E (Aeroplane Flight Training Manual)"
+  - "Transport Canada CPL-A Written Exam Guide"
+questions:
+  - id: q1
+    prompt: "What is the minimum age to hold a Canadian Commercial Pilot Licence (Aeroplane)?"
+    choices:
+      A: "16 years"
+      B: "17 years"
+      C: "18 years"
+      D: "21 years"
+    answer: C
+    explanation: "CARs Part IV requires applicants for a Commercial Pilot Licence — Aeroplane to be at least 18 years of age. This is higher than the PPL minimum of 17 years. Source: CARs 421.32."
+  - id: q2
+    prompt: "What category of medical certificate is required to exercise the privileges of a Canadian CPL (Aeroplane)?"
+    choices:
+      A: "Category 3 (the same as a PPL)"
+      B: "Category 2"
+      C: "Category 1"
+      D: "No medical is required for CPL"
+    answer: C
+    explanation: "A Category 1 medical certificate is required for CPL privileges. A PPL requires only a Category 3 medical. The higher standard reflects the commercial-operations context. Source: CARs 404.04."
+  - id: q3
+    prompt: "Under CARs 421.32, what is the minimum total flight time required to qualify for a CPL (Aeroplane)?"
+    choices:
+      A: "100 hours"
+      B: "150 hours"
+      C: "175 hours"
+      D: "200 hours"
+    answer: D
+    explanation: "The minimum total flight time for a CPL — Aeroplane is 200 hours. This includes specified requirements for pilot-in-command time, cross-country time, instrument time, and night time. Source: CARs 421.32."
+  - id: q4
+    prompt: "Of the 200 hours total time required for a CPL (Aeroplane), how many hours must be logged as pilot-in-command time?"
+    choices:
+      A: "50 hours"
+      B: "100 hours"
+      C: "120 hours"
+      D: "150 hours"
+    answer: B
+    explanation: "CARs 421.32 requires a minimum of 100 hours of pilot-in-command flight time as part of the 200-hour total. This PIC time must include specific cross-country and night requirements. Source: CARs 421.32."
+  - id: q5
+    prompt: "A candidate for a CPL (Aeroplane) has completed all flight-time requirements. Which of the following must ALSO be completed before Transport Canada will issue the licence?"
+    choices:
+      A: "A minimum of 50 hours on multi-engine aircraft"
+      B: "A valid instrument rating"
+      C: "A successful written examination and flight test"
+      D: "An Airline Transport Pilot Licence night rating endorsement"
+    answer: C
+    explanation: "To obtain a CPL (Aeroplane), candidates must pass the Transport Canada CPL written examination and complete a flight test with a designated pilot examiner. Neither an IR nor multi-engine time is a prerequisite for the basic CPL. Source: CARs 421.32."
+---
+
+# Lesson CAL-001: CPL Licensing Requirements
+
+**Subject:** Commercial Air Law  
+**Lesson number:** 001  
+**Estimated time:** 20 minutes  
+**Sources:** CARs Part IV; CARs 421.32; CARs 404.04; TP 12880E
+
+---
+
+## Narration Script
+
+This lesson covers the licensing requirements for the Canadian Commercial Pilot Licence — Aeroplane (CPL-A). If you hold a PPL-A, you already know the private pilot standard. The CPL raises every bar: minimum age, medical standard, flight time, and the regulatory privileges and limitations that come with the licence.
+
+---
+
+### Why the CPL Exists
+
+A Private Pilot Licence authorises you to fly for pleasure and personal transportation — you cannot be paid. A Commercial Pilot Licence authorises you to fly for hire or reward: you can be paid as a pilot, act as pilot-in-command of commercially operated aircraft, and carry passengers or cargo for remuneration.
+
+The higher requirements for the CPL reflect the fact that commercial pilots are responsible for the safety of paying passengers and operate under stricter regulatory oversight.
+
+---
+
+### Minimum Age
+
+To apply for a CPL (Aeroplane), you must be at least **18 years of age**. This compares with:
+
+- PPL (Aeroplane): 17 years minimum
+- Student Pilot Permit: 14 years minimum (solo), 16 years minimum (cross-country)
+
+The 18-year minimum is set in **CARs Part IV**. No exceptions exist; the licence cannot be issued until the applicant's 18th birthday.
+
+---
+
+### Medical Certificate
+
+You must hold a valid **Category 1 medical certificate** issued by a Transport Canada–designated Aviation Medical Examiner (AME).
+
+| Licence | Required Medical |
+|---------|-----------------|
+| Student Pilot Permit | Category 3 |
+| Recreational Pilot Permit | Category 3 |
+| Private Pilot Licence | Category 3 |
+| Commercial Pilot Licence | **Category 1** |
+| Airline Transport Pilot Licence | Category 1 |
+
+A Category 1 medical is more stringent than a Category 3. Vision standards are higher, cardiovascular standards are stricter, and the renewal interval is shorter (annual for pilots under 40; every 6 months for pilots 40 and over, for first class), with specific requirements that may change over time — always confirm current standards with a Transport Canada AME.
+
+**Source:** CARs 404.04.
+
+---
+
+### Flight Time Requirements
+
+Under **CARs 421.32**, to be eligible for a CPL (Aeroplane) you must have logged:
+
+| Requirement | Minimum Hours |
+|-------------|--------------|
+| Total flight time | **200 hours** |
+| Pilot-in-command (PIC) time | **100 hours** |
+| PIC cross-country time | **20 hours** |
+| Instrument time (dual or simulated) | **10 hours** |
+| Night time (dual and solo combined) | Minimum dual night + solo night take-offs and landings |
+| Flight time in the 12 months before the test | **5 hours** (currency) |
+
+The 200-hour total is the most frequently tested number on the written exam. Remember the breakdown: 100 hours PIC, of which 20 hours must be cross-country PIC.
+
+**Instrument time** (10 hours minimum) may include time in an approved flight simulator. It does not require an instrument rating — it is basic hood/IMC training toward the CPL standard.
+
+**Night time** requirements are set out in CARs 421.32 and require both dual instruction and solo night flights including specific numbers of take-offs and landings.
+
+---
+
+### Written Examination and Flight Test
+
+Flight time alone does not qualify you for the CPL. You must also:
+
+1. **Pass the Transport Canada CPL written examination** — a multiple-choice exam covering Air Law (commercial emphasis), Navigation, Meteorology, and Aeronautics/General Knowledge. The passing grade is 60%; targeting 80%+ is strongly recommended.
+
+2. **Complete a flight test** with a Transport Canada–designated pilot examiner. The flight test evaluates you against the CPL Pilot Training Standards (PTS).
+
+Both requirements must be met before the licence is issued.
+
+---
+
+### CPL Privileges
+
+Once issued, a CPL (Aeroplane) authorises you to:
+
+- Act as PIC of any aeroplane operated for hire or reward
+- Carry passengers and cargo commercially on aircraft up to the categories covered by the licence
+- Be paid as a commercial pilot
+
+Additional ratings (multi-engine, instrument, etc.) expand which operations you may conduct.
+
+---
+
+### Key Numbers Summary
+
+| Item | Requirement | Source |
+|------|-------------|--------|
+| Minimum age | 18 years | CARs Part IV |
+| Medical | Category 1 | CARs 404.04 |
+| Total flight time | 200 hours | CARs 421.32 |
+| PIC time | 100 hours | CARs 421.32 |
+| PIC cross-country | 20 hours | CARs 421.32 |
+| Instrument time | 10 hours | CARs 421.32 |
+| Written exam passing grade | 60% (target 80%+) | Transport Canada |
+
+---
+
+*End of Lesson CAL-001.*

--- a/lessons/cpl-a/002-commercial-air-services.md
+++ b/lessons/cpl-a/002-commercial-air-services.md
@@ -1,0 +1,163 @@
+---
+id: CAL-002
+topic: cpl-a
+order: 2
+slug: commercial-air-services
+title: "Commercial Air Services and Operator Certificates"
+duration_min: 20
+status: draft
+audio: null
+visual: null
+sources:
+  - "CARs Part VII (Commercial Air Services)"
+  - "CARs 700 (General Commercial Air Service Regulations)"
+  - "CARs 703 (Air Taxi Operations)"
+  - "CARs 704 (Commuter Operations)"
+  - "CARs 705 (Airline Operations)"
+  - "TP 12880E (Aeroplane Flight Training Manual)"
+questions:
+  - id: q1
+    prompt: "Under CARs Part VII, what document must an operator hold before conducting commercial air services in Canada?"
+    choices:
+      A: "A Private Operator Certificate"
+      B: "An Air Operator Certificate (AOC)"
+      C: "A Type Certificate"
+      D: "A Special Flight Operations Certificate"
+    answer: B
+    explanation: "CARs Part VII requires operators conducting commercial air services to hold an Air Operator Certificate (AOC) issued by Transport Canada. The AOC specifies the operations the operator is authorised to conduct. Source: CARs 700.02."
+  - id: q2
+    prompt: "Which CARs sub-part governs Air Taxi Operations — the commercial use of aircraft with a maximum certified take-off weight of 19,000 kg or less, carrying 9 or fewer passengers?"
+    choices:
+      A: "CARs 700"
+      B: "CARs 703"
+      C: "CARs 704"
+      D: "CARs 705"
+    answer: B
+    explanation: "CARs 703 governs Air Taxi Operations, which covers single-pilot commercial operations with aircraft not exceeding 19,000 kg MCTOW and a passenger seating configuration of 9 or fewer. Source: CARs 703.01."
+  - id: q3
+    prompt: "Which CARs sub-part covers Commuter Operations — commercial services conducted with aircraft up to 19,000 kg carrying 10 to 19 passengers?"
+    choices:
+      A: "CARs 703"
+      B: "CARs 704"
+      C: "CARs 705"
+      D: "CARs 706"
+    answer: B
+    explanation: "CARs 704 covers Commuter Operations, which applies to aircraft with a MCTOW of 19,000 kg or less carrying 10 to 19 passengers. This category typically requires two-pilot crews. Source: CARs 704.01."
+  - id: q4
+    prompt: "A commercial operator is required to maintain a Company Operations Manual (COM). What is the PRIMARY purpose of the COM?"
+    choices:
+      A: "To serve as the aircraft's Pilot Operating Handbook"
+      B: "To provide crew members with policies, procedures, and limitations for conducting operations in compliance with CARs"
+      C: "To satisfy the AOC application requirement only — it has no operational use"
+      D: "To document passenger safety briefings"
+    answer: B
+    explanation: "The Company Operations Manual (COM) is required under CARs Part VII and documents the operator's policies, procedures, and duty/rest limitations. Crew members are required to follow it. It is a living operational document, not just an application artifact. Source: CARs 700.09."
+  - id: q5
+    prompt: "A pilot flies a friend from one city to another in their personal aircraft and the friend pays for half the fuel. Is this a 'commercial air service' under CARs?"
+    choices:
+      A: "Yes — any time money changes hands it is a commercial air service"
+      B: "No — cost-sharing among passengers does not constitute hire or reward"
+      C: "Yes — but only if the aircraft is certified for commercial operations"
+      D: "No — only scheduled airlines constitute commercial air services"
+    answer: B
+    explanation: "Cost-sharing is not considered hire or reward under CARs, provided the pilot is sharing actual operating costs with passengers on a pro-rata basis and not profiting. A 'commercial air service' requires remuneration to the operator beyond cost recovery. Source: CARs 101.01 (definition of 'aerial work') and CARs interpretation guidance."
+---
+
+# Lesson CAL-002: Commercial Air Services and Operator Certificates
+
+**Subject:** Commercial Air Law  
+**Lesson number:** 002  
+**Estimated time:** 20 minutes  
+**Sources:** CARs Part VII; CARs 700–705; TP 12880E
+
+---
+
+## Narration Script
+
+Once you hold a CPL, you're eligible to be employed as a commercial pilot. But before you can carry passengers for hire, the *operator* you work for must also hold the proper certificate. This lesson explains the regulatory framework governing commercial air services in Canada: what constitutes a commercial operation, what operators need to be certificated, and which sub-parts of CARs Part VII apply to which operations.
+
+---
+
+### What Is a Commercial Air Service?
+
+Under CARs, a **commercial air service** means any use of an aircraft for hire or reward. The key element is remuneration — the operator is being paid beyond mere cost recovery.
+
+This is different from:
+- **Private operation** — flying for pleasure, personal transport, or business travel without offering the service to others for pay.
+- **Cost-sharing** — splitting actual operating costs with passengers on a pro-rata basis. Provided the pilot does not profit, this is not a commercial service.
+
+The distinction matters because commercial services trigger the requirements of CARs Part VII: operator certificates, operating manuals, maintenance standards, and duty/rest rules.
+
+---
+
+### The Air Operator Certificate (AOC)
+
+Before conducting commercial air services, an operator must hold an **Air Operator Certificate (AOC)** issued by Transport Canada under **CARs Part VII**.
+
+The AOC specifies:
+- Which types of operations the holder is authorised to conduct (e.g., air taxi, commuter)
+- The aircraft types approved for operations
+- The geographic area of operations
+- Any special authorisations
+
+Without an AOC, no commercial service may be offered. The AOC is issued to the operator (company), not the individual pilot.
+
+**Source:** CARs 700.02.
+
+---
+
+### CARs Part VII Structure
+
+Part VII is divided into sub-parts by operation type. Each sub-part has progressively higher requirements as the complexity and risk of the operation increase.
+
+| Sub-Part | Operation | MCTOW | Passengers | Crew |
+|----------|-----------|-------|------------|------|
+| **703** | Air Taxi | ≤ 19,000 kg | ≤ 9 | Single PIC |
+| **704** | Commuter | ≤ 19,000 kg | 10–19 | Two-crew |
+| **705** | Airline | > 19,000 kg or ≥ 20 passengers | Any | Two-crew (ATPL required for PIC) |
+
+Most CPL holders begin their commercial careers under CARs 703 (air taxi). This sub-part allows single-pilot operations on smaller aircraft and is the entry point for bush flying, charter, and cargo work.
+
+**CARs 704 commuter operations** require two-crew and a higher qualification standard. The PIC must hold a CPL; the co-pilot must hold at minimum a CPL with appropriate ratings.
+
+**CARs 705 airline operations** require the PIC to hold an Airline Transport Pilot Licence (ATPL). The CPL is insufficient to act as PIC of CARs 705 operations.
+
+---
+
+### Company Operations Manual (COM)
+
+Every AOC holder must maintain a **Company Operations Manual** (COM). This is a required document under **CARs 700.09** and must be accepted by Transport Canada.
+
+The COM governs:
+- Crew qualification requirements
+- Weather minima for specific routes and airports
+- Duty time and rest limitations (fatigue management)
+- Emergency procedures
+- Load and weight-and-balance procedures
+
+As a commercial pilot, you are *required to know and follow your operator's COM*. Ignorance of its contents is not a defence if you violate its provisions.
+
+---
+
+### Private Operator Registration
+
+Not all paid aviation falls under the AOC system. **Private operator registration** (under CARs Part IV, Subpart 4) applies to companies that operate aircraft for business purposes and carry their own employees — but do not offer air service to the public.
+
+A private operator carrying its own executives from city to city does not need an AOC. However, the pilot flying them must still hold at minimum a PPL (with appropriate ratings), and different safety standards apply.
+
+---
+
+### Key Distinctions for the Exam
+
+| Concept | Key Point |
+|---------|-----------|
+| Commercial air service | Hire or reward — not just cost-sharing |
+| AOC | Required for all commercial operators |
+| CARs 703 | Air taxi ≤ 9 pax, single-pilot allowed |
+| CARs 704 | Commuter 10–19 pax, two-crew required |
+| CARs 705 | Airline, ATPL required for PIC |
+| COM | Operator's operations bible — pilots must follow it |
+
+---
+
+*End of Lesson CAL-002.*

--- a/lessons/cpl-a/003-air-taxi-operations.md
+++ b/lessons/cpl-a/003-air-taxi-operations.md
@@ -1,0 +1,176 @@
+---
+id: CAL-003
+topic: cpl-a
+order: 3
+slug: air-taxi-operations
+title: "Air Taxi Operations (CARs 703)"
+duration_min: 20
+status: draft
+audio: null
+visual: null
+sources:
+  - "CARs 703 (Air Taxi Operations)"
+  - "CARs 700 (General Commercial Air Service Regulations)"
+  - "TP 12880E (Aeroplane Flight Training Manual)"
+  - "Transport Canada CPL-A PTS"
+questions:
+  - id: q1
+    prompt: "Under CARs 703, the maximum number of passenger seats (excluding the pilot's seat) permitted for an air taxi operation is:"
+    choices:
+      A: "5"
+      B: "7"
+      C: "9"
+      D: "12"
+    answer: C
+    explanation: "CARs 703 (Air Taxi Operations) applies to aircraft with a passenger seating configuration of 9 or fewer, excluding the pilot's seat. Aircraft with 10 or more passenger seats fall under CARs 704 (Commuter Operations). Source: CARs 703.01."
+  - id: q2
+    prompt: "A pilot conducting air taxi operations under CARs 703 is about to depart on a flight but is uncertain whether the weather at the destination meets the operator's minimums. Under CARs 703, who has the final authority to determine if the flight may proceed?"
+    choices:
+      A: "The air traffic controller at the departure airport"
+      B: "The operator's dispatch centre"
+      C: "The pilot-in-command"
+      D: "The chief pilot, who must be consulted before any flight in marginal weather"
+    answer: C
+    explanation: "Under CARs 703 (and CARs 700.15), the pilot-in-command has final authority over the safety of the flight and may refuse to commence or continue a flight if, in their judgment, it would be unsafe. No external authority can override the PIC's safety decision. Source: CARs 700.15; CARs 703."
+  - id: q3
+    prompt: "Under CARs 703, before beginning a flight, the PIC must be satisfied that the aircraft has been maintained in accordance with:"
+    choices:
+      A: "The private pilot maintenance schedule"
+      B: "The operator's approved maintenance schedule and that all required inspections are current"
+      C: "A 50-hour inspection completed within the last calendar month"
+      D: "Manufacturer's recommendations only — TC schedules do not apply to air taxi aircraft"
+    answer: B
+    explanation: "The PIC of an air taxi operation must confirm that the aircraft has been maintained in accordance with the operator's approved maintenance schedule and that all required airworthiness documents are current and in order. Source: CARs 703; CARs 605.84."
+  - id: q4
+    prompt: "CARs 703 imposes duty time and rest period requirements on commercial pilots. The PRIMARY purpose of these regulations is to:"
+    choices:
+      A: "Limit the number of revenue hours an operator can sell per month"
+      B: "Ensure pilots are adequately rested and fatigue does not impair flight safety"
+      C: "Standardise pilot schedules across all Canadian operators"
+      D: "Satisfy international ICAO Annex 6 requirements for data collection"
+    answer: B
+    explanation: "Duty time and rest period regulations exist to manage pilot fatigue, which is a recognised contributor to aviation accidents. The regulations set maximum daily flight duty periods and minimum rest periods between duty days. Source: CARs 700.15; CARs 703 Subpart 17."
+  - id: q5
+    prompt: "Under CARs 703, before each flight with passengers, the pilot must ensure that a passenger safety briefing is conducted. Which of the following items is REQUIRED to be included?"
+    choices:
+      A: "The price of the flight and refund policy"
+      B: "The location and operation of emergency exits, and the use of seat belts"
+      C: "The cruising altitude and expected turbulence forecast"
+      D: "The pilot's name and certificate number"
+    answer: B
+    explanation: "Passenger safety briefings under CARs 703 must include the location and use of emergency exits, seat belt fastening and unfastening, carry-on baggage stowage, and smoking prohibitions. The briefing is a regulatory requirement — not discretionary. Source: CARs 703.69."
+---
+
+# Lesson CAL-003: Air Taxi Operations (CARs 703)
+
+**Subject:** Commercial Air Law  
+**Lesson number:** 003  
+**Estimated time:** 20 minutes  
+**Sources:** CARs 703; CARs 700; TP 12880E
+
+---
+
+## Narration Script
+
+For most CPL graduates, CARs 703 is where commercial flying begins. Air taxi operations — bush flying, charter, cargo, survey — are governed by this sub-part of CARs Part VII. This lesson covers the key requirements: who CARs 703 applies to, the PIC's authority and responsibilities, duty time limits, and the operational rules that distinguish air taxi from private flying.
+
+---
+
+### Scope of CARs 703
+
+**CARs 703 — Air Taxi Operations** applies to commercial air services conducted with aeroplanes that have:
+- A maximum certificated take-off weight (MCTOW) of **19,000 kg or less**, and
+- A passenger seating configuration of **9 or fewer seats** (excluding the pilot's seat)
+
+This captures everything from a two-seat Cessna 172 doing survey work to a nine-seat Cessna 208 Caravan on a charter. It is the most common sub-part for newly licensed CPL pilots.
+
+**Source:** CARs 703.01.
+
+---
+
+### The AOC and Operations Manual
+
+Before conducting CARs 703 operations, the operator must hold an **Air Operator Certificate (AOC)** endorsed for air taxi operations. The operator must also have a **Company Operations Manual (COM)** accepted by Transport Canada.
+
+As the PIC, you are required to be familiar with and follow the COM. If the operator's minimums are higher than the regulatory minimums, you follow the operator's minimums.
+
+---
+
+### PIC Authority and Final Authority
+
+**CARs 700.15** establishes a foundational principle of Canadian commercial aviation: the **pilot-in-command has final authority over the safety of the flight**.
+
+This means:
+- The PIC may refuse to commence or continue a flight if, in their judgment, it is unsafe.
+- No operator, dispatcher, or customer can override a PIC safety decision.
+- The PIC is also responsible for ensuring the aircraft is airworthy, loaded correctly, and that all required documents are aboard.
+
+This authority is absolute on safety matters — and with it comes full responsibility.
+
+---
+
+### Pre-Flight Responsibilities
+
+Before each air taxi flight, the PIC must:
+
+1. **Confirm airworthiness** — ensure required maintenance is current and the aircraft journey log and maintenance release are in order. Source: CARs 605.84.
+2. **Check performance** — confirm the aircraft can meet all performance requirements for the planned flight (takeoff, en-route, landing).
+3. **Weight and balance** — verify loading is within limits.
+4. **Weather** — ensure conditions at departure, en route, and destination meet operator and regulatory minimums.
+5. **Fuel** — confirm fuel reserves meet the requirements of CARs 602.88 (day VFR) or CARs 602.89 (night/IFR).
+6. **Passenger safety briefing** — required before every passenger flight (CARs 703.69).
+
+---
+
+### Passenger Safety Briefings
+
+Under **CARs 703.69**, a safety briefing must be given to all passengers before every flight. The briefing must cover:
+
+- Seat belt fastening and unfastening
+- Location and operation of emergency exits
+- Smoking prohibition
+- Carry-on baggage stowage
+
+The briefing may be oral, by video, or by card. It is mandatory — not optional, regardless of how short the flight.
+
+---
+
+### Duty Time and Rest Requirements
+
+CARs 703 imposes **flight duty period** and **rest period** limits on commercial pilots to manage fatigue.
+
+Key concepts:
+- **Flight duty period (FDP):** The time from when a crew member reports for duty until the engines are shut down at the end of the last flight.
+- **Maximum FDP:** Varies by start time and number of sectors; typically 13–14 hours maximum under standard rules.
+- **Minimum rest period:** Must be sufficient to allow adequate sleep before the next duty period.
+
+Fatigue management is a safety responsibility shared between the operator (scheduling) and the pilot (personal responsibility to be fit for duty). A pilot who is too fatigued to fly safely must not fly, regardless of schedule pressure.
+
+**Source:** CARs 700.15; CARs 703 Subpart 17.
+
+---
+
+### VFR Weather Minimums for Air Taxi
+
+Under CARs 703, operators may have specific minima in their COM that exceed regulatory minimums. The regulatory baseline for VFR is:
+- CARs Part VI weather minimums (same as for private operations)
+- However, operators often require higher visibility and ceiling minima for commercial flights, particularly at non-towered airports or in challenging terrain
+
+Always check the COM before each flight — and if uncertain about weather, invoke your PIC authority.
+
+---
+
+### Key Points for the Exam
+
+| Item | Requirement |
+|------|-------------|
+| Scope | MCTOW ≤ 19,000 kg; ≤ 9 passenger seats |
+| Required documents | AOC, COM |
+| PIC final authority | CARs 700.15 — safety decisions are final |
+| Passenger briefing | Required before every passenger flight (CARs 703.69) |
+| Duty time limits | Fatigue management — max FDP per CARs 703 |
+| Pre-flight checks | Airworthiness, W&B, weather, fuel, performance |
+
+---
+
+*End of Lesson CAL-003.*

--- a/lessons/cpl-a/004-pic-authority-responsibilities.md
+++ b/lessons/cpl-a/004-pic-authority-responsibilities.md
@@ -1,0 +1,174 @@
+---
+id: CAL-004
+topic: cpl-a
+order: 4
+slug: pic-authority-responsibilities
+title: "PIC Authority and Commercial Crew Responsibilities"
+duration_min: 20
+status: draft
+audio: null
+visual: null
+sources:
+  - "CARs 700.15 (Pilot-in-Command Authority)"
+  - "CARs 602.02 (Responsibility of Pilot-in-Command)"
+  - "CARs Part VII (Commercial Air Services)"
+  - "TP 12880E (Aeroplane Flight Training Manual)"
+  - "Transport Canada CPL-A PTS"
+questions:
+  - id: q1
+    prompt: "Under CARs 602.02, who is responsible for the safe conduct of a flight?"
+    choices:
+      A: "The aircraft owner"
+      B: "The air traffic controller in whose airspace the flight is conducted"
+      C: "The pilot-in-command"
+      D: "The operator's chief pilot"
+    answer: C
+    explanation: "CARs 602.02 establishes that the pilot-in-command is responsible for the safe conduct of the flight. This responsibility cannot be delegated or transferred, regardless of instructions from an employer, dispatcher, or ATC. Source: CARs 602.02."
+  - id: q2
+    prompt: "A commercial operator instructs a CPL pilot to depart into weather below the operator's published minimums, claiming the flight is essential. Under CARs 700.15, what should the pilot do?"
+    choices:
+      A: "Comply — the operator has the authority to grant exceptions to their own minimums"
+      B: "Refuse the flight — PIC authority over safety decisions cannot be overridden by the operator"
+      C: "Proceed with caution and file a post-flight safety report"
+      D: "Request ATC to waive the minimums requirement"
+    answer: B
+    explanation: "CARs 700.15 gives the pilot-in-command final authority over the safety of the operation. The operator cannot compel the PIC to conduct a flight that the PIC reasonably believes is unsafe. Refusing a flight on safety grounds is protected under this provision. Source: CARs 700.15."
+  - id: q3
+    prompt: "During a CARs 703 air taxi flight, a crew member suspects another crew member is impaired by alcohol. The CARs provision that prohibits acting as a crew member within eight hours of consuming alcohol, or while impaired, is found in:"
+    choices:
+      A: "CARs 602.01"
+      B: "CARs 602.03"
+      C: "CARs 700.15"
+      D: "CARs 703.86"
+    answer: B
+    explanation: "CARs 602.03 prohibits a person from acting as a crew member within eight hours of consuming alcohol, while under the influence of alcohol, or while using any drug that impairs their ability to carry out their responsibilities. Source: CARs 602.03."
+  - id: q4
+    prompt: "In a multi-crew commercial operation, the PIC delegates the takeoff to the co-pilot. During the takeoff roll, a bird strike damages an engine. Who has the authority to initiate the rejected takeoff procedure?"
+    choices:
+      A: "The co-pilot, as the handling pilot"
+      B: "The PIC, who retains final authority regardless of who is flying"
+      C: "The ATC tower controller"
+      D: "Either pilot may initiate, with the PIC making the final call only if the co-pilot hesitates"
+    answer: B
+    explanation: "Even when the co-pilot is the handling pilot (pilot flying), the PIC retains final authority over all safety decisions including rejected takeoffs. Both pilots may call for a rejected takeoff under standard crew resource management (CRM) — the PIC has the final authority if there is disagreement. Source: CARs 602.02; CARs 700.15; standard CRM doctrine."
+  - id: q5
+    prompt: "Under CARs, a commercial pilot who refuses to conduct a flight on safety grounds may NOT be:"
+    choices:
+      A: "Required to file a safety report after landing"
+      B: "Subject to disciplinary action, suspension, or termination because of that refusal"
+      C: "Asked to explain the safety concern to the chief pilot"
+      D: "Replaced by another pilot willing to conduct the flight"
+    answer: B
+    explanation: "Canadian aviation regulations protect commercial pilots who exercise their PIC authority to refuse unsafe flights. An operator cannot discipline, suspend, or terminate a pilot solely because the pilot exercised safety authority under CARs 700.15. This protection is fundamental to a just safety culture. Source: CARs 700.15; Aeronautics Act."
+---
+
+# Lesson CAL-004: PIC Authority and Commercial Crew Responsibilities
+
+**Subject:** Commercial Air Law  
+**Lesson number:** 004  
+**Estimated time:** 20 minutes  
+**Sources:** CARs 602.02; CARs 602.03; CARs 700.15; TP 12880E
+
+---
+
+## Narration Script
+
+One of the most important concepts in commercial aviation law is the authority of the pilot-in-command. As a CPL holder, you are not just a licence number — you are the person legally and operationally responsible for the safety of every flight you command. This lesson covers the PIC's authority under CARs, crew responsibilities, and the protections available when you exercise that authority.
+
+---
+
+### The Foundation: CARs 602.02
+
+**CARs 602.02** establishes the bedrock principle:
+
+> The pilot-in-command of an aircraft is responsible for the safe conduct of the flight.
+
+This is not modified by:
+- Instructions from the operator or dispatch
+- Requests from passengers
+- Commercial pressure to meet schedules
+- ATC clearances (which authorise but do not guarantee safety)
+
+The PIC is responsible. Full stop.
+
+---
+
+### PIC Final Authority: CARs 700.15
+
+In commercial operations, **CARs 700.15** reinforces and extends the PIC authority principle:
+
+> The pilot-in-command has final authority over the safety of the operation.
+
+This means the PIC may, in the interest of safety:
+- Refuse to commence a flight
+- Discontinue a flight already in progress
+- Deviate from an ATC clearance in an emergency
+- Reject any instruction that would compromise safety
+
+The operator cannot override this authority. An operator who tries to compel a PIC to fly against the PIC's safety judgment is in violation of CARs.
+
+**The key practical rule:** If you, as PIC, believe a flight is unsafe, you do not fly it. Document your decision, notify the operator, and if required, file an incident report through Transport Canada's Aviation Safety Reporting Program (ASRP).
+
+---
+
+### Protection from Retaliation
+
+A pilot who exercises PIC safety authority is legally protected. Under Canadian law, an operator **cannot** discipline, fire, or take adverse action against a pilot *solely because* that pilot refused a flight on safety grounds.
+
+This protection exists because the entire safety system depends on pilots being willing to say "no" without fear of consequences. A pilot who fears job loss is less likely to refuse unsafe assignments — and that creates systemic risk.
+
+**Source:** CARs 700.15; Aeronautics Act.
+
+---
+
+### Fitness for Duty: CARs 602.03
+
+**CARs 602.03** prohibits crew members from acting in any capacity if:
+- They have consumed alcohol within **8 hours** of the flight
+- They are **under the influence** of alcohol
+- They are using **any drug** that impairs their capacity to carry out their responsibilities
+- They are **fatigued** to the point where safety would be compromised
+
+The 8-hour rule is the minimum. Many operators require 12 hours, and the CARs standard is "not impaired" — even 8+ hours after drinking, if impairment persists, the pilot must not fly.
+
+**Practical point:** If you are not fit to fly — for any reason — you must not fly. Inform your employer and stand down. This is a responsibility, not just a right.
+
+---
+
+### Crew Resource Management (CRM)
+
+In multi-crew operations, authority is shared between the PIC and co-pilot, but the PIC has final authority. Good CRM means:
+
+- Both crew members monitor and cross-check
+- Either crew member may and should call out safety concerns
+- The PIC listens and considers input from the co-pilot
+- The PIC makes the final decision
+
+The co-pilot's role is not passive. Transport Canada expects active participation in safety monitoring. A co-pilot who sees a safety issue must speak up — and a PIC who ignores valid safety concerns from the co-pilot is not operating safely.
+
+---
+
+### Passenger and Cargo Responsibilities
+
+As PIC under CARs 703, you are also responsible for:
+
+- Ensuring all passengers are briefed before flight (CARs 703.69)
+- Confirming weight and balance are within limits
+- Verifying dangerous goods are not carried in violation of CARs Part IX
+- Ensuring passengers are not disruptive or impaired in a way that compromises safety
+
+You may refuse to carry a passenger who poses a safety risk. This is PIC authority in action.
+
+---
+
+### Summary of Key Provisions
+
+| Provision | Content |
+|-----------|---------|
+| CARs 602.02 | PIC responsible for safe conduct of flight |
+| CARs 602.03 | Prohibits impaired or fatigued crew members |
+| CARs 700.15 | PIC has final authority in commercial operations; retaliation for safety refusals is prohibited |
+
+---
+
+*End of Lesson CAL-004.*

--- a/lessons/cpl-a/005-commercial-vfr-night-regulations.md
+++ b/lessons/cpl-a/005-commercial-vfr-night-regulations.md
@@ -1,0 +1,178 @@
+---
+id: CAL-005
+topic: cpl-a
+order: 5
+slug: commercial-vfr-night-regulations
+title: "Commercial VFR and Night Regulations"
+duration_min: 20
+status: draft
+audio: null
+visual: null
+sources:
+  - "CARs 602.114–602.116 (VFR Weather Minimums)"
+  - "CARs 602.88–602.89 (Fuel Requirements)"
+  - "CARs 603 (Night VFR)"
+  - "CARs 605.16–605.17 (Navigation and Anti-Collision Lights)"
+  - "CARs 703 (Air Taxi Operations)"
+  - "TP 12880E (Aeroplane Flight Training Manual)"
+questions:
+  - id: q1
+    prompt: "A commercial VFR flight is planned to a destination with a published aerodrome weather forecast. Under CARs 602.88, what is the minimum fuel reserve required for a day VFR flight in an aeroplane?"
+    choices:
+      A: "20 minutes at cruise power"
+      B: "30 minutes at cruise power"
+      C: "45 minutes at cruise power"
+      D: "1 hour at normal cruise power"
+    answer: C
+    explanation: "CARs 602.88 requires that a day VFR flight in an aeroplane have sufficient fuel to fly to the destination plus a fuel reserve of 45 minutes at normal cruise power. Night VFR requires a 45-minute reserve as well, under CARs 602.89. Source: CARs 602.88."
+  - id: q2
+    prompt: "Under CARs, to conduct night VFR flight, an aeroplane must be equipped with which of the following lights?"
+    choices:
+      A: "Landing light only"
+      B: "Anti-collision light only"
+      C: "Navigation lights (red, green, white) and an anti-collision light"
+      D: "Navigation lights, anti-collision light, and a taxi light"
+    answer: C
+    explanation: "Night VFR requires navigation lights (red on port/left, green on starboard/right, white aft) under CARs 605.16, and an anti-collision light under CARs 605.17. A landing light is not regulatory required for night VFR but is strongly recommended. Source: CARs 605.16; CARs 605.17."
+  - id: q3
+    prompt: "A commercial air taxi pilot under CARs 703 wishes to conduct a night VFR flight. In addition to standard VFR requirements, what additional pilot qualification is needed?"
+    choices:
+      A: "An Instrument Rating"
+      B: "A Night Rating"
+      C: "An endorsement in the operator's COM"
+      D: "A Multi-Engine Rating"
+    answer: B
+    explanation: "To act as PIC of an aircraft on a night VFR flight, a pilot must hold a Night Rating (or an Instrument Rating, which encompasses night flying). A Night Rating is separate from, and lesser than, the IR — it authorises night VFR but not IMC. Source: CARs 401.45; CARs 421.40."
+  - id: q4
+    prompt: "In controlled airspace (Class C, D, or E), what are the minimum VFR weather conditions for a commercial aeroplane during the day?"
+    choices:
+      A: "1 SM visibility, clear of cloud"
+      B: "2 SM visibility, 500/1,000/2,000 cloud clearance"
+      C: "3 SM visibility, 500 feet below / 1,000 feet above / 2,000 feet horizontal from cloud"
+      D: "5 SM visibility, 1,000 feet below / 2,000 feet above / 1 NM horizontal from cloud"
+    answer: C
+    explanation: "In controlled airspace (Class C, D, E), VFR minimums are 3 statute miles visibility and 500 feet below, 1,000 feet above, and 2,000 feet horizontal from cloud — for both day and night, and for both private and commercial operations. Source: CARs 602.114."
+  - id: q5
+    prompt: "An air taxi operator's COM requires VFR flights to destinations to have a ceiling of at least 1,000 feet. The regulatory VFR minimum for the route is 500 feet below cloud. Which standard governs?"
+    choices:
+      A: "The regulatory minimum — operators cannot impose higher minimums than the CARs"
+      B: "The operator's COM minimum — it is higher and the pilot must follow the COM"
+      C: "The pilot's personal minimums — the PIC decides which standard to apply"
+      D: "The ATC standard — as issued with the clearance"
+    answer: B
+    explanation: "When an operator's COM imposes higher minimums than the regulatory minimum, the operator's minimums govern. A CPL holder operating under an AOC must comply with both the CARs minimums AND the operator's COM. The COM may only be more restrictive, never less restrictive, than the regulations. Source: CARs 700.09; CARs 703."
+---
+
+# Lesson CAL-005: Commercial VFR and Night Regulations
+
+**Subject:** Commercial Air Law  
+**Lesson number:** 005  
+**Estimated time:** 20 minutes  
+**Sources:** CARs 602.88–602.89; CARs 602.114–602.116; CARs 603; CARs 605.16–605.17; CARs 703; TP 12880E
+
+---
+
+## Narration Script
+
+Commercial VFR operations are subject to the same CARs Part VI weather minimums as private flying — but layered on top of those are the operator's own minimums, equipment requirements, and fuel rules. For night operations, an additional pilot qualification — the Night Rating — is required. This lesson consolidates the key regulatory requirements for commercial VFR and night flight that appear frequently on the CPL written exam.
+
+---
+
+### VFR Weather Minimums — Commercial vs. Private
+
+The regulatory VFR weather minimums under CARs Part VI apply equally to private and commercial operations. There is no separate "commercial minimum" in the CARs — the airspace class determines the minimum.
+
+| Airspace | Day VFR | Night VFR |
+|---------|---------|-----------|
+| Controlled (Class C/D/E) | 3 SM, 500/1,000/2,000 | Same — 3 SM, 500/1,000/2,000 |
+| Class G ≤ 1,000 ft AGL | 2 SM, clear of cloud | 3 SM, 500/1,000/2,000 |
+| Class G > 1,000 ft AGL | 1 SM, clear of cloud | 3 SM, 500/1,000/2,000 |
+
+**Key exam point:** Night minimums in Class G above 1,000 ft AGL are the same as controlled airspace — 3 SM and the full cloud clearances. The reduced day Class G minimums do NOT apply at night.
+
+**Source:** CARs 602.114–602.115.
+
+---
+
+### Operator Minimums vs. Regulatory Minimums
+
+A commercial operator's Company Operations Manual (COM) may impose **higher** minimums than the CARs require. In that case:
+
+- The pilot **must** follow the COM minimum
+- The CARs minimum is a floor — operators can only raise it, not lower it
+- Dispatchers and management cannot authorise operations below COM minimums
+
+This is a common exam topic. Know that operators can be **more** restrictive but never less.
+
+---
+
+### Fuel Requirements: Day and Night VFR
+
+**CARs 602.88 — Day VFR fuel:**  
+An aeroplane must have enough fuel to reach the destination plus a **45-minute reserve** at normal cruise power.
+
+**CARs 602.89 — Night VFR fuel:**  
+Same 45-minute reserve applies for night VFR.
+
+**IFR fuel (for reference):**  
+Fuel to alternate, plus 45 minutes at normal cruise. (IFR fuel rules are more complex and covered in the IR syllabus.)
+
+The 45-minute reserve is a *minimum*. Commercial operators often require more, especially for remote operations. Check the COM.
+
+---
+
+### Night Rating Requirement
+
+To act as PIC of an aircraft on a **night VFR flight**, a pilot must hold:
+
+- A **Night Rating**, or
+- An **Instrument Rating** (which includes night privileges)
+
+The Night Rating requires specific dual and solo night flight training and is an endorsement on your CPL. Without it, you cannot fly passengers at night under VFR.
+
+**Source:** CARs 401.45; CARs 421.40.
+
+---
+
+### Night VFR Equipment
+
+Night VFR requires specific aircraft equipment:
+
+**Navigation lights (CARs 605.16):**
+- Red — left (port) wingtip
+- Green — right (starboard) wingtip
+- White — tail (aft position light)
+
+**Anti-collision light (CARs 605.17):**
+- A flashing beacon or strobe visible from all directions
+
+Landing lights are not required by regulation for night VFR, but most operators require them and they are strongly recommended for safety.
+
+---
+
+### Special VFR (SVFR)
+
+Special VFR clearances may be issued by ATC to allow VFR flight in controlled airspace when the weather is below VFR minimums. Under SVFR, an aircraft may operate with:
+- At least 1 SM flight visibility
+- Clear of cloud
+
+SVFR clearances are available only in Class C and D airspace (around certain aerodromes) and are subject to restrictions: night SVFR requires an instrument rating; SVFR is not available in all locations.
+
+**Key exam point:** SVFR lowers the visibility and cloud clearance minimums with an ATC clearance — it does not eliminate them entirely.
+
+---
+
+### Key Numbers Summary
+
+| Rule | Requirement | Source |
+|------|-------------|--------|
+| Controlled airspace VFR | 3 SM, 500/1,000/2,000 | CARs 602.114 |
+| Night Class G > 1,000 ft | 3 SM, 500/1,000/2,000 | CARs 602.115 |
+| Day VFR fuel reserve | 45 minutes | CARs 602.88 |
+| Night VFR fuel reserve | 45 minutes | CARs 602.89 |
+| Night PIC qualification | Night Rating or IR | CARs 421.40 |
+| SVFR minimums | 1 SM, clear of cloud | CARs 601.07 |
+
+---
+
+*End of Lesson CAL-005.*

--- a/lessons/cpl-a/006-upper-level-charts-sigwx.md
+++ b/lessons/cpl-a/006-upper-level-charts-sigwx.md
@@ -1,0 +1,82 @@
+---
+id: AMT-001
+topic: cpl-a
+order: 6
+slug: upper-level-charts-sigwx
+title: "Upper Level Charts and Significant Weather Forecasts"
+duration_min: 20
+status: draft
+audio: null
+visual: null
+sources:
+  - "TP 1102 Vol. 5 (Advanced Meteorology)"
+  - "Environment and Climate Change Canada Aviation Weather Products"
+  - "AIM MET Chapter"
+  - "Transport Canada CPL-A Written Exam Guide"
+questions:
+  - id: q1
+    prompt: "A Significant Weather (SIGWX) chart for the low-level layer covers altitudes from the surface up to:"
+    choices:
+      A: "10,000 feet ASL"
+      B: "18,000 feet ASL (FL180)"
+      C: "24,000 feet ASL (FL240)"
+      D: "45,000 feet ASL (FL450)"
+    answer: B
+    explanation: "The low-level Significant Weather (SIGWX) chart covers the surface to FL180 (18,000 feet ASL). The high-level SIGWX chart covers FL250 to FL630. The low-level chart is the primary planning tool for VFR and low-altitude commercial IFR. Source: ECCC aviation weather products documentation."
+  - id: q2
+    prompt: "On a Constant Pressure Chart (upper level chart), what does the plotted wind barb represent?"
+    choices:
+      A: "Surface wind at the nearest reporting station"
+      B: "Wind at the pressure altitude of the chart"
+      C: "The tropopause wind speed"
+      D: "Forecast wind at 10,000 feet regardless of chart level"
+    answer: B
+    explanation: "A Constant Pressure Chart (e.g., 850 hPa, 700 hPa, 500 hPa) shows conditions at that specific pressure level. Plotted wind barbs reflect actual or forecast wind at that pressure altitude, not at the surface or a fixed altitude. Source: TP 1102 Vol. 5."
+  - id: q3
+    prompt: "A Graphical Area Forecast (GFA) is valid for a period of:"
+    choices:
+      A: "6 hours"
+      B: "12 hours"
+      C: "18 hours"
+      D: "24 hours"
+    answer: D
+    explanation: "A GFA (Graphical Area Forecast) is valid for 24 hours. It is issued four times daily and covers clouds, weather, and icing for Canadian airspace. Two charts per issuance cover the 0–12 hour and 12–24 hour forecast periods. Source: ECCC aviation weather products."
+  - id: q4
+    prompt: "On a SIGWX chart, an area enclosed by a scalloped line indicates:"
+    choices:
+      A: "Moderate or severe turbulence"
+      B: "Convective activity or thunderstorm areas"
+      C: "Moderate or severe icing"
+      D: "Mountain wave activity"
+    answer: C
+    explanation: "On Significant Weather charts, icing areas are enclosed by scalloped (saw-tooth) lines. Turbulence areas are enclosed by smooth curved lines. Understanding these conventions is essential for interpreting SIGWX charts during flight planning. Source: ECCC SIGWX chart legend."
+  - id: q5
+    prompt: "The tropopause height shown on a high-level SIGWX chart is important for commercial pilots because:"
+    choices:
+      A: "VFR flight is not permitted above the tropopause"
+      B: "Jet stream cores and associated turbulence are typically found at or near the tropopause"
+      C: "SIGWX chart coverage ends at the tropopause"
+      D: "Fuel burn increases significantly above the tropopause"
+    answer: B
+    explanation: "The tropopause is the boundary between the troposphere and stratosphere, where temperature stops decreasing with altitude. Jet stream cores and clear-air turbulence (CAT) are commonly found near the tropopause. Knowing its height helps commercial pilots anticipate turbulence and take advantage of favourable winds. Source: TP 1102 Vol. 5."
+---
+
+# Lesson AMT-001: Upper Level Charts and Significant Weather Forecasts
+
+**Subject:** Advanced Meteorology  
+**Lesson number:** 006 (AMT-001)  
+**Estimated time:** 20 minutes  
+**Status:** Draft skeleton — content authoring pending
+
+This lesson covers the interpretation of upper-level weather charts (Constant Pressure Charts, SIGWX charts, and GFAs) as used in commercial flight planning. Content to be expanded before audio production.
+
+Topics to be authored:
+- Constant Pressure Charts: pressure levels, contour lines, wind plotting, temperature
+- Graphical Area Forecast (GFA): structure, coverage, validity periods
+- Significant Weather (SIGWX) charts: low-level vs. high-level, symbology
+- Tropopause depiction and relevance to commercial flight
+- Practical application: reading charts for a cross-country flight plan
+
+---
+
+*Skeleton only — full narration script to be added before audio production.*

--- a/lessons/cpl-a/007-icing-types-avoidance.md
+++ b/lessons/cpl-a/007-icing-types-avoidance.md
@@ -1,0 +1,83 @@
+---
+id: AMT-002
+topic: cpl-a
+order: 7
+slug: icing-types-avoidance
+title: "Icing — Causes, Types, and Avoidance"
+duration_min: 20
+status: draft
+audio: null
+visual: null
+sources:
+  - "TP 1102 Vol. 5 (Advanced Meteorology)"
+  - "CARs 605 (Aircraft Equipment Requirements)"
+  - "AIM MET Chapter (Icing)"
+  - "Transport Canada CPL-A Written Exam Guide"
+questions:
+  - id: q1
+    prompt: "Which type of structural icing forms when large supercooled water droplets spread and freeze, creating a smooth, dense, and heavy ice layer?"
+    choices:
+      A: "Rime ice"
+      B: "Clear (glaze) ice"
+      C: "Frost"
+      D: "Mixed ice"
+    answer: B
+    explanation: "Clear ice (also called glaze ice) forms from large supercooled water droplets that spread before freezing, creating a smooth, transparent, and very dense deposit. It is the most hazardous structural icing type because it adds the most weight and is hardest to detect visually. Source: TP 1102 Vol. 5."
+  - id: q2
+    prompt: "Rime ice is characterised by:"
+    choices:
+      A: "A clear, dense, heavy deposit that is difficult to remove"
+      B: "A rough, milky-white, brittle deposit formed from small supercooled droplets"
+      C: "Freezing rain that coats horizontal surfaces only"
+      D: "Ice that forms inside the engine intake only"
+    answer: B
+    explanation: "Rime ice is rough, milky-white, and brittle. It forms when small supercooled water droplets freeze almost instantly on contact with the aircraft surface, trapping air bubbles. While lighter than clear ice, rime ice seriously disrupts airfoil shape. Source: TP 1102 Vol. 5."
+  - id: q3
+    prompt: "The temperature range most conducive to carburetor icing in an aircraft without carburetor heat is approximately:"
+    choices:
+      A: "−40°C to −20°C"
+      B: "−20°C to 0°C"
+      C: "−10°C to +25°C"
+      D: "0°C to +35°C"
+    answer: C
+    explanation: "Carburetor icing can occur in ambient temperatures from approximately −10°C to +25°C, even in clear air with no visible moisture, due to the venturi effect cooling and fuel vaporisation in the carburetor. The risk is highest in humid conditions around 10°C–20°C. Source: TP 12880E; TP 1102."
+  - id: q4
+    prompt: "A PIREP reports moderate icing at FL095. A commercial pilot is planning to cruise at FL085 on the same route 90 minutes later. How should this PIREP be used?"
+    choices:
+      A: "It can be disregarded — PIREPs are only valid at the time of report"
+      B: "It should be treated as a current hazard warning; icing conditions at nearby altitudes should be assumed until confirmed otherwise"
+      C: "The pilot may proceed since the planned altitude is 1,000 feet below the reported icing"
+      D: "A PIREP at FL095 only applies to IFR aircraft — VFR pilots are not required to consider it"
+    answer: B
+    explanation: "PIREPs are valuable real-time hazard information but age quickly. A report 90 minutes old at an adjacent altitude should be treated with caution — icing layers can shift vertically. The pilot should seek more recent reports and treat the area as potentially hazardous. Source: AIM MET Chapter."
+  - id: q5
+    prompt: "The primary regulatory requirement governing flight into known icing conditions for a non-ice-certified aircraft is:"
+    choices:
+      A: "The pilot must file IFR"
+      B: "Flight into known icing conditions is prohibited without appropriate de-ice or anti-ice equipment"
+      C: "Flight is permitted provided the PIC files a special routing"
+      D: "Night flight into icing is prohibited but day flight is permitted"
+    answer: B
+    explanation: "CARs prohibit flight into known or forecast icing conditions unless the aircraft is equipped with appropriate de-icing or anti-icing equipment certified for flight in icing conditions. For aircraft not equipped for icing, the pilot must avoid all known icing areas. Source: CARs 605; TP 1102 Vol. 5."
+---
+
+# Lesson AMT-002: Icing — Causes, Types, and Avoidance
+
+**Subject:** Advanced Meteorology  
+**Lesson number:** 007 (AMT-002)  
+**Estimated time:** 20 minutes  
+**Status:** Draft skeleton — content authoring pending
+
+Extends PPL-A icing basics to commercial-standard depth. See `lessons/meteorology/` for PPL-A foundation lesson on icing.
+
+Topics to be authored:
+- Structural icing: clear (glaze) vs. rime vs. mixed — formation, hazards, recognition
+- Carburetor icing: temperature-humidity envelope, recognition, remedy
+- Tail plane icing and its specific aerodynamic hazards
+- De-ice vs. anti-ice systems — boots, bleed-air, TKS, pitot heat
+- Regulatory requirements for flight in known icing (CARs 605)
+- PIREPs and SIGMETs for icing — how to interpret and apply
+
+---
+
+*Skeleton only — full narration script to be added before audio production.*

--- a/lessons/cpl-a/008-thunderstorm-hazards.md
+++ b/lessons/cpl-a/008-thunderstorm-hazards.md
@@ -1,0 +1,83 @@
+---
+id: AMT-003
+topic: cpl-a
+order: 8
+slug: thunderstorm-hazards
+title: "Thunderstorm Structure and Aviation Hazards"
+duration_min: 20
+status: draft
+audio: null
+visual: null
+sources:
+  - "TP 1102 Vol. 5 (Advanced Meteorology)"
+  - "AIM MET Chapter (Thunderstorms and Convective Weather)"
+  - "Transport Canada CPL-A Written Exam Guide"
+  - "NAV CANADA SIGMET Procedures"
+questions:
+  - id: q1
+    prompt: "The three stages of a single-cell thunderstorm in order are:"
+    choices:
+      A: "Dissipating, mature, cumulus"
+      B: "Cumulus, mature, dissipating"
+      C: "Mature, cumulus, dissipating"
+      D: "Cumulus, dissipating, mature"
+    answer: B
+    explanation: "A thunderstorm progresses through three stages: the cumulus stage (building, updrafts only), the mature stage (both updrafts and downdrafts, most severe — rain begins), and the dissipating stage (downdrafts dominate, storm weakens). Source: TP 1102 Vol. 5."
+  - id: q2
+    prompt: "During the mature stage of a thunderstorm, an aircraft can encounter which of the following simultaneously?"
+    choices:
+      A: "Light icing and smooth air only"
+      B: "Updrafts, downdrafts, hail, lightning, severe icing, and wind shear"
+      C: "Turbulence only if penetrating the cloud core"
+      D: "Hazards are limited to the precipitation area beneath the cloud base"
+    answer: B
+    explanation: "The mature stage is the most dangerous. An aircraft penetrating a mature thunderstorm can simultaneously encounter severe updrafts and downdrafts (each potentially exceeding 6,000 fpm), severe icing, hail, lightning, wind shear, and greatly reduced visibility. Source: TP 1102 Vol. 5."
+  - id: q3
+    prompt: "A SIGMET for convective activity (WS-type) is issued when thunderstorms are expected to affect an area. What minimum action should a VFR commercial pilot take upon receiving a SIGMET for the route ahead?"
+    choices:
+      A: "Continue the flight and report conditions to NAV CANADA on landing"
+      B: "Land immediately at the nearest aerodrome"
+      C: "Evaluate whether the SIGMET affects the planned route and altitude, and consider rerouting or delaying the flight"
+      D: "Descend below 1,000 feet AGL to remain clear of the convective tops"
+    answer: C
+    explanation: "A SIGMET for convective activity is a serious hazard warning. The pilot should evaluate the affected area relative to the planned route, consider all available weather information, and make a decision to reroute, delay, or divert. Continuing into known severe convective activity would violate the PIC's duty of care. Source: AIM MET; CARs 602.02."
+  - id: q4
+    prompt: "Microburst wind shear is most hazardous during which phase of flight?"
+    choices:
+      A: "En-route cruise at altitude"
+      B: "Takeoff and landing when the aircraft is slow and close to the ground"
+      C: "Climb above 10,000 feet"
+      D: "Holding patterns near thunderstorm cells"
+    answer: B
+    explanation: "Microburst wind shear is most dangerous during takeoff and final approach because the aircraft is operating at low speed with little altitude margin for recovery. A microburst produces a sudden headwind increase followed by a rapid headwind decrease and downdraft that can cause the aircraft to sink rapidly below the approach path. Source: TP 1102 Vol. 5."
+  - id: q5
+    prompt: "What is the recommended minimum horizontal distance from a visible thunderstorm cell for VFR flight?"
+    choices:
+      A: "2 nautical miles"
+      B: "5 nautical miles"
+      C: "10 nautical miles"
+      D: "20 nautical miles"
+    answer: C
+    explanation: "Transport Canada and industry guidance recommend a minimum of 10 nautical miles horizontal separation from visible thunderstorm cells. Even at 10 NM, severe turbulence, hail, and lightning are possible. If embedded thunderstorms are present and the cells are not visible, the entire area should be avoided. Source: TP 1102 Vol. 5; Transport Canada guidance."
+---
+
+# Lesson AMT-003: Thunderstorm Structure and Aviation Hazards
+
+**Subject:** Advanced Meteorology  
+**Lesson number:** 008 (AMT-003)  
+**Estimated time:** 20 minutes  
+**Status:** Draft skeleton — content authoring pending
+
+Extends PPL-A thunderstorm basics to commercial-standard depth. See `lessons/meteorology/` for PPL-A foundation lesson on thunderstorms.
+
+Topics to be authored:
+- Thunderstorm life cycle: cumulus, mature, dissipating stages
+- Hazards in detail: turbulence, hail, icing, lightning, wind shear, microburst
+- Embedded thunderstorms — detecting and avoiding when not visible
+- SIGMET and AIRMET for convective activity — how to read and respond
+- Squall lines and mesoscale convective systems
+- Go/no-go decision making around convective weather
+
+---
+
+*Skeleton only — full narration script to be added before audio production.*

--- a/lessons/cpl-a/009-mountain-wave-turbulence.md
+++ b/lessons/cpl-a/009-mountain-wave-turbulence.md
@@ -1,0 +1,83 @@
+---
+id: AMT-004
+topic: cpl-a
+order: 9
+slug: mountain-wave-turbulence
+title: "Mountain Wave Turbulence and Orographic Effects"
+duration_min: 20
+status: draft
+audio: null
+visual: null
+sources:
+  - "TP 1102 Vol. 5 (Advanced Meteorology)"
+  - "AIM MET Chapter (Turbulence)"
+  - "Transport Canada CPL-A Written Exam Guide"
+  - "ECCC Aviation Weather Products"
+questions:
+  - id: q1
+    prompt: "Mountain wave turbulence is most likely to occur when wind direction is within approximately what angle of perpendicular to the mountain ridge?"
+    choices:
+      A: "Within 10 degrees"
+      B: "Within 30 degrees"
+      C: "Within 60 degrees"
+      D: "Mountain waves can occur at any wind angle relative to the ridge"
+    answer: B
+    explanation: "Mountain wave activity is strongest when the wind is within approximately 30 degrees of perpendicular (90 degrees) to the mountain ridge and wind speed is 25 knots or more at ridge level. Source: TP 1102 Vol. 5."
+  - id: q2
+    prompt: "Lenticular clouds (lens-shaped clouds) are associated with mountain waves. Their significance to pilots is that they indicate:"
+    choices:
+      A: "Areas of heavy precipitation downwind of mountains"
+      B: "Stable, smooth air in the wave crests"
+      C: "Standing waves with potentially severe turbulence in the rotor zone below"
+      D: "Thunderstorm development over the ridgeline"
+    answer: C
+    explanation: "Lenticular (altocumulus standing lenticularis) clouds form at the crests of mountain waves. They are a visual indicator of wave activity. The rotor zone, located below the wave crests and near or below ridge level, contains severe mechanical turbulence and violent vertical air currents. Source: TP 1102 Vol. 5."
+  - id: q3
+    prompt: "A rotor, found in the lower portion of a mountain wave system, is characterised by:"
+    choices:
+      A: "Smooth laminar airflow with embedded icing"
+      B: "Violent turbulence with possible roll-overs — the most dangerous area of the wave system"
+      C: "Updrafts only — no downdrafts exist in the rotor zone"
+      D: "Light turbulence and moderate icing at ridge altitude"
+    answer: B
+    explanation: "The rotor is the area of recirculating air beneath the wave crests, near the base of the wave system. It contains the most violent turbulence in the mountain wave system — aircraft have been lost due to structural failure or uncontrolled flight in rotors. It is the most dangerous area. Source: TP 1102 Vol. 5."
+  - id: q4
+    prompt: "When crossing a mountain range with forecast wave activity, what is the recommended technique for crossing at the lowest risk?"
+    choices:
+      A: "Cross at the lowest possible altitude to stay below the wave system"
+      B: "Cross perpendicular to the ridge at a high enough altitude to clear the ridgeline by a safe margin, avoiding the rotor zone"
+      C: "Cross parallel to the ridge to minimise exposure time"
+      D: "Increase airspeed to penetrate the turbulence quickly"
+    answer: B
+    explanation: "The recommended technique is to cross mountain ridges at a high enough altitude to stay well above the rotor zone, crossing perpendicular to the ridge when possible. Fly at a point where a downdraft would not push you below safe terrain clearance. Never cross at ridge level in wave conditions. Source: TP 1102 Vol. 5; Transport Canada guidance."
+  - id: q5
+    prompt: "A SIGMET for mountain wave turbulence (WS SIGMET) is issued by NAV CANADA when the intensity is expected to be:"
+    choices:
+      A: "Light or greater"
+      B: "Moderate or greater"
+      C: "Severe or greater"
+      D: "Extreme only"
+    answer: B
+    explanation: "A SIGMET for turbulence (including mountain wave turbulence) is issued when moderate or greater intensity turbulence is expected. Light turbulence is not subject to SIGMETs. Pilots must monitor SIGMETs and AIRMETs for turbulence when flying near mountain ranges. Source: NAV CANADA AIM; ECCC weather products."
+---
+
+# Lesson AMT-004: Mountain Wave Turbulence and Orographic Effects
+
+**Subject:** Advanced Meteorology  
+**Lesson number:** 009 (AMT-004)  
+**Estimated time:** 20 minutes  
+**Status:** Draft skeleton — content authoring pending
+
+Topics to be authored:
+- Orographic lift: how mountains disturb airflow
+- Mountain wave formation: wind speed, direction, stability requirements
+- Wave zones: cap cloud, lenticular clouds, rotor zone
+- Turbulence intensity levels and effects on aircraft
+- Recognition: visual and non-visual indicators of wave activity
+- Avoidance strategies and recommended crossing techniques
+- PIREPs and SIGMETs for mountain wave turbulence
+- Canadian mountain ranges with common wave activity (Rockies, Coast Range)
+
+---
+
+*Skeleton only — full narration script to be added before audio production.*

--- a/lessons/cpl-a/010-rnav-high-level-navigation.md
+++ b/lessons/cpl-a/010-rnav-high-level-navigation.md
@@ -1,0 +1,83 @@
+---
+id: ANV-001
+topic: cpl-a
+order: 10
+slug: rnav-high-level-navigation
+title: "RNAV and High-Level Navigation Concepts"
+duration_min: 20
+status: draft
+audio: null
+visual: null
+sources:
+  - "TP 12880E (Aeroplane Flight Training Manual)"
+  - "AIM ENR Chapter (Navigation)"
+  - "CARs Part VI (General Operating and Flight Rules)"
+  - "Transport Canada CPL-A Written Exam Guide"
+questions:
+  - id: q1
+    prompt: "Area Navigation (RNAV) differs from conventional VOR-to-VOR navigation primarily because:"
+    choices:
+      A: "RNAV requires GPS and cannot use VOR signals"
+      B: "RNAV allows flight on any desired path within the coverage of navigation aids, not limited to direct radials"
+      C: "RNAV is used exclusively for IFR flights"
+      D: "RNAV only applies to aircraft equipped with inertial navigation systems (INS)"
+    answer: B
+    explanation: "RNAV (Area Navigation) allows aircraft to fly any desired path within the coverage of navigation aids or the accuracy of self-contained systems, rather than being limited to direct radials from VOR stations. RNAV can use GPS, VOR/DME, DME/DME, or inertial navigation as the source. Source: TP 12880E; AIM ENR."
+  - id: q2
+    prompt: "On a VFR Navigational Chart (VNC), the maximum altitude shown is:"
+    choices:
+      A: "9,500 feet ASL"
+      B: "12,500 feet ASL"
+      C: "18,000 feet ASL"
+      D: "VNCs have no altitude limit — they cover all altitudes"
+    answer: B
+    explanation: "VFR Navigational Charts (VNCs) are used for VFR flight below 18,000 feet ASL, but the primary operational coverage is below 12,500 feet ASL. Above that altitude, Enroute charts (high-level) are more appropriate. Source: AIM ENR."
+  - id: q3
+    prompt: "The Canadian Domestic Airspace is divided into the Northern Domestic Airspace (NDA) and the Southern Domestic Airspace (SDA). In the NDA, altimeter setting procedures differ in that:"
+    choices:
+      A: "Altimeters are set to QFE at all times"
+      B: "The standard altimeter setting of 29.92 in.Hg (1013.2 hPa) is used at all times"
+      C: "Local QNH is used up to FL180 then standard setting above"
+      D: "Altimeter settings are not required in the NDA"
+    answer: B
+    explanation: "In the Northern Domestic Airspace (NDA), the standard altimeter setting of 29.92 in.Hg (1013.2 hPa) is used at all altitudes at all times, because weather reporting stations are too sparse to provide reliable local QNH. In the SDA, local QNH is used below the transition altitude. Source: AIM RAC; TP 12880E."
+  - id: q4
+    prompt: "Required Navigation Performance (RNP) specifications define:"
+    choices:
+      A: "The maximum airspeed for GPS-equipped aircraft"
+      B: "The navigation accuracy and integrity required for a specific operation, including on-board monitoring"
+      C: "The minimum number of GPS satellites required for IFR flight"
+      D: "The maximum cross-track error allowed for VFR navigation"
+    answer: B
+    explanation: "RNP defines both the accuracy (e.g., RNP 1 = within 1 NM of centreline 95% of time) and the integrity requirement that the system monitors its own performance and alerts the crew if it cannot meet the requirement. The monitoring capability distinguishes RNP from basic RNAV. Source: AIM ENR; Transport Canada."
+  - id: q5
+    prompt: "When flying at high altitudes on a long-distance cross-country, the effect of the Earth's curvature means that great circle routes:"
+    choices:
+      A: "Follow lines of constant latitude and are the shortest path only near the equator"
+      B: "Are the shortest distance between two points and appear as curved lines on Mercator projections"
+      C: "Are only applicable for transatlantic and transpacific routes, not domestic"
+      D: "Are the same as rhumb lines for all practical purposes in Canada"
+    answer: B
+    explanation: "A great circle route is the shortest distance between two points on the Earth's surface. On a Mercator projection chart (which shows meridians as parallel vertical lines), great circle routes appear as curved lines. For long-distance Canadian or polar flights, great circle routing provides significant fuel savings. Source: TP 12880E; AIM ENR."
+---
+
+# Lesson ANV-001: RNAV and High-Level Navigation Concepts
+
+**Subject:** Advanced Navigation  
+**Lesson number:** 010 (ANV-001)  
+**Estimated time:** 20 minutes  
+**Status:** Draft skeleton — content authoring pending
+
+Topics to be authored:
+- Conventional vs. area navigation (RNAV): concepts and differences
+- GPS-based RNAV: RAIM, WAAS/SBAS, integrity monitoring
+- VOR/DME-based RNAV: position fixing from multiple stations
+- Required Navigation Performance (RNP): concept and application
+- Great circle vs. rhumb line: practical implications for long-range routing
+- NDA altimeter procedures: standard setting at all altitudes
+- High-level enroute charts: reading and applying to commercial navigation
+- Canadian airspace structure at high altitudes
+
+---
+
+*Skeleton only — full narration script to be added before audio production.*

--- a/lessons/cpl-a/011-time-distance-calculations.md
+++ b/lessons/cpl-a/011-time-distance-calculations.md
@@ -1,0 +1,84 @@
+---
+id: ANV-002
+topic: cpl-a
+order: 11
+slug: time-distance-calculations
+title: "Time and Distance Calculations for Long-Range Flying"
+duration_min: 20
+status: draft
+audio: null
+visual: null
+sources:
+  - "TP 12880E (Aeroplane Flight Training Manual)"
+  - "AIM ENR Chapter"
+  - "Transport Canada CPL-A Written Exam Guide"
+  - "CARs 602.88–602.89 (Fuel Requirements)"
+questions:
+  - id: q1
+    prompt: "An aircraft is flying at a true airspeed of 140 knots. The wind is directly on the nose at 20 knots. What is the groundspeed?"
+    choices:
+      A: "120 knots"
+      B: "140 knots"
+      C: "160 knots"
+      D: "Cannot be determined without knowing the aircraft heading"
+    answer: A
+    explanation: "With a direct headwind, groundspeed = TAS minus headwind component = 140 − 20 = 120 knots. The heading does not affect the calculation when the wind is directly on the nose. Source: TP 12880E Chapter 8."
+  - id: q2
+    prompt: "An aircraft departs at 1415Z and arrives at 1632Z. What is the total elapsed time?"
+    choices:
+      A: "2 hours 07 minutes"
+      B: "2 hours 17 minutes"
+      C: "2 hours 47 minutes"
+      D: "3 hours 17 minutes"
+    answer: B
+    explanation: "From 1415Z to 1632Z: from 1415 to 1615 is 2 hours; from 1615 to 1632 is 17 minutes. Total elapsed time = 2 hours 17 minutes. Always use 24-hour UTC (Zulu) time for navigation calculations. Source: TP 12880E."
+  - id: q3
+    prompt: "A flight covers 210 NM in 1 hour 45 minutes. What is the average groundspeed?"
+    choices:
+      A: "100 knots"
+      B: "105 knots"
+      C: "120 knots"
+      D: "130 knots"
+    answer: C
+    explanation: "Groundspeed = distance ÷ time. Convert 1 hour 45 minutes to decimal: 1.75 hours. GS = 210 ÷ 1.75 = 120 knots. Source: TP 12880E Chapter 8."
+  - id: q4
+    prompt: "At a groundspeed of 150 knots, how long will it take to fly 75 nautical miles?"
+    choices:
+      A: "20 minutes"
+      B: "30 minutes"
+      C: "45 minutes"
+      D: "50 minutes"
+    answer: B
+    explanation: "Time = distance ÷ groundspeed. Time = 75 ÷ 150 = 0.5 hours = 30 minutes. Source: TP 12880E Chapter 8."
+  - id: q5
+    prompt: "An aircraft has 3.5 hours of usable fuel. Current groundspeed is 140 knots. Regulatory fuel reserve is 45 minutes. What is the maximum safe range?"
+    choices:
+      A: "350 NM"
+      B: "385 NM"
+      C: "420 NM"
+      D: "490 NM"
+    answer: B
+    explanation: "Usable time after reserve = 3.5 hours − 0.75 hours (45 min) = 2.75 hours. Range = 2.75 × 140 = 385 NM. The 45-minute reserve must be subtracted before calculating maximum range. Source: CARs 602.88; TP 12880E."
+---
+
+# Lesson ANV-002: Time and Distance Calculations for Long-Range Flying
+
+**Subject:** Advanced Navigation  
+**Lesson number:** 011 (ANV-002)  
+**Estimated time:** 20 minutes  
+**Status:** Draft skeleton — content authoring pending
+
+Extends PPL-A dead reckoning. See `lessons/navigation/` for the PPL-A foundation lessons on time/speed/distance.
+
+Topics to be authored:
+- Time-speed-distance formula applications at commercial level
+- Wind triangle: wind correction angle, groundspeed, true heading
+- Off-track correction: 1-in-60 rule, double track error method
+- Point of no return (PNR) / critical point calculations
+- Equal time point (ETP) for engine-out diversion planning
+- Fuel planning for commercial cross-country with alternates
+- Using the flight computer (whiz wheel) for commercial-level calculations
+
+---
+
+*Skeleton only — full narration script to be added before audio production.*

--- a/lessons/cpl-a/012-cross-country-commercial.md
+++ b/lessons/cpl-a/012-cross-country-commercial.md
@@ -1,0 +1,84 @@
+---
+id: ANV-003
+topic: cpl-a
+order: 12
+slug: cross-country-commercial
+title: "Cross-Country Flight Planning — Commercial Standards"
+duration_min: 20
+status: draft
+audio: null
+visual: null
+sources:
+  - "CARs 602.73–602.78 (Flight Plans and Itineraries)"
+  - "CARs 602.88–602.89 (Fuel Requirements)"
+  - "TP 12880E (Aeroplane Flight Training Manual)"
+  - "AIM ENR Chapter"
+  - "Transport Canada CPL-A Written Exam Guide"
+questions:
+  - id: q1
+    prompt: "A commercial cross-country flight plan filed with NAV CANADA is closed when:"
+    choices:
+      A: "The aircraft departs from the departure aerodrome"
+      B: "The pilot contacts ATC at the destination"
+      C: "The pilot files an arrival report or cancels the flight plan with the appropriate unit"
+      D: "The flight plan automatically closes 1 hour after the estimated time of arrival"
+    answer: C
+    explanation: "A flight plan must be closed by the pilot after landing by filing an arrival report with the FISE (Flight Information Service Element) or an ATC unit, or by cancelling it on arrival. If the flight plan is not closed and the ETA passes, search and rescue action may be initiated. Source: CARs 602.73; AIM RAC."
+  - id: q2
+    prompt: "Under CARs 602.73, which of the following domestic VFR flights requires a flight plan or flight itinerary?"
+    choices:
+      A: "A local area flight staying within 10 NM of the departure aerodrome"
+      B: "A cross-country flight of 30 NM from the departure aerodrome"
+      C: "Any flight conducted in Class E airspace"
+      D: "A flight plan is only required for IFR flights"
+    answer: B
+    explanation: "CARs 602.73 requires a flight plan or flight itinerary for any VFR flight conducted beyond 25 NM from the departure aerodrome. A 30 NM flight exceeds this threshold. Source: CARs 602.73."
+  - id: q3
+    prompt: "When planning a commercial VFR cross-country with a weather forecast showing possible IFR conditions en route, what is the most appropriate action?"
+    choices:
+      A: "Proceed VFR and divert if actual conditions are encountered"
+      B: "File IFR immediately since the forecast shows possible IFR conditions"
+      C: "Evaluate whether a VFR alternate route or delayed departure would allow the flight to be conducted safely"
+      D: "Notify ATC of the forecast and request priority handling"
+    answer: C
+    explanation: "Good flight planning requires evaluating whether the planned route can be flown safely given the forecast. If IFR conditions are possible, the options are to find an alternate VFR route, delay departure, or consider filing IFR if the pilot is qualified and the aircraft equipped. Proceeding and hoping to divert is poor practice. Source: CARs 602.02; TP 12880E."
+  - id: q4
+    prompt: "A VFR cross-country flight plan was filed with an ETA of 1430Z. It is now 1530Z and no arrival report has been received. Under standard SAR procedures, what occurs?"
+    choices:
+      A: "Nothing — the ETA window is automatically extended by 2 hours"
+      B: "One hour after the ETA, the FISE initiates a communication search by attempting to contact the aircraft"
+      C: "SAR is launched immediately at 1531Z without any communication search"
+      D: "The flight plan is automatically cancelled after 2 hours with no further action"
+    answer: B
+    explanation: "If a flight plan is not closed within 1 hour of the ETA, NAV CANADA initiates a communication search — attempting to locate the aircraft by radio and telephone. If the aircraft cannot be located after that search, SAR action is initiated. Source: AIM RAC; NAV CANADA flight plan procedures."
+  - id: q5
+    prompt: "For a commercial VFR cross-country flight, the phrase 'point of no return' (PNR) refers to:"
+    choices:
+      A: "The point beyond which a diversion to the departure aerodrome is no longer possible due to fuel"
+      B: "The midpoint of the route where equal distance remains to destination and departure"
+      C: "The point where the aircraft enters the destination's Class C airspace"
+      D: "The point beyond which the weather forecast is no longer reliable"
+    answer: A
+    explanation: "The Point of No Return (PNR) is the furthest point from the departure aerodrome to which the aircraft can fly and still have enough fuel to return. Beyond the PNR, the aircraft is committed to proceeding toward the destination (or finding an alternate). Source: TP 12880E Chapter 8."
+---
+
+# Lesson ANV-003: Cross-Country Flight Planning — Commercial Standards
+
+**Subject:** Advanced Navigation  
+**Lesson number:** 012 (ANV-003)  
+**Estimated time:** 20 minutes  
+**Status:** Draft skeleton — content authoring pending
+
+Topics to be authored:
+- Commercial-standard pre-flight planning process
+- NOTAMs: types, interpretation, and how to access (NAV CANADA)
+- Weather briefing: integrating METARs, TAFs, GFAs, SIGMETs, PIREPs
+- Fuel planning: reserve requirements, contingency, alternate fuel
+- Flight plan filing and closing procedures (CARs 602.73)
+- Point of no return (PNR) and equal time point (ETP) for commercial planning
+- Alternate aerodrome selection: CARs requirements and practical criteria
+- Handling unexpected weather deterioration en route
+
+---
+
+*Skeleton only — full narration script to be added before audio production.*

--- a/lessons/cpl-a/013-high-speed-aerodynamics.md
+++ b/lessons/cpl-a/013-high-speed-aerodynamics.md
@@ -1,0 +1,84 @@
+---
+id: ADE-001
+topic: cpl-a
+order: 13
+slug: high-speed-aerodynamics
+title: "High-Speed Aerodynamics and Compressibility Effects"
+duration_min: 20
+status: draft
+audio: null
+visual: null
+sources:
+  - "TP 12880E (Aeroplane Flight Training Manual)"
+  - "TP 1102 Vol. 4 (Aerodynamics)"
+  - "Transport Canada CPL-A Written Exam Guide"
+questions:
+  - id: q1
+    prompt: "Mach number is defined as the ratio of:"
+    choices:
+      A: "True airspeed to calibrated airspeed"
+      B: "Indicated airspeed to true airspeed"
+      C: "The aircraft's speed to the local speed of sound"
+      D: "True airspeed to the speed of sound at sea level"
+    answer: C
+    explanation: "Mach number = aircraft speed ÷ local speed of sound. The local speed of sound varies with temperature (and therefore altitude). At Mach 1, the aircraft is travelling at the speed of sound in the surrounding air mass. Source: TP 12880E; TP 1102 Vol. 4."
+  - id: q2
+    prompt: "As an aircraft approaches the critical Mach number (Mcrit), what aerodynamic effect first becomes significant?"
+    choices:
+      A: "Increased lift due to compressed air under the wing"
+      B: "Shock wave formation on the wing, causing buffet and a rise in drag"
+      C: "Decreased induced drag due to compressibility"
+      D: "Reduction in stall speed caused by higher air density"
+    answer: B
+    explanation: "The critical Mach number (Mcrit) is the speed at which airflow over the wing first reaches Mach 1 locally. Above Mcrit, shock waves form on the wing surface, causing a rapid drag rise, buffet, and possible loss of control effectiveness. Source: TP 1102 Vol. 4."
+  - id: q3
+    prompt: "Mach tuck (pitch-down tendency at high Mach numbers) occurs primarily because:"
+    choices:
+      A: "The pilot fails to trim the aircraft adequately at altitude"
+      B: "Shock waves cause the centre of pressure to move rearward, shifting the aerodynamic balance"
+      C: "Engine thrust decreases above Mach 0.9, allowing the nose to drop"
+      D: "Sweepback on the wings causes adverse yaw at high speed"
+    answer: B
+    explanation: "Mach tuck is caused by rearward migration of the centre of pressure as shock waves develop. This moves the lift force behind the centre of gravity, creating a nose-down pitching moment. Recovery requires immediate speed reduction and may require significant nose-up trim. Source: TP 1102 Vol. 4."
+  - id: q4
+    prompt: "VMO/MMO refers to:"
+    choices:
+      A: "The minimum operating manoeuvring speed and minimum Mach number for level flight"
+      B: "The maximum operating speed in IAS and the maximum operating Mach number, above which structural or controllability limits may be exceeded"
+      C: "The maximum speed with flaps extended and maximum speed in turbulence"
+      D: "The never-exceed speed (VNE) expressed in Mach number only"
+    answer: B
+    explanation: "VMO is the maximum operating speed in indicated airspeed; MMO is the maximum operating Mach number. Exceeding either limit may cause structural damage, buffet, or loss of control. On most high-speed aircraft, the more restrictive of the two limits applies at any given altitude. Source: TP 12880E; aircraft AFM."
+  - id: q5
+    prompt: "High-speed buffet (coffin corner) occurs when an aircraft flying at high altitude finds that:"
+    choices:
+      A: "The stall speed and the high-speed buffet speed converge, leaving a very narrow speed margin"
+      B: "The engine cannot produce enough thrust to maintain level flight"
+      C: "Turbulence causes the aircraft to exceed its maximum operating altitude"
+      D: "The aircraft's autopilot disengages at high altitude Mach numbers"
+    answer: A
+    explanation: "At extreme altitudes, the stall speed (which increases as air density decreases) and the high-speed buffet (compressibility) onset speed converge. The narrow speed band between them is colloquially called 'coffin corner.' This limits the maximum altitude at which an aircraft can be safely operated. Source: TP 1102 Vol. 4."
+---
+
+# Lesson ADE-001: High-Speed Aerodynamics and Compressibility Effects
+
+**Subject:** Aerodynamics & Engines  
+**Lesson number:** 013 (ADE-001)  
+**Estimated time:** 20 minutes  
+**Status:** Draft skeleton — content authoring pending
+
+Topics to be authored:
+- Speed of sound: dependence on temperature, not pressure
+- Mach number: definition and calculation
+- Subsonic, transonic, supersonic regimes
+- Critical Mach number (Mcrit): when local Mach 1 first occurs on the wing
+- Shock wave formation: normal and oblique shock waves, their effects
+- Wave drag: why drag increases dramatically above Mcrit
+- Mach tuck: cause, recognition, and recovery
+- VMO/MMO limits: definition and why both exist
+- Coffin corner: high-altitude speed margins
+- Design features that delay compressibility: swept wings, supercritical airfoils
+
+---
+
+*Skeleton only — full narration script to be added before audio production.*

--- a/lessons/cpl-a/014-advanced-engine-systems.md
+++ b/lessons/cpl-a/014-advanced-engine-systems.md
@@ -1,0 +1,83 @@
+---
+id: ADE-002
+topic: cpl-a
+order: 14
+slug: advanced-engine-systems
+title: "Advanced Engine Systems and High-Altitude Performance"
+duration_min: 20
+status: draft
+audio: null
+visual: null
+sources:
+  - "TP 12880E (Aeroplane Flight Training Manual)"
+  - "TP 1102 Vol. 4 (Aerodynamics and Engines)"
+  - "Transport Canada CPL-A Written Exam Guide"
+questions:
+  - id: q1
+    prompt: "A turbocharger (turbosupercharger) maintains engine power at altitude by:"
+    choices:
+      A: "Injecting additional fuel to compensate for thinner air"
+      B: "Using exhaust gases to drive a compressor that increases induction air density"
+      C: "Heating the intake air to increase its energy content"
+      D: "Reducing the engine's compression ratio to prevent detonation at altitude"
+    answer: B
+    explanation: "A turbocharger uses exhaust gases to spin a turbine, which drives a compressor (impeller) that forces higher-density air into the engine intake. This compensates for the decreased air density at altitude, allowing the engine to maintain near sea-level manifold pressure up to the critical altitude. Source: TP 12880E."
+  - id: q2
+    prompt: "The critical altitude of a turbocharged engine is:"
+    choices:
+      A: "The altitude at which the engine exceeds its temperature limits"
+      B: "The highest altitude at which the turbocharger can maintain the engine's rated manifold pressure"
+      C: "The altitude above which the propeller becomes inefficient"
+      D: "The service ceiling as published in the aircraft's POH"
+    answer: B
+    explanation: "Critical altitude is the highest altitude at which the turbocharger can maintain the rated manifold pressure. Above the critical altitude, manifold pressure begins to decrease just as with a normally-aspirated engine. Source: TP 12880E."
+  - id: q3
+    prompt: "Detonation in a piston engine is primarily caused by:"
+    choices:
+      A: "Fuel starvation at high altitude"
+      B: "Abnormal combustion where the fuel-air mixture ignites prematurely due to high temperature and pressure"
+      C: "The spark plugs firing too late in the combustion cycle"
+      D: "Moisture in the fuel causing uneven combustion"
+    answer: B
+    explanation: "Detonation occurs when the fuel-air mixture in the cylinder ignites spontaneously from heat and pressure before the spark plug fires, or a second time after normal ignition. It causes extreme pressure spikes that can rapidly damage pistons, rings, and cylinders. It is usually caused by using fuel with insufficient octane rating or by operating with excessively high manifold pressure relative to RPM. Source: TP 12880E."
+  - id: q4
+    prompt: "At high altitudes, a lean mixture setting is typically required to maintain best power because:"
+    choices:
+      A: "The fuel density decreases at altitude, so less fuel is needed"
+      B: "Air density decreases with altitude, requiring a leaner mixture to maintain the correct fuel-to-air ratio"
+      C: "The turbocharger adds extra fuel that must be compensated for"
+      D: "Leaning increases fuel temperature, which aids vaporisation in cold air"
+    answer: B
+    explanation: "As altitude increases, air density decreases. Without leaning, the mixture becomes progressively richer (too much fuel for the available air). Leaning the mixture restores the correct fuel-to-air ratio, maximising efficiency and preventing fouled spark plugs. Source: TP 12880E."
+  - id: q5
+    prompt: "An aircraft certified for flight above FL250 must be equipped with:"
+    choices:
+      A: "Weather radar"
+      B: "Supplemental oxygen for all occupants when operating above FL250"
+      C: "A pressurisation system"
+      D: "Both a pressurisation system and oxygen as backup"
+    answer: B
+    explanation: "CARs require supplemental oxygen when operating at cabin pressure altitudes above FL250. In unpressurised aircraft, this means oxygen equipment must be available for all occupants. In pressurised aircraft, the system maintains a lower equivalent altitude, but supplemental oxygen must be available if pressurisation fails. Source: CARs 605.31."
+---
+
+# Lesson ADE-002: Advanced Engine Systems and High-Altitude Performance
+
+**Subject:** Aerodynamics & Engines  
+**Lesson number:** 014 (ADE-002)  
+**Estimated time:** 20 minutes  
+**Status:** Draft skeleton — content authoring pending
+
+Topics to be authored:
+- Normally aspirated engines: power loss with altitude, density altitude effects
+- Turbocharging: components, operation, critical altitude
+- Turbonormalised vs. turbosupercharged: differences and limitations
+- Mixture management at altitude: leaning procedures, best power vs. best economy
+- Detonation: causes, recognition, prevention
+- Piston engine failure modes at altitude: vapour lock, fuel system issues
+- Oxygen requirements: CARs regulations for supplemental oxygen
+- Pressurisation basics: concept, cabin altitude, differential pressure
+- Engine failure at altitude: survival ceiling, immediate actions
+
+---
+
+*Skeleton only — full narration script to be added before audio production.*

--- a/lessons/cpl-a/015-propeller-theory.md
+++ b/lessons/cpl-a/015-propeller-theory.md
@@ -1,0 +1,82 @@
+---
+id: ADE-003
+topic: cpl-a
+order: 15
+slug: propeller-theory
+title: "Propeller Theory and Variable-Pitch Systems"
+duration_min: 20
+status: draft
+audio: null
+visual: null
+sources:
+  - "TP 12880E (Aeroplane Flight Training Manual)"
+  - "TP 1102 Vol. 4 (Aerodynamics)"
+  - "Transport Canada CPL-A Written Exam Guide"
+questions:
+  - id: q1
+    prompt: "Propeller efficiency is defined as the ratio of:"
+    choices:
+      A: "Thrust horsepower to brake horsepower"
+      B: "Indicated airspeed to true airspeed"
+      C: "Engine RPM to propeller RPM"
+      D: "Static thrust to dynamic thrust"
+    answer: A
+    explanation: "Propeller efficiency = thrust horsepower (useful power output) ÷ brake horsepower (power delivered to the propeller shaft). A perfectly efficient propeller would convert all engine power into thrust, but in practice efficiency is less than 100% due to aerodynamic losses. Source: TP 12880E."
+  - id: q2
+    prompt: "A constant-speed propeller maintains constant RPM by:"
+    choices:
+      A: "The pilot manually adjusting the throttle to keep RPM constant"
+      B: "A governor that changes blade pitch to absorb varying power demands"
+      C: "An electronic fuel injection system that limits engine power automatically"
+      D: "A fixed gear ratio between the engine and propeller"
+    answer: B
+    explanation: "A constant-speed propeller uses a governor that senses RPM deviations and automatically adjusts blade pitch (coarse = more resistance, fine = less resistance) to maintain the selected RPM. This allows the engine to operate at its most efficient RPM across a range of power settings. Source: TP 12880E."
+  - id: q3
+    prompt: "When a constant-speed propeller's governor fails and the propeller goes to full fine pitch, the engine will:"
+    choices:
+      A: "Overspeed, potentially beyond its red-line RPM limit"
+      B: "Underspeed, causing the aircraft to lose performance"
+      C: "Maintain its current RPM automatically"
+      D: "Shut down due to the overly rich mixture caused by reduced airflow"
+    answer: A
+    explanation: "If the propeller goes to full fine (low) pitch and the governor fails, the propeller offers minimal resistance to the engine. Without the governor's control, the engine will tend to overspeed — potentially exceeding the red-line RPM. The pilot must immediately reduce throttle to prevent engine damage. Source: TP 12880E."
+  - id: q4
+    prompt: "Torque effect in a single-engine aircraft (with a clockwise-rotating propeller as seen from the rear) causes the aircraft to:"
+    choices:
+      A: "Yaw left and roll left"
+      B: "Yaw right and roll right"
+      C: "Pitch up on takeoff"
+      D: "Have no effect because modern aircraft are designed to counteract torque"
+    answer: A
+    explanation: "Newton's third law: if the propeller rotates clockwise (as seen from the cockpit), the engine reacts by rotating counterclockwise. This reaction torque tends to roll the aircraft to the left. Combined with P-factor and gyroscopic precession on takeoff, it also creates a left-yaw tendency. Source: TP 12880E."
+  - id: q5
+    prompt: "P-factor (propeller asymmetric thrust) is most pronounced at:"
+    choices:
+      A: "High airspeed in level cruise"
+      B: "High power, low airspeed, and high angle of attack (e.g., takeoff and initial climb)"
+      C: "Descent with idle power"
+      D: "Level flight at cruise power"
+    answer: B
+    explanation: "P-factor occurs because at a high angle of attack, the descending propeller blade (on the right side for a clockwise-rotating prop as seen from the rear) has a greater effective angle of attack and produces more thrust than the ascending blade. This creates asymmetric thrust that yaws the nose to the left. P-factor is most significant at high power and low airspeed. Source: TP 12880E."
+---
+
+# Lesson ADE-003: Propeller Theory and Variable-Pitch Systems
+
+**Subject:** Aerodynamics & Engines  
+**Lesson number:** 015 (ADE-003)  
+**Estimated time:** 20 minutes  
+**Status:** Draft skeleton — content authoring pending
+
+Topics to be authored:
+- Propeller basics: blade angle, pitch, angle of attack of the blade
+- Geometric pitch vs. effective pitch, propeller slip
+- Fixed-pitch vs. variable-pitch vs. constant-speed: trade-offs
+- Constant-speed propeller: governor operation, oil pressure system
+- Feathering: when and why used (engine failure on multi-engine)
+- Propeller asymmetric effects: torque, P-factor, gyroscopic precession, slipstream
+- Critical engine on a multi-engine aircraft: concept and VMC
+- Propeller-related emergency procedures: governor failure, propeller overspeed
+
+---
+
+*Skeleton only — full narration script to be added before audio production.*

--- a/lessons/cpl-a/016-performance-charts-cruise.md
+++ b/lessons/cpl-a/016-performance-charts-cruise.md
@@ -1,0 +1,84 @@
+---
+id: PAL-001
+topic: cpl-a
+order: 16
+slug: performance-charts-cruise
+title: "Performance Charts — Cruise and Range Computations"
+duration_min: 20
+status: draft
+audio: null
+visual: null
+sources:
+  - "TP 12880E (Aeroplane Flight Training Manual)"
+  - "CARs 605 (Aircraft Equipment and Maintenance)"
+  - "Transport Canada CPL-A Written Exam Guide"
+  - "Aircraft AFM/POH (Pilot's Operating Handbook)"
+questions:
+  - id: q1
+    prompt: "Density altitude is defined as:"
+    choices:
+      A: "The altitude shown on the altimeter when set to 29.92 in.Hg"
+      B: "Pressure altitude corrected for non-standard temperature"
+      C: "The height of the aircraft above mean sea level"
+      D: "The altitude at which the air density equals standard sea-level density"
+    answer: B
+    explanation: "Density altitude is pressure altitude corrected for non-standard temperature. High density altitude (hot, high, or humid conditions) reduces engine performance and increases takeoff/landing distances. All performance charts use density altitude as the basis for calculations. Source: TP 12880E Chapter 5."
+  - id: q2
+    prompt: "On a cruise performance chart, 'best range' airspeed is the speed at which:"
+    choices:
+      A: "Endurance (time aloft) is maximised"
+      B: "Fuel burn per nautical mile is minimised — maximum distance per unit of fuel"
+      C: "True airspeed is maximised for a given power setting"
+      D: "The aircraft can fly level with maximum fuel load"
+    answer: B
+    explanation: "Best range speed (L/Dmax) minimises fuel consumption per nautical mile — it is the most efficient speed for covering distance. Best endurance speed (minimum fuel burn per hour) is slower and used to maximise time aloft. Source: TP 12880E Chapter 5."
+  - id: q3
+    prompt: "A performance chart shows that the aircraft burns 45 litres/hour at 65% power cruise. With a total usable fuel of 200 litres, the maximum endurance (ignoring reserves) is:"
+    choices:
+      A: "3 hours 45 minutes"
+      B: "4 hours"
+      C: "4 hours 26 minutes"
+      D: "5 hours"
+    answer: C
+    explanation: "Endurance = total fuel ÷ fuel burn rate = 200 ÷ 45 = 4.44 hours = 4 hours 26.7 minutes (approximately 4 hours 27 minutes). Always remember that the regulatory reserve must be subtracted when calculating safe endurance. Source: TP 12880E."
+  - id: q4
+    prompt: "When interpolating between entries in a performance chart for an intermediate density altitude, the correct approach is to:"
+    choices:
+      A: "Always use the more conservative (worse) performance value"
+      B: "Interpolate linearly between the two nearest table entries"
+      C: "Use the lower altitude entry for all calculations as a safety margin"
+      D: "Use the manufacturer's performance calculator — manual charts should never be interpolated"
+    answer: B
+    explanation: "Linear interpolation between chart entries is the standard method for values between tabulated points. For example, at a density altitude halfway between two chart rows, interpolate halfway between the corresponding performance values. This gives a more accurate result than always rounding to the conservative entry. Source: TP 12880E; AFM/POH guidance."
+  - id: q5
+    prompt: "A tailwind affects en-route range performance by:"
+    choices:
+      A: "Reducing range — tailwinds increase groundspeed, using more fuel per hour"
+      B: "Increasing range — for a fixed fuel load, greater groundspeed means more distance per hour"
+      C: "Having no effect — range is determined by airspeed and fuel burn, not groundspeed"
+      D: "Reducing range only at high altitudes where density altitude effects dominate"
+    answer: B
+    explanation: "A tailwind increases groundspeed without changing fuel burn (which depends on airspeed and power setting). This means the aircraft covers more nautical miles per litre of fuel, increasing range. A headwind has the opposite effect. Source: TP 12880E Chapter 8."
+---
+
+# Lesson PAL-001: Performance Charts — Cruise and Range Computations
+
+**Subject:** Performance & Limitations  
+**Lesson number:** 016 (PAL-001)  
+**Estimated time:** 20 minutes  
+**Status:** Draft skeleton — content authoring pending
+
+Topics to be authored:
+- Density altitude: calculation from pressure altitude and temperature
+- Performance chart structure: how to read tables and graphs
+- Interpolation technique for intermediate values
+- Cruise performance: percent power, TAS, fuel flow relationships
+- Best power vs. best economy mixture in cruise
+- Range vs. endurance: definitions, airspeeds, trade-offs
+- Effect of wind on range: tailwind increases range, headwind decreases
+- Fuel planning using performance charts: systematic approach
+- Factors affecting actual vs. chart performance: contamination, age, technique
+
+---
+
+*Skeleton only — full narration script to be added before audio production.*

--- a/lessons/cpl-a/017-weight-balance-commercial.md
+++ b/lessons/cpl-a/017-weight-balance-commercial.md
@@ -1,0 +1,86 @@
+---
+id: PAL-002
+topic: cpl-a
+order: 17
+slug: weight-balance-commercial
+title: "Weight and Balance for Commercial Operations"
+duration_min: 20
+status: draft
+audio: null
+visual: null
+sources:
+  - "TP 12880E (Aeroplane Flight Training Manual)"
+  - "CARs 605.92–605.96 (Weight and Balance)"
+  - "Transport Canada CPL-A Written Exam Guide"
+  - "Aircraft AFM/POH"
+questions:
+  - id: q1
+    prompt: "Centre of gravity (CG) limits are established primarily to ensure:"
+    choices:
+      A: "The aircraft can be lifted by the maximum number of passengers"
+      B: "The aircraft remains controllable throughout its operating envelope"
+      C: "Fuel burn is equal between left and right fuel tanks"
+      D: "The landing gear is not overloaded on touchdown"
+    answer: B
+    explanation: "CG limits define the range within which the aircraft is stable and controllable. A CG too far forward creates a nose-heavy aircraft that may require excessive elevator to rotate on takeoff. A CG too far aft creates instability and may make the aircraft uncontrollable. Source: TP 12880E Chapter 6; CARs 605.92."
+  - id: q2
+    prompt: "The moment arm in a weight-and-balance calculation is:"
+    choices:
+      A: "The maximum weight allowed at a given loading station"
+      B: "The distance from the datum to the point where a weight is applied"
+      C: "The arm length of the flight control surface"
+      D: "The distance between the leading edge and the CG"
+    answer: B
+    explanation: "The moment arm is the horizontal distance from the aircraft's datum (reference point) to the location of a given weight. Moment = weight × arm. Summing all moments and dividing by total weight gives the CG location. Source: TP 12880E Chapter 6."
+  - id: q3
+    prompt: "Under CARs 605.92, who is responsible for ensuring an aircraft is loaded within its weight and balance limits before flight?"
+    choices:
+      A: "The aircraft maintenance engineer who last signed the maintenance release"
+      B: "The operator's load controller"
+      C: "The pilot-in-command"
+      D: "The operator's chief pilot"
+    answer: C
+    explanation: "CARs 605.92 makes the pilot-in-command responsible for ensuring the aircraft is loaded within its approved weight and balance limits prior to flight. While operators may use load control staff, the PIC has final responsibility and cannot delegate it. Source: CARs 605.92."
+  - id: q4
+    prompt: "If fuel is burned during flight, the effect on CG position depends on:"
+    choices:
+      A: "Only the total weight reduction — CG position does not change as fuel burns"
+      B: "The location of the fuel tanks relative to the CG and datum"
+      C: "Whether the engines are burning fuel from the left or right tank"
+      D: "The CG always moves forward as fuel burns in any aircraft"
+    answer: B
+    explanation: "As fuel burns, CG moves toward the CG of the empty aircraft. If fuel tanks are located ahead of the CG datum, burning fuel moves CG aft. If tanks are aft of CG, burning fuel moves CG forward. The pilot must check that CG remains within limits at all points during flight (start, mid-flight, and landing). Source: TP 12880E Chapter 6."
+  - id: q5
+    prompt: "Maximum Zero Fuel Weight (MZFW) is a structural limit that means:"
+    choices:
+      A: "The aircraft must carry at least this weight of fuel"
+      B: "The maximum weight of the aircraft excluding all fuel in the tanks"
+      C: "The aircraft must be below this weight when fuel tanks are empty at landing"
+      D: "The maximum weight at which zero-g flight is permitted"
+    answer: B
+    explanation: "Maximum Zero Fuel Weight (MZFW) is the maximum permissible weight of the aircraft without any fuel in the fuel tanks. It protects the wing structure from excessive bending loads imposed by payload in the fuselage. All weight above MZFW must be fuel. Source: TP 12880E; AFM/POH."
+---
+
+# Lesson PAL-002: Weight and Balance for Commercial Operations
+
+**Subject:** Performance & Limitations  
+**Lesson number:** 017 (PAL-002)  
+**Estimated time:** 20 minutes  
+**Status:** Draft skeleton — content authoring pending
+
+Extends PPL-A weight and balance. See `lessons/general-knowledge/` for PPL-A W&B foundation lesson.
+
+Topics to be authored:
+- CG concepts: datum, moment arm, moment, CG calculation method
+- Weight limits: MTOW, MZFW, maximum landing weight, fuel weight
+- CG limits: forward limit (elevator authority), aft limit (stability)
+- W&B calculation process: index units vs. moment method
+- Fuel burn effect on CG: must check CG at all fuel states
+- Loading envelopes: reading and plotting on graphs
+- Commercial W&B documentation: CARs 605.92 requirements
+- Passenger manifests and cargo loading in air taxi (CARs 703)
+- Consequences of out-of-limits loading
+
+---
+
+*Skeleton only — full narration script to be added before audio production.*

--- a/lessons/cpl-a/018-aircraft-limitations.md
+++ b/lessons/cpl-a/018-aircraft-limitations.md
@@ -1,0 +1,84 @@
+---
+id: PAL-003
+topic: cpl-a
+order: 18
+slug: aircraft-limitations
+title: "Aircraft Limitations — Operating Envelope and Flight Manual"
+duration_min: 20
+status: draft
+audio: null
+visual: null
+sources:
+  - "TP 12880E (Aeroplane Flight Training Manual)"
+  - "CARs 605 (Aircraft Equipment and Maintenance)"
+  - "Transport Canada CPL-A Written Exam Guide"
+  - "Aircraft AFM/POH (Approved Flight Manual)"
+questions:
+  - id: q1
+    prompt: "The Approved Flight Manual (AFM) is a regulatory document because:"
+    choices:
+      A: "It is published by Transport Canada and applies to all aircraft of the same type"
+      B: "It is approved by Transport Canada and forms part of the aircraft's type certificate — it is legally binding on the operator and pilot"
+      C: "It is recommended guidance only, superseded by the manufacturer's POH"
+      D: "It only applies to commercial operators — private pilots may use the POH instead"
+    answer: B
+    explanation: "The Approved Flight Manual (AFM) is approved by Transport Canada (or the certifying authority) and is part of the aircraft's type certificate data. Its limitations section is legally binding. The pilot and operator must not exceed any limitation in the AFM. Source: CARs 605.84; TP 12880E."
+  - id: q2
+    prompt: "VNE (never-exceed speed) is shown on the airspeed indicator by:"
+    choices:
+      A: "A yellow arc"
+      B: "A red radial line"
+      C: "A green arc"
+      D: "A white arc"
+    answer: B
+    explanation: "VNE is indicated by a red radial line on the airspeed indicator. It must never be exceeded in any operation. Exceeding VNE risks structural damage or failure due to aeroelastic or flutter effects. Source: TP 12880E; CARs 605."
+  - id: q3
+    prompt: "VA (manoeuvring speed) is the speed below which:"
+    choices:
+      A: "The aircraft can be stalled only by abrupt full control deflection"
+      B: "Full and abrupt control deflection will not exceed the aircraft's structural limit load factor"
+      C: "The aircraft must be flown in turbulence"
+      D: "Flaps may be extended without structural risk"
+    answer: B
+    explanation: "Manoeuvring speed (VA) is the speed at or below which full, abrupt control inputs will not exceed the aircraft's design limit load factor. Above VA, full deflection of a single control could cause structural damage. VA decreases as the aircraft gets lighter. Source: TP 12880E."
+  - id: q4
+    prompt: "The green arc on the airspeed indicator represents:"
+    choices:
+      A: "The normal operating range — from power-off stall speed (VS1) to the maximum structural cruise speed (VNO)"
+      B: "The flap operating range — from minimum flap extension speed to maximum flap speed (VFE)"
+      C: "The caution range — speeds that should be avoided in turbulence"
+      D: "The speed range approved for instrument flight"
+    answer: A
+    explanation: "The green arc on the airspeed indicator covers the normal operating range from VS1 (stall speed in the clean configuration, lower end) to VNO (maximum structural cruising speed, upper end). Flight in this range is normal and approved. Source: TP 12880E; CARs 605."
+  - id: q5
+    prompt: "When an aircraft component's mandatory life limit has been reached (as specified in the AFM or maintenance schedule), the pilot-in-command's responsibility is to:"
+    choices:
+      A: "Log the limitation in the journey log and continue operations until the next scheduled maintenance"
+      B: "Not operate the aircraft until the component has been replaced or the life limit reset by a licensed engineer"
+      C: "Reduce cruise power by 10% to extend component life until maintenance can be performed"
+      D: "Complete only local flights until the component is replaced"
+    answer: B
+    explanation: "Mandatory life limits in the AFM or maintenance schedule are regulatory limits. An aircraft with a time-expired component is unairworthy. The pilot-in-command must not fly the aircraft, and the component must be replaced by a licensed AME before return to service. Source: CARs 605; Aeronautics Act."
+---
+
+# Lesson PAL-003: Aircraft Limitations — Operating Envelope and Flight Manual
+
+**Subject:** Performance & Limitations  
+**Lesson number:** 018 (PAL-003)  
+**Estimated time:** 20 minutes  
+**Status:** Draft skeleton — content authoring pending
+
+Topics to be authored:
+- Approved Flight Manual (AFM): legal status, structure, limitations section
+- Airspeed limitations: VS, VS1, VFE, VNO, VNE, VA, VMC (multi-engine)
+- Airspeed indicator markings: colour codes and their meanings
+- G-load limits: normal vs. utility vs. aerobatic category
+- Operating envelope: V-n diagram, load factor vs. airspeed
+- Temperature limits: OAT limitations for engine start, operations
+- Altitude limits: service ceiling, certified maximum operating altitude
+- Mandatory life limits and airworthiness directives (ADs)
+- PIC responsibility: pre-flight check of airworthiness documents
+
+---
+
+*Skeleton only — full narration script to be added before audio production.*

--- a/web-app/scripts/validate-playlist-audio.mjs
+++ b/web-app/scripts/validate-playlist-audio.mjs
@@ -55,7 +55,7 @@ let failed = false;
 
 for (const [topic, { total, withAudio, allSkippable }] of Object.entries(topics).sort()) {
   if (allSkippable) {
-    console.log(`- ${topic}: ${total} lessons, all in planning — skipped`);
+    console.log(`- ${topic}: ${total} lessons, all pre-deploy — skipped`);
   } else if (withAudio === 0) {
     console.log(`✗ ${topic}: ${total} lessons, 0 with audio  ← FAIL`);
     failed = true;


### PR DESCRIPTION
Closes #422

## Changes

### `docs/curriculum-cpl-a.md` (new)
Curriculum document listing all 5 CPL-A subject areas (Commercial Air Law, Advanced Meteorology, Advanced Navigation, Aerodynamics & Engines, Performance & Limitations) with 18 lessons indexed by file, ID, and title. Includes cross-reference table linking CPL-A skeletons to PPL-A foundation lessons.

### `lessons/cpl-a/` (18 new files)
All files have complete frontmatter (`id`, `topic: cpl-a`, `order`, `slug`, `title`, `duration_min: 20`, `status: draft`, `audio: null`, `visual: null`, `sources`, `questions`).

**Fully authored (5 lessons — Commercial Air Law):**
- `001-cpl-licensing-requirements.md` (CAL-001) — Age 18, Category 1 medical, 200h total/100h PIC/20h XC/10h instrument, written exam + flight test. Sources: CARs 421.32, CARs 404.04.
- `002-commercial-air-services.md` (CAL-002) — AOC requirement, CARs Part VII structure, 703/704/705 sub-parts, Company Operations Manual. Sources: CARs 700.02, CARs 703/704/705.
- `003-air-taxi-operations.md` (CAL-003) — CARs 703 scope (≤9 pax), PIC final authority, pre-flight duties, passenger briefing, duty-time limits. Sources: CARs 703, CARs 700.15.
- `004-pic-authority-responsibilities.md` (CAL-004) — CARs 602.02 (PIC responsible for safe conduct), CARs 700.15 (final authority + retaliation protection), CARs 602.03 (fitness for duty).
- `005-commercial-vfr-night-regulations.md` (CAL-005) — VFR minimums, operator vs. regulatory minimums, fuel reserve (CARs 602.88/89), Night Rating requirement, nav lights (CARs 605.16/17).

**Skeleton lessons (13 files):**
- AMT-001–004: Upper Level Charts, Icing, Thunderstorms, Mountain Wave
- ANV-001–003: RNAV, Time/Distance, Cross-Country Planning
- ADE-001–003: High-Speed Aerodynamics, Advanced Engines, Propeller Theory
- PAL-001–003: Performance Charts, Weight & Balance, Aircraft Limitations

Each skeleton has: full frontmatter, 5 accurate quiz questions with correct answers and source citations, and a topic outline for content authors.

### `web-app/scripts/validate-playlist-audio.mjs`
Updated skip log message from `"all in planning — skipped"` to `"all pre-deploy — skipped"` to accurately reflect that both `planning` and `draft` (no-audio) topics are skipped. The predicate was already updated in a prior PR.

## Test Plan
- `npm test` — smoke test reports `- cpl-a: 18 lessons, all pre-deploy — skipped` and exits 0 ✓
- `npm run build` — TypeScript + Vite build passes ✓
- No existing lesson files modified ✓
- All 18 new lesson files have complete YAML frontmatter and exactly 5 questions ✓