### PR TITLE
[PPL-417] Scope final exam pool and practice quiz scores to active track

### DIFF
--- a/web-app/src/pages/Exam.tsx
+++ b/web-app/src/pages/Exam.tsx
@@ -45,14 +45,12 @@ export default function Exam() {
   const { store: activeStore, activeTrack } = useExamTrack();
   const { progress, store } = useProgress(activeStore);
 
-  const lessons = getAllLessons().filter((l) => l.questions.length > 0);
+  const lessons = getAllLessons().filter(activeTrack.lessonFilter).filter((l) => l.questions.length > 0);
 
-  const [topicFilter, setTopicFilter] = useState<TopicFilter>(() =>
-    activeTrack.id === 'pstar' ? 'air-law' : 'all',
-  );
+  const [topicFilter, setTopicFilter] = useState<TopicFilter>('all');
 
   useEffect(() => {
-    setTopicFilter(activeTrack.id === 'pstar' ? 'air-law' : 'all');
+    setTopicFilter('all');
   }, [activeTrack.id]);
   const [selectedLessonId, setSelectedLessonId] = useState<string>(() => {
     const fromUrl = searchParams.get('lesson');

--- a/web-app/src/pages/LessonQuiz.tsx
+++ b/web-app/src/pages/LessonQuiz.tsx
@@ -12,6 +12,7 @@ import Typography from '@mui/material/Typography';
 import { getLessonBySlug, getAdjacentLessons } from '../lib/lesson-loader';
 import { scoreQuiz } from '../lib/quiz';
 import type { QuizResult } from '../lib/quiz';
+import { useExamTrack } from '../context/ExamTrackContext';
 import QuizRunner from '../components/QuizRunner';
 
 type Phase = 'intro' | 'quiz' | 'results';
@@ -21,6 +22,7 @@ const TOUCH_TARGET = { minHeight: 48, minWidth: 48 };
 export default function LessonQuiz() {
   const { topic, slug } = useParams<{ topic: string; slug: string }>();
   const navigate = useNavigate();
+  const { store } = useExamTrack();
 
   const lesson = topic && slug ? getLessonBySlug(topic, slug) : undefined;
 
@@ -76,14 +78,14 @@ export default function LessonQuiz() {
 
   function handleQuizComplete(answers: Record<string, string>) {
     const result = scoreQuiz(answers, lesson!.questions);
-    try {
-      localStorage.setItem(
-        `ppl-quiz-result-${lesson!.id}`,
-        JSON.stringify({ correct: result.correct, total: result.total }),
-      );
-    } catch {
-      // storage unavailable — non-fatal
-    }
+    store.recordQuizAttempt({
+      lessonId: lesson!.id,
+      timestamp: new Date().toISOString(),
+      score: result.correct,
+      total: result.total,
+      percent: result.percent,
+      answers,
+    });
     setQuizResult(result);
     setPhase('results');
   }


### PR DESCRIPTION
Closes #417

## Changes

**`web-app/src/pages/Exam.tsx`**
- Applied `activeTrack.lessonFilter` as a pre-filter before the `questions.length > 0` filter, so the lesson pool is always scoped to the active track (PSTAR → air-law only, RROE → radio only, PPL-A → all).
- Removed the hardcoded `activeTrack.id === 'pstar' ? 'air-law' : 'all'` initialisation for `topicFilter` — replaced with plain `'all'` in both `useState` and the `useEffect` reset. PSTAR users already see only air-law lessons due to the `lessonFilter`; the topic chip just sub-filters within that pool.

**`web-app/src/pages/LessonQuiz.tsx`**
- Added `useExamTrack` import and obtains `store` from the context.
- Replaced the direct `localStorage.setItem` call with `store.recordQuizAttempt(attempt)`, so quiz scores are stored in the per-track progress store (`ppl.progress.{trackId}`) rather than a legacy global key.

## Test Plan
- [ ] Switch to PSTAR track → `/exam` shows only air-law lessons
- [ ] Switch to RROE track → `/exam` shows only radio lessons
- [ ] Switch to PPL-A track → `/exam` shows all lessons with questions
- [ ] Topic filter chips still work within the already-scoped pool
- [ ] Complete a practice quiz on any lesson; check DevTools → Application → LocalStorage that `ppl.progress.{trackId}` contains the attempt in `quizHistory`
- [ ] `npm run build` passes with no TypeScript errors