### PR TITLE
[PPL-420] Scope lesson library to active exam track

### DIFF
--- a/web-app/src/pages/LessonsIndex.tsx
+++ b/web-app/src/pages/LessonsIndex.tsx
@@ -17,13 +17,23 @@ import { useExamTrack } from '../context/ExamTrackContext';
 import TopicMasteryCard from '../components/TopicMasteryCard';
 
 export default function LessonsIndex() {
-  const { store } = useExamTrack();
+  const { store, activeTrack } = useExamTrack();
   const { isComplete } = useProgress(store);
 
-  const lessonMap = useMemo(() => {
-    const map = new Map(getAllLessons().map((l) => [l.id, l]));
-    return map;
-  }, []);
+  const visibleLessons = useMemo(
+    () => getAllLessons().filter(activeTrack.lessonFilter),
+    [activeTrack],
+  );
+
+  const lessonMap = useMemo(
+    () => new Map(visibleLessons.map((l) => [l.id, l])),
+    [visibleLessons],
+  );
+
+  const visibleTopics = useMemo(
+    () => TOPICS.filter((t) => visibleLessons.some((l) => l.topic === t)),
+    [visibleLessons],
+  );
 
   return (
     <Container id="main-content" tabIndex={-1} maxWidth="md" sx={{ py: 4 }}>
@@ -31,11 +41,11 @@ export default function LessonsIndex() {
         Browse Lessons
       </Typography>
       <Typography variant="body2" color="text.secondary" sx={{ mb: 4 }}>
-        {CURRICULUM.length} lessons across {TOPICS.length} topics
+        {visibleLessons.length} lessons across {visibleTopics.length} topics
       </Typography>
 
-      {TOPICS.map((topic) => {
-        const slots = CURRICULUM.filter((s) => s.topic === topic);
+      {visibleTopics.map((topic) => {
+        const slots = CURRICULUM.filter((s) => s.topic === topic && lessonMap.has(s.id));
 
         return (
           <Box key={topic} id={topic} sx={{ mb: 5 }}>


### PR DESCRIPTION
Closes #420

## Changes

**`web-app/src/pages/LessonsIndex.tsx`** — single-file change (~18 lines net):

1. Pull `activeTrack` from `useExamTrack()` (was already using `store` from that hook).
2. Compute `visibleLessons` via `activeTrack.lessonFilter` — memoized on `activeTrack`.
3. Derive `lessonMap` from `visibleLessons` (was previously built from all lessons).
4. Compute `visibleTopics` by filtering `TOPICS` to those present in `visibleLessons`, preserving canonical order.
5. Iterate `visibleTopics` instead of the full `TOPICS` array.
6. Filter `CURRICULUM` slots to `lessonMap.has(s.id)` so placeholder cards don't appear for lessons outside the active track.
7. Update the header subtitle to show visible counts (`visibleLessons.length` / `visibleTopics.length`) instead of hardcoded totals.

No new files, no new dependencies, no design-system changes. `npm run build` passes.

## Test Plan

- Switch to **PSTAR** track → only Air Law section renders; Navigation/Met/GK/Radio absent; header reads "N lessons across 1 topics".
- Switch to **RROE** → only Radio section renders.
- Switch to **PPL-A** → all existing topics render, behaviour unchanged.
- Switch to **PPL-H** → only Helicopter section renders.
- Switch to **CPL-A** → only CPL-A section renders.
- Switching tracks via TrackSwitcher updates the list in the same tab without reload.
- Per-lesson read/complete state preserved per track (falls out for free from track-scoped `store`).