### PR TITLE
[PPL-447] Reset Exam state on track switch to fix stale selection

### DIFF
--- a/web-app/src/pages/Exam.tsx
+++ b/web-app/src/pages/Exam.tsx
@@ -50,8 +50,14 @@ export default function Exam() {
   const [topicFilter, setTopicFilter] = useState<TopicFilter>('all');
 
   useEffect(() => {
+    const trackLessons = getAllLessons()
+      .filter(activeTrack.lessonFilter)
+      .filter((l) => l.questions.length > 0);
     setTopicFilter('all');
-  }, [activeTrack.id]);
+    setSelectedLessonId(trackLessons[0]?.id ?? '');
+    setPhase('select');
+    setQuizResult(null);
+  }, [activeTrack]);
   const [selectedLessonId, setSelectedLessonId] = useState<string>(() => {
     const fromUrl = searchParams.get('lesson');
     if (fromUrl && lessons.some((l) => l.id === fromUrl)) return fromUrl;


### PR DESCRIPTION
Closes #447

## Audit results

All 5 pages were audited for missing `activeTrack` dependencies:

| Page | Finding | Action |
|------|---------|--------|
| **LessonsIndex** | `visibleLessons` useMemo already has `[activeTrack]` dep | No change needed |
| **Exam** | `useEffect` only reset `topicFilter`; `selectedLessonId`, `phase`, and `quizResult` were not reset on track switch | **Fixed** |
| **Plan** | `filteredCurriculum` and `filteredTopics` useMemos already have `[activeTrack]` dep | No change needed |
| **LessonDetail** | Lesson loaded by URL params (topic/slug), not track-filtered; uses `store` from context which updates with track | No change needed |
| **Playlist** | `PlaylistLibrary` uses inline computations (no useMemo) off `activeTrack.playlistTopics`; subscribes to context directly | No change needed |

## Changes

**`web-app/src/pages/Exam.tsx`** — expanded the track-change `useEffect`:

- Added `setSelectedLessonId(trackLessons[0]?.id ?? '')` so the selection defaults to the first lesson of the new track instead of staying on a potentially non-existent old-track lesson.
- Added `setPhase('select')` so in-progress or results-phase quizzes are cleared instead of hanging on a now-missing lesson.
- Added `setQuizResult(null)` to clean up result state.
- Changed dep from `[activeTrack.id]` to `[activeTrack]` (consistent with useMemo patterns elsewhere in the codebase; context provides stable object references).

## Manual validation

1. `cd web-app && npm run dev`
2. Open `localhost:5173`
3. **Browse (LessonsIndex)** — switch track → lesson grid updates to new track's lessons ✓ (was already working via `[activeTrack]` useMemo)
4. **Quiz (Exam)** — switch track → lesson list resets to new track, topic filter clears, no stale selection, phase resets to 'select' ✓
5. **Study Plan (Plan)** — switch track → topic sections and progress counts update ✓ (was already working)
6. **Lesson Detail (LessonDetail)** — page is URL-scoped to a specific lesson; switching track updates progress indicator (uses new track's store) but lesson content stays (correct by design)
7. **Listen (Playlist)** — switch track → topic playlist cards update to new track's topics ✓ (was already working via inline computations)

## TypeScript build

`cd web-app && npm run build` — passes clean ✓