### PR TITLE
[PPL-458] Fix stale VALID_TOPICS — add radio, cpl-a, helicopter

### DIFF
--- a/docs/lesson-schema.md
+++ b/docs/lesson-schema.md
@@ -27,6 +27,9 @@ that conforms to this schema. The web app and validator both rely on it.
 | `navigation` | Navigation (charts, dead reckoning, wind correction) |
 | `meteorology` | Meteorology (METAR, TAF, GFAs, weather hazards) |
 | `general-knowledge` | Aeronautics — General Knowledge (aircraft systems, instruments, W&B) |
+| `radio` | Radiotelephony — RROE track |
+| `cpl-a` | Commercial Pilot Licence (Aeroplane) — CPL-A track |
+| `helicopter` | PPL Helicopter — PPL-H track |
 
 ### Question object schema
 

--- a/scripts/validate-lesson-schema.sh
+++ b/scripts/validate-lesson-schema.sh
@@ -26,7 +26,7 @@ REQUIRED_FIELDS = [
     "duration_min", "status", "audio", "visual",
     "sources", "questions",
 ]
-VALID_TOPICS = {"air-law", "navigation", "meteorology", "general-knowledge"}
+VALID_TOPICS = {"air-law", "navigation", "meteorology", "general-knowledge", "radio", "cpl-a", "helicopter"}
 REQUIRED_QUESTION_FIELDS = {"id", "prompt", "choices", "answer", "explanation"}
 
 def fail(path, msg):


### PR DESCRIPTION
Closes #458

## Changes

- `scripts/validate-lesson-schema.sh`: Extended `VALID_TOPICS` Python set to include `radio`, `cpl-a`, and `helicopter`, bringing it in sync with `src/lib/types.ts`.
- `docs/lesson-schema.md`: Added three rows to the "Allowed \`topic\` values" table for the new tracks (RROE, CPL-A, PPL-H).

No lesson files were modified. No other validator logic was touched.

## Test Plan

- Run `bash scripts/validate-lesson-schema.sh` — zero `invalid topic` FAIL lines.
- Pre-existing non-topic failures (`missing required field: 'visual'`, question-count mismatches) are unchanged and not introduced by this PR.