### PR TITLE
[PPL-460] Add missing q5 to 5 navigation lessons (NAV-003–005, NAV-009, NAV-010)

### DIFF
--- a/lessons/navigation/003-true-magnetic-compass.md
+++ b/lessons/navigation/003-true-magnetic-compass.md
@@ -49,6 +49,15 @@ questions:
       D: "075°"
     answer: A
     explanation: "With easterly variation, you SUBTRACT the variation from true to get magnetic: 090° − 25° = 065°. Easterly variation means magnetic north is east of true north, so compass headings are numerically less than true headings. Source: TP 12880E Chapter 9, AIM GEN 1.1."
+  - id: q5
+    prompt: "A pilot is flying a magnetic heading of 090°. The aircraft's deviation card shows −2° (westerly deviation) for this heading. What compass heading should the pilot steer?"
+    choices:
+      A: "086°"
+      B: "088°"
+      C: "090°"
+      D: "092°"
+    answer: B
+    explanation: "With westerly (−2°) deviation, subtract from the magnetic heading: Compass = Magnetic − deviation = 090° − 2° = 088°. Westerly deviation means the compass needle is pulled 2° toward the west, reading lower than the true magnetic heading; the pilot must fly a lower compass heading to achieve the intended magnetic heading. The full TVMDC rule: East deviation is added; West is subtracted. Source: TP 12880E Chapter 9."
 ---
 
 # Lesson NAV-003: True vs Magnetic vs Compass Heading

--- a/lessons/navigation/004-dead-reckoning-basics.md
+++ b/lessons/navigation/004-dead-reckoning-basics.md
@@ -47,6 +47,15 @@ questions:
       D: "Dead reckoning does not use magnetic headings"
     answer: B
     explanation: "In dead reckoning, position is estimated by projecting from the last known point. Any small error in heading or ground speed estimate multiplies with time: a 2° heading error becomes a 3.5 NM track error after 100 NM. Regular checkpoint verification is essential to correct accumulated errors. Source: TP 12880E Chapter 9."
+  - id: q5
+    prompt: "A pilot plans a cross-country leg of 75 NM with a calculated ground speed of 90 knots. What is the estimated time en route for this leg?"
+    choices:
+      A: "40 minutes"
+      B: "45 minutes"
+      C: "50 minutes"
+      D: "55 minutes"
+    answer: C
+    explanation: "Time (min) = (Distance ÷ Ground Speed) × 60 = (75 ÷ 90) × 60 = 0.833 × 60 = 50 minutes. Ground speed — not TAS — is used for time calculations because it accounts for the wind effect on actual progress over the ground. Source: TP 12880E Chapter 9."
 ---
 
 # Lesson NAV-004: Dead Reckoning

--- a/lessons/navigation/005-wind-correction-angle.md
+++ b/lessons/navigation/005-wind-correction-angle.md
@@ -48,6 +48,15 @@ questions:
       D: "Turn left because wind from the north creates a southerly drift"
     answer: A
     explanation: "Wind from 360° (north) pushes the aircraft south (to the right of a 090° track). To correct, the pilot must point the nose into the wind — to the left (north), turning to a heading less than 090°. Source: TP 12880E Chapter 9."
+  - id: q5
+    prompt: "An aircraft is flying a track of 180° (due south) at a TAS of 115 knots. The winds aloft forecast reports winds from 180° at 30 knots. What is the expected ground speed?"
+    choices:
+      A: "145 knots — the wind is a tailwind"
+      B: "85 knots — the wind is a headwind"
+      C: "115 knots — the wind is a crosswind with no GS effect"
+      D: "100 knots — the wind reduces GS by half the wind speed"
+    answer: B
+    explanation: "Wind direction is always stated as the direction FROM which it blows. A wind 'from 180°' blows from the south toward the north. An aircraft flying a 180° track (southbound) is flying directly into this wind — a direct headwind. Ground speed = TAS − headwind component = 115 − 30 = 85 knots. Source: TP 12880E Chapter 9."
 ---
 
 # Lesson NAV-005: Wind Correction Angle and Ground Speed

--- a/lessons/navigation/009-pilotage.md
+++ b/lessons/navigation/009-pilotage.md
@@ -47,6 +47,15 @@ questions:
       D: "It requires a second pilot to read the chart"
     answer: B
     explanation: "Pilotage depends on being able to see and identify ground features. In featureless terrain (large flat areas of farmland, tundra, ocean, or dense boreal forest), landmarks may be absent or indistinguishable. In reduced visibility (haze, rain, smoke), even identifiable features may not be visible. In these conditions, pilotage must be supplemented by dead reckoning and radio aids. Source: TP 12880E Chapter 9."
+  - id: q5
+    prompt: "A pilot's dead reckoning estimate places the aircraft over a lake, but the pilot identifies what appears to be a different lake 5 NM to the left. What is the recommended action?"
+    choices:
+      A: "Turn toward the identified lake and navigate from there as the new confirmed position"
+      B: "Investigate the discrepancy — verify heading flown, ground speed, and re-examine the landmark identification before changing course"
+      C: "Climb to a higher altitude so more landmarks become visible for a better fix"
+      D: "Declare uncertainty on 121.5 MHz and request radar vectors to the nearest airport"
+    answer: B
+    explanation: "When DR and pilotage disagree, the recommended action is to investigate: verify the heading was correctly flown, check whether ground speed matched the forecast, and critically re-examine whether the landmark was positively identified. Abandoning the DR plan to follow an ambiguous or unconfirmed landmark is a common cause of becoming lost. Maintain the DR heading as primary until a positive identification is made. Source: TP 12880E Chapter 9."
 ---
 
 # Lesson NAV-009: Pilotage — Navigating by Ground Reference

--- a/lessons/navigation/010-vor-navigation.md
+++ b/lessons/navigation/010-vor-navigation.md
@@ -48,6 +48,15 @@ questions:
       D: "By confirming the CDI centres on the expected radial"
     answer: B
     explanation: "VOR stations broadcast a continuous Morse code identifier (3 letters) on the VOR frequency. The pilot must identify the VOR by listening to or decoding the Morse identifier and confirming it matches the identifier printed on the chart. If a VOR is undergoing maintenance, it transmits TST or no identifier as a signal to pilots not to use it. Source: TP 12880E Chapter 10, AIM COM 5.0."
+  - id: q5
+    prompt: "To obtain a precise position fix using two VOR stations, a pilot should:"
+    choices:
+      A: "Fly toward the first VOR until station passage, then track the second VOR outbound"
+      B: "Tune each VOR, centre the CDI with a FROM flag displayed, read the OBS for each, and plot both radials on the chart — the intersection is the aircraft's position"
+      C: "Average the two OBS readings and apply the result to the nearest chart feature"
+      D: "Use the TO/FROM flags from both VORs to determine which quadrant the aircraft is in"
+    answer: B
+    explanation: "A position fix by cross-bearing requires tuning each VOR in turn, rotating the OBS until the CDI centres with a FROM flag, and reading the OBS — that value is the radial from that station. Plotting both radials on the VNC gives a precise fix at their intersection. This technique provides a reliable position confirmation independent of visual ground contact. Source: TP 12880E Chapter 10."
 ---
 
 # Lesson NAV-010: VOR Navigation


### PR DESCRIPTION
Closes #460

## Changes

Added a 5th practice question (`q5`) to each of the 5 navigation lesson files that previously had only 4 questions, causing `validate-lesson-schema.sh` to fail.

| File | q5 Concept Tested |
|------|-------------------|
| `lessons/navigation/003-true-magnetic-compass.md` | Applying westerly compass deviation (Compass = Magnetic − deviation) |
| `lessons/navigation/004-dead-reckoning-basics.md` | Time en route formula: (Distance ÷ GS) × 60 |
| `lessons/navigation/005-wind-correction-angle.md` | Wind direction convention (FROM direction) and headwind GS effect |
| `lessons/navigation/009-pilotage.md` | Recommended action when DR and pilotage disagree |
| `lessons/navigation/010-vor-navigation.md` | Position fix by cross-bearing using two VORs |

Each q5 covers a concept from the lesson narration not already tested by q1–q4, follows the existing question schema (id, prompt, choices A–D, answer, explanation), and cites a Transport Canada source (TP 12880E or AIM).

## Test Plan

- [ ] `bash scripts/validate-lesson-schema.sh` run across all lessons — all 5 edited files show `OK`
- [ ] Each q5 answer is verified correct against the lesson narration
- [ ] No other lesson files, scripts, audio, visuals, or web-app code were modified