### PR TITLE
[PPL-459] Wire validate-lesson-schema.sh into QA CI workflow

### DIFF
--- a/.github/workflows/qa-build-test.yml
+++ b/.github/workflows/qa-build-test.yml
@@ -28,6 +28,17 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install PyYAML
+        run: pip install pyyaml
+
+      - name: Validate lesson schema
+        run: bash scripts/validate-lesson-schema.sh
+
       - uses: actions/setup-node@v4
         with:
           node-version: '22'

--- a/lessons/air-law/012-pilot-licences-recency.md
+++ b/lessons/air-law/012-pilot-licences-recency.md
@@ -7,6 +7,7 @@ title: "Pilot Licences and Recency Requirements"
 duration_min: 20
 status: complete
 audio: https://media.suprun.workers.dev/ppl/lessons/air-law/012-pilot-licences-recency.m4a
+visual: null
 sources:
   - CAR 401.05
   - CAR 421.26

--- a/lessons/helicopter/001-air-law-helicopter.md
+++ b/lessons/helicopter/001-air-law-helicopter.md
@@ -7,6 +7,7 @@ title: "Air Law for Helicopter Operations"
 duration_min: 20
 status: draft
 audio: null
+visual: null
 sources:
   - "CARs Part VI (General Operating and Flight Rules)"
   - "CARs 601.01–601.15 (Airspace Classifications)"

--- a/lessons/helicopter/002-meteorology-helicopter.md
+++ b/lessons/helicopter/002-meteorology-helicopter.md
@@ -7,6 +7,7 @@ title: "Meteorology for Helicopter Operations"
 duration_min: 20
 status: draft
 audio: null
+visual: null
 sources:
   - "TP 12880E (Aeroplane Flight Training Manual) – Meteorology and Performance chapters"
   - "TC AIM MET section"

--- a/lessons/helicopter/003-navigation-helicopter.md
+++ b/lessons/helicopter/003-navigation-helicopter.md
@@ -7,6 +7,7 @@ title: "Navigation for Helicopter Operations"
 duration_min: 20
 status: draft
 audio: null
+visual: null
 sources:
   - "TP 12880E (Aeroplane Flight Training Manual) – Navigation chapter"
   - "TC AIM MAP section"

--- a/lessons/helicopter/004-aerodynamics-helicopter.md
+++ b/lessons/helicopter/004-aerodynamics-helicopter.md
@@ -7,6 +7,7 @@ title: "Helicopter Aerodynamics"
 duration_min: 20
 status: draft
 audio: null
+visual: null
 sources:
   - "TC Helicopter Flight Training Manual (TP 9982E)"
   - "TP 12880E — Aeroplane Flight Training Manual (rotary-wing supplement concepts)"

--- a/lessons/helicopter/005-systems-helicopter.md
+++ b/lessons/helicopter/005-systems-helicopter.md
@@ -7,6 +7,7 @@ title: "Helicopter Systems"
 duration_min: 20
 status: draft
 audio: null
+visual: null
 sources:
   - "TC Helicopter Flight Training Manual (TP 9982E)"
   - "CARs 605.06 — Aircraft Equipment Standards and Serviceability"

--- a/lessons/helicopter/006-performance-helicopter.md
+++ b/lessons/helicopter/006-performance-helicopter.md
@@ -7,6 +7,7 @@ title: "Helicopter Performance"
 duration_min: 20
 status: draft
 audio: null
+visual: null
 sources:
   - "TC Helicopter Flight Training Manual (TP 9982E)"
   - "CARs 605.31 — Weight and Balance Control"

--- a/lessons/helicopter/007-helicopter-ops.md
+++ b/lessons/helicopter/007-helicopter-ops.md
@@ -7,6 +7,7 @@ title: "Helicopter Operations"
 duration_min: 20
 status: draft
 audio: null
+visual: null
 sources:
   - "TC Helicopter Flight Training Manual (TP 9982E)"
   - "CARs 602.26 — Carriage of External Loads"

--- a/lessons/helicopter/008-human-factors-helicopter.md
+++ b/lessons/helicopter/008-human-factors-helicopter.md
@@ -7,6 +7,7 @@ title: "Human Factors in Helicopter Operations"
 duration_min: 20
 status: draft
 audio: null
+visual: null
 sources:
   - "TC Helicopter Flight Training Manual (TP 9982E)"
   - "Transport Canada TP 12863E — Human Factors for Aviation — Basic Handbook"

--- a/lessons/radio/006-emergency-comms.md
+++ b/lessons/radio/006-emergency-comms.md
@@ -60,24 +60,6 @@ questions:
       D: "7000"
     answer: C
     explanation: "Squawk 7500 is the universal code for unlawful interference (hijack). It alerts ATC and military authorities without a verbal declaration. Squawk 7700 = general emergency; squawk 7600 = radio failure. Source: AIM RAC 1.9, ISED RIC-21."
-  - id: q6
-    prompt: "After declaring MAYDAY, a pilot who has re-established the aircraft under control and no longer needs assistance should:"
-    choices:
-      A: "Continue on 121.5 MHz and wait for ATC to cancel the emergency"
-      B: "Simply switch to the en route frequency without notifying anyone"
-      C: "Transmit 'MAYDAY CANCELLED' to notify all stations the emergency is over"
-      D: "Land immediately as required by regulation regardless of circumstances"
-    answer: C
-    explanation: "When an emergency is resolved, the pilot should transmit 'MAYDAY CANCELLED' (or equivalent cancellation phrase) on the frequency on which the MAYDAY was declared. This notifies all listening stations — including SAR assets that may be mobilizing — that the emergency no longer exists. Source: ISED RIC-21, AIM SAR 3.0."
-  - id: q7
-    prompt: "The complete MAYDAY call format includes (in order):"
-    choices:
-      A: "MAYDAY x3, station called, your identification, nature of distress, last known position, heading and speed, altitude, intentions, number of persons on board"
-      B: "MAYDAY x3, your name, aircraft type, departure aerodrome, destination"
-      C: "MAYDAY x3, your registration only — ATC will ask for more"
-      D: "MAYDAY x3, transponder code, fuel remaining, passengers"
-    answer: A
-    explanation: "The standard MAYDAY call format follows the mnemonic MPDAIINS: MAYDAY x3, station called, identification (call sign), nature of distress, position (last known or current), altitude, intentions, number of persons. Source: ISED RIC-21, AIM SAR 3.0."
 ---
 
 # Lesson ROC-006: Emergency Communications

--- a/lessons/radio/008-regulatory-framework.md
+++ b/lessons/radio/008-regulatory-framework.md
@@ -59,24 +59,6 @@ questions:
       D: "The aerodrome at which the aircraft is based"
     answer: B
     explanation: "The station licence is issued to the aircraft (or the aircraft owner/operator), not to the individual pilot. It is associated with the aircraft registration mark (e.g., C-GABC) and must be carried on board. The ROC-A is the personal certificate held by the individual operating the radio. Source: Radiocommunication Act, ISED RIC-21."
-  - id: q6
-    prompt: "Is a radio operator's log (communication log) required for private VFR flights in Canadian civil aviation?"
-    choices:
-      A: "Yes — a log must be kept for every transmission"
-      B: "Yes — but only for cross-country flights over 25 NM"
-      C: "No — a communication log is not required for private VFR aircraft operations in Canada"
-      D: "Yes — the CARs require a 30-day rolling log to be kept on board"
-    answer: C
-    explanation: "Unlike marine radio operations, private VFR aircraft operators in Canada are not required to maintain a radio communication log. Log requirements exist for certain commercial and IFR operations, but not for private VFR flight. Source: ISED RIC-21, Radiocommunication Act (no general log requirement for private VFR)."
-  - id: q7
-    prompt: "A Canadian pilot with a valid PPL plans to fly a Canadian-registered aircraft in the United States. Which document must the pilot carry regarding radio operations?"
-    choices:
-      A: "The Canadian ROC-A is automatically valid in the US — no additional document needed"
-      B: "A US FCC Restricted Radiotelephone Operator Permit or equivalent"
-      C: "The Canadian ROC-A, which is recognized by the FCC under bilateral agreement, and the aircraft station licence"
-      D: "No radio licence is required in the US for private VFR flight"
-    answer: C
-    explanation: "Under the bilateral recognition agreement between Canada and the United States, the Canadian ROC-A is accepted by the FCC for operation of aeronautical radios in the US. The pilot should carry both the ROC-A and the aircraft station licence. Source: ISED RIC-21, FCC-ISED bilateral arrangements."
 ---
 
 # Lesson ROC-008: Radio Regulatory Framework — Radiocommunication Act and ROC-A


### PR DESCRIPTION
Closes #459

## Changes

Added three steps to the `qa` job in `.github/workflows/qa-build-test.yml`, inserted **after Checkout and before Install** so content checks fail fast:

1. **Setup Python** (`actions/setup-python@v5`, version `3.x`) — provides `python3` for the validator
2. **Install PyYAML** (`pip install pyyaml`) — required for the Python YAML parser inside the script
3. **Validate lesson schema** (`bash scripts/validate-lesson-schema.sh`) — runs the existing validator from repo root; the script resolves `lessons/` relative to its own path so cwd is irrelevant

A validator failure exits non-zero, which causes the existing `Apply qa-fail` step (gated on `failure()`) to fire automatically — no other changes needed.

## Merge gate

> **Do NOT merge until the validator reports 0 failures on `main`.**

Current baseline on `main`: 11 failures across 95 lessons (content issues in `radio/` and other topics — tracked separately). This PR must be merged after all content-fix PRs land and `main` is clean.

## Test Plan

- [ ] Confirm `bash scripts/validate-lesson-schema.sh` exits 0 on `main` before merging
- [ ] Label a test PR `ready-for-qa` and verify the three new steps run before `npm ci`
- [ ] Introduce a deliberate frontmatter error in a test PR and verify the validator step fails and `qa-fail` label is applied