### PR TITLE
[PPL-461] Add missing visual: null frontmatter to all 8 helicopter lessons

### DIFF
--- a/lessons/helicopter/001-air-law-helicopter.md
+++ b/lessons/helicopter/001-air-law-helicopter.md
@@ -7,6 +7,7 @@ title: "Air Law for Helicopter Operations"
 duration_min: 20
 status: draft
 audio: null
+visual: null
 sources:
   - "CARs Part VI (General Operating and Flight Rules)"
   - "CARs 601.01–601.15 (Airspace Classifications)"

--- a/lessons/helicopter/002-meteorology-helicopter.md
+++ b/lessons/helicopter/002-meteorology-helicopter.md
@@ -7,6 +7,7 @@ title: "Meteorology for Helicopter Operations"
 duration_min: 20
 status: draft
 audio: null
+visual: null
 sources:
   - "TP 12880E (Aeroplane Flight Training Manual) – Meteorology and Performance chapters"
   - "TC AIM MET section"

--- a/lessons/helicopter/003-navigation-helicopter.md
+++ b/lessons/helicopter/003-navigation-helicopter.md
@@ -7,6 +7,7 @@ title: "Navigation for Helicopter Operations"
 duration_min: 20
 status: draft
 audio: null
+visual: null
 sources:
   - "TP 12880E (Aeroplane Flight Training Manual) – Navigation chapter"
   - "TC AIM MAP section"

--- a/lessons/helicopter/004-aerodynamics-helicopter.md
+++ b/lessons/helicopter/004-aerodynamics-helicopter.md
@@ -7,6 +7,7 @@ title: "Helicopter Aerodynamics"
 duration_min: 20
 status: draft
 audio: null
+visual: null
 sources:
   - "TC Helicopter Flight Training Manual (TP 9982E)"
   - "TP 12880E — Aeroplane Flight Training Manual (rotary-wing supplement concepts)"

--- a/lessons/helicopter/005-systems-helicopter.md
+++ b/lessons/helicopter/005-systems-helicopter.md
@@ -7,6 +7,7 @@ title: "Helicopter Systems"
 duration_min: 20
 status: draft
 audio: null
+visual: null
 sources:
   - "TC Helicopter Flight Training Manual (TP 9982E)"
   - "CARs 605.06 — Aircraft Equipment Standards and Serviceability"

--- a/lessons/helicopter/006-performance-helicopter.md
+++ b/lessons/helicopter/006-performance-helicopter.md
@@ -7,6 +7,7 @@ title: "Helicopter Performance"
 duration_min: 20
 status: draft
 audio: null
+visual: null
 sources:
   - "TC Helicopter Flight Training Manual (TP 9982E)"
   - "CARs 605.31 — Weight and Balance Control"

--- a/lessons/helicopter/007-helicopter-ops.md
+++ b/lessons/helicopter/007-helicopter-ops.md
@@ -7,6 +7,7 @@ title: "Helicopter Operations"
 duration_min: 20
 status: draft
 audio: null
+visual: null
 sources:
   - "TC Helicopter Flight Training Manual (TP 9982E)"
   - "CARs 602.26 — Carriage of External Loads"

--- a/lessons/helicopter/008-human-factors-helicopter.md
+++ b/lessons/helicopter/008-human-factors-helicopter.md
@@ -7,6 +7,7 @@ title: "Human Factors in Helicopter Operations"
 duration_min: 20
 status: draft
 audio: null
+visual: null
 sources:
   - "TC Helicopter Flight Training Manual (TP 9982E)"
   - "Transport Canada TP 12863E — Human Factors for Aviation — Basic Handbook"


### PR DESCRIPTION
Closes #461

## Changes
Added `visual: null` immediately after `audio: null` in all 8 helicopter lesson files. This brings them into conformance with the lesson frontmatter schema used across the rest of the repo (e.g. `lessons/air-law/009-flight-plans-itineraries.md`). No visual assets exist yet for helicopter lessons, so `null` is the correct value.

Files changed:
- `lessons/helicopter/001-air-law-helicopter.md`
- `lessons/helicopter/002-meteorology-helicopter.md`
- `lessons/helicopter/003-navigation-helicopter.md`
- `lessons/helicopter/004-aerodynamics-helicopter.md`
- `lessons/helicopter/005-systems-helicopter.md`
- `lessons/helicopter/006-performance-helicopter.md`
- `lessons/helicopter/007-helicopter-ops.md`
- `lessons/helicopter/008-human-factors-helicopter.md`

`git diff` shows exactly 8 single-line additions — one `visual: null` per file, no other changes.

## Test Plan
- Verify `grep "^visual:" lessons/helicopter/*.md` returns a match in all 8 files
- Verify each value is `null`
- Verify `visual:` appears immediately after `audio:` in each file
- Confirm no other frontmatter fields or body content were modified