### PR TITLE
[PPL-467] Add check-in storage module and recording triggers

### DIFF
--- a/web-app/src/components/AudioPlayer.tsx
+++ b/web-app/src/components/AudioPlayer.tsx
@@ -10,6 +10,7 @@ import FastForwardIcon from '@mui/icons-material/FastForward';
 import FastRewindIcon from '@mui/icons-material/FastRewind';
 import { readSpeed, writeSpeed, readPosition, writePosition, clearAudioPosition } from '../lib/audio-state';
 import { useMediaSession } from './MediaSessionBridge';
+import { recordCheckin } from '../lib/checkins';
 
 const SPEEDS = [0.75, 1, 1.1, 1.25, 1.5, 1.75, 2] as const;
 type Speed = (typeof SPEEDS)[number];
@@ -61,6 +62,7 @@ export default function AudioPlayer({ src, title, topic, lessonId }: AudioPlayer
     }
 
     function handlePlay() {
+      recordCheckin();
       if (intervalRef.current) clearInterval(intervalRef.current);
       intervalRef.current = setInterval(savePos, 5000);
     }

--- a/web-app/src/lib/checkins.ts
+++ b/web-app/src/lib/checkins.ts
@@ -1,0 +1,73 @@
+const STORAGE_KEY = 'ppl.checkins.v1';
+
+function today(): string {
+  return new Date().toLocaleDateString('en-CA');
+}
+
+function yesterday(): string {
+  const d = new Date();
+  d.setDate(d.getDate() - 1);
+  return d.toLocaleDateString('en-CA');
+}
+
+function load(): string[] {
+  if (typeof window === 'undefined') return [];
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter((v): v is string => typeof v === 'string');
+  } catch {
+    return [];
+  }
+}
+
+function save(dates: string[]): void {
+  if (typeof window === 'undefined') return;
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(dates));
+  } catch {
+    // quota or private mode — ignore
+  }
+}
+
+export function recordCheckin(): void {
+  const dates = load();
+  const t = today();
+  if (dates.includes(t)) return;
+  save([...dates, t].sort());
+}
+
+export function getCheckins(): string[] {
+  return load().sort();
+}
+
+export function getCurrentStreak(): number {
+  const dates = new Set(load());
+  const t = today();
+  const yest = yesterday();
+
+  let cursor: string;
+  if (dates.has(t)) {
+    cursor = t;
+  } else if (dates.has(yest)) {
+    cursor = yest;
+  } else {
+    return 0;
+  }
+
+  let streak = 0;
+  let current = new Date(cursor + 'T12:00:00');
+  while (true) {
+    const key = current.toLocaleDateString('en-CA');
+    if (!dates.has(key)) break;
+    streak++;
+    current.setDate(current.getDate() - 1);
+  }
+  return streak;
+}
+
+export function getTotalDays(): number {
+  return load().length;
+}

--- a/web-app/src/pages/LessonDetail.tsx
+++ b/web-app/src/pages/LessonDetail.tsx
@@ -15,6 +15,7 @@ import LessonProgressBar from '../components/LessonProgressBar';
 import SourceList from '../components/SourceList';
 import { getLessonBySlug, getAdjacentLessons, getLessonsByTopic } from '../lib/lesson-loader';
 import { useProgress } from '../lib/progress';
+import { recordCheckin } from '../lib/checkins';
 import { useExamTrack } from '../context/ExamTrackContext';
 import { useThemeMode } from '../context/ThemeModeContext';
 import { TOPIC_LABELS } from '../lib/curriculum';
@@ -105,6 +106,7 @@ export default function LessonDetail() {
   const progressTotal = topicLessons.length;
 
   useEffect(() => {
+    recordCheckin();
     return () => {
       localStorage.setItem(LAST_SESSION_KEY, new Date().toISOString());
     };


### PR DESCRIPTION
Closes #467

## Changes
- **Created** `web-app/src/lib/checkins.ts` — new module with four exports:
  - `recordCheckin()` — adds today's date (`YYYY-MM-DD`) to `ppl.checkins.v1` localStorage if not already present
  - `getCheckins()` — returns sorted ascending array of ISO date strings
  - `getCurrentStreak()` — consecutive-day streak ending today (or yesterday if no check-in today); 0 if neither
  - `getTotalDays()` — total distinct check-in days
  - SSR-safe (guards `typeof window === 'undefined'`), corrupt-JSON-safe (resets to `[]`)
- **Edited** `web-app/src/pages/LessonDetail.tsx` — calls `recordCheckin()` inside the existing mount `useEffect`
- **Edited** `web-app/src/components/AudioPlayer.tsx` — calls `recordCheckin()` at the start of the `handlePlay` audio event handler (module dedup prevents duplicates)

No UI changes — recording only, as required by child 1 of epic #238.

## Test Plan
- Visit any lesson page → `ppl.checkins.v1` in localStorage should contain today's date after the first visit
- Press play on audio → same key updated (dedup: date appears only once regardless of how many times play is hit)
- Revisit same day → only one entry for today in the array
- Verify build passes: `npm run build` ✓
- Verify test suite passes: `npm test` ✓