### PR TITLE
[PPL-459] Add validate-lesson-schema.sh to QA CI workflow

### DIFF
--- a/.github/workflows/qa-build-test.yml
+++ b/.github/workflows/qa-build-test.yml
@@ -28,6 +28,17 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install PyYAML
+        run: pip install pyyaml
+
+      - name: Validate lesson schema
+        run: bash scripts/validate-lesson-schema.sh
+
       - uses: actions/setup-node@v4
         with:
           node-version: '22'


### PR DESCRIPTION
Closes #459

## Changes

Added three steps to `.github/workflows/qa-build-test.yml` in the `qa` job, placed after `Checkout` and before the Node.js install:

1. **Setup Python** — uses `actions/setup-python@v5` with `python-version: '3.x'`
2. **Install PyYAML** — runs `pip install pyyaml` so the embedded Python validator can parse YAML frontmatter
3. **Validate lesson schema** — runs `bash scripts/validate-lesson-schema.sh` from repo root (the script resolves the lessons dir relative to its own path, so cwd doesn't matter)

The validator step runs before `npm ci`/`npm run build`/`npm test` so cheap content checks fail fast. Because it runs in the same `qa` job, any failure automatically triggers the existing `Apply qa-fail` step (gated on `failure()`).

**Note:** The validator currently reports 3 failures on this branch (content issues in radio lessons — question count). These are separate content tickets and are out of scope for this PR. Per the issue AC, this PR should not be merged until `main` shows 0 validator failures.

## Test Plan

- [ ] Apply `ready-for-qa` label to this PR — the new steps should appear in the workflow run
- [ ] Verify `Setup Python`, `Install PyYAML`, and `Validate lesson schema` steps execute before `Install` (npm ci)
- [ ] After content failures are resolved on main, re-run QA and confirm 0 failures
- [ ] Confirm that a PR with a broken lesson file causes the `qa-fail` label to be applied