### PR TITLE
[PPL-462] Replace hardcoded rgba literals with theme-token alpha() calls

### DIFF
--- a/web-app/src/pages/LessonsIndex.tsx
+++ b/web-app/src/pages/LessonsIndex.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from 'react';
 import { Link as RouterLink } from 'react-router-dom';
+import { alpha, useTheme } from '@mui/material/styles';
 import Box from '@mui/material/Box';
 import Card from '@mui/material/Card';
 import CardActionArea from '@mui/material/CardActionArea';
@@ -17,6 +18,7 @@ import { useExamTrack } from '../context/ExamTrackContext';
 import TopicMasteryCard from '../components/TopicMasteryCard';
 
 export default function LessonsIndex() {
+  const theme = useTheme();
   const { store, activeTrack } = useExamTrack();
   const { isComplete } = useProgress(store);
 
@@ -71,7 +73,7 @@ export default function LessonsIndex() {
 
                 if (!lesson) {
                   return (
-                    <Card key={slot.id} variant="outlined" sx={{ opacity: 0.5, borderLeft: '3px solid rgba(255,255,255,0.12)' }}>
+                    <Card key={slot.id} variant="outlined" sx={{ opacity: 0.5, borderLeft: `3px solid ${alpha(theme.palette.divider, 0.12)}` }}>
                       <CardContent sx={{ pb: '12px !important' }}>
                         <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 0.5 }}>
                           <Chip label={slot.id} size="small" variant="outlined" color="default" sx={{ fontFamily: 'monospace', fontWeight: 600 }} />
@@ -96,7 +98,7 @@ export default function LessonsIndex() {
                       transition: 'all 0.15s ease',
                       '&:hover': {
                         transform: 'translateY(-2px)',
-                        boxShadow: '0 4px 20px rgba(245, 166, 35, 0.2)',
+                        boxShadow: `0 4px 20px ${alpha(theme.palette.primary.main, 0.2)}`,
                       },
                     }}
                   >

--- a/web-app/src/pages/SRSQueue.tsx
+++ b/web-app/src/pages/SRSQueue.tsx
@@ -1,5 +1,6 @@
 import { useState, useMemo } from 'react';
 import { Link as RouterLink } from 'react-router-dom';
+import { alpha, useTheme } from '@mui/material/styles';
 import Box from '@mui/material/Box';
 import Container from '@mui/material/Container';
 import Typography from '@mui/material/Typography';
@@ -69,6 +70,7 @@ function SectionHead({ title, meta }: { title: string; meta: string }) {
 }
 
 export default function SRSQueue() {
+  const theme = useTheme();
   const { activeTrack } = useExamTrack();
   const { updateCard, getDueCards } = useSRSStore(activeTrack.id);
 
@@ -586,12 +588,12 @@ export default function SRSQueue() {
                     '&:hover': {
                       borderColor: grade === 0 ? 'error.main' : grade === 2 ? 'warning.main' : grade === 3 ? 'info.main' : 'success.main',
                       bgcolor: grade === 0
-                        ? 'rgba(224,80,80,0.08)'
+                        ? alpha(theme.palette.error.main, 0.08)
                         : grade === 2
-                        ? 'rgba(240,192,64,0.08)'
+                        ? alpha(theme.palette.warning.main, 0.08)
                         : grade === 3
-                        ? 'rgba(91,155,213,0.08)'
-                        : 'rgba(76,175,125,0.08)',
+                        ? alpha(theme.palette.info.main, 0.08)
+                        : alpha(theme.palette.success.main, 0.08),
                     },
                   }}
                 >


### PR DESCRIPTION
Closes #462

## Changes

Replaced six hardcoded `rgba(…)` colour literals in two pages with `alpha(theme.palette.…, opacity)` calls from `@mui/material/styles`:

**`LessonsIndex.tsx`**
- `rgba(255,255,255,0.12)` → `alpha(theme.palette.divider, 0.12)` (missing-lesson card border)
- `rgba(245, 166, 35, 0.2)` → `alpha(theme.palette.primary.main, 0.2)` (hover box-shadow)

**`SRSQueue.tsx`**
- `rgba(224,80,80,0.08)` → `alpha(theme.palette.error.main, 0.08)`
- `rgba(240,192,64,0.08)` → `alpha(theme.palette.warning.main, 0.08)`
- `rgba(91,155,213,0.08)` → `alpha(theme.palette.info.main, 0.08)`
- `rgba(76,175,125,0.08)` → `alpha(theme.palette.success.main, 0.08)`

Both files received `import { alpha, useTheme } from '@mui/material/styles'` and a `const theme = useTheme()` call.

## Test Plan
- `npm run build` completes with zero TypeScript errors ✓
- Verify both pages render correctly in dark and light mode (especially the missing-lesson card border and grade button hover states)