### PR TITLE
[PPL-468] Add streak counter to Nav

### DIFF
--- a/web-app/src/components/Nav.tsx
+++ b/web-app/src/components/Nav.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import { getCurrentStreak } from '../lib/checkins';
 import AppBar from '@mui/material/AppBar';
 import BottomNavigation from '@mui/material/BottomNavigation';
 import BottomNavigationAction from '@mui/material/BottomNavigationAction';
@@ -20,7 +21,7 @@ import HeadphonesIcon from '@mui/icons-material/Headphones';
 import ChevronLeftIcon from '@mui/icons-material/ChevronLeft';
 import ChevronRightIcon from '@mui/icons-material/ChevronRight';
 import { Link as RouterLink, useLocation, useNavigate } from 'react-router-dom';
-import { colorTokens } from '../tokens';
+import { colorTokens, radiusTokens } from '../tokens';
 import { useThemeMode } from '../context/ThemeModeContext';
 import ModeToggle from './ModeToggle';
 import TrackSwitcher from './TrackSwitcher';
@@ -58,6 +59,8 @@ export default function Nav() {
     }
   });
 
+  const [streak, setStreak] = useState<number>(0);
+
   useEffect(() => {
     try {
       localStorage.setItem(LS_KEY, String(collapsed));
@@ -65,6 +68,10 @@ export default function Nav() {
       // ignore storage errors
     }
   }, [collapsed]);
+
+  useEffect(() => {
+    setStreak(getCurrentStreak());
+  }, [location.pathname]);
 
   const activeIndex = NAV_LINKS.findIndex(({ to }) => isActiveRoute(location.pathname, to));
   const railWidth = collapsed ? RAIL_COLLAPSED : RAIL_EXPANDED;
@@ -117,6 +124,26 @@ export default function Nav() {
             <span aria-hidden="true">✈ </span>
             {!collapsed && 'PPL Study'}
           </Typography>
+          {streak > 0 && (
+            <Box
+              component="span"
+              aria-label={`${streak}-day streak`}
+              sx={{
+                ml: collapsed ? 'auto' : 1,
+                fontSize: '0.7rem',
+                fontWeight: 700,
+                color: c.primary.main,
+                backgroundColor: c.primary.muted,
+                borderRadius: `${radiusTokens.sm}px`,
+                px: 0.75,
+                py: 0.25,
+                lineHeight: 1.4,
+                flexShrink: 0,
+              }}
+            >
+              {collapsed ? '🔥' : `🔥 ${streak}`}
+            </Box>
+          )}
         </Box>
 
         {/* Track switcher */}
@@ -258,18 +285,38 @@ export default function Nav() {
             px: 2,
           }}
         >
-          <Typography
-            component="span"
-            sx={{
-              color: c.primary.main,
-              fontWeight: 700,
-              fontSize: '1rem',
-              letterSpacing: '0.01em',
-            }}
-          >
-            <span aria-hidden="true">✈ </span>
-            PPL Study
-          </Typography>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+            <Typography
+              component="span"
+              sx={{
+                color: c.primary.main,
+                fontWeight: 700,
+                fontSize: '1rem',
+                letterSpacing: '0.01em',
+              }}
+            >
+              <span aria-hidden="true">✈ </span>
+              PPL Study
+            </Typography>
+            {streak > 0 && (
+              <Box
+                component="span"
+                aria-label={`${streak}-day streak`}
+                sx={{
+                  fontSize: '0.7rem',
+                  fontWeight: 700,
+                  color: c.primary.main,
+                  backgroundColor: c.primary.muted,
+                  borderRadius: `${radiusTokens.sm}px`,
+                  px: 0.75,
+                  py: 0.25,
+                  lineHeight: 1.4,
+                }}
+              >
+                {streak}
+              </Box>
+            )}
+          </Box>
           <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
             <ModeToggle />
             <TrackSwitcher />


### PR DESCRIPTION
Closes #468

## Changes

- Imported `getCurrentStreak` and `radiusTokens` into `Nav.tsx`
- Added `streak` state (initialised to `0`, SSR-safe — no browser API at module scope)
- Added `useEffect` keyed on `location.pathname` that calls `getCurrentStreak()` on every route change
- **Desktop sidebar**: renders `🔥 {streak}` badge next to the branding text; collapses to `🔥` emoji only when the rail is collapsed
- **Mobile AppBar**: renders a number-only badge (`{streak}`) next to the title, which satisfies the 360 px mobile minimum fallback requirement
- `streak > 0` guard ensures nothing renders when the streak is zero
- All colours from `colorTokens[mode].primary.{main,muted}`; border-radius from `radiusTokens.sm` (4 px, well under the 8 px cap); no hardcoded hex; no box-shadows

## Test Plan

- [ ] Visit the app with no check-in history → no badge visible anywhere
- [ ] Call `recordCheckin()` from the browser console, then navigate between routes → badge appears showing `🔥 1`
- [ ] Add check-ins for consecutive past days in localStorage (key `ppl.checkins.v1`) → badge reflects the correct streak count
- [ ] On desktop with sidebar collapsed → only the flame emoji `🔥` shows in branding area
- [ ] At 360 px viewport width → mobile AppBar shows a number-only badge, no overflow
- [ ] Light mode and dark mode both render without hardcoded colours or box-shadows
- [ ] TypeScript build passes: `npm run build` exits 0