### PR TITLE
[PPL-469] Add 30-day check-in activity heatmap to Home page

### DIFF
--- a/web-app/src/components/CheckinHeatmap.tsx
+++ b/web-app/src/components/CheckinHeatmap.tsx
@@ -1,0 +1,57 @@
+import Box from '@mui/material/Box';
+import { typographyTokens } from '../tokens';
+import { getCheckins } from '../lib/checkins';
+
+const MONO = typographyTokens.fontFamily.mono;
+
+export default function CheckinHeatmap() {
+  const checkinSet = new Set(getCheckins());
+
+  const days: Array<{ date: string; studied: boolean }> = [];
+  for (let i = 29; i >= 0; i--) {
+    const d = new Date();
+    d.setDate(d.getDate() - i);
+    const date = d.toLocaleDateString('en-CA');
+    days.push({ date, studied: checkinSet.has(date) });
+  }
+
+  return (
+    <Box>
+      <Box
+        aria-label="Study activity, last 30 days"
+        sx={{
+          display: 'grid',
+          gridTemplateColumns: { xs: 'repeat(15, 1fr)', sm: 'repeat(30, 1fr)' },
+          gap: '3px',
+        }}
+      >
+        {days.map(({ date, studied }) => (
+          <Box
+            key={date}
+            aria-label={`${date}: ${studied ? 'studied' : 'not studied'}`}
+            sx={{
+              aspectRatio: '1',
+              borderRadius: '3px',
+              bgcolor: studied ? 'primary.main' : 'background.surfaceRaised',
+              opacity: studied ? 1 : 0.6,
+            }}
+          />
+        ))}
+      </Box>
+      <Box
+        sx={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          mt: '6px',
+          fontFamily: MONO,
+          fontSize: '10px',
+          color: 'text.secondary',
+          letterSpacing: '0.08em',
+        }}
+      >
+        <span>30 days ago</span>
+        <span>today</span>
+      </Box>
+    </Box>
+  );
+}

--- a/web-app/src/pages/Home.tsx
+++ b/web-app/src/pages/Home.tsx
@@ -9,6 +9,7 @@ import { CURRICULUM } from '../lib/curriculum';
 import { getLessonsByTrack } from '../lib/lesson-loader';
 import type { Lesson } from '../lib/types';
 import StatusBar, { LAST_SESSION_KEY } from '../components/home/StatusBar';
+import CheckinHeatmap from '../components/CheckinHeatmap';
 import ReadinessGauge from '../components/home/ReadinessGauge';
 import TopicCoverageGrid from '../components/home/TopicCoverageGrid';
 import NextActionCard from '../components/home/NextActionCard';
@@ -201,6 +202,10 @@ export default function Home() {
             <NextActionCard lesson={nextLesson} lastSessionAgo={lastSessionAgo} />
           </>
         )}
+
+        {/* Study Activity */}
+        <SectionHead title="Study Activity" meta="Last 30 Days" />
+        <CheckinHeatmap />
 
         {/* Topic Coverage */}
         <SectionHead title="Topic Coverage · TC Exam Weight" meta="4 Domains" />


### PR DESCRIPTION
Closes #469

## Changes

- **New:** `web-app/src/components/CheckinHeatmap.tsx` — 30-cell grid component reading check-in dates via `getCheckins()`. Builds a 30-date array ending today, stores dates in a `Set<string>` for O(1) lookup, and renders one cell per day (oldest left → today right). Uses `repeat(15, 1fr)` on mobile (two rows of 15) and `repeat(30, 1fr)` on wider screens — no horizontal overflow at 360 px. Colours use `primary.main` for studied days and `background.surfaceRaised` for empty days (both from theme, no hardcoded hex). Each cell has an `aria-label` with date + studied/not-studied state; container has `aria-label="Study activity, last 30 days"`.
- **Edit:** `web-app/src/pages/Home.tsx` — imports and renders `<CheckinHeatmap />` under a new "Study Activity · Last 30 Days" section head, placed above Topic Coverage.

## Test Plan
- [ ] Home page renders without errors in both dark and light modes
- [ ] 30 cells visible at 360 px viewport width with no horizontal scroll (two rows of 15)
- [ ] Cells for days with check-ins are amber (`primary.main`); empty days show surface colour
- [ ] `aria-label` on each cell contains the ISO date and "studied"/"not studied"
- [ ] Container has `aria-label="Study activity, last 30 days"`
- [ ] No hardcoded hex values in the component