### PR TITLE
[PPL-480] Wire up night exam track infrastructure

### DIFF
--- a/scripts/validate-lesson-schema.sh
+++ b/scripts/validate-lesson-schema.sh
@@ -26,7 +26,7 @@ REQUIRED_FIELDS = [
     "duration_min", "status", "audio", "visual",
     "sources", "questions",
 ]
-VALID_TOPICS = {"air-law", "navigation", "meteorology", "general-knowledge", "radio", "cpl-a", "helicopter"}
+VALID_TOPICS = {"air-law", "navigation", "meteorology", "general-knowledge", "radio", "cpl-a", "helicopter", "night"}
 REQUIRED_QUESTION_FIELDS = {"id", "prompt", "choices", "answer", "explanation"}
 
 def fail(path, msg):

--- a/web-app/src/lib/exam-tracks.ts
+++ b/web-app/src/lib/exam-tracks.ts
@@ -39,6 +39,15 @@ export const TRACKS: Track[] = [
     heroSubtitle: 'Air Law focus. 50 questions, 40 minutes, 90% pass mark.',
     status: 'active',
   },
+  {
+    slug: 'night',
+    label: 'Night Rating',
+    shortLabel: 'NIGHT',
+    description: 'Transport Canada Night Rating',
+    heroHeading: 'Earn your Night Rating. Twenty minutes a day.',
+    heroSubtitle: 'Focused lessons for the Transport Canada Night Rating. Audio-first, exam-weighted.',
+    status: 'active',
+  },
 ];
 
 export type TrackStatus = 'active' | 'coming-soon' | 'locked';
@@ -154,6 +163,22 @@ export const EXAM_TRACKS: ExamTrack[] = [
     lessonFilter: (l) => l.topic === 'cpl-a',
     playlistTopics: ['cpl-a'] as const,
     playlistHeading: 'CPL-A Playlist',
+  },
+  {
+    id: 'night',
+    code: 'NIGHT',
+    name: 'Night Rating',
+    tagline: 'Transport Canada Night Rating',
+    examHeading: 'Night Rating Practice',
+    status: 'active',
+    byline: 'Night Rating · 20 Min / Day',
+    heroHeading: 'Earn your Night Rating. Twenty minutes a day.',
+    heroHeadingAccent: 'Night Rating',
+    heroSubtitle: 'Structured lessons for the Transport Canada Night Rating. Audio-first, exam-weighted.',
+    credibilityTag: 'Covers TC Night Rating written exam',
+    lessonFilter: (l) => l.topic === 'night',
+    playlistTopics: ['night'] as const,
+    playlistHeading: 'Night Rating Playlist',
   },
   {
     id: 'ifr',

--- a/web-app/src/lib/types.ts
+++ b/web-app/src/lib/types.ts
@@ -1,4 +1,4 @@
-export type Topic = 'air-law' | 'navigation' | 'meteorology' | 'general-knowledge' | 'radio' | 'cpl-a' | 'helicopter';
+export type Topic = 'air-law' | 'navigation' | 'meteorology' | 'general-knowledge' | 'radio' | 'cpl-a' | 'helicopter' | 'night';
 export type LessonStatus = 'planning' | 'draft' | 'complete';
 
 export interface Question {


### PR DESCRIPTION
Closes #480

## Changes
- Added \`night\` ExamTrack entry to \`web-app/src/lib/exam-tracks.ts\` with id, code, full name, byline, tagline, examHeading, and status active
- Added \`night\` to \`TRACKS\` array in same file for hero/landing display
- Added \`night\` to the \`Topic\` union type in \`web-app/src/lib/types.ts\` so lesson/quiz items tagged night are not stripped
- Added \`night\` to \`VALID_TOPICS\` set in \`scripts/validate-lesson-schema.sh\`

## Test Plan
- Track switcher chip renders NIGHT
- Navigating to ?track=night renders track shell without runtime errors
- Home / Browse / Quiz / Final Exam / Study Plan / Listen do not break after switching to night track
- No lesson content or quiz questions authored (children 2-4 own that)