### PR TITLE
[PPL-481] Author 6 Night Rating lessons and register in curriculum

### DIFF
--- a/lessons/night/001-visual-illusions-dark-adaptation.md
+++ b/lessons/night/001-visual-illusions-dark-adaptation.md
@@ -1,0 +1,145 @@
+---
+id: NIGHT-001
+topic: night
+order: 1
+slug: visual-illusions-dark-adaptation
+title: "Visual Illusions at Night and Dark Adaptation"
+duration_min: 20
+status: draft
+audio: null
+visual: ""
+sources:
+  - TP 12880E Chapter 10
+  - CARs Part VI
+questions:
+  - id: q1
+    prompt: "Dark adaptation — the process by which the eyes become more sensitive to low light — is primarily handled by which cells in the retina?"
+    choices:
+      A: "Cones, concentrated in the fovea"
+      B: "Rods, located in the peripheral retina"
+      C: "Ganglia cells in the optic nerve"
+      D: "Both rods and cones equally"
+    answer: B
+    explanation: "Rods are the photoreceptors responsible for scotopic (low-light) vision. They are most dense in the peripheral retina, away from the fovea. Because cones (concentrated at the fovea) require brighter light, looking slightly off-centre — off-centre viewing — is the recommended technique to maximize rod use in dark conditions. Source: TP 12880E Chapter 10."
+  - id: q2
+    prompt: "A pilot looking directly at a dim object at night may find it disappears. The correct technique to counteract this is:"
+    choices:
+      A: "Increase cockpit lighting to improve contrast"
+      B: "Use off-centre viewing — look 10–15° to the side of the object"
+      C: "Close one eye to reduce glare"
+      D: "Descend to a lower altitude where ambient light is stronger"
+    answer: B
+    explanation: "Looking directly at a dim object places it on the fovea, which is rod-free. Off-centre viewing (10–15° off-axis) puts the image on the rod-rich peripheral retina, making the object visible. Source: TP 12880E Chapter 10."
+  - id: q3
+    prompt: "How long does full dark adaptation typically take for a pilot who has been exposed to bright light?"
+    choices:
+      A: "5 minutes"
+      B: "15 minutes"
+      C: "30 minutes"
+      D: "60 minutes"
+    answer: C
+    explanation: "Full dark adaptation takes approximately 30 minutes. Exposure to even a brief flash of bright light can reset the process significantly. Pilots should avoid bright light for at least 30 minutes before night flight and should use red cockpit lighting (which affects rods less than white light) to preserve night vision. Source: TP 12880E Chapter 10."
+  - id: q4
+    prompt: "Autokinesis is a visual illusion most likely to affect a pilot who:"
+    choices:
+      A: "Is flying through a rain shower at night"
+      B: "Stares at a single stationary light against a dark featureless background"
+      C: "Looks too far to the side of a landing light"
+      D: "Flies at high altitude where atmospheric pressure is low"
+    answer: B
+    explanation: "Autokinesis occurs when a pilot fixates on a single stationary point of light in an otherwise dark, featureless background. The light appears to move — even though it is stationary — after several seconds of fixation. This can cause the pilot to chase the illusion. Prevention: scan regularly; never fixate on a single light. Source: TP 12880E Chapter 10."
+  - id: q5
+    prompt: "Which of the following lighting conditions will least impair dark adaptation?"
+    choices:
+      A: "White overhead cabin lighting"
+      B: "Bright external strobe lights"
+      C: "Red cockpit instrument lighting"
+      D: "High-intensity runway edge lights"
+    answer: C
+    explanation: "Red light (long wavelength) stimulates cones but has minimal effect on rods, so it preserves dark adaptation better than white or blue-white light. Aircraft cockpits traditionally use red or low-intensity lighting for this reason. Source: TP 12880E Chapter 10."
+---
+
+# Lesson NIGHT-001: Visual Illusions at Night and Dark Adaptation
+
+**Section:** Night Rating  
+**Lesson number:** 001  
+**Estimated time:** 20 minutes  
+**Source:** TP 12880E Chapter 10
+
+---
+
+## Narration Script
+
+Welcome to Night Rating. This first lesson covers the physiology of night vision — how your eyes work in the dark, why they fail in specific ways, and what illusions can deceive you at night. Understanding this material is not just exam content — it is directly relevant to surviving night operations.
+
+---
+
+### How the Eye Works at Night
+
+Your retina contains two types of photoreceptors: **cones** and **rods**.
+
+**Cones** handle colour and fine detail. They require relatively bright light to function and are concentrated at the **fovea** — the centre of your visual field, directly where you look when you focus on something. In daylight, cones are your primary vision tool.
+
+**Rods** handle low-light, black-and-white perception. They are distributed across the peripheral retina — away from the fovea — and are roughly a thousand times more sensitive to light than cones. At night, rods are doing the heavy lifting.
+
+Here is the critical implication: **when you look directly at something at night, you are placing its image on the rod-free fovea.** The object can literally disappear.
+
+---
+
+### Off-Centre Viewing
+
+The remedy is **off-centre viewing** — also called eccentric viewing. Instead of looking directly at a dim object, look approximately 10–15 degrees to the side of it. This shifts the image off the fovea and onto the peripheral, rod-rich area of the retina. The object becomes visible.
+
+Practice this technique before you need it. If you're trying to spot a dim aircraft or a light on the ground at night and it keeps disappearing, you're looking directly at it. Move your gaze slightly off-target.
+
+---
+
+### Dark Adaptation
+
+Dark adaptation is the process by which your eyes increase sensitivity to low light levels. It happens in two stages:
+
+1. **Cone adaptation** — occurs in the first 5–7 minutes. Sensitivity improves quickly, but cones remain poor low-light sensors.
+2. **Rod adaptation** — takes up to **30 minutes** for full effect. Rhodopsin (the rod pigment) regenerates slowly after bleaching by bright light.
+
+The 30-minute figure is exam-relevant and operationally important. If you walk out of a brightly lit crew room and straight into a dark cockpit, your eyes will not be dark-adapted for half an hour.
+
+**What destroys dark adaptation:**
+- Exposure to bright white light — even a few seconds can reset the process significantly
+- Cabin overhead lighting left on white
+- Strobe lights in cloud or haze reflecting back into the cockpit
+- A phone screen at full brightness
+
+**What preserves dark adaptation:**
+- Red cockpit lighting — red wavelengths affect rods minimally. This is why traditional cockpits use red instrumentation lighting at night.
+- Keeping one eye closed briefly if unavoidable bright light occurs
+- Stepping outside wearing sunglasses before transition to low light
+
+---
+
+### Autokinesis
+
+**Autokinesis** is an illusion of movement of a stationary light source when viewed against a dark, featureless background.
+
+Here is how it happens: if you fixate on a single point of light in an otherwise black sky for more than a few seconds — no horizon, no other references — the light will appear to drift or move. This is not the light moving. It is your visual system manufacturing apparent motion in the absence of reference points.
+
+The danger: a pilot may unconsciously manoeuvre the aircraft to "follow" or "stay in formation with" a light that is actually stationary on the ground, on a tower, or on another aircraft that is holding position.
+
+**Prevention:** Do not fixate. Scan continuously. Cross-check instruments. If a light seems to be moving, look away for a moment and re-acquire it — stationary lights will return to the same position.
+
+---
+
+### The Black Hole Approach Illusion
+
+One additional illusion worth knowing for night operations: the **black hole approach** or **featureless terrain illusion**. When approaching an airport at night over dark, featureless terrain — water, flat farmland, no city lights — there are no visual cues to judge height or slope. Pilots tend to fly lower approach angles than they intend, sometimes resulting in controlled flight into terrain short of the runway threshold.
+
+The remedy: trust the PAPI or VASI lights (covered in Lesson NIGHT-003), use an instrument glide path where available, and do not rely solely on visual perception of the runway.
+
+---
+
+### Summary
+
+The night visual system depends on rods, not cones. Full dark adaptation takes 30 minutes and is destroyed by bright light. Off-centre viewing compensates for the rod-free fovea. Autokinesis is an illusion triggered by fixating on a lone light in a dark field — scan to prevent it. Night approaches over dark terrain carry the black hole illusion risk — use external references like PAPI/VASI.
+
+---
+
+*End of Lesson NIGHT-001.*

--- a/lessons/night/002-aircraft-lighting.md
+++ b/lessons/night/002-aircraft-lighting.md
@@ -1,0 +1,172 @@
+---
+id: NIGHT-002
+topic: night
+order: 2
+slug: aircraft-lighting
+title: "Aircraft Lighting — Interior and Exterior"
+duration_min: 20
+status: draft
+audio: null
+visual: ""
+sources:
+  - TP 12880E Chapter 10
+  - CARs 605.16
+  - CARs 602.30
+questions:
+  - id: q1
+    prompt: "Under CARs, when must navigation lights (position lights) be illuminated on an aircraft?"
+    choices:
+      A: "During takeoff and landing only"
+      B: "Whenever the aircraft is operated between sunset and sunrise"
+      C: "Only when flying in controlled airspace"
+      D: "Whenever visibility is less than 3 statute miles"
+    answer: B
+    explanation: "CARs 605.16 requires navigation lights to be operating on any aircraft operated between sunset and sunrise. This includes taxiing, not just flight. Source: CARs 605.16, TP 12880E Chapter 10."
+  - id: q2
+    prompt: "The standard navigation light colours on a fixed-wing aircraft are:"
+    choices:
+      A: "Red on the right wingtip, green on the left, white on the tail"
+      B: "Green on the right wingtip, red on the left, white on the tail"
+      C: "White on both wingtips, red on the tail"
+      D: "Red on the left wingtip, green on the right, amber on the tail"
+    answer: B
+    explanation: "Navigation lights follow the maritime convention: green (starboard) on the right wingtip, red (port) on the left wingtip, and white on the tail. A useful memory aid: 'red light means left' — red is on the left. Source: CARs 605.16, TP 12880E Chapter 10."
+  - id: q3
+    prompt: "When observing another aircraft showing only a red light on your left and a white light on your right, the aircraft is:"
+    choices:
+      A: "Flying toward you"
+      B: "Flying away from you"
+      C: "Crossing from right to left"
+      D: "Crossing from left to right"
+    answer: D
+    explanation: "Red on your left = the other aircraft's left wingtip is closest to you on its left side, white on your right = you are seeing its tail from an angle. The aircraft is crossing from left to right in front of you. Tracking the nav lights to determine relative geometry is a critical night-flight skill. Source: TP 12880E Chapter 10."
+  - id: q4
+    prompt: "A pilot is about to depart on a night VFR flight. The aircraft anti-collision beacon is inoperative. Which statement is correct under CARs?"
+    choices:
+      A: "Night VFR flight may proceed if the pilot-in-command determines the flight is safe"
+      B: "Flight is permitted as long as navigation lights are functioning"
+      C: "The aircraft is unairworthy for night flight and may not depart"
+      D: "The pilot must notify ATC before departure, after which the flight may proceed"
+    answer: C
+    explanation: "The anti-collision beacon is required equipment for night flight under CARs 605.16. An inoperative anti-collision beacon renders the aircraft unairworthy for night operations. Minimum equipment provisions do not permit deferral of lights required for the type of flight being conducted. Source: CARs 605.16."
+  - id: q5
+    prompt: "Landing lights are required by CARs for aircraft operating at night in:"
+    choices:
+      A: "All night VFR operations"
+      B: "Controlled airspace only"
+      C: "Air taxi and commercial operations"
+      D: "No specific operations — they are recommended but not required for private VFR"
+    answer: C
+    explanation: "CARs require landing lights for air taxi, commuter operations, and aircraft used in commercial operations at night. Private VFR aircraft are not required to carry a landing light under the basic night VFR rules, though it is strongly recommended for safety. Source: CARs 605.16, TP 12880E Chapter 10."
+---
+
+# Lesson NIGHT-002: Aircraft Lighting — Interior and Exterior
+
+**Section:** Night Rating  
+**Lesson number:** 002  
+**Estimated time:** 20 minutes  
+**Source:** TP 12880E Chapter 10, CARs 605.16
+
+---
+
+## Narration Script
+
+This lesson covers the lighting equipment on the aircraft itself — what it is, where it goes, what it's required for, and how to use it to track other traffic at night. This material appears directly on the Night Rating exam.
+
+---
+
+### Exterior Lighting — Navigation Lights (Position Lights)
+
+**Navigation lights** — also called position lights — are the red, green, and white lights on the wingtips and tail of the aircraft. They serve one purpose: allow other pilots to determine your position and direction of travel from a distance.
+
+The colour convention follows maritime tradition:
+- **Red** — left (port) wingtip
+- **Green** — right (starboard) wingtip
+- **White** — tail (rear-facing)
+
+Memory hook: **"Port wine is red"** — port (left) is red.
+
+**Visibility requirement:** Each light must be visible through a defined arc. The red and green lights cover 110 degrees each on their respective sides. The white tail light covers 140 degrees rearward, overlapping slightly to ensure no gap in coverage.
+
+**When required:** CARs 605.16 requires navigation lights to be operating on any aircraft operated between **sunset and sunrise** — this includes ground operations (taxiing), not just airborne flight.
+
+---
+
+### Reading Traffic at Night Using Nav Lights
+
+Understanding what colour combination you see tells you the other aircraft's orientation relative to you.
+
+| What you see | What it means |
+|---|---|
+| Green only | Aircraft's right side is toward you — it's moving away to your left |
+| Red only | Aircraft's left side is toward you — it's moving away to your right |
+| Both red and green | Aircraft is heading toward you (head-on) |
+| White only | You are seeing the aircraft's tail — it's moving away from you |
+| Red left + white right | Aircraft is crossing from left to right — has right-of-way |
+| Green left + white right | Aircraft is crossing from right to left — you have right-of-way |
+
+In practice, tracking the movement of nav lights against the star background allows you to determine closure rate and crossing geometry. If a light is not moving in your windscreen, you are on a collision course.
+
+---
+
+### Anti-Collision Lights
+
+**Anti-collision lights** are high-intensity flashing lights designed to make the aircraft conspicuous. There are two types:
+
+1. **Rotating beacon** — an older-style red rotating light, typically mounted on the top of the fuselage. It flashes as it rotates.
+2. **Strobe lights** — high-intensity white xenon strobe lights on the wingtips and tail. These are more effective and have largely replaced beacons on modern aircraft.
+
+**When required:** CARs 605.16 requires anti-collision lights to be operating from sunset to sunrise. The anti-collision system (beacon or strobe) is mandatory equipment for night flight — an inoperative anti-collision light grounds the aircraft for night operations.
+
+**Operational note:** Strobe lights should be **turned off** when taxiing near other aircraft, when entering cloud (they create disorienting reflections), and when operating in fog or precipitation. The rotating beacon can remain on during ground operations.
+
+---
+
+### Landing Light
+
+The **landing light** is a powerful forward-facing light used during approach and landing to illuminate the runway environment.
+
+For **private VFR night operations**, a landing light is not strictly required by CARs — but Transport Canada strongly recommends it. For **air taxi and commercial night operations**, a landing light is required.
+
+Operational tips:
+- Turn on the landing light on final approach and during landing
+- Use it on takeoff for terrain awareness and to be seen by other traffic
+- Turn it off at cruise altitude — it consumes significant electrical power and its beam reaches nothing useful
+- Check its serviceability on your pre-flight inspection — a burned-out landing light can severely complicate a night landing
+
+---
+
+### Interior Lighting — Cockpit Illumination
+
+Cockpit lighting at night must balance two competing needs: you need enough light to read instruments, but you want to preserve your dark adaptation for seeing outside.
+
+**Red instrument lighting** — traditional solution. Red light allows instrument reading while minimally affecting rod dark adaptation. Many older aircraft instrument panels use red backlighting.
+
+**White/dimmed lighting** — modern glass cockpits use fully dimmable white displays. Set brightness to the lowest usable level.
+
+**Avoid:** white overhead dome lights on full brightness, bright tablet or phone screens, bright flashlights shone at the instrument panel. Any of these will significantly impair your ability to see outside after you look up.
+
+**Flashlight (torch):** Carry one, and preferably carry a red-filter flashlight. You should be able to access charts, checklists, and the cockpit if the panel lighting fails. A dead flashlight on a night flight is a serious problem — carry a backup.
+
+---
+
+### Taxi Light
+
+Many aircraft have a **taxi light** — a white forward-facing light on the nose gear or cowling, less powerful than the landing light, used during ground operations. On aircraft without a separate taxi light, the landing light may be used for taxiing, though this increases wear on the bulb.
+
+---
+
+### Pre-Flight Lighting Checks
+
+Before any night flight, verify:
+- All navigation lights operational (walk around and check each one)
+- Anti-collision beacon and/or strobes operational
+- Landing light operational (if fitted)
+- Cockpit lighting functional and dimmable
+- Flashlight accessible and batteries checked
+
+A failed nav light discovered mid-flight cannot be fixed from the cockpit. Check before you depart.
+
+---
+
+*End of Lesson NIGHT-002.*

--- a/lessons/night/003-aerodrome-lighting.md
+++ b/lessons/night/003-aerodrome-lighting.md
@@ -1,0 +1,196 @@
+---
+id: NIGHT-003
+topic: night
+order: 3
+slug: aerodrome-lighting
+title: "Aerodrome Lighting — PAPI, VASI, Runway and Beacon"
+duration_min: 20
+status: draft
+audio: null
+visual: ""
+sources:
+  - TP 12880E Chapter 10
+  - AIM AIR 4.0
+  - Transport Canada Aerodrome Standards
+questions:
+  - id: q1
+    prompt: "You are on final approach. The PAPI shows three white lights and one red light. This indicates:"
+    choices:
+      A: "You are slightly above the glide path"
+      B: "You are on the correct glide path"
+      C: "You are significantly below the glide path"
+      D: "You are significantly above the glide path"
+    answer: A
+    explanation: "On a standard 4-light PAPI: 4 white = high; 3 white + 1 red = slightly high; 2 white + 2 red = on glidepath; 1 white + 3 red = slightly low; 4 red = dangerously low. Three white / one red means slightly high — lower slightly to intercept the glide path. Source: TP 12880E Chapter 10, AIM AIR 4.0."
+  - id: q2
+    prompt: "An aerodrome rotating beacon showing alternating white and green flashes indicates:"
+    choices:
+      A: "A military aerodrome"
+      B: "A land airport (civilian)"
+      C: "A water aerodrome (seaplane base)"
+      D: "A hospital helipad"
+    answer: B
+    explanation: "White + green alternating flashes = civilian land airport. White + white = military aerodrome. Yellow + white = water aerodrome (seaplane base). White alone (steady) = an obstruction beacon, not an aerodrome. Source: TP 12880E Chapter 10, AIM."
+  - id: q3
+    prompt: "Runway edge lights on an instrument runway are:"
+    choices:
+      A: "White throughout, with red lights at the threshold"
+      B: "White for most of the length, changing to yellow in the last 600 m (2,000 ft) before the far end"
+      C: "Green throughout"
+      D: "Amber throughout"
+    answer: B
+    explanation: "Runway edge lights are white. The final 600 m (approximately 2,000 ft) before the far-end threshold are yellow, warning the pilot that the end of the runway is approaching. Threshold lights are green (facing approach) and red (facing rollout). Source: AIM AIR 4.0, TP 12880E Chapter 10."
+  - id: q4
+    prompt: "Threshold lights — the lights marking the beginning of the usable landing surface — are which colour as seen by an approaching pilot?"
+    choices:
+      A: "White"
+      B: "Red"
+      C: "Green"
+      D: "Amber"
+    answer: C
+    explanation: "Threshold lights are green when seen from the approach side (they mark where you may land). The same light fixtures are red when seen from the runway side (looking back toward the threshold from a rollout or go-around), warning that you have passed the usable landing area. Source: AIM AIR 4.0."
+  - id: q5
+    prompt: "An aerodrome identification beacon flashes the airport's identifier in Morse code. At what colour does it flash on a civilian land aerodrome?"
+    choices:
+      A: "Red"
+      B: "Green"
+      C: "White"
+      D: "Yellow"
+    answer: B
+    explanation: "Aerodrome identification beacons flash the airport's two-letter identifier in Morse code in green. They are used to help pilots positively identify an aerodrome at night, especially in areas with multiple airports. Source: AIM AIR 4.0."
+---
+
+# Lesson NIGHT-003: Aerodrome Lighting — PAPI, VASI, Runway and Beacon
+
+**Section:** Night Rating  
+**Lesson number:** 003  
+**Estimated time:** 20 minutes  
+**Source:** TP 12880E Chapter 10, Transport Canada AIM AIR 4.0
+
+---
+
+## Narration Script
+
+This lesson covers the ground lighting systems that make night landing possible — approach slope indicators, runway markings, taxiway lights, and aerodrome beacons. You will be tested on this material, and you will use it on every night flight.
+
+---
+
+### Visual Approach Slope Indicators
+
+The most important lights for a night approach are the **visual approach slope indicators** — systems that tell you whether you are above, on, or below the correct glide path.
+
+#### PAPI — Precision Approach Path Indicator
+
+PAPI is the current Canadian standard. It consists of four lights in a horizontal row on the left side of the runway. Each light box contains optics that project red below a threshold angle and white above it, so that your angle of view determines the colour you see.
+
+**Reading the PAPI:**
+
+| Lights seen | Meaning |
+|---|---|
+| 4 white | Significantly above glide path — go lower |
+| 3 white + 1 red | Slightly above glide path — lower slightly |
+| 2 white + 2 red | **On glide path** |
+| 1 white + 3 red | Slightly below glide path — climb |
+| 4 red | Significantly below glide path — danger, climb immediately |
+
+Memory hook: **"White = high, red = dead"** — the more red you see, the lower (and more dangerous) your situation. Four red is a ground proximity warning situation.
+
+The standard glide path angle is **3 degrees**. PAPI systems are typically calibrated to provide adequate obstacle clearance only when you are at the correct lateral position on final approach — a wide approach may give misleading indications.
+
+#### VASI — Visual Approach Slope Indicator
+
+VASI is an older system still found at some aerodromes. It uses two bars of lights — an upwind bar and a downwind bar — each of which displays red or white depending on your angle.
+
+**Reading the VASI:**
+
+| Near bar | Far bar | Meaning |
+|---|---|---|
+| White | White | Above glide path |
+| White | Red | On glide path |
+| Red | Red | Below glide path |
+
+Memory hook: **"Red over white — you're all right. Red over red — you're dead."**
+
+If you find yourself at an unfamiliar aerodrome with a VASI instead of a PAPI, apply the same principle: match the "on glide path" indication before correcting.
+
+---
+
+### Runway Lighting
+
+#### Runway Edge Lights
+
+Runway edge lights are white lights placed on both sides of the runway, defining its width and length. They are spaced at regular intervals.
+
+Key detail: the **last 600 metres (approximately 2,000 feet)** of runway edge lights before the far-end threshold are **yellow**. This is the caution zone — the runway is ending. If you see yellow edge lights during a landing rollout, you are using up the last portion of the usable surface.
+
+#### Threshold Lights
+
+Threshold lights mark the beginning of the usable landing surface:
+- **Green** facing the approach — you see green on final, telling you this is where the usable runway starts
+- **Red** facing the runway — if you look back from the rollout or from a low go-around, you see red, meaning you have passed the threshold
+
+The same fixtures project two colours in opposite directions.
+
+#### Runway End Lights
+
+Red lights mark the far end of the runway, facing the landing direction. These tell you the runway has ended. In night operations, if you see red runway end lights approaching during your rollout, you are near the end of the pavement.
+
+#### Touchdown Zone Lights
+
+Higher-category instrument runways have **touchdown zone lights** — white lights embedded in the pavement in the first 900 metres of the runway, helping pilots identify the touchdown zone during instrument approaches in low visibility. You may encounter these at larger controlled airports.
+
+---
+
+### Taxiway Lighting
+
+Taxiway edge lights are **blue**. This is a firm association to memorize: blue lights on the ground at night = taxiway. They define the edges of taxiways and help you navigate from the runway to the apron after landing.
+
+**Taxiway centreline lights** — where installed — are green.
+
+**Stop bar lights** — red lights across a taxiway at a runway hold position. When illuminated, they mean stop and do not cross onto the runway. Stop bars are a critical safety feature at complex controlled airports at night and in low visibility.
+
+---
+
+### Aerodrome Rotating Beacon
+
+The rotating beacon is mounted at a prominent location on the aerodrome and continuously rotates, producing flashes visible from the air.
+
+**Flash code by aerodrome type:**
+
+| Flash combination | Aerodrome type |
+|---|---|
+| Alternating white + green | Civilian land aerodrome |
+| Two whites + one green | Military aerodrome |
+| Alternating white + yellow | Water aerodrome (seaplane base) |
+
+The beacon helps you positively identify and locate an aerodrome at night — particularly useful when flying cross-country and identifying which airport is which among several in a metropolitan area.
+
+At **controlled aerodromes**, the beacon being illuminated during the day has a specific meaning: it signals that the aerodrome is below VFR minimums and IFR conditions prevail. At night, the beacon is usually on regardless of weather conditions.
+
+---
+
+### Aerodrome Identification Beacon
+
+Separate from the rotating beacon, some aerodromes have an **identification beacon** that flashes the airport's two-letter identifier in Morse code, in **green**, allowing positive identification.
+
+---
+
+### Apron and Ramp Lighting
+
+Aprons are often lit with high-pressure sodium or LED floodlights. These provide bright illumination for fuelling and parking but can be disorienting relative to surrounding darkness. Be cautious moving from a brightly lit apron area into a dark taxiway — your dark adaptation will be temporarily compromised.
+
+---
+
+### Pilot-Controlled Lighting (PCL)
+
+At many uncontrolled aerodromes, runway lights are not left on permanently — they are activated by the pilot using the radio. This is **Pilot-Controlled Lighting (PCL)**:
+
+- Tune the Common Traffic Advisory Frequency (CTAF) for the aerodrome
+- Key the microphone a specified number of times (usually 3, 5, or 7 times) within 5 seconds
+- The lights illuminate for 15 minutes
+
+The CFS (Canada Flight Supplement) entry for each aerodrome specifies the PCL frequency and keying sequence. Check this before a night arrival at an unfamiliar uncontrolled aerodrome — arriving at a dark airport with no lighting and no advance plan is a serious hazard.
+
+---
+
+*End of Lesson NIGHT-003.*

--- a/lessons/night/004-night-navigation.md
+++ b/lessons/night/004-night-navigation.md
@@ -1,0 +1,174 @@
+---
+id: NIGHT-004
+topic: night
+order: 4
+slug: night-navigation
+title: "Night Navigation"
+duration_min: 20
+status: draft
+audio: null
+visual: ""
+sources:
+  - TP 12880E Chapter 10
+  - CARs 602.115
+  - AIM NAV
+questions:
+  - id: q1
+    prompt: "When planning a night VFR cross-country flight, which of the following is the most important additional consideration compared to a day flight?"
+    choices:
+      A: "Filing a detailed PIREP before departure"
+      B: "Ensuring adequate en-route terrain clearance and identifying lit checkpoints"
+      C: "Requesting a Special VFR clearance through all controlled airspace"
+      D: "Carrying a minimum of 1 hour of additional fuel"
+    answer: B
+    explanation: "At night, pilotage (identifying ground features) is severely degraded. Terrain clearance must be calculated with extra margin since unlighted obstacles are invisible, and checkpoints must be identified in advance as features that will be visible at night (towns, lit roads, bodies of water reflecting moonlight). Source: TP 12880E Chapter 10."
+  - id: q2
+    prompt: "Under Canadian night VFR rules, the minimum altitude over built-up areas at night is:"
+    choices:
+      A: "The same as daytime VFR — 1,000 ft above the highest obstacle within 2,000 ft"
+      B: "500 ft above the highest obstacle within 600 m"
+      C: "Night VFR has no specific minimum altitude rule beyond the standard VFR minimums"
+      D: "2,000 ft AGL at all times"
+    answer: A
+    explanation: "The night VFR minimum altitude rules in CARs are the same as the daytime low-altitude rules — 1,000 ft above the highest obstacle within 2,000 ft horizontally for built-up areas, and 500 ft AGL elsewhere. However, practical night navigation requires greater margins because unlighted obstacles are invisible. Source: CARs 602.14, TP 12880E Chapter 10."
+  - id: q3
+    prompt: "A pilot is tracking a highway at night and notices the road curves significantly to the left. When using pilotage at night, the pilot should:"
+    choices:
+      A: "Turn left to follow the road — roads are reliable linear features at night"
+      B: "Cross-check the heading with the directional gyro and planned track before adjusting course"
+      C: "Climb to a higher altitude to get a broader view of the terrain"
+      D: "Switch to GPS and abandon pilotage entirely"
+    answer: B
+    explanation: "At night, pilotage can be unreliable — lit roads, rivers, and towns can be misidentified. A highway that appears to curve may be a different road than the one you're tracking. Cross-check any visual observation with instruments (heading, track, elapsed time, GPS) before adjusting course. Source: TP 12880E Chapter 10."
+  - id: q4
+    prompt: "At night, which natural feature is most useful as a navigation checkpoint?"
+    choices:
+      A: "Forests, which appear as large dark patches"
+      B: "Bodies of water, which reflect moonlight and artificial light"
+      C: "Mountain peaks, which are silhouetted against the sky"
+      D: "Unharvested agricultural fields"
+    answer: B
+    explanation: "Bodies of water — lakes, rivers, coastal features — are among the most reliable night visual checkpoints because they reflect light well and create high contrast against surrounding dark terrain. Towns and lit highways are also useful. Unlighted natural features like forests and fields are difficult or impossible to identify at night. Source: TP 12880E Chapter 10."
+  - id: q5
+    prompt: "Before a night cross-country VFR flight, a pilot should specifically plan which of the following for each intended destination and alternate?"
+    choices:
+      A: "Night fuel pricing at destination"
+      B: "Whether the destination aerodrome has pilot-controlled lighting (PCL) and the CTAF frequency"
+      C: "ILS availability in case of deteriorating weather"
+      D: "Nearest VOR and its frequency"
+    answer: B
+    explanation: "Arriving at an uncontrolled aerodrome at night with no lighting and no plan to activate it is a serious hazard. The Canada Flight Supplement (CFS) lists PCL frequencies and keying codes. A pre-flight check of PCL availability and CTAF frequency is essential for every uncontrolled aerodrome night arrival. Source: AIM, TP 12880E Chapter 10."
+---
+
+# Lesson NIGHT-004: Night Navigation
+
+**Section:** Night Rating  
+**Lesson number:** 004  
+**Estimated time:** 20 minutes  
+**Source:** TP 12880E Chapter 10, CARs 602.14
+
+---
+
+## Narration Script
+
+Night navigation uses the same fundamental tools as day navigation — dead reckoning, pilotage, radio aids, GPS — but the environment limits your options significantly. Ground features that are obvious in daylight disappear at night. Obstacles you can see and avoid in the day become invisible hazards. This lesson covers how to adapt your navigation strategy for night operations.
+
+---
+
+### What Changes at Night
+
+The core challenge of night navigation is the **degradation of visual situational awareness**. During the day, you can look out the window and continuously monitor your position, terrain clearance, proximity to obstacles, and general geography. At night, you lose most of this.
+
+Specific things you lose:
+- Horizon reference in all but the brightest moonlit conditions
+- Recognition of terrain features (hills, valleys, ridge lines)
+- Identification of unlighted obstacles (towers, wires, ridges)
+- The ability to "see" weather developing around you until it affects your instruments or blocks stars
+
+What you retain or gain:
+- Town lighting — cities, towns, villages appear as clusters of light
+- Road networks — highways are often visible from their vehicle traffic and roadside lighting
+- Body of water features — lakes and rivers reflect ambient and moon light
+- Aerodrome beacons — rotating beacons are visible from considerable distance
+- Instrument panel — instruments become more, not less, important
+
+---
+
+### Pre-Flight Planning for Night Navigation
+
+Night cross-country planning requires extra steps beyond your normal VFR planning:
+
+**1. Identify lit checkpoints along the route**
+
+Plot your course and identify, at each waypoint, what you will actually be able to see at night. Towns and their light clusters are the best checkpoints. Major lit highway junctions work. Large bodies of water work. Forests, agricultural fields, and unlighted terrain do not.
+
+Note the expected time over each checkpoint and the heading you expect to maintain between them. If you are not over a checkpoint when expected, you need to know before committing further.
+
+**2. Calculate terrain clearance with extra margin**
+
+The minimum altitude rules are the same day and night (CARs 602.14: 1,000 ft over the highest obstacle within 2,000 ft horizontally in built-up areas; 500 ft AGL elsewhere). But unlighted terrain and towers are invisible at night. Transport Canada recommends selecting a cruise altitude that provides extra terrain clearance — typically 1,000 ft above the minimum, especially over hilly or mountainous terrain.
+
+**3. Identify each destination aerodrome's lighting system**
+
+Check the CFS entry for each aerodrome you plan to use — destination, alternate, and fuel stops:
+- Does it have pilot-controlled lighting (PCL)?
+- What is the PCL frequency and keying sequence?
+- Does it have a rotating beacon?
+- What are the runway lights (edge lights, PAPI)?
+
+Arriving at a dark aerodrome because you didn't pre-brief the PCL frequency is an avoidable error.
+
+**4. Plan for your fuel stop before dark if possible**
+
+Refuelling at an unfamiliar aerodrome at night is more difficult than in daylight. Plan refuelling stops at familiar or well-lit aerodromes where the ramp layout is clear.
+
+---
+
+### Airborne Navigation Techniques
+
+#### Dead Reckoning and Instrument Cross-Check
+
+At night, dead reckoning becomes more important than it is during the day. Maintain accurate tracking of:
+- Heading (cross-check directional gyro against compass regularly)
+- Elapsed time since last checkpoint
+- Expected ground speed
+
+If you are not over a checkpoint at the expected time, fly your planned heading and time before assuming you are off course — wind variation may have slowed you, not necessarily drifted you sideways.
+
+#### Using Lit Features
+
+As you approach a lit town or road junction you identified as a checkpoint, confirm it matches what you planned. Look for the specific geometry — a town at the intersection of two highways looks different from a single-road town. The aerodrome beacon is your best specific identifier for a destination aerodrome.
+
+If a feature doesn't look right, don't commit to it. Cross-check GPS or distance from the last known position before assuming you have found your checkpoint.
+
+#### Attitude and Terrain Avoidance
+
+In dark areas without a visual horizon, your primary attitude reference is your flight instruments. Maintain controlled, coordinated flight using the attitude indicator. Do not allow yourself to be distracted by external features to the point of neglecting instrument scan — spatial disorientation at night can develop quickly.
+
+If at any point you become unsure of your terrain clearance, climb. Height is your primary protection against unlighted obstacles.
+
+---
+
+### Radio Navigation and GPS at Night
+
+**VOR** — VOR navigation is unaffected by darkness and is an excellent cross-check. Use VOR radials to confirm your position when passing abeam a station.
+
+**GPS** — GPS is your most reliable position reference at night. Cross-reference GPS groundspeed and track against your dead reckoning and visual checkpoints. Note that GPS gives you position but does not give you terrain clearance directly — your sectional chart and altitude planning remain essential.
+
+**ATC assistance** — En route, ATC can provide radar identification and position confirmation if you are in controlled airspace or can reach a radar-equipped facility. If you become disoriented or uncertain of position at night, declaring a PAN-PAN or MAYDAY and requesting radar vectors is the correct action.
+
+---
+
+### Night Currency
+
+You cannot legally fly at night without current night flying experience. Night currency requirements are covered in Lesson NIGHT-006. Before any night cross-country, verify your logbook currency.
+
+---
+
+### Summary
+
+Night navigation demands more pre-flight planning, greater reliance on instruments and dead reckoning, extra terrain clearance margins, and careful pre-briefing of aerodrome lighting systems. Lit checkpoints replace visual terrain identification. Height protects against unseen obstacles.
+
+---
+
+*End of Lesson NIGHT-004.*

--- a/lessons/night/005-night-emergency-procedures.md
+++ b/lessons/night/005-night-emergency-procedures.md
@@ -1,0 +1,189 @@
+---
+id: NIGHT-005
+topic: night
+order: 5
+slug: night-emergency-procedures
+title: "Night Emergency Procedures"
+duration_min: 20
+status: draft
+audio: null
+visual: ""
+sources:
+  - TP 12880E Chapter 10
+  - CARs 602.131
+  - Transport Canada AIP Canada
+questions:
+  - id: q1
+    prompt: "You experience a complete electrical failure at night. The FIRST action should be:"
+    choices:
+      A: "Declare a MAYDAY immediately on 121.5 MHz"
+      B: "Execute the engine-out procedure from memory"
+      C: "Attempt to restore electrical power by resetting circuit breakers and switching buses"
+      D: "Turn on the emergency locator transmitter (ELT)"
+    answer: C
+    explanation: "A total electrical failure at night is serious but the first response is to attempt restoration of electrical power — reset circuit breakers, switch the bus selector (if equipped), check the master switch and alternator switch. Many apparent total failures are caused by a tripped breaker or a failed alternator that can be reset. If power cannot be restored, declare an emergency. Source: TP 12880E Chapter 10."
+  - id: q2
+    prompt: "During a night forced landing following engine failure, after selecting an area and setting the aircraft up for landing, a pilot should:"
+    choices:
+      A: "Turn off all remaining lights to avoid identification by emergency services"
+      B: "Keep the landing light off to preserve battery for the radio"
+      C: "Turn on the landing light when committed to the landing area, at a low altitude where it will illuminate the surface"
+      D: "Maintain instrument references only and not use the landing light, which may cause spatial disorientation"
+    answer: C
+    explanation: "In a night forced landing, the landing light should be turned on at low altitude when committed to the landing area. It is of limited use at altitude (beam reaches nothing), but on short final it can reveal the surface condition. Timing the switch-on is important — too early and battery drain is wasted; too late and you won't benefit from what it reveals. Source: TP 12880E Chapter 10."
+  - id: q3
+    prompt: "When selecting an emergency landing area at night following engine failure, the preferred initial reference is:"
+    choices:
+      A: "A large dark area (likely flat terrain with no obstacles)"
+      B: "The glow of a town or city as a navigation reference to reach a known airport"
+      C: "A lit road or highway, which can serve as an emergency landing strip"
+      D: "Any area away from built-up regions to avoid populated zones"
+    answer: C
+    explanation: "At night with an engine failure, a lit road or highway is the preferred forced landing site if a proper airport cannot be reached — the surface is known to be paved, relatively flat, and free of major obstacles in the direction of traffic. A dark area could be anything. Towns indicate civilization but not necessarily a safe landing surface. Source: TP 12880E Chapter 10."
+  - id: q4
+    prompt: "A pilot becomes spatially disoriented at night in IMC. The correct response is:"
+    choices:
+      A: "Transition to visual flight by looking outside for the horizon"
+      B: "Trust the body's sense of attitude and maintain the perceived level flight"
+      C: "Trust the attitude indicator exclusively and make slow, deliberate corrections"
+      D: "Immediately declare an emergency and initiate a spiral descent to get below cloud"
+    answer: C
+    explanation: "Spatial disorientation occurs when the vestibular system contradicts the instruments. The vestibular system is wrong in this situation — the instruments are right. The correct response is to trust the attitude indicator, make slow deliberate corrections, and not attempt to chase the felt sensation. Trusting bodily sensation in IMC is fatal. Source: TP 12880E Chapter 10."
+  - id: q5
+    prompt: "Emergency frequency 121.5 MHz is monitored by:"
+    choices:
+      A: "ATC towers only"
+      B: "ATC radar facilities, most airliners, and search and rescue satellites (Cospas-Sarsat)"
+      C: "Military aircraft and Nav Canada only"
+      D: "Civil aircraft voluntarily on a best-effort basis"
+    answer: B
+    explanation: "121.5 MHz (international aeronautical emergency frequency) is monitored by ATC radar facilities, and most commercial airliners carry it on a second receiver. The Cospas-Sarsat satellite system also monitors 121.5 MHz from ELTs. A MAYDAY on 121.5 MHz has the broadest possible reach. Source: TP 12880E Chapter 10, AIP Canada."
+---
+
+# Lesson NIGHT-005: Night Emergency Procedures
+
+**Section:** Night Rating  
+**Lesson number:** 005  
+**Estimated time:** 20 minutes  
+**Source:** TP 12880E Chapter 10, CARs 602.131
+
+---
+
+## Narration Script
+
+Night emergencies are handled with the same principles as day emergencies — aviate, navigate, communicate — but every step is harder. The lack of visual references, limited ability to see the surface, and increased risk of spatial disorientation make night emergencies more demanding. This lesson covers the adaptations night requires.
+
+---
+
+### The Three-Step Priority: Aviate, Navigate, Communicate
+
+This hierarchy does not change at night. Every emergency, including at night, starts with flying the aircraft.
+
+**Aviate first:** If the engine fails, glide attitude first. If you become disoriented, recover to controlled flight first. The aircraft must remain flyable before anything else matters.
+
+**Navigate second:** Once control is assured, determine where you are, where you can safely go, and select an emergency landing area.
+
+**Communicate third:** Once you have control and a plan, declare your emergency. A MAYDAY or PAN-PAN on 121.5 MHz reaches the widest possible audience — ATC, commercial airliners overhead, search and rescue systems.
+
+---
+
+### Engine Failure at Night
+
+An engine failure at night follows the same memory drill as in the day. Know your aircraft's memory items cold. The difference: your selection of a forced landing area is severely constrained.
+
+#### Immediate Actions (Memory Items)
+
+Verify engine-out memory items per your aircraft's Pilot Operating Handbook (POH). Generically:
+1. Best glide speed — establish immediately
+2. Fuel — switch tanks, check fuel selector on
+3. Mixture — full rich
+4. Magnetos — check BOTH
+5. Primer — locked
+6. Carburettor heat — apply if applicable
+7. Attempt restart
+
+If restart is unsuccessful, declare MAYDAY on 121.5 MHz and advise your position, altitude, and intentions.
+
+#### Selecting a Forced Landing Area at Night
+
+This is where night makes everything harder. Your options, in order of preference:
+
+1. **A nearby aerodrome** — if one is within gliding distance, go there. You know the surface, there are lights, there may be emergency services available. If the aerodrome has PCL, activate it on the CTAF immediately.
+
+2. **A lit road or highway** — a lit road means traffic, which means a paved surface. It is a known flat area in the direction of traffic flow. Risks: vehicles on the road, intersections, overhead wires at underpasses, lamp posts. Declare MAYDAY so ATC can alert emergency services.
+
+3. **A large dark area** — dark may be a field or dark may be a pond, a ravine, or anything. A featureless dark area should be last resort. If moonlight is available and the dark area is clearly flat and large, it is preferable to water or trees.
+
+#### Using the Landing Light
+
+The landing light during a night forced landing:
+- At altitude during glide: it illuminates nothing useful beyond 100 metres. Conserve battery.
+- At low altitude on final approach to your chosen area: turn it on. It may reveal the surface condition — obstacles, terrain slope, standing water. Even if it reveals bad news, you have time to adjust.
+- If the battery is failing or you have no electrical power remaining, the landing light may not be available. Plan accordingly.
+
+---
+
+### Electrical Failure at Night
+
+A complete electrical failure at night is a serious emergency. You lose:
+- All radio communication
+- Navigation lights (making you invisible to other traffic)
+- Instrument lighting (though a flashlight can substitute)
+- Electric fuel pump (if fitted)
+- Transponder
+
+**Immediate action:** Attempt to restore power. Reset the master switch, alternator switch, and check circuit breakers. Many failures are partial — a tripped alternator breaker or a failed alternator field that can be reset.
+
+If power cannot be restored:
+- Switch to a handheld radio if carried (strongly recommended for night flying)
+- Use a flashlight or headlamp for instrument illumination
+- Squawk 7600 (loss of communication) on the transponder if it has battery backup
+- Land at the nearest suitable aerodrome using visual signals if at a controlled airport
+
+Navigation lights being off at night makes you invisible to other traffic. Minimize your time in the air and avoid high-traffic areas. File a MAYDAY on 121.5 MHz using a handheld radio if available.
+
+---
+
+### Fire at Night
+
+Engine fire or cabin fire at night follows the same emergency drill as day — but the darkness makes identification of smoke and flame from outside more difficult. You may smell smoke or see flames before you see discolouration that would be visible in daylight.
+
+If you see an orange glow ahead or beside the cowling at night, that is fire. Execute your aircraft's emergency checklist immediately. Electrical fires in the cockpit may be identified by burning insulation smell before visible flame.
+
+---
+
+### Spatial Disorientation
+
+Spatial disorientation is significantly more likely at night than during the day, particularly in:
+- Reduced visibility or hazy conditions
+- Overwater flight with no horizon
+- Flight over dark, unlighted terrain
+- Entry into cloud or IMC
+
+The vestibular (inner ear) system is reliable during sustained, constant-rate turns and gentle accelerations — the exact conditions common in inadvertent IMC entry. You will feel level when you are in a banked spiral, and you will feel like you are turning when you recover to level flight.
+
+**Rule: when instruments disagree with your body's sense, the instruments are right. Always.**
+
+If you become spatially disoriented:
+1. Focus on the attitude indicator
+2. Level the wings — slowly and deliberately
+3. Establish a positive climb if at low altitude
+4. Do not trust what you feel — trust what you see on the instruments
+5. Declare MAYDAY if in IMC or unable to recover
+
+---
+
+### Communication During Night Emergencies
+
+**121.5 MHz** is the international aeronautical distress frequency. Monitor it as a second frequency or primary if leaving controlled airspace. All ATC radar facilities and most commercial airliners monitor 121.5 MHz.
+
+**MAYDAY call format:**
+> "MAYDAY MAYDAY MAYDAY, [callsign], [nature of emergency], [position], [altitude], [intentions], [number of persons on board]"
+
+If unsure of position, give your best estimate — ATC can help refine it with radar.
+
+A handheld VHF radio is valuable night safety equipment. If the aircraft radio fails with electrical power, a handheld allows communication on 121.5 MHz and the local area frequency.
+
+---
+
+*End of Lesson NIGHT-005.*

--- a/lessons/night/006-night-cars-regulations.md
+++ b/lessons/night/006-night-cars-regulations.md
@@ -1,0 +1,195 @@
+---
+id: NIGHT-006
+topic: night
+order: 6
+slug: night-cars-regulations
+title: "Night CARs and Regulations — CAR 401.42 and Recency"
+duration_min: 20
+status: draft
+audio: null
+visual: ""
+sources:
+  - CARs 401.42
+  - CARs 401.05
+  - CARs 602.115
+  - CARs 605.16
+  - TP 12880E Chapter 10
+questions:
+  - id: q1
+    prompt: "Under CARs 401.42, a Night Rating is required to carry passengers at night. 'Night' is defined for this purpose as:"
+    choices:
+      A: "The period between official sunset and official sunrise"
+      B: "The period between the end of evening civil twilight and the beginning of morning civil twilight"
+      C: "The period beginning 30 minutes after sunset and ending 30 minutes before sunrise"
+      D: "Any period when ambient lighting requires navigation lights to be illuminated"
+    answer: B
+    explanation: "For the purpose of CARs night rating and night recency requirements, 'night' is defined as the period between the end of evening civil twilight and the beginning of morning civil twilight. Civil twilight ends when the centre of the sun is 6 degrees below the horizon. This is a later start and earlier end compared to sunset/sunrise. Source: CARs 101.01, 401.42."
+  - id: q2
+    prompt: "A private pilot with a Night Rating must meet night recency requirements under CARs 401.05 to carry passengers at night. Those requirements are:"
+    choices:
+      A: "5 night take-offs and 5 night full-stop landings in the preceding 6 months"
+      B: "5 night take-offs and 5 night landings in the preceding 12 months"
+      C: "10 night take-offs and 10 night landings in the preceding 12 months"
+      D: "3 night take-offs and 3 night full-stop landings in the preceding 6 months"
+    answer: A
+    explanation: "CARs 401.05(2) requires that to carry passengers at night, a pilot must have completed at least 5 night take-offs and 5 night full-stop landings in the previous 6 months, in an aircraft of the same category and class. These must be full-stop landings — touch-and-go landings do not count. Source: CARs 401.05(2)."
+  - id: q3
+    prompt: "To qualify for a Night Rating under CARs 401.42, a private pilot must have completed a minimum of:"
+    choices:
+      A: "5 hours of night flight including 5 night take-offs and 5 night landings"
+      B: "10 hours of night flight including solo and dual"
+      C: "10 hours of night flight including at least 5 hours of dual and at least 5 hours as pilot-in-command, with a minimum of 10 take-offs and 10 full-stop landings as pilot-in-command"
+      D: "10 hours of night flight including at least 5 hours dual and 2 hours of solo cross-country"
+    answer: C
+    explanation: "CARs 401.42 requires at least 10 hours of night flight time including: a minimum of 5 hours dual instruction in night flight, and at least 5 hours as pilot-in-command including a minimum of 10 night take-offs and 10 night full-stop landings. Source: CARs 401.42."
+  - id: q4
+    prompt: "Night VFR flight in uncontrolled airspace requires visibility and cloud clearance minimums of:"
+    choices:
+      A: "The same as day VFR — 1 statute mile and clear of cloud in Class G below 1,000 ft AGL"
+      B: "3 statute miles visibility and 500 ft below, 1,000 ft above, 2,000 ft horizontally from cloud"
+      C: "5 statute miles visibility and clear of cloud"
+      D: "1 statute mile visibility and 500 ft below, 1,000 ft above, 1,000 ft horizontally from cloud"
+    answer: B
+    explanation: "Night VFR in uncontrolled (Class G) airspace above 1,000 ft AGL requires 3 statute miles visibility and 500 ft below, 1,000 ft above, 2,000 ft horizontal cloud clearance — the same as controlled airspace VFR minimums. The relaxed daytime minimums (1 mile / clear of cloud at low altitudes) do NOT apply at night. CARs 602.115 specifies stricter night minimums. Source: CARs 602.115, TP 12880E Chapter 10."
+  - id: q5
+    prompt: "A pilot holds a Night Rating but has not completed any night flights in the past 8 months. May they carry passengers on a night flight?"
+    choices:
+      A: "Yes — the Night Rating is permanent and carries no recency requirement"
+      B: "No — they must complete the 5 take-off / 5 landing recency requirement before carrying passengers at night"
+      C: "Yes — but only if accompanied by another current Night Rating holder"
+      D: "No — they must re-apply for the Night Rating and complete a night flight test"
+    answer: B
+    explanation: "The Night Rating itself is permanent once issued, but CARs 401.05(2) imposes a recency requirement to carry passengers. Without 5 night take-offs and 5 night full-stop landings in the preceding 6 months, the pilot may fly solo at night (maintaining their own currency) but may not carry passengers. They do not need to re-apply for the rating. Source: CARs 401.05(2), 401.42."
+---
+
+# Lesson NIGHT-006: Night CARs and Regulations — CAR 401.42 and Recency
+
+**Section:** Night Rating  
+**Lesson number:** 006  
+**Estimated time:** 20 minutes  
+**Source:** CARs 401.42, CARs 401.05, CARs 602.115, CARs 605.16, TP 12880E Chapter 10
+
+---
+
+## Narration Script
+
+This lesson covers the Canadian regulations governing night flight — what the Night Rating is, what you need to qualify for it, how to stay current once you have it, and what VFR weather minimums apply at night. These regulations are directly exam-testable.
+
+---
+
+### What Is the Night Rating?
+
+In Canada, a **Night Rating** is an add-on to the Private Pilot Licence (Aeroplane). Without a Night Rating, a PPL holder may **not carry passengers during night hours**. They may fly solo at night — but carrying even one passenger at night requires the Night Rating.
+
+The Night Rating is not a separate licence — it is an annotation on the PPL. Once issued, the rating itself does not expire. However, recency requirements (covered below) must be maintained to exercise the passenger-carrying privilege.
+
+This is different from the FAA system — do not confuse the two. In Canada, the distinction is explicit: solo night flight permitted without a Night Rating; passenger-carrying at night requires it.
+
+---
+
+### Definition of "Night"
+
+Before anything else: you need to know what the regulations mean by "night."
+
+For the purposes of the Night Rating and night recency, **"night" is defined as the period between the end of evening civil twilight and the beginning of morning civil twilight** (CARs 101.01).
+
+**Civil twilight** ends in the evening when the centre of the sun is 6 degrees below the horizon. This occurs roughly 25–35 minutes after sunset, depending on latitude and season.
+
+This means that "night" under CARs is not the same as "after sunset." A flight that departs just before official sunset may not enter "night" until 30 minutes later.
+
+Practical implication: if you are planning a flight that will arrive at the destination near civil twilight and you have passengers, confirm whether you will actually be in "night" by the time of arrival or landing. The CFS and aviation weather sites provide civil twilight times.
+
+---
+
+### CAR 401.42 — Night Rating Requirements
+
+**CARs 401.42** specifies the prerequisites for obtaining a Night Rating:
+
+**Training requirements:**
+- At least **10 hours of night flight time**, consisting of:
+  - At least **5 hours of dual instruction** in night flight, given by an authorized instructor
+  - At least **5 hours as pilot-in-command** (solo night time), which must include:
+    - A minimum of **10 night take-offs** (as PIC)
+    - A minimum of **10 night full-stop landings** (as PIC)
+
+Note that the 10 take-offs and 10 landings must be as pilot-in-command, not as student during dual. Your dual instruction night experience builds toward the total hours but the PIC requirements are separate.
+
+**Flight test:** A Night Rating requires a Pilot Proficiency Check (PPC) or flight test conducted at night, covering the skills required by the Night Rating flight test standard.
+
+---
+
+### CAR 401.05 — Night Recency (Passenger Currency)
+
+**CARs 401.05(2)** sets the recency requirement for carrying passengers at night. Once you hold a Night Rating, to carry passengers at night you must have completed, in the **preceding 6 months**, in an aircraft of the same category and class:
+
+- At least **5 night take-offs**, and
+- At least **5 night full-stop landings**
+
+Key points:
+- **6-month window** — not 12 months; not calendar year. Rolling 6-month period.
+- **Full-stop landings** — touch-and-go landings do **not** count toward this recency requirement. The landing must be a full stop.
+- **Same category and class** — if you are current in a Cessna 172 (single-engine land), that currency counts for any other single-engine land aeroplane. If you also fly floats, you need separate float night recency for passenger-carrying on floats.
+- **Solo night flight is not affected** — if you are out of currency, you may still fly solo at night (maintaining your own safety), but you may not carry a passenger until you restore currency.
+
+To restore currency, you simply complete the required take-offs and landings — no instructor sign-off required, no new flight test. Log them, and you are current.
+
+---
+
+### Night VFR Weather Minimums — CARs 602.115
+
+Night VFR has stricter weather minimums than daytime VFR in uncontrolled airspace. This is an exam-critical distinction.
+
+**Daytime VFR minimums in Class G uncontrolled airspace at or below 1,000 ft AGL:**
+- 2 statute miles visibility, clear of cloud
+
+**Night VFR minimums in Class G uncontrolled airspace (all altitudes):**
+- **3 statute miles visibility** and 500 ft below / 1,000 ft above / 2,000 ft horizontal cloud clearance
+
+The relaxed day minimums (2 miles / clear of cloud at low altitude) do **not** apply at night. At night, 3 miles and the standard cloud clearances apply throughout Class G airspace. Source: CARs 602.115.
+
+In **controlled airspace** (Class C, D, E), the standard VFR minimums apply day and night:
+- 3 statute miles visibility
+- 500 ft below / 1,000 ft above / 2,000 ft horizontal from cloud
+
+So controlled airspace minimums are the same day and night; uncontrolled airspace minimums are stricter at night than during the day.
+
+---
+
+### Required Equipment for Night VFR — CARs 605.16
+
+CARs 605.16 lists equipment required for night VFR:
+
+**Lighting — must be operating:**
+- Position lights (navigation lights) — red, green, white
+- Anti-collision light (rotating beacon or strobes)
+
+These are not optional or deferrable for night flight. An inoperative nav light or anti-collision light grounds the aircraft for night operations.
+
+**Additional instruments required for night:**
+- Sensitive altimeter
+- Airspeed indicator
+- Rate of turn indicator (or slip-skid indicator + attitude indicator)
+- Attitude indicator (artificial horizon)
+- Directional indicator (directional gyro)
+
+These gyroscopic instruments are required at night because the natural horizon is unavailable or unreliable. Flying night VFR requires basic instrument flying capability.
+
+---
+
+### Summary of Key Regulatory Numbers
+
+| Requirement | Rule | Value |
+|---|---|---|
+| Night rating total hours | CARs 401.42 | 10 hours night |
+| Night rating — dual required | CARs 401.42 | 5 hours dual |
+| Night rating — PIC required | CARs 401.42 | 5 hours PIC |
+| Night rating — PIC take-offs | CARs 401.42 | 10 night take-offs |
+| Night rating — PIC landings | CARs 401.42 | 10 full-stop landings |
+| Passenger currency period | CARs 401.05(2) | 6 months |
+| Passenger currency take-offs | CARs 401.05(2) | 5 night take-offs |
+| Passenger currency landings | CARs 401.05(2) | 5 full-stop landings |
+| Night VFR Class G visibility | CARs 602.115 | 3 statute miles |
+
+---
+
+*End of Lesson NIGHT-006.*

--- a/scripts/validate-lesson-schema.sh
+++ b/scripts/validate-lesson-schema.sh
@@ -26,7 +26,7 @@ REQUIRED_FIELDS = [
     "duration_min", "status", "audio", "visual",
     "sources", "questions",
 ]
-VALID_TOPICS = {"air-law", "navigation", "meteorology", "general-knowledge", "radio", "cpl-a", "helicopter"}
+VALID_TOPICS = {"air-law", "navigation", "meteorology", "general-knowledge", "radio", "cpl-a", "helicopter", "night"}
 REQUIRED_QUESTION_FIELDS = {"id", "prompt", "choices", "answer", "explanation"}
 
 def fail(path, msg):

--- a/web-app/src/lib/curriculum.ts
+++ b/web-app/src/lib/curriculum.ts
@@ -79,6 +79,14 @@ export const CURRICULUM: CurriculumSlot[] = [
   { id: 'GK-013', slug: 'load-factor', title: 'Load Factor and Maneuvering Speed', topic: 'general-knowledge', order: 13 },
   { id: 'GK-014', slug: 'preflight-inspection', title: 'Pre-Flight Inspection and Maintenance', topic: 'general-knowledge', order: 14 },
 
+  // Night Rating (6)
+  { id: 'NIGHT-001', slug: 'visual-illusions-dark-adaptation', title: 'Visual Illusions at Night and Dark Adaptation', topic: 'night', order: 1 },
+  { id: 'NIGHT-002', slug: 'aircraft-lighting', title: 'Aircraft Lighting — Interior and Exterior', topic: 'night', order: 2 },
+  { id: 'NIGHT-003', slug: 'aerodrome-lighting', title: 'Aerodrome Lighting — PAPI, VASI, Runway and Beacon', topic: 'night', order: 3 },
+  { id: 'NIGHT-004', slug: 'night-navigation', title: 'Night Navigation', topic: 'night', order: 4 },
+  { id: 'NIGHT-005', slug: 'night-emergency-procedures', title: 'Night Emergency Procedures', topic: 'night', order: 5 },
+  { id: 'NIGHT-006', slug: 'night-cars-regulations', title: 'Night CARs and Regulations — CAR 401.42 and Recency', topic: 'night', order: 6 },
+
   // Radio (ROC-A) (9)
   { id: 'ROC-001', slug: 'phonetic-alphabet-numbers', title: 'Phonetic Alphabet and Numbers', topic: 'radio', order: 1, audio: 'https://media.suprun.workers.dev/ppl/lessons/radio/001-phonetic-alphabet-numbers.m4a', visual: '' },
   { id: 'ROC-002', slug: 'standard-phraseology-readback', title: 'Standard Phraseology and Readback', topic: 'radio', order: 2, audio: 'https://media.suprun.workers.dev/ppl/lessons/radio/002-standard-phraseology-readback.m4a', visual: '' },
@@ -98,6 +106,7 @@ export const TOPIC_LABELS: Record<string, string> = {
   'general-knowledge': 'General Knowledge',
   'radio': 'Radio (ROC-A)',
   'helicopter': 'Helicopter',
+  'night': 'Night Rating',
 };
 
-export const TOPICS = ['air-law', 'navigation', 'meteorology', 'general-knowledge', 'radio', 'cpl-a', 'helicopter'] as const;
+export const TOPICS = ['air-law', 'navigation', 'meteorology', 'general-knowledge', 'radio', 'cpl-a', 'helicopter', 'night'] as const;

--- a/web-app/src/lib/types.ts
+++ b/web-app/src/lib/types.ts
@@ -1,4 +1,4 @@
-export type Topic = 'air-law' | 'navigation' | 'meteorology' | 'general-knowledge' | 'radio' | 'cpl-a' | 'helicopter';
+export type Topic = 'air-law' | 'navigation' | 'meteorology' | 'general-knowledge' | 'radio' | 'cpl-a' | 'helicopter' | 'night';
 export type LessonStatus = 'planning' | 'draft' | 'complete';
 
 export interface Question {


### PR DESCRIPTION
Closes #481

## Changes

### New lesson files (`lessons/night/`)
Six self-contained 20-minute lessons covering all required Night Rating knowledge areas:

| File | Topic |
|---|---|
| `001-visual-illusions-dark-adaptation.md` | Visual illusions, dark adaptation, autokinesis, off-centre viewing |
| `002-aircraft-lighting.md` | Position lights, anti-collision lights, landing light, interior lighting |
| `003-aerodrome-lighting.md` | PAPI, VASI, runway edge/threshold/end lights, rotating beacon, PCL |
| `004-night-navigation.md` | Pre-flight planning, lit checkpoints, terrain clearance, instruments |
| `005-night-emergency-procedures.md` | Engine failure, electrical failure, spatial disorientation, MAYDAY |
| `006-night-cars-regulations.md` | CAR 401.42 (Night Rating requirements), CAR 401.05(2) (recency), 602.115 (weather mins) |

Each lesson: 5 practice questions in frontmatter, full narration script body, sources cited.

### Registry updates
- `web-app/src/lib/types.ts` — added `'night'` to `Topic` union
- `web-app/src/lib/curriculum.ts` — added 6 `NIGHT-0XX` slots, `'night'` to `TOPICS` array, `'Night Rating'` to `TOPIC_LABELS`
- `scripts/validate-lesson-schema.sh` — added `'night'` to `VALID_TOPICS` in the schema validator

### Status
Lessons are marked `status: draft` (audio deferred per issue scope). The playlist audio test correctly skips the `night` topic as pre-deploy.

## Test Plan
- [x] `bash scripts/validate-lesson-schema.sh` — 101 lessons validated, 0 failures
- [x] `npm run build` (in `web-app/`) — TypeScript + Vite build passes
- [x] `npm test` (in `web-app/`) — playlist audio smoke test passes (night topic skipped as pre-deploy)
- [ ] Verify night lessons appear under the `night` track in Browse once #480 wires the track in exam-tracks.ts