### PR TITLE
[PPL-483] Night Rating study plan order + Practice Oral exam mode

### DIFF
--- a/web-app/src/lib/curriculum.ts
+++ b/web-app/src/lib/curriculum.ts
@@ -80,6 +80,7 @@ export const CURRICULUM: CurriculumSlot[] = [
   { id: 'GK-014', slug: 'preflight-inspection', title: 'Pre-Flight Inspection and Maintenance', topic: 'general-knowledge', order: 14 },
 
   // Night Rating (6) — pedagogical order: regulations & recency → physiology / vision → aircraft lighting → aerodrome lighting → night navigation → night emergencies
+  // Intentional: NIGHT-006 is order:1 because it was authored last but taught first. IDs reflect authoring sequence; order reflects pedagogy — see #483.
   { id: 'NIGHT-006', slug: 'night-cars-regulations', title: 'Night CARs and Regulations — CAR 401.42 and Recency', topic: 'night', order: 1 },
   { id: 'NIGHT-001', slug: 'visual-illusions-dark-adaptation', title: 'Visual Illusions at Night and Dark Adaptation', topic: 'night', order: 2 },
   { id: 'NIGHT-002', slug: 'aircraft-lighting', title: 'Aircraft Lighting — Interior and Exterior', topic: 'night', order: 3 },

--- a/web-app/src/lib/curriculum.ts
+++ b/web-app/src/lib/curriculum.ts
@@ -79,13 +79,13 @@ export const CURRICULUM: CurriculumSlot[] = [
   { id: 'GK-013', slug: 'load-factor', title: 'Load Factor and Maneuvering Speed', topic: 'general-knowledge', order: 13 },
   { id: 'GK-014', slug: 'preflight-inspection', title: 'Pre-Flight Inspection and Maintenance', topic: 'general-knowledge', order: 14 },
 
-  // Night Rating (6)
-  { id: 'NIGHT-001', slug: 'visual-illusions-dark-adaptation', title: 'Visual Illusions at Night and Dark Adaptation', topic: 'night', order: 1 },
-  { id: 'NIGHT-002', slug: 'aircraft-lighting', title: 'Aircraft Lighting — Interior and Exterior', topic: 'night', order: 2 },
-  { id: 'NIGHT-003', slug: 'aerodrome-lighting', title: 'Aerodrome Lighting — PAPI, VASI, Runway and Beacon', topic: 'night', order: 3 },
-  { id: 'NIGHT-004', slug: 'night-navigation', title: 'Night Navigation', topic: 'night', order: 4 },
-  { id: 'NIGHT-005', slug: 'night-emergency-procedures', title: 'Night Emergency Procedures', topic: 'night', order: 5 },
-  { id: 'NIGHT-006', slug: 'night-cars-regulations', title: 'Night CARs and Regulations — CAR 401.42 and Recency', topic: 'night', order: 6 },
+  // Night Rating (6) — pedagogical order: regulations & recency → physiology / vision → aircraft lighting → aerodrome lighting → night navigation → night emergencies
+  { id: 'NIGHT-006', slug: 'night-cars-regulations', title: 'Night CARs and Regulations — CAR 401.42 and Recency', topic: 'night', order: 1 },
+  { id: 'NIGHT-001', slug: 'visual-illusions-dark-adaptation', title: 'Visual Illusions at Night and Dark Adaptation', topic: 'night', order: 2 },
+  { id: 'NIGHT-002', slug: 'aircraft-lighting', title: 'Aircraft Lighting — Interior and Exterior', topic: 'night', order: 3 },
+  { id: 'NIGHT-003', slug: 'aerodrome-lighting', title: 'Aerodrome Lighting — PAPI, VASI, Runway and Beacon', topic: 'night', order: 4 },
+  { id: 'NIGHT-004', slug: 'night-navigation', title: 'Night Navigation', topic: 'night', order: 5 },
+  { id: 'NIGHT-005', slug: 'night-emergency-procedures', title: 'Night Emergency Procedures', topic: 'night', order: 6 },
 
   // Radio (ROC-A) (9)
   { id: 'ROC-001', slug: 'phonetic-alphabet-numbers', title: 'Phonetic Alphabet and Numbers', topic: 'radio', order: 1, audio: 'https://media.suprun.workers.dev/ppl/lessons/radio/001-phonetic-alphabet-numbers.m4a', visual: '' },

--- a/web-app/src/lib/final-exam.ts
+++ b/web-app/src/lib/final-exam.ts
@@ -2,6 +2,7 @@ import type { Question } from './types';
 import { scoreQuiz } from './quiz';
 import { getAllLessons } from './lesson-loader';
 import { TOPIC_LABELS } from './curriculum';
+import { getTrack } from './exam-tracks';
 
 export type { QuizResult } from './quiz';
 
@@ -70,6 +71,32 @@ function shuffle<T>(arr: T[], rng: () => number): T[] {
     [a[i], a[j]] = [a[j], a[i]];
   }
   return a;
+}
+
+/**
+ * Builds a shuffled pool of questions for Practice Oral mode.
+ * Draws from lessons filtered by the given trackId's lessonFilter (e.g. 'night').
+ * Does NOT apply TOPIC_WEIGHTS — all matching questions are treated equally.
+ */
+export function buildPracticeOralPool(trackId: string, count: number, seed?: number): ExamQuestion[] {
+  const track = getTrack(trackId);
+  const rng = seededRng(seed !== undefined ? seed : (Date.now() >>> 0));
+  const allLessons = getAllLessons().filter((l) => (track ? track.lessonFilter(l) : true) && l.questions.length > 0);
+
+  const pool: ExamQuestion[] = [];
+  for (const lesson of allLessons) {
+    for (const q of lesson.questions) {
+      pool.push({
+        ...q,
+        lessonId: lesson.id,
+        lessonSlug: lesson.slug,
+        lessonTopic: lesson.topic,
+      });
+    }
+  }
+
+  const shuffled = shuffle(pool, rng);
+  return shuffled.slice(0, Math.min(count, shuffled.length));
 }
 
 export function buildExamPool(totalCount: number, seed?: number): ExamQuestion[] {

--- a/web-app/src/pages/FinalExam.tsx
+++ b/web-app/src/pages/FinalExam.tsx
@@ -22,6 +22,7 @@ import { useTheme } from '@mui/material/styles';
 
 import { buildExamPool, scoreExam, formatTime, POOL_CONFIGS } from '../lib/final-exam';
 import type { ExamQuestion, ExamResult } from '../lib/final-exam';
+import PracticeOral from './PracticeOral';
 
 type Phase = 'config' | 'running' | 'results';
 type PoolType = 'full' | 'quick' | 'custom';
@@ -91,8 +92,15 @@ function poolLabel(type: PoolType): string {
 export default function FinalExam() {
   const theme = useTheme();
   const [searchParams] = useSearchParams();
+  const mode = searchParams.get('mode');
+  const trackParam = searchParams.get('track') ?? 'night';
   const seedParam = searchParams.get('seed');
   const seedValue = seedParam !== null ? Number(seedParam) : undefined;
+
+  // Practice Oral mode — lightweight quiz for night track (no timer, no TC weighting)
+  if (mode === 'practice-oral') {
+    return <PracticeOral trackId={trackParam} count={20} />;
+  }
 
   const [phase, setPhase] = useState<Phase>('config');
   const [poolType, setPoolType] = useState<PoolType>('full');

--- a/web-app/src/pages/FinalExam.tsx
+++ b/web-app/src/pages/FinalExam.tsx
@@ -89,18 +89,25 @@ function poolLabel(type: PoolType): string {
   return 'Custom';
 }
 
+// Thin router: reads search params, then delegates to PracticeOral or FinalExamContent.
+// FinalExamContent owns all hooks — keeping them here would violate the rules-of-hooks
+// when the early return for practice-oral mode fires before they are called.
 export default function FinalExam() {
-  const theme = useTheme();
   const [searchParams] = useSearchParams();
   const mode = searchParams.get('mode');
   const trackParam = searchParams.get('track') ?? 'night';
   const seedParam = searchParams.get('seed');
   const seedValue = seedParam !== null ? Number(seedParam) : undefined;
 
-  // Practice Oral mode — lightweight quiz for night track (no timer, no TC weighting)
   if (mode === 'practice-oral') {
     return <PracticeOral trackId={trackParam} count={20} />;
   }
+
+  return <FinalExamContent seedValue={seedValue} />;
+}
+
+function FinalExamContent({ seedValue }: { seedValue?: number }) {
+  const theme = useTheme();
 
   const [phase, setPhase] = useState<Phase>('config');
   const [poolType, setPoolType] = useState<PoolType>('full');

--- a/web-app/src/pages/Plan.tsx
+++ b/web-app/src/pages/Plan.tsx
@@ -16,6 +16,7 @@ import List from '@mui/material/List';
 import ListItem from '@mui/material/ListItem';
 import ListItemIcon from '@mui/material/ListItemIcon';
 import Typography from '@mui/material/Typography';
+import { useTheme } from '@mui/material/styles';
 
 import { CURRICULUM, TOPIC_LABELS, TOPICS } from '../lib/curriculum';
 import { getAllLessons } from '../lib/lesson-loader';
@@ -24,6 +25,7 @@ import { useExamTrack } from '../context/ExamTrackContext';
 import type { Lesson } from '../lib/types';
 
 export default function Plan() {
+  const theme = useTheme();
   const [resetOpen, setResetOpen] = useState(false);
   const { store, activeTrack } = useExamTrack();
   const { progress, markComplete, markIncomplete, isComplete, reset } = useProgress(store);
@@ -86,6 +88,36 @@ export default function Plan() {
           Reset Progress
         </Button>
       </Box>
+
+      {/* ── Practice Oral (night track only) ── */}
+      {activeTrack.id === 'night' && (
+        <Box
+          component={RouterLink}
+          to="/final-exam?mode=practice-oral&track=night"
+          sx={{
+            display: 'block',
+            mb: 4,
+            p: 2,
+            border: '1px solid',
+            borderColor: 'primary.main',
+            borderRadius: 2,
+            bgcolor: theme.palette.primaryMuted,
+            textDecoration: 'none',
+            color: 'text.primary',
+            '&:hover': { opacity: 0.85 },
+          }}
+        >
+          <Typography variant="overline" color="primary.main" sx={{ display: 'block' }}>
+            Night Rating · Practice Oral
+          </Typography>
+          <Typography variant="subtitle1" sx={{ fontWeight: 600, mb: 0.5 }}>
+            Practice Oral Exam
+          </Typography>
+          <Typography variant="body2" color="text.secondary">
+            20 shuffled questions from all Night Rating lessons — no timer, full explanations.
+          </Typography>
+        </Box>
+      )}
 
       {/* ── Topic sections ── */}
       {filteredTopics.map((topic) => {

--- a/web-app/src/pages/PracticeOral.tsx
+++ b/web-app/src/pages/PracticeOral.tsx
@@ -1,0 +1,282 @@
+import { useState, useMemo } from 'react';
+import { Link as RouterLink } from 'react-router-dom';
+import Alert from '@mui/material/Alert';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Container from '@mui/material/Container';
+import Divider from '@mui/material/Divider';
+import FormControl from '@mui/material/FormControl';
+import FormControlLabel from '@mui/material/FormControlLabel';
+import LinearProgress from '@mui/material/LinearProgress';
+import Radio from '@mui/material/Radio';
+import RadioGroup from '@mui/material/RadioGroup';
+import Typography from '@mui/material/Typography';
+import { useTheme } from '@mui/material/styles';
+
+import { buildPracticeOralPool, scoreExam } from '../lib/final-exam';
+import type { ExamQuestion, ExamResult } from '../lib/final-exam';
+import { EXAM_TRACKS } from '../lib/exam-tracks';
+
+interface Props {
+  trackId: string;
+  count: number;
+}
+
+type Phase = 'running' | 'results';
+
+export default function PracticeOral({ trackId, count }: Props) {
+  const theme = useTheme();
+
+  const track = EXAM_TRACKS.find((t) => t.id === trackId);
+
+  const questions: ExamQuestion[] = useMemo(
+    () => buildPracticeOralPool(trackId, count),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [trackId, count],
+  );
+
+  const [phase, setPhase] = useState<Phase>('running');
+  const [answers, setAnswers] = useState<Record<string, string>>({});
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const [examResult, setExamResult] = useState<ExamResult | null>(null);
+
+  const currentQuestion: ExamQuestion | undefined = questions[currentIndex];
+  const answeredCount = Object.keys(answers).length;
+  const progress = questions.length > 0 ? (answeredCount / questions.length) * 100 : 0;
+
+  function selectAnswer(questionId: string, value: string) {
+    setAnswers((prev) => ({ ...prev, [questionId]: value }));
+  }
+
+  function doSubmit() {
+    const result = scoreExam(answers, questions);
+    setExamResult(result);
+    setPhase('results');
+  }
+
+  if (questions.length === 0) {
+    return (
+      <Container id="main-content" tabIndex={-1} maxWidth="md" sx={{ py: 4 }}>
+        <Alert severity="warning">
+          No questions found for this track. Make sure the night lessons are loaded.
+        </Alert>
+        <Button sx={{ mt: 2 }} variant="outlined" component={RouterLink} to="/plan">
+          Back to Plan
+        </Button>
+      </Container>
+    );
+  }
+
+  // ---- Running phase ----
+  if (phase === 'running' && currentQuestion) {
+    return (
+      <Container id="main-content" tabIndex={-1} maxWidth="md" sx={{ py: 3 }}>
+        {/* Header */}
+        <Box
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 1.5,
+            mb: 2,
+            pb: 2,
+            borderBottom: '1px solid',
+            borderColor: 'divider',
+            flexWrap: 'wrap',
+          }}
+        >
+          <Box sx={{ flex: 1, minWidth: 120 }}>
+            <Typography variant="overline" color="primary.main" sx={{ display: 'block', mb: 0.5 }}>
+              Practice Oral · {track?.code ?? trackId.toUpperCase()}
+            </Typography>
+            <LinearProgress variant="determinate" value={progress} sx={{ height: 6, borderRadius: 3, mb: 0.5 }} />
+            <Typography variant="caption" color="text.secondary">
+              {answeredCount} / {questions.length} answered
+            </Typography>
+          </Box>
+          <Button
+            size="small"
+            variant="contained"
+            color="error"
+            onClick={doSubmit}
+          >
+            Submit
+          </Button>
+        </Box>
+
+        {/* Question */}
+        <Box sx={{ mb: 3 }}>
+          <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+            Question {currentIndex + 1} of {questions.length}
+          </Typography>
+          <Typography variant="h6" sx={{ mb: 3 }}>
+            {currentQuestion.prompt}
+          </Typography>
+          <FormControl component="fieldset" sx={{ width: '100%' }}>
+            <RadioGroup
+              value={answers[currentQuestion.id] ?? ''}
+              onChange={(e) => selectAnswer(currentQuestion.id, e.target.value)}
+            >
+              {Object.entries(currentQuestion.choices).map(([key, value]) => (
+                <FormControlLabel
+                  key={key}
+                  value={key}
+                  control={<Radio />}
+                  label={`${key}. ${value}`}
+                  sx={{ mb: 0.5 }}
+                />
+              ))}
+            </RadioGroup>
+          </FormControl>
+        </Box>
+
+        {/* Navigation */}
+        <Box sx={{ display: 'flex', gap: 2 }}>
+          <Button
+            variant="outlined"
+            disabled={currentIndex === 0}
+            onClick={() => setCurrentIndex((i) => i - 1)}
+          >
+            ← Prev
+          </Button>
+          <Button
+            variant="outlined"
+            disabled={currentIndex === questions.length - 1}
+            onClick={() => setCurrentIndex((i) => i + 1)}
+          >
+            Next →
+          </Button>
+        </Box>
+      </Container>
+    );
+  }
+
+  // ---- Results phase ----
+  if (phase === 'results' && examResult) {
+    const missed = examResult.perQuestion.filter((pq) => !pq.isCorrect);
+
+    return (
+      <Container id="main-content" tabIndex={-1} maxWidth="md" sx={{ py: 4 }}>
+        <Typography variant="overline" color="primary.main" sx={{ display: 'block', mb: 1 }}>
+          Practice Oral · {track?.code ?? trackId.toUpperCase()}
+        </Typography>
+        <Typography variant="h4" sx={{ mb: 3, fontWeight: 700 }}>
+          Oral Results
+        </Typography>
+
+        {/* Score — no pass/fail, just X / 20 */}
+        <Box
+          sx={{
+            mb: 4,
+            p: 3,
+            border: '1px solid',
+            borderColor: 'divider',
+            borderRadius: 2,
+            bgcolor: theme.palette.primaryMuted,
+          }}
+        >
+          <Typography variant="h2" sx={{ fontWeight: 700 }}>
+            {examResult.correct} / {examResult.total}
+          </Typography>
+          <Typography variant="body1" color="text.secondary">
+            {examResult.percent}% correct
+          </Typography>
+        </Box>
+
+        <Divider sx={{ mb: 4 }} />
+
+        {/* Per-topic breakdown */}
+        {examResult.perTopic.length > 0 && (
+          <>
+            <Typography variant="h6" sx={{ mb: 2 }}>
+              Topic Breakdown
+            </Typography>
+            <Box sx={{ mb: 4 }}>
+              {examResult.perTopic.map((t) => (
+                <Box key={t.topic} sx={{ mb: 2 }}>
+                  <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 0.5 }}>
+                    <Typography variant="body2">{t.label}</Typography>
+                    <Typography variant="body2" color="text.secondary">
+                      {t.correct}/{t.total} · {t.percent}%
+                    </Typography>
+                  </Box>
+                  <LinearProgress
+                    variant="determinate"
+                    value={t.percent}
+                    color={t.percent >= 80 ? 'success' : t.percent >= 60 ? 'primary' : 'error'}
+                    sx={{ height: 8, borderRadius: 4 }}
+                  />
+                </Box>
+              ))}
+            </Box>
+          </>
+        )}
+
+        {/* Missed questions with explanations */}
+        {missed.length > 0 && (
+          <>
+            <Typography variant="h6" sx={{ mb: 2 }}>
+              Review Missed Questions ({missed.length})
+            </Typography>
+            <Box sx={{ mb: 4 }}>
+              {missed.map((pq) => (
+                <Box
+                  key={pq.questionId}
+                  sx={{
+                    mb: 2,
+                    p: 2,
+                    border: '1px solid',
+                    borderColor: 'divider',
+                    borderRadius: 2,
+                  }}
+                >
+                  <Typography variant="body2" sx={{ mb: 0.5, fontWeight: 500 }}>
+                    {pq.prompt}
+                  </Typography>
+                  <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 0.5 }}>
+                    Your answer: {pq.userAnswer || '(none)'} · Correct: {pq.correctAnswer}
+                  </Typography>
+                  {pq.explanation && (
+                    <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 1 }}>
+                      {pq.explanation}
+                    </Typography>
+                  )}
+                  <Button
+                    component={RouterLink}
+                    to={`/lessons/${pq.lessonTopic}/${pq.lessonSlug}`}
+                    size="small"
+                    variant="outlined"
+                  >
+                    Review Lesson
+                  </Button>
+                </Box>
+              ))}
+            </Box>
+          </>
+        )}
+
+        <Box sx={{ display: 'flex', gap: 2, flexWrap: 'wrap' }}>
+          <Button
+            variant="contained"
+            onClick={() => {
+              setAnswers({});
+              setCurrentIndex(0);
+              setExamResult(null);
+              setPhase('running');
+            }}
+          >
+            Retake
+          </Button>
+          <Button variant="outlined" component={RouterLink} to="/plan">
+            Back to Plan
+          </Button>
+        </Box>
+      </Container>
+    );
+  }
+
+  return (
+    <Container id="main-content" tabIndex={-1} maxWidth="md" sx={{ py: 4 }}>
+      <Alert severity="info">Loading…</Alert>
+    </Container>
+  );
+}


### PR DESCRIPTION
## Summary

- **Pedagogical reorder of night curriculum**: Night lessons in `curriculum.ts` now follow the defensible learning order: regulations & recency (CARs 401.42) → physiology/vision (dark adaptation) → aircraft lighting → aerodrome lighting → night navigation → night emergencies
- **`buildPracticeOralPool(trackId, count)`**: New helper in `final-exam.ts` that filters lessons via the track's `lessonFilter` (so `night` gets only `topic === 'night'` questions) and shuffles without TC topic weighting
- **`?mode=practice-oral` on `/final-exam`**: FinalExam detects the mode flag and delegates to the new `PracticeOral` component — no config screen, no timer, just 20 shuffled questions
- **`PracticeOral.tsx`**: Lightweight quiz component — displays "X / 20 correct", full explanations on missed questions, Retake and Back to Plan actions. No pass/fail threshold shown.
- **Plan page entry point**: When the active track is `night`, a Practice Oral card appears on `/plan` linking to `/final-exam?mode=practice-oral&track=night`

## No regressions
- `ppl-a`, `pstar` Final Exam, Plan, and Quiz pages are unaffected — `buildExamPool` and `TOPIC_WEIGHTS` are unchanged
- `npm run build` passes cleanly

## Test plan
- [ ] Switch to Night Rating track → `/plan` shows Practice Oral card
- [ ] Click Practice Oral card → 20 questions load from night lessons only
- [ ] Answer all questions → submit → results show "X / 20 correct", explanations for missed Qs
- [ ] Retake button resets quiz; Back to Plan returns to `/plan`
- [ ] Night lessons appear in correct order on `/plan`: CARs regs → dark adaptation → aircraft lighting → aerodrome lighting → navigation → emergencies
- [ ] Switch to PPL-A track → Practice Oral card absent on `/plan`
- [ ] `/final-exam` (no mode param) still shows full PPL-A exam config as before
- [ ] `/pstar-exam` still works as before

Closes #483

🤖 Generated with [Claude Code](https://claude.com/claude-code)