### PR TITLE
[PPL-488] Generate and upload Kokoro narration for all 6 night lessons

### DIFF
--- a/lessons/night/001-visual-illusions-dark-adaptation.md
+++ b/lessons/night/001-visual-illusions-dark-adaptation.md
@@ -6,7 +6,7 @@ slug: visual-illusions-dark-adaptation
 title: "Visual Illusions at Night and Dark Adaptation"
 duration_min: 20
 status: draft
-audio: null
+audio: https://media.suprun.workers.dev/ppl/lessons/night/001-visual-illusions-dark-adaptation.m4a
 visual: ""
 sources:
   - TP 12880E Chapter 10

--- a/lessons/night/002-aircraft-lighting.md
+++ b/lessons/night/002-aircraft-lighting.md
@@ -6,7 +6,7 @@ slug: aircraft-lighting
 title: "Aircraft Lighting — Interior and Exterior"
 duration_min: 20
 status: draft
-audio: null
+audio: https://media.suprun.workers.dev/ppl/lessons/night/002-aircraft-lighting.m4a
 visual: ""
 sources:
   - TP 12880E Chapter 10

--- a/lessons/night/003-aerodrome-lighting.md
+++ b/lessons/night/003-aerodrome-lighting.md
@@ -6,7 +6,7 @@ slug: aerodrome-lighting
 title: "Aerodrome Lighting — PAPI, VASI, Runway and Beacon"
 duration_min: 20
 status: draft
-audio: null
+audio: https://media.suprun.workers.dev/ppl/lessons/night/003-aerodrome-lighting.m4a
 visual: ""
 sources:
   - TP 12880E Chapter 10

--- a/lessons/night/004-night-navigation.md
+++ b/lessons/night/004-night-navigation.md
@@ -6,7 +6,7 @@ slug: night-navigation
 title: "Night Navigation"
 duration_min: 20
 status: draft
-audio: null
+audio: https://media.suprun.workers.dev/ppl/lessons/night/004-night-navigation.m4a
 visual: ""
 sources:
   - TP 12880E Chapter 10

--- a/lessons/night/005-night-emergency-procedures.md
+++ b/lessons/night/005-night-emergency-procedures.md
@@ -6,7 +6,7 @@ slug: night-emergency-procedures
 title: "Night Emergency Procedures"
 duration_min: 20
 status: draft
-audio: null
+audio: https://media.suprun.workers.dev/ppl/lessons/night/005-night-emergency-procedures.m4a
 visual: ""
 sources:
   - TP 12880E Chapter 10

--- a/lessons/night/006-night-cars-regulations.md
+++ b/lessons/night/006-night-cars-regulations.md
@@ -6,7 +6,7 @@ slug: night-cars-regulations
 title: "Night CARs and Regulations — CAR 401.42 and Recency"
 duration_min: 20
 status: draft
-audio: null
+audio: https://media.suprun.workers.dev/ppl/lessons/night/006-night-cars-regulations.m4a
 visual: ""
 sources:
   - CARs 401.42


### PR DESCRIPTION
Closes #488

## Changes

Generated Kokoro TTS narration (`mlx-community/Kokoro-82M-bf16`, voice `am_echo`, speed `1.1`, AAC/M4A 64 kbps) for all 6 Night Rating lessons and updated each lesson's `audio:` frontmatter to the R2 public URL.

**Files changed** (frontmatter `audio:` field only):
- `lessons/night/001-visual-illusions-dark-adaptation.md`
- `lessons/night/002-aircraft-lighting.md`
- `lessons/night/003-aerodrome-lighting.md`
- `lessons/night/004-night-navigation.md`
- `lessons/night/005-night-emergency-procedures.md`
- `lessons/night/006-night-cars-regulations.md`

All 6 `.m4a` files are uploaded to R2 under `ppl/lessons/night/` and verified HTTP 200 / `audio/mp4`.

## Test Plan

- [x] Each lesson file has a non-null `audio:` URL pointing at `https://media.suprun.workers.dev/ppl/lessons/night/{NNN}-{slug}.m4a`
- [x] All 6 URLs return HTTP 200 with `content-type: audio/mp4` (verified via `curl -sI`)
- [ ] Navigate to `/playlist` on the Night track — confirm all 6 lesson cards show a playable audio player