### PR TITLE
[PPL-489] Generate and upload Kokoro narration for all 8 helicopter lessons (HEL-001–008)

### DIFF
--- a/lessons/helicopter/001-air-law-helicopter.md
+++ b/lessons/helicopter/001-air-law-helicopter.md
@@ -6,7 +6,7 @@ slug: air-law-helicopter
 title: "Air Law for Helicopter Operations"
 duration_min: 20
 status: draft
-audio: null
+audio: https://media.suprun.workers.dev/ppl/lessons/helicopter/001-air-law-helicopter.m4a
 visual: null
 sources:
   - "CARs Part VI (General Operating and Flight Rules)"

--- a/lessons/helicopter/002-meteorology-helicopter.md
+++ b/lessons/helicopter/002-meteorology-helicopter.md
@@ -6,7 +6,7 @@ slug: meteorology-helicopter
 title: "Meteorology for Helicopter Operations"
 duration_min: 20
 status: draft
-audio: null
+audio: https://media.suprun.workers.dev/ppl/lessons/helicopter/002-meteorology-helicopter.m4a
 visual: null
 sources:
   - "TP 12880E (Aeroplane Flight Training Manual) – Meteorology and Performance chapters"

--- a/lessons/helicopter/003-navigation-helicopter.md
+++ b/lessons/helicopter/003-navigation-helicopter.md
@@ -6,7 +6,7 @@ slug: navigation-helicopter
 title: "Navigation for Helicopter Operations"
 duration_min: 20
 status: draft
-audio: null
+audio: https://media.suprun.workers.dev/ppl/lessons/helicopter/003-navigation-helicopter.m4a
 visual: null
 sources:
   - "TP 12880E (Aeroplane Flight Training Manual) – Navigation chapter"

--- a/lessons/helicopter/004-aerodynamics-helicopter.md
+++ b/lessons/helicopter/004-aerodynamics-helicopter.md
@@ -6,7 +6,7 @@ slug: aerodynamics-helicopter
 title: "Helicopter Aerodynamics"
 duration_min: 20
 status: draft
-audio: null
+audio: https://media.suprun.workers.dev/ppl/lessons/helicopter/004-aerodynamics-helicopter.m4a
 visual: null
 sources:
   - "TC Helicopter Flight Training Manual (TP 9982E)"

--- a/lessons/helicopter/005-systems-helicopter.md
+++ b/lessons/helicopter/005-systems-helicopter.md
@@ -6,7 +6,7 @@ slug: systems-helicopter
 title: "Helicopter Systems"
 duration_min: 20
 status: draft
-audio: null
+audio: https://media.suprun.workers.dev/ppl/lessons/helicopter/005-systems-helicopter.m4a
 visual: null
 sources:
   - "TC Helicopter Flight Training Manual (TP 9982E)"

--- a/lessons/helicopter/006-performance-helicopter.md
+++ b/lessons/helicopter/006-performance-helicopter.md
@@ -6,7 +6,7 @@ slug: performance-helicopter
 title: "Helicopter Performance"
 duration_min: 20
 status: draft
-audio: null
+audio: https://media.suprun.workers.dev/ppl/lessons/helicopter/006-performance-helicopter.m4a
 visual: null
 sources:
   - "TC Helicopter Flight Training Manual (TP 9982E)"

--- a/lessons/helicopter/007-helicopter-ops.md
+++ b/lessons/helicopter/007-helicopter-ops.md
@@ -6,7 +6,7 @@ slug: helicopter-ops
 title: "Helicopter Operations"
 duration_min: 20
 status: draft
-audio: null
+audio: https://media.suprun.workers.dev/ppl/lessons/helicopter/007-helicopter-ops.m4a
 visual: null
 sources:
   - "TC Helicopter Flight Training Manual (TP 9982E)"

--- a/lessons/helicopter/008-human-factors-helicopter.md
+++ b/lessons/helicopter/008-human-factors-helicopter.md
@@ -6,7 +6,7 @@ slug: human-factors-helicopter
 title: "Human Factors in Helicopter Operations"
 duration_min: 20
 status: draft
-audio: null
+audio: https://media.suprun.workers.dev/ppl/lessons/helicopter/008-human-factors-helicopter.m4a
 visual: null
 sources:
   - "TC Helicopter Flight Training Manual (TP 9982E)"


### PR DESCRIPTION
Closes #489

## Changes

Generated Kokoro TTS audio (voice `am_echo`, speed 1.1, M4A AAC 64 kbps) for all 8 PPL-H helicopter lessons and updated each lesson's `audio:` frontmatter field to the resulting R2 URL.

All 8 lessons had a `## Narration Script` section — no lessons were skipped or generated from full body text.

### Updated lessons

| Lesson | R2 URL |
|---|---|
| HEL-001 Air Law | `ppl/lessons/helicopter/001-air-law-helicopter.m4a` |
| HEL-002 Meteorology | `ppl/lessons/helicopter/002-meteorology-helicopter.m4a` |
| HEL-003 Navigation | `ppl/lessons/helicopter/003-navigation-helicopter.m4a` |
| HEL-004 Aerodynamics | `ppl/lessons/helicopter/004-aerodynamics-helicopter.m4a` |
| HEL-005 Systems | `ppl/lessons/helicopter/005-systems-helicopter.m4a` |
| HEL-006 Performance | `ppl/lessons/helicopter/006-performance-helicopter.m4a` |
| HEL-007 Helicopter Ops | `ppl/lessons/helicopter/007-helicopter-ops.m4a` |
| HEL-008 Human Factors | `ppl/lessons/helicopter/008-human-factors-helicopter.m4a` |

## Test Plan

- [x] All 8 `audio:` frontmatter fields updated from `null` to `https://media.suprun.workers.dev/ppl/lessons/helicopter/{NNN}-{slug}.m4a`
- [x] HEL-001 spot-check: `curl -I` → HTTP 200
- [x] HEL-008 spot-check: `curl -I` → HTTP 200
- [ ] Navigate to /playlist on PPL-H track — all 8 lesson cards should have a functional audio player