### PR TITLE
[PPL-491] Add Night Rating curated playlist

### DIFF
--- a/web-app/src/data/curated-playlists.ts
+++ b/web-app/src/data/curated-playlists.ts
@@ -34,4 +34,11 @@ export const CURATED_PLAYLISTS: CuratedPlaylist[] = [
     lessonIds: ['NAV-001', 'NAV-002', 'NAV-003', 'NAV-004', 'NAV-005'],
     badge: 'Nav',
   },
+  {
+    id: 'night-rating-full',
+    name: 'Night Rating',
+    tagline: 'Dark adaptation, lighting, aerodrome systems, navigation, and emergency procedures — TC night endorsement curriculum.',
+    lessonIds: ['NIGHT-001', 'NIGHT-002', 'NIGHT-003', 'NIGHT-004', 'NIGHT-005', 'NIGHT-006'],
+    badge: 'Night',
+  },
 ];


### PR DESCRIPTION
Closes #491

## Changes
Appended a `night-rating-full` entry to `CURATED_PLAYLISTS` in `web-app/src/data/curated-playlists.ts`. The playlist covers all 6 NIGHT lessons in ascending `order:` sequence (NIGHT-001 → NIGHT-006), consistent with how other curated playlists (e.g. nav-fundamentals) are ordered. Badge is `Night`, tagline matches the accepted wording from the issue AC.

## Test Plan
- Visit `/playlist` — Night Rating card appears alongside existing playlists.
- Click the Night Rating card — all 6 lessons queue and NIGHT-001 plays first.
- No TypeScript errors (build passes locally).
- Existing playlists unaffected.