### PR TITLE
[PPL-490] Generate Kokoro narration for CPL-A lessons 001–005 (partial)

### DIFF
--- a/lessons/cpl-a/001-cpl-licensing-requirements.md
+++ b/lessons/cpl-a/001-cpl-licensing-requirements.md
@@ -6,7 +6,7 @@ slug: cpl-licensing-requirements
 title: "CPL Licensing Requirements"
 duration_min: 20
 status: draft
-audio: null
+audio: https://media.suprun.workers.dev/ppl/lessons/cpl-a/001-cpl-licensing-requirements.m4a
 visual: null
 sources:
   - "CARs Part IV (Personnel Licensing)"

--- a/lessons/cpl-a/002-commercial-air-services.md
+++ b/lessons/cpl-a/002-commercial-air-services.md
@@ -6,7 +6,7 @@ slug: commercial-air-services
 title: "Commercial Air Services and Operator Certificates"
 duration_min: 20
 status: draft
-audio: null
+audio: https://media.suprun.workers.dev/ppl/lessons/cpl-a/002-commercial-air-services.m4a
 visual: null
 sources:
   - "CARs Part VII (Commercial Air Services)"

--- a/lessons/cpl-a/003-air-taxi-operations.md
+++ b/lessons/cpl-a/003-air-taxi-operations.md
@@ -6,7 +6,7 @@ slug: air-taxi-operations
 title: "Air Taxi Operations (CARs 703)"
 duration_min: 20
 status: draft
-audio: null
+audio: https://media.suprun.workers.dev/ppl/lessons/cpl-a/003-air-taxi-operations.m4a
 visual: null
 sources:
   - "CARs 703 (Air Taxi Operations)"

--- a/lessons/cpl-a/004-pic-authority-responsibilities.md
+++ b/lessons/cpl-a/004-pic-authority-responsibilities.md
@@ -6,7 +6,7 @@ slug: pic-authority-responsibilities
 title: "PIC Authority and Commercial Crew Responsibilities"
 duration_min: 20
 status: draft
-audio: null
+audio: https://media.suprun.workers.dev/ppl/lessons/cpl-a/004-pic-authority-responsibilities.m4a
 visual: null
 sources:
   - "CARs 700.15 (Pilot-in-Command Authority)"

--- a/lessons/cpl-a/005-commercial-vfr-night-regulations.md
+++ b/lessons/cpl-a/005-commercial-vfr-night-regulations.md
@@ -6,7 +6,7 @@ slug: commercial-vfr-night-regulations
 title: "Commercial VFR and Night Regulations"
 duration_min: 20
 status: draft
-audio: null
+audio: https://media.suprun.workers.dev/ppl/lessons/cpl-a/005-commercial-vfr-night-regulations.m4a
 visual: null
 sources:
   - "CARs 602.114–602.116 (VFR Weather Minimums)"


### PR DESCRIPTION
Partial progress on #490 (lessons 001–005 only)

## Changes

Updated `audio:` frontmatter in 5 CPL-A lesson files:
- `lessons/cpl-a/001-cpl-licensing-requirements.md` → `https://media.suprun.workers.dev/ppl/lessons/cpl-a/001-cpl-licensing-requirements.m4a`
- `lessons/cpl-a/002-commercial-air-services.md` → `https://media.suprun.workers.dev/ppl/lessons/cpl-a/002-commercial-air-services.m4a`
- `lessons/cpl-a/003-air-taxi-operations.md` → `https://media.suprun.workers.dev/ppl/lessons/cpl-a/003-air-taxi-operations.m4a`
- `lessons/cpl-a/004-pic-authority-responsibilities.md` → `https://media.suprun.workers.dev/ppl/lessons/cpl-a/004-pic-authority-responsibilities.m4a`
- `lessons/cpl-a/005-commercial-vfr-night-regulations.md` → `https://media.suprun.workers.dev/ppl/lessons/cpl-a/005-commercial-vfr-night-regulations.m4a`

## Blocker: lessons 006–018 are content stubs

Lessons 006–018 (`AMT-001` through `PAL-003`) are skeleton-only drafts. None of them have a `## Narration Script` section — they contain only a placeholder:

> *Skeleton only — full narration script to be added before audio production.*

Per `docs/audio-standards.md` and the issue spec, audio generation must not fall back to the full lesson body when `## Narration Script` is absent. The script exits with an error for all 13 remaining lessons.

**Action needed:** author `## Narration Script` sections in lessons 006–018 before audio can be generated for them. This is a content bug tracked separately (see follow-up issue).

## Test Plan

- [ ] Visit `/playlist`, select CPL-A track — lessons 001–005 should show a playable audio player
- [ ] `curl -I https://media.suprun.workers.dev/ppl/lessons/cpl-a/001-cpl-licensing-requirements.m4a` returns HTTP 200 with audio content-type
- [ ] Same for lessons 002–005
- [ ] Lessons 006–018 still show `audio: null` (no change)