### PR TITLE
[PPL-490] Generate Kokoro narration for CPL-A lessons 001–005 (partial — 006–018 blocked)

### DIFF
--- a/lessons/cpl-a/001-cpl-licensing-requirements.md
+++ b/lessons/cpl-a/001-cpl-licensing-requirements.md
@@ -6,7 +6,7 @@ slug: cpl-licensing-requirements
 title: "CPL Licensing Requirements"
 duration_min: 20
 status: draft
-audio: null
+audio: https://media.suprun.workers.dev/ppl/lessons/cpl-a/001-cpl-licensing-requirements.m4a
 visual: null
 sources:
   - "CARs Part IV (Personnel Licensing)"

--- a/lessons/cpl-a/002-commercial-air-services.md
+++ b/lessons/cpl-a/002-commercial-air-services.md
@@ -6,7 +6,7 @@ slug: commercial-air-services
 title: "Commercial Air Services and Operator Certificates"
 duration_min: 20
 status: draft
-audio: null
+audio: https://media.suprun.workers.dev/ppl/lessons/cpl-a/002-commercial-air-services.m4a
 visual: null
 sources:
   - "CARs Part VII (Commercial Air Services)"

--- a/lessons/cpl-a/003-air-taxi-operations.md
+++ b/lessons/cpl-a/003-air-taxi-operations.md
@@ -6,7 +6,7 @@ slug: air-taxi-operations
 title: "Air Taxi Operations (CARs 703)"
 duration_min: 20
 status: draft
-audio: null
+audio: https://media.suprun.workers.dev/ppl/lessons/cpl-a/003-air-taxi-operations.m4a
 visual: null
 sources:
   - "CARs 703 (Air Taxi Operations)"

--- a/lessons/cpl-a/004-pic-authority-responsibilities.md
+++ b/lessons/cpl-a/004-pic-authority-responsibilities.md
@@ -6,7 +6,7 @@ slug: pic-authority-responsibilities
 title: "PIC Authority and Commercial Crew Responsibilities"
 duration_min: 20
 status: draft
-audio: null
+audio: https://media.suprun.workers.dev/ppl/lessons/cpl-a/004-pic-authority-responsibilities.m4a
 visual: null
 sources:
   - "CARs 700.15 (Pilot-in-Command Authority)"

--- a/lessons/cpl-a/005-commercial-vfr-night-regulations.md
+++ b/lessons/cpl-a/005-commercial-vfr-night-regulations.md
@@ -6,7 +6,7 @@ slug: commercial-vfr-night-regulations
 title: "Commercial VFR and Night Regulations"
 duration_min: 20
 status: draft
-audio: null
+audio: https://media.suprun.workers.dev/ppl/lessons/cpl-a/005-commercial-vfr-night-regulations.m4a
 visual: null
 sources:
   - "CARs 602.114–602.116 (VFR Weather Minimums)"


### PR DESCRIPTION
Partial progress on #490 (lessons 001–005 only). Lessons 006–018 blocked on content stubs — see #498.

## Changes

Generated Kokoro TTS audio (`am_echo`, speed 1.1, AAC/M4A 64 kbps) for 5 of 18 CPL-A lessons and updated each lesson's `audio:` frontmatter field. All 5 uploaded URLs verified HTTP 200.

**Completed (5/18):**
- `001-cpl-licensing-requirements` → [✓ 200](https://media.suprun.workers.dev/ppl/lessons/cpl-a/001-cpl-licensing-requirements.m4a)
- `002-commercial-air-services` → [✓ 200](https://media.suprun.workers.dev/ppl/lessons/cpl-a/002-commercial-air-services.m4a)
- `003-air-taxi-operations` → [✓ 200](https://media.suprun.workers.dev/ppl/lessons/cpl-a/003-air-taxi-operations.m4a)
- `004-pic-authority-responsibilities` → [✓ 200](https://media.suprun.workers.dev/ppl/lessons/cpl-a/004-pic-authority-responsibilities.m4a)
- `005-commercial-vfr-night-regulations` → [✓ 200](https://media.suprun.workers.dev/ppl/lessons/cpl-a/005-commercial-vfr-night-regulations.m4a)

**Blocked (13/18): lessons 006–018 are missing `## Narration Script` sections**

Per `docs/audio-standards.md` and the issue spec, the script exits with an error when this section is absent. These files have frontmatter and questions but no narration body. A separate content ticket is needed to add `## Narration Script` sections to lessons 006–018 before audio can be generated.

Affected files:
- `006-upper-level-charts-sigwx.md`
- `007-icing-types-avoidance.md`
- `008-thunderstorm-hazards.md`
- `009-mountain-wave-turbulence.md`
- `010-rnav-high-level-navigation.md`
- `011-time-distance-calculations.md`
- `012-cross-country-commercial.md`
- `013-high-speed-aerodynamics.md`
- `014-advanced-engine-systems.md`
- `015-propeller-theory.md`
- `016-performance-charts-cruise.md`
- `017-weight-balance-commercial.md`
- `018-aircraft-limitations.md`

## Test Plan
- [x] `curl -I` each URL returns `200 OK` with `audio/` content-type
- [ ] Switch to CPL-A track at `/playlist` — lessons 001–005 show playable audio players (lessons 006–018 will not, pending content fix)
- [ ] Verify only `audio:` frontmatter field changed in each file (no body edits)