### PR TITLE
[PPL-499] Author narration scripts and generate Kokoro audio for CPL-A lessons 006–018

### DIFF
--- a/lessons/cpl-a/006-upper-level-charts-sigwx.md
+++ b/lessons/cpl-a/006-upper-level-charts-sigwx.md
@@ -6,7 +6,7 @@ slug: upper-level-charts-sigwx
 title: "Upper Level Charts and Significant Weather Forecasts"
 duration_min: 20
 status: draft
-audio: null
+audio: https://media.suprun.workers.dev/ppl/lessons/cpl-a/006-upper-level-charts-sigwx.m4a
 visual: null
 sources:
   - "TP 1102 Vol. 5 (Advanced Meteorology)"
@@ -79,4 +79,58 @@ Topics to be authored:
 
 ---
 
-*Skeleton only — full narration script to be added before audio production.*
+## Narration Script
+
+### Introduction
+
+When you plan a cross-country flight as a commercial pilot, the surface weather reports and terminal forecasts you learned for your PPL give you a solid foundation — but they only tell part of the story. At higher altitudes, the weather behaves very differently, and the products that describe it require a different set of skills to read and apply. In this lesson you will learn to interpret three families of upper-level weather products that are essential tools for commercial flight planning in Canada: Constant Pressure Charts, Graphical Area Forecasts, and Significant Weather charts. Together, these products paint a three-dimensional picture of the atmosphere that will allow you to plan safer, more efficient flights.
+
+### Constant Pressure Charts
+
+A Constant Pressure Chart — also called an upper level chart — is fundamentally different from what you might expect. Instead of depicting conditions at a fixed altitude above sea level, it depicts conditions along a surface of constant atmospheric pressure. The three charts most commonly used in aviation planning are the 850 hectopascal chart, the 700 hectopascal chart, and the 500 hectopascal chart. On a standard atmosphere day, 850 hectopascals corresponds to roughly 5,000 feet above sea level, 700 hectopascals to about 10,000 feet, and 500 hectopascals to approximately 18,000 feet. However, because pressure surfaces slope and undulate with temperature, the actual altitude of the pressure surface varies from place to place — and that variation is what makes these charts so useful.
+
+The most important features plotted on a Constant Pressure Chart are contour lines, wind barbs, and temperature. Contour lines connect points where the pressure surface is at the same height above sea level. They work like topographic contour lines, but instead of showing terrain, they show the shape of the pressure surface. Where contours are packed close together, the pressure gradient is steep and winds will be strong. Where contours curve around a low centre, flow is cyclonic. Understanding this gives you an immediate sense of the large-scale wind pattern at that level.
+
+Wind barbs are plotted at each upper air station and show the wind direction and speed at that pressure level. Each full barb on the wind symbol represents 10 knots, and each half barb represents 5 knots. A pennant, which is a solid triangle, represents 50 knots. So a barb with two full feathers and one half feather indicates 25 knots. The wind on a Constant Pressure Chart is the actual or forecast wind at that pressure altitude — it is not a surface wind, and it is not interpolated to a fixed elevation. This is critical: when you are planning to cruise at 10,000 feet and you want to know the forecast wind, you look at the 700 hectopascal chart, because that is the chart whose pressure surface most closely matches your planned cruise altitude on a standard day.
+
+Temperature is also shown at each station, typically plotted in degrees Celsius. At the 700 and 500 hectopascal levels, temperatures will be considerably below zero. For example, the 500 hectopascal chart routinely shows temperatures of minus 20 to minus 30 degrees Celsius even in summer. These temperatures matter for icing and for true airspeed calculations.
+
+When you use these charts operationally, you look at the contour patterns to identify the broad-scale flow, locate ridges and troughs, note where winds are strongest, and check the temperature field for icing potential. A trough of low pressure on the 500 hectopascal chart typically precedes a surface system by 12 to 24 hours, so upper level chart analysis also helps you anticipate weather system movement.
+
+### Graphical Area Forecast
+
+The Graphical Area Forecast, known universally as the GFA, is the primary aviation weather forecast product issued by Environment and Climate Change Canada, or ECCC, for flight planning within Canadian domestic airspace. The GFA covers the area from the surface to 24,000 feet above sea level. It is issued four times daily, at 0000 UTC, 0600 UTC, 1200 UTC, and 1800 UTC. Each issuance consists of two charts: one covering the forecast period from zero to twelve hours and one covering twelve to twenty-four hours after issuance. The GFA is therefore valid for a total of 24 hours from the time it is issued, though the two charts within that period address different forecast windows.
+
+Each GFA chart shows clouds and weather on one panel and icing and turbulence on another. The clouds and weather panel depicts forecast cloud bases and tops, areas of precipitation, fog, and visibility restrictions. Cloud bases and tops are given in feet above sea level, and cloud amounts are indicated using standard okta notation combined with coded symbols. The icing and turbulence panel shows where moderate or greater icing and moderate or greater turbulence are expected, along with the altitude range of these phenomena.
+
+For the commercial pilot, the GFA is not a single glance product. You need to methodically examine both the zero-to-twelve-hour chart and the twelve-to-twenty-four-hour chart as they apply to your departure time and estimated arrival time. If you are departing three hours from issuance time, you use the zero-to-twelve-hour chart for your departure and initial cruise phase. If you expect a long flight that extends beyond twelve hours after the GFA issuance, you must also check the second chart. Failure to check both panels for the relevant time period is a planning error.
+
+The GFA is produced specifically for Canadian airspace and reflects the Canadian forecast system. It is the foundation for pre-flight weather decision-making on any commercial flight within Canada. Sources for accessing the GFA include the NAV CANADA flight planning website and the aviation weather portion of the ECCC website. The product documentation in the Aeronautical Information Manual, or AIM, MET Chapter provides the detailed legend and interpretation guidance.
+
+### Significant Weather Charts
+
+The Significant Weather chart, abbreviated SIGWX, is a forecast chart that highlights aviation weather hazards expected to affect a defined altitude band during a specific time window. In Canada, two SIGWX chart families are produced: the low-level SIGWX and the high-level SIGWX.
+
+The low-level SIGWX chart covers the atmosphere from the surface up to Flight Level 180 — that is, 18,000 feet above sea level when the altimeter is set to the standard setting of 29.92 inches of mercury. This chart is the one most relevant to commercial VFR and low-altitude IFR operations. The high-level SIGWX chart covers Flight Level 250 to Flight Level 630, which is the altitude band used by jet transport aircraft and is primarily relevant to high-altitude IFR operations.
+
+The symbology on SIGWX charts follows internationally standardised conventions. Two symbols are particularly important for your exam and for practical flight planning. Areas where moderate or greater icing is forecast are enclosed by scalloped lines — lines with a saw-tooth or jagged edge. When you see a region bounded by scalloped lines on a SIGWX chart, you know that icing is expected within that boundary, and the chart will annotate the altitude range of the icing layer. Areas where moderate or greater turbulence is forecast are enclosed by smooth curved lines. The smoothness of the turbulence boundary is what distinguishes it from the rough-edged icing boundary. Within the turbulence area, the intensity and altitude range are indicated.
+
+Convective activity — cumulonimbus clouds and thunderstorm areas — is shown using the standard cumulonimbus symbol, which resembles a cloud with a flat anvil top. When an isolated CB symbol appears, it represents a single or few cells. When a widespread area of embedded cumulonimbus is expected, the chart may shade or cross-hatch the affected region. Accompanying text identifies whether the convective activity is isolated, scattered, or widespread, and whether it is embedded in cloud layers that would make it invisible to the pilot.
+
+On the high-level SIGWX chart, two additional features are critical for commercial pilot understanding. The first is the tropopause height, which is depicted by a dashed line with numbers indicating the height of the tropopause in hundreds of feet. The tropopause is the boundary between the troposphere, where temperature decreases with altitude and weather occurs, and the stratosphere, where temperature is more stable. The tropopause sits at roughly 36,000 feet in mid-latitudes but dips lower near the poles and rises near the equator. Knowing its height matters because jet stream cores are typically found at or very near the tropopause level, and clear-air turbulence is most likely in the same vicinity. The second high-level feature is the jet stream itself, shown as an arrowed line with annotated wind speeds. Jet streams can carry 100-knot or even 150-knot tailwinds for high-altitude jets, and the associated turbulence on the boundaries of the jet core is a significant hazard.
+
+### Putting It All Together
+
+When you conduct a commercial pre-flight weather briefing, you do not look at these products in isolation. The skill lies in integrating them into a coherent picture. Your approach might go like this: start with the GFA to identify the broad pattern — where are the clouds, icing, and turbulence expected at your cruise altitude and along your route? Then check whether a SIGWX chart is available for your flight level and time period, and note where scalloped icing boundaries or smooth turbulence boundaries cross your route. If you are flying at higher altitudes, look at the Constant Pressure Chart for the level closest to your cruise altitude to understand the wind speed and direction, and the temperature. Finally, overlay this picture with any active SIGMETs and PIREPs, which are the most recent and specific hazard information available.
+
+Consider a practical example. You are planning a flight at 10,000 feet from Edmonton to Calgary, a distance that would take you about an hour and a half in a typical piston aircraft. You check the 700 hectopascal Constant Pressure Chart and find a west-southwest flow at 35 knots over Alberta, with temperatures around minus 12 degrees Celsius. You check the GFA and find a cloud layer forecast between 6,000 and 14,000 feet, with moderate icing possible in cloud above 8,000 feet. The SIGWX chart confirms a scalloped icing boundary covering your route between 7,000 and 12,000 feet. Your aircraft is not certified for flight in known icing conditions. You now have three independent products all telling you the same thing: your planned cruise altitude of 10,000 feet places you inside a forecast icing layer. That is a go/no-go decision point that requires you to either find an altitude that is clear of icing — likely below 6,000 feet or above 14,000 feet — or to delay the flight until the system moves through.
+
+This integration of multiple products is exactly the skill that separates commercial-standard flight planning from simpler PPL planning, and it is tested on the Transport Canada CPL-A written examination. The AIM MET Chapter and TP 1102 Volume 5 are your authoritative references for the details of each product.
+
+### Summary
+
+In this lesson you learned that Constant Pressure Charts show atmospheric conditions at specific pressure levels, with contour lines representing the height of the pressure surface and wind barbs showing winds at that level. You learned that the GFA is issued four times daily, valid for 24 hours, and consists of two charts per issuance — one for the zero-to-twelve-hour period and one for twelve to twenty-four hours. You learned that SIGWX charts use scalloped lines for icing and smooth curved lines for turbulence, and that high-level SIGWX charts additionally depict the tropopause and jet stream. Finally, you learned that effective commercial weather planning requires integrating all of these products together with PIREPs and SIGMETs to form a complete picture of the atmosphere along your route. In your next lessons, you will go deeper into specific hazards including icing and convective weather, where these chart-reading skills will become essential.
+
+---
+
+*End of Lesson AMT-001.*

--- a/lessons/cpl-a/007-icing-types-avoidance.md
+++ b/lessons/cpl-a/007-icing-types-avoidance.md
@@ -6,7 +6,7 @@ slug: icing-types-avoidance
 title: "Icing — Causes, Types, and Avoidance"
 duration_min: 20
 status: draft
-audio: null
+audio: https://media.suprun.workers.dev/ppl/lessons/cpl-a/007-icing-types-avoidance.m4a
 visual: null
 sources:
   - "TP 1102 Vol. 5 (Advanced Meteorology)"
@@ -80,4 +80,62 @@ Topics to be authored:
 
 ---
 
-*Skeleton only — full narration script to be added before audio production.*
+## Narration Script
+
+### Introduction
+
+Icing is one of the most insidious hazards in aviation because it works silently, it degrades aircraft performance in multiple ways at once, and it can develop far faster than many pilots expect. For the commercial pilot, understanding icing goes beyond the basic awareness introduced at the PPL level. You need to understand exactly how different ice types form, how each type affects the aircraft differently, where carburetor icing fits into the picture, and what the regulations say about operating in icing conditions. This lesson covers all of that, and it will also prepare you to interpret icing information from PIREPs and SIGMETs accurately. Let us start at the physics level and build up to the operational picture.
+
+### The Physics of Supercooled Water
+
+Water does not always freeze at zero degrees Celsius. In a clean atmosphere with no ice nuclei to trigger crystallisation, liquid water droplets can remain liquid at temperatures well below freezing. These are called supercooled water droplets, and they are the root cause of structural icing. When a supercooled droplet strikes the surface of an aircraft, the impact provides the energy needed to trigger freezing, and the droplet rapidly solidifies. The form that ice takes — and therefore its density, weight, and aerodynamic impact — depends mainly on the size of the droplets and the temperature at which they contact the aircraft.
+
+### Clear Ice
+
+Clear ice, also called glaze ice, is the most hazardous form of structural icing. It forms when large supercooled water droplets — the kind found in freezing rain or in cumuliform clouds — strike the aircraft and spread out as a thin film before freezing. Because the droplets are large and spread before solidifying, they trap fewer air bubbles, and the resulting ice layer is smooth, hard, transparent, and extremely dense. Dense ice is heavy ice. On a wing leading edge, clear ice may be nearly invisible against the grey or white paint of the aircraft, making it very difficult to detect visually. More importantly, because the ice flows back from the leading edge before freezing, it adheres to the wing surface in a shape that does not follow the contour of the deicing boot, which means even an aircraft with pneumatic boot deicers can accumulate clear ice faster than the boots can shed it. Clear ice forms most readily at temperatures close to zero degrees Celsius, where large droplets remain mostly liquid until impact, and it is commonly encountered in freezing rain, drizzle, and in the lower portions of convective cloud. Source: TP 1102 Vol. 5.
+
+### Rime Ice
+
+Rime ice forms from small supercooled water droplets — the kind found in stratus-type cloud or fog at subfreezing temperatures. When a small droplet strikes the aircraft, it freezes almost instantly with very little spreading. The rapid freezing traps many air bubbles, giving rime ice its characteristic rough, milky-white, opaque, and brittle texture. Rime ice is lighter per unit volume than clear ice, but it is still extremely dangerous because its rough surface disrupts the laminar flow over the airfoil. Even a thin coating of rough ice on a wing leading edge can significantly increase drag and reduce lift, effectively ruining the wing's aerodynamic efficiency. Rime ice typically forms in the temperature range of minus 10 to minus 20 degrees Celsius, though the boundaries are not sharp. Source: TP 1102 Vol. 5.
+
+### Mixed Ice
+
+In real-world icing encounters, pure clear ice or pure rime ice is the exception rather than the rule. You will commonly encounter mixed ice, which is a combination of both types. The classic scenario involves a cloud layer with large supercooled droplets near its warmer base where temperatures are close to zero, transitioning to smaller droplets and colder temperatures nearer the cloud top. As the aircraft climbs through such a layer, the ice character can change from clear at the bottom to a mixed or rime form higher up. Mixed ice has the dangerous physical properties of both types — it can be heavy and adhere strongly like clear ice, while also being rough enough to seriously disrupt airflow. It is also the most unpredictable in terms of how it accumulates and whether it responds to deicing systems.
+
+### Carburetor Icing
+
+Structural icing affects the outside of the aircraft, but carburetor icing attacks from inside the engine. It is an entirely separate mechanism and can occur under conditions where structural icing would never form — even on a clear, sunny day. Here is how it works. Air entering the carburetor passes through a venturi tube that causes a pressure drop. By Bernoulli's principle, the pressure drop causes a temperature drop — the so-called venturi cooling effect. This temperature drop can be as much as 20 to 30 degrees Celsius within the carburetor throat. Additionally, as fuel vaporises in the carburetor, it absorbs heat from the airflow, cooling the mixture even further. The combined effect can lower the temperature inside the carburetor below zero degrees Celsius even when the outside air temperature is well above freezing, and any moisture in the air will then freeze on the throttle butterfly valve and the carburetor walls, progressively restricting the airflow and richening the mixture.
+
+The temperature range for carburetor icing risk extends from approximately minus 10 degrees Celsius to plus 25 degrees Celsius, with the risk highest in humid conditions between plus 10 and plus 20 degrees Celsius. This is exactly the kind of mild, warm, hazy summer day that looks deceptively benign. Relative humidity does not need to be 100 percent; even moderate humidity of 50 to 80 percent can produce enough moisture for carburetor ice to form.
+
+In an aircraft with a fixed-pitch propeller, the first symptom of carburetor icing is an unexplained drop in engine RPM with no change in throttle position. In an aircraft with a constant-speed propeller and a manifold pressure gauge, the symptom is a drop in manifold pressure — the RPM stays constant because the governor adjusts pitch, but the engine is producing less power. The remedy is to apply full carburetor heat, which routes warm air from around the exhaust manifold into the carburetor. This will temporarily worsen the situation as the ice melts and water passes through the engine, causing a rough-running period. If the engine then smooths out and power returns, carburetor ice was the culprit. Carburetor heat should be applied before power reductions, on approach, and during any prolonged low-power operation. Source: TP 12880E; TP 1102.
+
+### Tailplane Icing
+
+Tailplane icing is a particularly dangerous phenomenon because the recovery action is counterintuitive to everything a pilot normally does. The horizontal stabiliser on most aircraft has a symmetric or reflexed airfoil that operates at a negative angle of attack — it is producing downforce to balance the nose-heavy tendency of the wing's lift. If ice accumulates on the leading edge of the horizontal stabiliser, it disrupts this airfoil, reducing its ability to maintain that downforce. The result is a sudden and aggressive pitch-down moment. In a turboprop or piston-powered aircraft, this can occur when flaps are extended on approach: flap extension shifts the centre of lift forward and increases the downwash over the tail, which increases the angle of attack on the tailplane — exactly the condition that will cause an iced-up tailplane to stall.
+
+The critical point for you to remember is that tailplane ice stall requires the opposite control response from a wing stall. If you experience a sudden pitch-down during approach in icing conditions, the instinct is to pull back on the controls. But if the cause is tailplane ice stall, pulling back increases the angle of attack on the already-stalled stabiliser and makes the situation dramatically worse. The correct response is to reduce flap setting, add power, and if possible, reduce airspeed. Retract flaps in stages while monitoring the pitch response. Recognising this scenario in advance is the best defence: if you have been flying in icing conditions and you see ice on the windshield or wing, assume the tailplane also has ice and treat every approach with extreme caution. Source: TP 1102 Vol. 5.
+
+### De-ice and Anti-ice Systems
+
+Aircraft systems for dealing with icing fall into two categories: anti-ice systems, which prevent ice from forming, and de-ice systems, which remove ice after it has already accumulated.
+
+Pneumatic de-ice boots are the most common de-ice system on general aviation and turboprop aircraft. Rubber bladders bonded to the leading edges of wings and tail surfaces are periodically inflated by bleed air or a venturi pump, cracking off the ice that has accumulated. The key operating principle is that boots should not be activated too early. If you inflate the boots as soon as ice begins to form, you may smooth the ice into the inflated bladder shape, and when the boots deflate, the ice bridges across them and resists subsequent inflation — a phenomenon called boot bridging. Let a small amount of ice accumulate first, then activate the boots, then allow them to return to the deflated position so subsequent ice accumulation can be cracked off in the next cycle.
+
+Anti-ice systems, in contrast, are designed to prevent accumulation. Bleed-air anti-ice heats wing leading edges, engine inlets, and windshields continuously, preventing supercooled droplets from freezing on contact. TKS systems, sometimes called weeping wing systems, pump a glycol-based fluid through porous titanium leading edges, forming a film that both prevents freezing and washes away any ice that does form. Pitot heat is one of the simplest anti-ice systems: an electrical element in the pitot tube keeps it warm to prevent blocking by ice, which would give erroneous airspeed indications.
+
+The important operational distinction for your exam is that anti-ice systems protect surfaces they are applied to continuously, but they cannot protect every surface. De-ice boots protect leading edges but not the entire airfoil. Even a fully certified icing aircraft is not immune to severe icing, and no aircraft is certified for unlimited flight in all icing conditions.
+
+### Regulations and PIREPs
+
+CARs prohibit flight into known or forecast icing conditions unless the aircraft is certified and equipped for flight in icing. The pilot-in-command must ensure that the aircraft's certificate of airworthiness includes an icing certification if icing conditions are forecast or encountered. An aircraft without icing certification must avoid all known icing areas. This is not advisory — it is regulatory. Source: CARs 605.
+
+For gathering icing information in flight, PIREPs are your most current tool. A PIREP reporting icing will specify the location, altitude, intensity (trace, light, moderate, severe), and the type of ice if the pilot was able to identify it. Icing intensity in PIREPs uses standard Transport Canada criteria: trace icing is barely noticeable and accumulates slowly; light icing requires occasional use of de-icing equipment; moderate icing requires frequent use and is potentially hazardous to an aircraft not equipped for icing; severe icing exceeds the capability of deicing equipment and must be exited immediately. SIGMETs for icing are issued by NAV CANADA when moderate or greater icing is expected over a defined geographic area. When you see a SIGMET for icing on your route, treat it as a hard constraint — not a factor to be weighed and minimised.
+
+### Summary
+
+In this lesson you learned that clear ice forms from large supercooled droplets near zero degrees Celsius, creating a smooth, dense, heavy layer that is the most hazardous structural ice type. Rime ice forms from small droplets at colder temperatures, creating a rough, milky, brittle deposit that severely disrupts airfoil performance. Mixed ice combines the properties of both. Carburetor icing can occur at temperatures between minus 10 and plus 25 degrees Celsius, and is remedied by applying carburetor heat. Tailplane icing produces a counterintuitive pitch-down tendency on approach that requires reducing flaps and adding power rather than pulling back. De-icing systems remove accumulated ice while anti-ice systems prevent accumulation. CARs prohibit flight into known icing without appropriate certification and equipment. And PIREPs and SIGMETs are your primary operational tools for icing avoidance. With these principles solid, you are well prepared for the icing questions on the Transport Canada CPL-A exam.
+
+---
+
+*End of Lesson AMT-002.*

--- a/lessons/cpl-a/008-thunderstorm-hazards.md
+++ b/lessons/cpl-a/008-thunderstorm-hazards.md
@@ -6,7 +6,7 @@ slug: thunderstorm-hazards
 title: "Thunderstorm Structure and Aviation Hazards"
 duration_min: 20
 status: draft
-audio: null
+audio: https://media.suprun.workers.dev/ppl/lessons/cpl-a/008-thunderstorm-hazards.m4a
 visual: null
 sources:
   - "TP 1102 Vol. 5 (Advanced Meteorology)"
@@ -80,4 +80,60 @@ Topics to be authored:
 
 ---
 
-*Skeleton only — full narration script to be added before audio production.*
+## Narration Script
+
+### Introduction
+
+No weather phenomenon in aviation combines as many simultaneous hazards as the thunderstorm. It can kill you with turbulence, hail, lightning, icing, wind shear, or by obliterating visibility — and in the mature stage, all of these threats exist at the same time. For the commercial pilot, the standard is not just to survive an inadvertent encounter with a thunderstorm; it is to understand storm structure well enough to make sound go/no-go decisions during planning, to interpret SIGMETs and PIREPs correctly, and to recognise threats like microbursts and embedded convection that require different strategies than the visible, towering cell you can simply fly around. In this lesson you will learn the thunderstorm lifecycle, the specific hazards at each stage, and the decision-making framework that keeps commercial operations safe. Sources for this lesson include TP 1102 Volume 5, the AIM MET Chapter, and CARs 602.02.
+
+### The Thunderstorm Lifecycle
+
+A thunderstorm is not a static phenomenon. It passes through three distinct stages that differ dramatically in their hazard profile.
+
+The cumulus stage is the building phase. Warm, moist surface air rises rapidly in strong updrafts, with cloud tops growing upward as the rising air cools and moisture condenses. At this stage, the storm is dominated by updrafts and there are no downdrafts of significance. Precipitation is forming inside the cloud but has not yet begun to fall. The cumulus stage looks dramatic but is actually the least dangerous to an aircraft — the hazard is almost entirely the strong updrafts, which can exceed 1,000 to 3,000 feet per minute. However, the cumulus stage is brief, often lasting only 15 to 30 minutes, and rapidly transitions to the mature stage.
+
+The mature stage is the most dangerous stage of a thunderstorm's life. It begins when precipitation reaches the ground — a defining observable feature. Inside the cloud, both updrafts and downdrafts exist simultaneously, creating a violent mixing of air masses with opposing vertical velocities that can each exceed 6,000 feet per minute. To put that in perspective, 6,000 feet per minute is 100 feet per second. An aircraft at full climb power might be capable of 1,500 feet per minute. A thunderstorm updraft or downdraft can therefore move an aircraft vertically at four times its maximum climb rate, in either direction, in seconds. During the mature stage, the full catalogue of thunderstorm hazards is active: violent updrafts and downdrafts, large hailstones that can be generated aloft and carried far outside the visible rain area by anvil winds, severe icing in the supercooled water regions above the freezing level, lightning throughout the storm, and extreme low-level wind shear. The mature stage can last 20 to 40 minutes in a single-cell storm and much longer in organised multicell and supercell systems. Source: TP 1102 Vol. 5.
+
+The dissipating stage begins when downdrafts spread throughout the cloud and cut off the supply of warm, moist surface air that was fuelling the updrafts. Without an energy source, the storm collapses. Precipitation weakens and the cloud begins to deteriorate. The anvil cloud — the flat, ice-crystal canopy that spreads downwind at the top of the storm — may persist for hours after the parent cell has dissipated. The dissipating stage is less dangerous than the mature stage, but turbulence and residual hazards remain, and pilots should not mistake a dissipating appearance for a safe aircraft — virga, which is precipitation that evaporates before reaching the ground, and gusty surface winds from outflow can still be hazardous.
+
+### Turbulence in Thunderstorms
+
+Turbulence inside a mature thunderstorm is categorised as severe to extreme, which corresponds to the upper range of the turbulence intensity scale. Aircraft have suffered structural failures when attempting to penetrate mature thunderstorm cells. Even modern jet airliners are not certified to penetrate severe-stage thunderstorm cores, and the Transport Canada CPL-A standard is that penetration of a thunderstorm is not acceptable. Turbulence also extends outside the visible cloud. Clear-air turbulence can exist several thousand feet above the storm's anvil top, and significant turbulence can occur 10 to 20 nautical miles laterally from the visible cell in the anvil debris region.
+
+### Hail
+
+Large hail is one of the most insidious thunderstorm hazards because it can occur well outside the visible precipitation area. Strong updrafts can suspend hailstones inside the cloud while they grow to large sizes. When they finally exit the cloud horizontally at altitude, carried by anvil winds, they can be descending through clear air 10 to 20 nautical miles away from the visible cell. A pilot who bypasses the rain core but flies beneath the anvil cloud is not safe from hail. Aircraft structures can be seriously damaged or destroyed by large hail in seconds. Source: TP 1102 Vol. 5.
+
+### Microburst
+
+The microburst is a concentrated downdraft that descends from a thunderstorm or a shower and spreads out when it hits the ground in all directions. The divergent horizontal outflow creates what is effectively a brief but violent wind shear. An aircraft approaching through a microburst first encounters a headwind component as it flies into the leading edge of the outflow. This temporarily increases airspeed and lift, which can cause the aircraft to climb above the glidepath. The pilot then reduces power to descend back to the approach path. But almost immediately, the aircraft enters the microburst core, where it encounters the strong downdraft. Then as it exits the trailing side of the outflow, the headwind transitions rapidly to a tailwind — the airspeed decreases sharply, lift falls, and the aircraft sinks. All of this happens in seconds at low altitude during a critical phase of flight, and the aircraft can sink below the approach path, or even below the terrain.
+
+Microbursts are most dangerous during takeoff and landing precisely because the aircraft is slow, close to the ground, and has no altitude margin for recovery. The sequence of events — temporary headwind, then downdraft, then tailwind — can be so rapid and so severe that recovery is impossible even with full power applied. The ATIS or SIGMET warning for microburst activity is a hard stop for the commercial pilot. Microburst-producing conditions include any active convective cell near the airport, towering cumulus with virga, and radar indications of strong precipitation near the runway environment. Source: TP 1102 Vol. 5.
+
+### Embedded Thunderstorms
+
+Embedded thunderstorms are convective cells hidden inside stratiform cloud layers. You cannot see them visually because they are masked by surrounding cloud. In VFR conditions you can navigate around visible cells, but in IMC with embedded convection, your only protection is airborne weather radar or weather avoidance systems. If you are not equipped with radar, the correct response to a SIGMET for embedded thunderstorms is to avoid the affected area entirely. There is no safe way to penetrate a region of embedded convection without the ability to detect cells.
+
+SIGMETs for convective activity, called WS-type SIGMETs, are issued by NAV CANADA when moderate or greater thunderstorm or convective activity is forecast. These are mandatory products for pre-flight planning and for in-flight monitoring. When a WS SIGMET is active for your route, you must either find a route that avoids the affected area, delay the flight until the SIGMET expires and the weather moves through, or obtain more information from PIREPs and flight watch to determine whether a safe routing exists. Proceeding into an area covered by a convective SIGMET without additional information is inconsistent with the duty of care requirements of CARs 602.02.
+
+### Minimum Separation Standards
+
+The Transport Canada standard and industry guidance recommend a minimum of 10 nautical miles horizontal separation from any visible thunderstorm cell. Even at this distance, severe turbulence, hail, and lightning are possible. If you can only maintain 5 nautical miles separation, you are too close. If you are in IMC with embedded convection, the minimum separation is not meaningful because you cannot see the cells, and the only appropriate decision is to avoid the affected airspace entirely.
+
+The 10 nautical mile rule applies to individual cells. Squall lines — organised lines of thunderstorms, often hundreds of kilometres long — do not have gaps large enough to penetrate safely between cells. A squall line must be treated as an impassable barrier, and the options are to fly around the entire system, find an alternate destination, or wait.
+
+### Decision Making
+
+The commercial pilot standard for thunderstorm decision making is straightforward in principle, even when it is difficult in practice. The question is always whether you can maintain the required separation from convective cells at all times during the flight. This requires honest evaluation of the forecast and real-time data, not optimistic planning.
+
+Before departure, check all available products: GFA, SIGMET, METAR, TAF, and any PIREPs for the route. If convective activity is forecast within the route corridor, determine whether the timing or routing can be adjusted to avoid it. If the convective activity covers the destination or alternate, consider whether an alternate destination is available outside the affected area.
+
+En route, if you encounter convective cells that cannot be avoided while maintaining the required separation, the decision is to divert. This is not a failure. A diversion made with adequate fuel and before the situation becomes urgent is exactly what good airmanship looks like. The PIC's duty under CARs 602.02 is to take every reasonable precaution for the safety of the aircraft and persons on board. Flying into known convective hazards is not consistent with that duty.
+
+### Summary
+
+In this lesson you learned that a thunderstorm passes through three stages — cumulus, mature, and dissipating — and that the mature stage is the most dangerous because it contains simultaneous violent updrafts and downdrafts, hail, severe icing, lightning, and wind shear. Microbursts are the most deadly thunderstorm hazard during takeoff and landing, producing a headwind-to-tailwind transition that can cause an aircraft to sink uncontrollably. Embedded thunderstorms cannot be seen visually and require either airborne weather radar or complete avoidance of the affected airspace. The minimum separation from visible cells is 10 nautical miles, and squall lines must be circumnavigated entirely. WS SIGMETs for convective activity trigger a serious re-evaluation of the flight plan, and the PIC's duty under CARs 602.02 requires that every reasonable precaution be taken. With this foundation, you are ready to tackle the thunderstorm and convective weather questions on the CPL-A exam with confidence.
+
+---
+
+*End of Lesson AMT-003.*

--- a/lessons/cpl-a/009-mountain-wave-turbulence.md
+++ b/lessons/cpl-a/009-mountain-wave-turbulence.md
@@ -6,7 +6,7 @@ slug: mountain-wave-turbulence
 title: "Mountain Wave Turbulence and Orographic Effects"
 duration_min: 20
 status: draft
-audio: null
+audio: https://media.suprun.workers.dev/ppl/lessons/cpl-a/009-mountain-wave-turbulence.m4a
 visual: null
 sources:
   - "TP 1102 Vol. 5 (Advanced Meteorology)"
@@ -80,4 +80,62 @@ Topics to be authored:
 
 ---
 
-*Skeleton only — full narration script to be added before audio production.*
+## Narration Script
+
+### Introduction
+
+When air flows over a mountain range, it does not simply deflect upward over the ridge and continue on its way. Under the right atmospheric conditions, the air sets up a series of oscillating waves that can extend hundreds of kilometres downwind of the mountains and reach all the way to the stratosphere. These mountain waves are one of the most hazardous phenomena pilots encounter over and near mountainous terrain, and they are particularly relevant in Canada given the scale of the Rocky Mountains and the Coast Range of British Columbia. As a commercial pilot operating near these ranges, you need to understand how waves form, how to recognise them from cockpit and visual cues, how to navigate them safely, and how to use PIREPs and SIGMETs to stay informed. Source: TP 1102 Vol. 5; AIM MET Chapter.
+
+### How Mountain Waves Form
+
+Three conditions must exist simultaneously for significant mountain wave activity to develop. First, the wind must be flowing roughly perpendicular to the mountain ridge — within about 30 degrees of the perpendicular direction. A wind blowing parallel to the ridge does not have the same wave-generating effect. Second, the wind speed at ridge level must be at least 25 knots. Weaker winds may produce minor disturbances but not the organised wave systems that create severe aviation hazards. Third, the atmosphere must be stable — specifically, it must have a stable layer at or near ridge level. This stability acts like a membrane that allows the displaced air to spring back after being forced over the ridge, setting up the oscillation. If the atmosphere were unstable, the displaced air would simply continue rising and the wave would not form.
+
+When these three conditions align, air that is pushed up and over the mountain ridge overshoots its equilibrium level, then sinks back down, overshoots again in the other direction, and oscillates in a series of waves downwind of the ridge. The wavelength of these oscillations is typically 20 to 40 kilometres, and the waves can extend 200 to 500 kilometres downwind before they are damped out by atmospheric friction. They also extend vertically, sometimes reaching well into the stratosphere at altitudes above 50,000 feet, well beyond the reach of any aircraft you will fly for a CPL-A. Source: TP 1102 Vol. 5.
+
+### The Three Wave Zones
+
+A mature mountain wave system has three distinct zones that a pilot needs to recognise and respond to differently.
+
+The first zone is the cap cloud, which forms directly over and just downwind of the ridge crest. Moist air that is lifted over the ridge cools to its dew point and forms a cloud that appears to drape over the ridge like a tablecloth. The cap cloud is a visual indicator that significant lifting is occurring at the ridge. Within the cap cloud, turbulence can be severe, icing is possible, and visibility may be limited. The cap cloud appears to be stationary relative to the ridge — and it is, in the sense that it is constantly forming on the windward side as moist air rises and condensing, and constantly dissipating on the lee side as the air descends and warms. The cloud itself is stationary but the air moving through it is anything but.
+
+The second zone contains lenticular clouds, formally called Altocumulus Standing Lenticularis — a memorable Latin phrase that you might see abbreviated ACSL on forecasts and PIREPs. Lenticular clouds are smooth, lens-shaped or almond-shaped cloud formations that appear at the crests of the standing waves, downwind of the ridge. Like the cap cloud, they are stationary relative to the ground while air streams through them. From a distance, a stack of lenticular clouds at different altitudes gives the appearance of stacked saucers or plates, and this is one of the most reliable visual indicators of mountain wave activity. Lenticular clouds typically form above the rotor zone at altitudes from several thousand feet above the ridge to very high altitudes. If you can see lenticular clouds over or downwind of a mountain range, you know that wave activity is occurring and the rotor zone below is almost certainly active.
+
+The third zone — and the most dangerous to aircraft — is the rotor zone. Rotors are areas of intense, recirculating air that form at the lower levels of the wave system, near and below ridge altitude, under the wave crests. The air in a rotor rolls in a closed loop: it surges upward on the upwind side, flows over the crest of the wave, descends on the downwind side, and then circles back to repeat the process. Inside the rotor, the turbulence is violent, chaotic, and unpredictable. Vertical accelerations in a rotor can exceed the structural limits of many aircraft, and there have been cases of aircraft being tumbled uncontrollably or suffering structural failure in rotor zones. Rotor turbulence is categorised as severe to extreme — the highest two levels on the turbulence intensity scale. If rotor clouds are present, they will appear as broken or cumulus-like cloud at lower altitudes beneath the smooth lenticulars. However, rotors can be active without producing visible cloud, so the absence of rotor cloud does not mean the rotor zone is safe. Source: TP 1102 Vol. 5.
+
+### Visual Indicators and Non-Visual Indicators
+
+The three visual indicators you should recognise are: the cap cloud draping the ridge, lenticular clouds downwind at wave crests, and rotor clouds beneath the lenticulars. When you see any of these features on a mountain range ahead of you, you should treat mountain wave activity as confirmed.
+
+Non-visual indicators are equally important, because waves can be active without producing visible cloud if the air is dry. Non-visual indicators include: an unexplained and persistent tendency to gain or lose altitude despite constant power and pitch settings; airspeed fluctuations without changes in power; altimeter fluctuations; and a rolling or pitching tendency that seems to come from outside the aircraft rather than from control inputs. Any of these sensations while flying near mountains in conditions that could support wave formation should be treated as a warning sign and trigger an immediate reassessment of your route and altitude.
+
+PIREPs are extremely valuable for mountain wave information. Pilots who have already transited the area can report turbulence location, intensity, and altitude, and this real-time information is often more accurate than the forecast for specific altitudes and locations. Check all available PIREPs for mountain routes before departure, and consider filing a PIREP yourself when you transit a mountain corridor, to help the pilots who follow you.
+
+### Canadian Mountain Ranges
+
+Canada's two most significant mountain wave-producing ranges are the Rocky Mountains and the Coast Range of British Columbia. The Rockies run roughly northwest to southeast through Alberta and British Columbia, and the prevailing westerly to southwesterly flow across Canada frequently meets the Rockies at a nearly perpendicular angle — exactly the orientation that generates strong wave systems. Wave activity in the Rockies can affect operations at Calgary International Airport itself, even though the airport is located east of the mountains on the prairies, because wave turbulence can extend several hundred kilometres downwind. The Coast Range parallels the Pacific coast and is frequently impacted by moist Pacific airmasses driving onshore, making it not only a wave generator but also a terrain-icing location. Source: ECCC; AIM MET Chapter.
+
+### Safe Mountain Crossing Techniques
+
+When you need to cross a mountain range in wave conditions, the principles are straightforward. First, cross at the highest altitude that performance and airspace allow, ensuring you are well above the rotor zone. A common planning guideline is to cross at least 2,000 feet above the ridge elevation, though more is always better. The rotor zone extends from the surface up to approximately ridge level, so being above the ridge by a substantial margin puts you above the most violent turbulence. Never cross at ridge level. If you cannot clear the ridge by a safe margin, do not attempt the crossing.
+
+Second, cross perpendicular to the ridge. A perpendicular crossing minimises the time you spend in the wave-disturbed air column over the ridge, and it is also the direction of maximum updraft and downdraft, which means you can assess the wave strength quickly and respond if needed.
+
+Third, slow to manoeuvring speed before entering any area of forecast or suspected turbulence. Manoeuvring speed, which you will study in detail in the limitations lesson, is the speed at or below which full control deflection will not overstress the aircraft structure. Flying at manoeuvring speed does not guarantee safety in extreme turbulence, but it reduces the risk of structural damage from a single severe vertical gust. Do not increase speed in an attempt to push through turbulence — higher speed combined with severe gusts can generate load factors that exceed certification limits.
+
+Fourth, if you find yourself unable to maintain altitude in a descent that feels like a downdraft, do not attempt to hold altitude by adding full power and raising the nose. This is the wrong response. In a severe mountain wave downdraft, the descent rate may exceed your climb capability even at full power, and if you raise the nose to compensate, you risk a stall. Instead, establish a cruise power and a known pitch attitude, accept a temporary altitude loss, and turn away from the terrain — ideally toward the valley floor and away from the ridgeline. A 180-degree turn in a wave-affected canyon is preferable to continuing into worsening conditions. Source: TP 1102 Vol. 5; Transport Canada guidance.
+
+### SIGMETs and Regulatory Considerations
+
+NAV CANADA issues SIGMETs for turbulence — including mountain wave turbulence — when the intensity is expected to be moderate or greater. A SIGMET for mountain wave turbulence is a significant advisory that should change your flight planning. It is not a prohibition on flight, but it requires you to evaluate whether your routing and the performance of your aircraft allow for safe operations in the affected area.
+
+In practice, the commercial pilot's decision-making for mountain wave conditions mirrors the process for icing and convective weather: gather all available information, including the GFA, SIGWX charts, PIREPs, and SIGMETs; assess whether the planned route and altitude are within the affected area and severity; consider altitude modifications, timing adjustments, or alternate routes; and if in doubt, do not go.
+
+The pilot-in-command's responsibility under CARs 602.02 is to take every reasonable precaution to ensure the safety of the flight. Mountain wave turbulence is a foreseeable hazard over Canadian mountain ranges whenever the meteorological conditions support wave formation. Failing to check for wave activity on a mountain crossing route is not consistent with that duty.
+
+### Summary
+
+In this lesson you learned that mountain waves form when wind is within 30 degrees of perpendicular to a ridge at 25 knots or more with a stable atmosphere. The three wave zones are the cap cloud at the ridge, lenticular clouds downwind at wave crests, and the rotor zone below — which is the most dangerous area with severe to extreme turbulence capable of causing structural damage. Wave systems can extend hundreds of kilometres downwind and into the stratosphere. In Canada, the Rocky Mountains and the Coast Range are the primary wave-generating terrain features. Safe crossing techniques include flying well above the ridge, crossing perpendicular to the ridge, slowing to manoeuvring speed, and being prepared to turn back if altitude cannot be maintained. PIREPs and SIGMETs are essential planning tools, and the duty of care under CARs 602.02 requires that mountain wave hazards be assessed before any mountainous terrain crossing.
+
+---
+
+*End of Lesson AMT-004.*

--- a/lessons/cpl-a/010-rnav-high-level-navigation.md
+++ b/lessons/cpl-a/010-rnav-high-level-navigation.md
@@ -6,7 +6,7 @@ slug: rnav-high-level-navigation
 title: "RNAV and High-Level Navigation Concepts"
 duration_min: 20
 status: draft
-audio: null
+audio: https://media.suprun.workers.dev/ppl/lessons/cpl-a/010-rnav-high-level-navigation.m4a
 visual: null
 sources:
   - "TP 12880E (Aeroplane Flight Training Manual)"
@@ -80,4 +80,60 @@ Topics to be authored:
 
 ---
 
-*Skeleton only — full narration script to be added before audio production.*
+## Narration Script
+
+### Introduction
+
+Navigation for the commercial pilot goes well beyond the dead reckoning and VOR tracking that formed the backbone of your PPL training. In commercial operations, you will encounter Area Navigation — or RNAV — systems, Required Navigation Performance specifications, great circle routing for long-distance flights, and the special procedures that apply in Canada's Northern Domestic Airspace. This lesson will walk you through these concepts systematically, giving you both the theoretical understanding needed for the CPL-A written exam and the practical knowledge you will use in commercial operations. Sources for this lesson include TP 12880E, the AIM ENR Chapter, and CARs Part VI.
+
+### Conventional Navigation vs. Area Navigation
+
+Conventional VOR-based navigation requires the aircraft to fly direct radials to and from VOR stations. You track outbound on a specific radial from one VOR, then navigate to the next VOR in sequence, then track the next radial. The route you fly is therefore defined entirely by the geometry of the VOR network, and if you want to fly between two points that are not aligned with convenient VOR radials, you must make multiple intermediate turns at each station. This works well where the VOR network is dense, but it is inefficient, and in Canada's vast northern regions, the network is simply not there.
+
+Area Navigation, abbreviated RNAV, is a navigation method that allows an aircraft to fly any desired path within the coverage area of navigation aids, or within the accuracy limits of self-contained navigation systems, without necessarily overflying each ground-based navaid. The key concept is the waypoint — a defined geographic position expressed in latitude and longitude that is entered into the flight management system or RNAV unit. The aircraft can navigate directly from one waypoint to another, regardless of where the nearest VOR station is located. The underlying position data can come from several sources: GPS, VOR/DME combinations, DME/DME triangulation, inertial navigation systems, or any combination. The navigation system itself computes the position and the required track, and presents the pilot with a course deviation indication just as a conventional CDI would. Source: TP 12880E; AIM ENR.
+
+### GPS and GNSS in Canadian Airspace
+
+The Global Navigation Satellite System — GNSS — is the overarching term for satellite-based positioning systems. GPS, operated by the United States, is the most common GNSS in Canadian aviation, though the system is used under that broader label. For aviation purposes, GPS provides continuous, three-dimensional position information with high accuracy, making it the most capable RNAV source currently available.
+
+However, GPS has a fundamental limitation: the system itself does not always tell you when its accuracy has degraded. If a satellite malfunctions or the signal geometry becomes poor, the position error can increase without any obvious warning to the pilot. This is where RAIM — Receiver Autonomous Integrity Monitoring — becomes essential. RAIM is a function built into aviation-grade GPS receivers that continuously checks the integrity of the GPS position solution. It does this by comparing redundant satellite measurements and looking for inconsistencies. If RAIM detects that the position accuracy has degraded below the required threshold, it alerts the pilot. Without RAIM, GPS cannot be used for IFR navigation in Canada.
+
+For precision approaches with GPS guidance down to low decision heights, a further enhancement is available. WAAS — the Wide Area Augmentation System — is a network of ground reference stations across North America that continuously monitor GPS signals and broadcast correction data to suitably equipped aircraft. WAAS-equipped GPS receivers can achieve horizontal accuracy of better than 3 metres, enabling Localiser Performance with Vertical guidance approaches — called LPV approaches — which provide precision approach capability at many airports that do not have ILS installations. Source: AIM ENR.
+
+### Required Navigation Performance
+
+Required Navigation Performance, or RNP, takes the concept of RNAV a step further by adding an integrity requirement. With basic RNAV, you know the system is navigating accurately, but you rely on external monitoring — RAIM, for example — to detect failures. RNP specifications require that the navigation system itself monitor its own performance continuously and alert the crew immediately if the required accuracy cannot be met. This on-board monitoring capability is what distinguishes RNP from basic RNAV.
+
+RNP values are expressed as numbers that represent the half-width of a corridor, in nautical miles, within which the aircraft must remain 95 percent of the time. RNP 1 means the aircraft must be within 1 nautical mile of the centreline 95 percent of the time, and the system must alert if this cannot be guaranteed. RNP approaches can have values as tight as RNP 0.1, enabling curved approaches through terrain-constrained corridors that would be impossible with conventional navigation. For commercial operations in Canada, you will encounter RNP requirements in approach plates, airspace designations, and company operations manuals. Source: AIM ENR; Transport Canada.
+
+### Great Circle vs. Rhumb Line
+
+For long-distance flights, the question of which path to follow on the Earth's curved surface becomes significant. A rhumb line is a path that crosses all meridians at the same angle — it appears as a straight line on a Mercator projection chart, which makes it easy to plot and fly. However, a rhumb line is not the shortest distance between two points on a sphere. The shortest distance is a great circle — the arc traced by the intersection of the Earth's surface with a plane passing through the two points and the centre of the Earth. On a Mercator projection, a great circle appears as a curved line that bows toward the poles.
+
+For short flights — say, within the same province or across a few hundred miles — the difference in distance between the great circle and the rhumb line route is negligible. But for very long flights, particularly those in higher latitudes where meridians are closer together, the great circle route can be hundreds of miles shorter than the equivalent rhumb line. Many flight management systems automatically compute great circle routes between waypoints, and you need to understand why your planned track curves poleward on Mercator charts when you file or brief a long-distance route. Source: TP 12880E; AIM ENR.
+
+### High-Level Airspace in Canada
+
+Canada divides its airspace into several categories, and the high-altitude structure is particularly important for commercial operations. Class A airspace in Canada begins at 18,000 feet above sea level and extends upward to Flight Level 600. All flight in Class A airspace must be conducted under Instrument Flight Rules regardless of weather conditions, because the combination of high speeds, reduced traffic separation margins, and the critical nature of high-altitude operations requires positive ATC control at all times.
+
+High-altitude enroute charts — the Jeppesen or NAV CANADA high enroute charts — show the airways, fixes, and MEAs applicable to Class A airspace. Jet routes, called J-routes, are the high-altitude airways that are the primary navigation structure at these levels. At the transition from low to high altitude operations, the altimeter procedures also change: at and above 18,000 feet ASL, the standard altimeter setting of 29.92 inches of mercury is used by all aircraft, eliminating the QNH variable and ensuring consistent altimetry across the entire high-altitude system.
+
+RVSM airspace — Reduced Vertical Separation Minima — applies in Canada between Flight Level 290 and Flight Level 410. In non-RVSM airspace, the standard IFR vertical separation above Flight Level 290 is 2,000 feet. RVSM reduces this to 1,000 feet, effectively doubling the number of usable flight levels in the busy upper airspace. To operate in RVSM airspace, an aircraft must be equipped with precise altimetry, dual autopilots capable of maintaining assigned altitude within tight tolerances, an altitude alerting system, and an ATC transponder. The aircraft must also be approved for RVSM operations in its certificate of airworthiness. Aircraft not meeting RVSM requirements must avoid this airspace or operate with the standard 2,000-foot separation, which severely limits their routing options. Source: CARs Part VI.
+
+### Northern Domestic Airspace Procedures
+
+Canada's airspace is divided into the Southern Domestic Airspace, or SDA, and the Northern Domestic Airspace, or NDA. The boundary between them runs roughly along the 60th parallel, which separates the southern provinces and territories from the Yukon, Northwest Territories, Nunavut, and the northern portions of Quebec and Labrador.
+
+In the Southern Domestic Airspace, the familiar altimeter setting procedure applies: below the transition altitude, pilots use the current local QNH setting, which provides altitude above mean sea level referenced to actual sea-level pressure. Above the transition altitude, the standard setting is used, giving Flight Level designations.
+
+In the Northern Domestic Airspace, the standard altimeter setting of 29.92 inches of mercury is used at all times and all altitudes. This is a critical difference you must know for the exam. The reason is practical: the NDA has very few weather reporting stations, and the spacing between them is so large that QNH readings from the nearest station may be significantly different from the actual sea-level pressure at the aircraft's location. Using local QNH in this environment could produce meaningful altimetry errors. By standardising on 29.92 at all altitudes, all aircraft in the NDA share the same altimeter reference, ensuring consistent vertical separation even without reliable local pressure data. Source: AIM RAC; TP 12880E.
+
+Navigation in the NDA also presents unique challenges. Navaids are sparse — VOR stations may be hundreds of miles apart, and DME coverage is limited. GPS is therefore the primary navigation tool for most NDA operations. Pilots operating in the NDA must be familiar with GPS operations including RAIM monitoring, must understand the limitations of their navigation system, and must plan carefully for any GPS outage, including understanding what alternate navigation means are available. Many northern operations also contend with magnetic compass unreliability near the magnetic north pole, where the direction of magnetic north changes rapidly over short distances. Some NDA operations use grid navigation — a navigation system referenced to the geographic North Pole rather than magnetic north — for operations in the highest latitudes. Source: AIM ENR.
+
+### Summary
+
+In this lesson you learned that RNAV allows aircraft to fly any desired path using waypoints rather than being constrained to flying direct VOR radials, and that the position source can be GPS, VOR/DME, DME/DME, or inertial navigation. GPS requires RAIM for integrity monitoring in IFR operations, and WAAS provides the additional accuracy required for LPV precision approaches. RNP specifications add on-board monitoring of navigation system integrity, with values expressed as nautical mile corridor half-widths. Great circle routes are the shortest path between two points on the Earth's surface and appear curved on Mercator projections, with significant fuel savings on long-distance high-latitude routes. Class A airspace in Canada begins at 18,000 feet ASL and requires IFR. RVSM applies between Flight Level 290 and 410, reducing vertical separation to 1,000 feet for appropriately equipped aircraft. In Canada's Northern Domestic Airspace, the standard altimeter setting of 29.92 inches of mercury is used at all altitudes, and GPS is the primary navigation tool given the sparse navaid environment.
+
+---
+
+*End of Lesson ANV-001.*

--- a/lessons/cpl-a/011-time-distance-calculations.md
+++ b/lessons/cpl-a/011-time-distance-calculations.md
@@ -6,7 +6,7 @@ slug: time-distance-calculations
 title: "Time and Distance Calculations for Long-Range Flying"
 duration_min: 20
 status: draft
-audio: null
+audio: https://media.suprun.workers.dev/ppl/lessons/cpl-a/011-time-distance-calculations.m4a
 visual: null
 sources:
   - "TP 12880E (Aeroplane Flight Training Manual)"
@@ -81,4 +81,70 @@ Topics to be authored:
 
 ---
 
-*Skeleton only — full narration script to be added before audio production.*
+## Narration Script
+
+### Introduction
+
+Accurate time, distance, and fuel calculations are foundational skills for any commercial pilot. At the PPL level, these calculations were relatively straightforward: fly a planned route, track your time and fuel, and navigate from point to point. At the commercial level, the same mathematical tools are applied with greater precision and extended to cover more complex planning scenarios, including multi-leg routes, critical point calculations, and fuel management with mandatory reserves and alternates. In this lesson you will work through the key calculation methods that appear on the Transport Canada CPL-A exam and that you will use throughout your commercial flying career. Sources: TP 12880E; CARs 602.88.
+
+### The Speed-Distance-Time Triangle
+
+Everything in time and distance calculation starts with one relationship: distance equals speed multiplied by time, or D equals S times T. From this single formula, all three variables can be derived. If you know speed and distance, time equals distance divided by speed. If you know distance and time, speed equals distance divided by time. If you know speed and time, distance equals speed times time.
+
+In aviation, speed is expressed as groundspeed in knots, distance as nautical miles, and time in hours and decimal fractions of hours. This is important: the formula works cleanly when time is expressed in hours, not in minutes. If you calculate a time in minutes, you need to convert it to hours before using it in another formula. For example, 30 minutes is 0.5 hours, and 45 minutes is 0.75 hours.
+
+The flight computer — the circular slide rule device also called the whiz wheel — performs this calculation mechanically by aligning scales on its rotating disc. Rotating the inner disc to set the speed on the outer scale, then reading the distance opposite the time, gives you the answer without any arithmetic. At the CPL-A level, you are expected to be proficient with both the flight computer and mental or written arithmetic for these calculations. Source: TP 12880E.
+
+### True Airspeed, Groundspeed, and the Wind Triangle
+
+True airspeed, abbreviated TAS, is the actual speed of the aircraft through the airmass. It is derived from indicated airspeed corrected for pressure altitude and temperature. However, it is the groundspeed — the speed of the aircraft relative to the ground — that determines how long a flight will take and therefore how much fuel will be consumed.
+
+The difference between TAS and groundspeed is caused by wind. If you are flying into a headwind, your groundspeed is less than your TAS. If you have a tailwind, your groundspeed exceeds your TAS. For winds from other directions, the wind component along your track — the headwind or tailwind component — is what matters for the groundspeed calculation, and you also need to apply a wind correction angle to your heading to compensate for the crosswind component that would otherwise push you off track.
+
+The wind triangle — also called the velocity triangle — is the geometric method for solving these problems. You construct a triangle using three vectors: the true airspeed vector in the direction of the true heading, the wind vector in the direction the wind is blowing toward, and the track vector in the direction from departure to destination. The groundspeed is the magnitude of the track vector, and the wind correction angle is the angular difference between the true heading and the desired track. The flight computer handles this geometry mechanically on its slide rule side, and you should be able to solve a wind triangle both with the computer and using the formula methods taught in TP 12880E Chapter 8.
+
+A simple case: if you are flying on a track of 090 degrees with a TAS of 140 knots, and the wind is from the north at 20 knots, the wind is a pure crosswind — no headwind or tailwind component. Your groundspeed equals your TAS, 140 knots. But you need to correct your heading into the crosswind to maintain the 090-degree track. The wind correction angle for a 20-knot crosswind at 140 knots TAS is approximately 8 degrees, so you would fly a heading of 098 degrees to track 090 degrees. Your ETA is calculated using the 140-knot groundspeed.
+
+### Fuel Burn Calculations
+
+Fuel burn is calculated using the formula: fuel used equals fuel flow rate multiplied by time. Fuel flow is typically expressed in litres per hour in Canadian metric documents, or pounds per hour or US gallons per hour in older American references. For the exam, work in consistent units — do not mix litres and gallons.
+
+If your aircraft burns 40 litres per hour and you are flying for 2.5 hours, fuel used is 40 times 2.5, which equals 100 litres. If you have 150 litres of usable fuel and need to carry a 30-minute reserve, your usable fuel for the flight is 150 minus 20 litres of reserve (30 minutes at 40 litres per hour is 0.5 hours times 40, which equals 20 litres), leaving 130 litres for actual flight. Your maximum endurance is 130 divided by 40, or 3.25 hours.
+
+Always determine your reserve requirement from the applicable CARs before calculating your usable flight fuel. For VFR day flights, CARs 602.88 requires a fuel reserve sufficient for 30 minutes of flight at normal cruise speed, in addition to the fuel needed to reach the destination. For VFR night flights, the required reserve is 45 minutes. For IFR flights, the reserve requirement is more complex: the aircraft must carry fuel to reach the destination, then to the alternate aerodrome, plus 45 minutes at normal cruise speed. These reserve requirements are minimums — operational practice and company standard operating procedures may require additional contingency fuel. Source: CARs 602.88.
+
+### Elapsed Time and ETA Calculations
+
+Coordinated Universal Time, abbreviated UTC and also called Zulu time, is the standard time reference in aviation. All flight plans, ATC clearances, and weather products use UTC. When calculating elapsed time, always work in UTC to avoid errors caused by time zone boundaries or daylight saving time.
+
+To calculate elapsed time from a departure time to an arrival time, subtract the departure time from the arrival time. If the arrival time is greater than the departure time, simple subtraction works: 1632 minus 1415 equals 2 hours and 17 minutes. If the arrival time is in the next day — that is, the flight crosses midnight UTC — you add 2400 to the arrival time before subtracting.
+
+To calculate an estimated time of arrival, add the estimated time en route to the departure time. If you depart at 1415 UTC and your estimated time en route is 2 hours 30 minutes, your ETA is 1415 plus 2 hours and 30 minutes, which equals 1645 UTC.
+
+### The 1-in-60 Rule and Off-Track Corrections
+
+In cross-country navigation, you rarely fly perfectly on track for the entire route. You will drift due to wind estimation errors, heading errors, or navigation system inaccuracies. The 1-in-60 rule is a simple mental arithmetic method for estimating how far off track you are and how much heading change is required to regain track and reach the destination.
+
+The rule states that for every 1 degree of track error, an aircraft will be displaced approximately 1 nautical mile off track for every 60 nautical miles flown. So if you have flown 90 nautical miles and discover you are 3 nautical miles off track, your track error is 3 divided by 90, times 60, which equals 2 degrees. To simply parallel the correct track from this point forward, you would correct your heading by 2 degrees into the error. But if you want to reach the destination rather than just parallel the track, you must also apply a closing angle to converge on the destination. The closing angle is calculated the same way, using the distance remaining to the destination instead of the distance flown. Total heading correction equals the track error angle plus the closing angle. Source: TP 12880E Chapter 8.
+
+### Point of No Return
+
+The point of no return, abbreviated PNR, is the furthest point from departure to which the aircraft can fly and still have enough fuel to return to the departure aerodrome with the required reserve. Beyond the PNR, the aircraft is committed — it cannot return, and must continue to the destination or divert to an alternate that is closer than the departure point.
+
+The PNR is calculated from two variables: the fuel available for the out-and-back legs, and the groundspeeds in each direction. The out-leg groundspeed is TAS minus the headwind component going out, and the return-leg groundspeed is TAS plus the tailwind component on the return (which is the same wind reversed). The formula for PNR distance from departure is: fuel available for the round trip, multiplied by the product of the out-leg groundspeed and the return-leg groundspeed, divided by the sum of those two groundspeeds. This formula emerges from the requirement that the time out equals the fuel available for the out leg divided by fuel flow, and the time back equals the fuel available for the return divided by fuel flow, and the total fuel used for both legs equals the available fuel.
+
+In a no-wind situation, the PNR is simply the total usable range divided by 2, which makes intuitive sense. With a headwind outbound, the PNR is closer to the departure point because you cover less distance going out for the same fuel burn. With a tailwind outbound, the PNR is further from departure because you cover more distance going out. Source: TP 12880E.
+
+### Equal Time Point
+
+The Equal Time Point, also called the Critical Point or ETP, is the point along the route where the time to continue to the destination equals the time to return to the departure or to divert to an alternate aerodrome. It is most commonly applied in the context of engine failure planning on long overwater or remote routes: if an engine fails at the ETP, the time to reach safety is minimised because both the destination and the alternate are equidistant in time.
+
+The ETP is calculated similarly to the PNR but uses time-to-destination rather than fuel. ETP distance from departure equals total route distance multiplied by the return-leg groundspeed, divided by the sum of the outbound and return-leg groundspeeds. In a no-wind situation, the ETP is the geographic midpoint of the route. With a headwind outbound, the ETP is closer to the destination because it takes longer to get there, so the equidistant-in-time point shifts downwind. Source: TP 12880E.
+
+### Summary
+
+In this lesson you learned that all time, distance, and fuel calculations flow from the single relationship: distance equals speed times time. True airspeed differs from groundspeed because of wind, and the wind triangle is used to determine the wind correction angle and the effective groundspeed. Fuel burn is fuel flow rate times time, and planning must account for mandatory reserves per CARs 602.88 — 30 minutes for VFR day, 45 minutes for VFR night. Elapsed time calculations use UTC. The 1-in-60 rule allows quick mental estimation of off-track corrections. The Point of No Return is the furthest point from which an aircraft can return to departure with required reserves. The Equal Time Point is the point where the time to destination equals the time to the alternate, and is used to plan for engine failure on extended routes. These calculations are core material for the CPL-A exam and for daily commercial flight planning.
+
+---
+
+*End of Lesson ANV-002.*

--- a/lessons/cpl-a/012-cross-country-commercial.md
+++ b/lessons/cpl-a/012-cross-country-commercial.md
@@ -6,7 +6,7 @@ slug: cross-country-commercial
 title: "Cross-Country Flight Planning — Commercial Standards"
 duration_min: 20
 status: draft
-audio: null
+audio: https://media.suprun.workers.dev/ppl/lessons/cpl-a/012-cross-country-commercial.m4a
 visual: null
 sources:
   - "CARs 602.73–602.78 (Flight Plans and Itineraries)"
@@ -81,4 +81,78 @@ Topics to be authored:
 
 ---
 
-*Skeleton only — full narration script to be added before audio production.*
+## Narration Script
+
+### Introduction
+
+When you conduct a cross-country flight as a commercial pilot, you are held to a higher planning standard than a private pilot making the same trip. The regulations are more specific, the documentation requirements are more detailed, and the accountability for your decisions is greater because you may be carrying passengers who are paying for a safe, professional service. In this lesson you will learn the complete commercial cross-country flight planning process — from NOTAMs and weather briefing through fuel planning, flight plan filing, alternate selection, and the decisions you must make when conditions deteriorate en route. Sources: CARs 602.73, CARs 602.88, TP 12880E, and the AIM ENR and FLT Chapters.
+
+### Starting With the Regulations
+
+Before you touch a chart or call up a weather product, you need to know which regulations govern the flight. For a VFR cross-country flight in Canada, the key regulatory references are CARs 602.73 for flight plans and itineraries, CARs 602.88 for fuel requirements, and CARs 602.02 for the pilot-in-command's authority and duty of care.
+
+CARs 602.73 requires a flight plan or flight itinerary for any VFR flight conducted more than 25 nautical miles from the departure aerodrome. A flight plan is filed with a NAV CANADA unit such as the Flight Information Service Element, or FISE, and triggers SAR notification procedures if the plan is not closed after arrival. A flight itinerary is a document left with a responsible person on the ground who agrees to contact authorities if the pilot does not report in by a specified time. Both serve the same safety function: if the aircraft is overdue, someone will know to start looking. For commercial operations, the flight plan is the standard — leaving an itinerary with a family member is not a commercial standard of operation. Source: CARs 602.73.
+
+Under CARs 602.02, the pilot-in-command is responsible for the safe operation of the flight and has final authority over all aspects of the operation, including the decision to depart, continue, or divert. This authority cannot be delegated, and it cannot be overridden by a dispatcher, operations manager, or commercial pressure. If the PIC determines that it is unsafe to continue, the flight does not continue.
+
+### NOTAM Checking
+
+NOTAMs — Notices to Air Missions — are regulatory notices that advise pilots of hazards, restrictions, temporary changes to published procedures, or aerodrome information that has changed since the charts and publications were printed. For a commercial cross-country flight, checking NOTAMs is not optional — it is a required element of pre-flight planning.
+
+You must check NOTAMs for the departure aerodrome, all en route navaids and fixes, any planned fuel stops, the destination aerodrome, and any planned alternate aerodrome. NOTAMs are available through the NAV CANADA NOTAMplus system, which can be accessed online or through a weather briefing call to NAV CANADA's FISE. Categories of NOTAMs that are particularly important for commercial operations include: runway or taxiway closures; unserviceable instrument approaches or navaids; changes to airspace activation, including temporary restricted airspace; airport lighting outages; and obstructions or construction activity.
+
+When you review NOTAMs, do not just scan for your specific aerodrome — look at all NOTAMs in the region of your route. A NOTAM for an en route VOR or NDB that is out of service may affect your navigation plan or alternate aerodrome strategy.
+
+### Weather Briefing
+
+A complete commercial weather briefing integrates multiple product types and applies them systematically to your planned route and altitude. The products you must consult include: the current METARs for departure, destination, alternates, and en route reporting stations; the Terminal Aerodrome Forecasts, or TAFs, for departure and destination; the Graphical Area Forecast for your route corridor and altitude; any active SIGMETs for the route; any available PIREPs; and the upper wind forecasts for your cruise altitude.
+
+The approach is to build a picture of the atmosphere along your route. Start with the GFA to understand the broad cloud, weather, and icing structure. Compare it to the METARs to see whether current conditions match the forecast. Look at the TAF for the destination to understand what to expect on arrival — particularly relevant if your flight is long enough that conditions will have changed significantly by the time you land. Check the TAF validity period against your estimated arrival time.
+
+When you find a discrepancy between the forecast and current conditions — for example, the GFA shows clear skies but the METAR shows a 2,000-foot overcast — take the more conservative interpretation. Forecasts are not always right, and conditions that are worse than forecast require you to revisit your go/no-go decision. If conditions at the destination or en route are forecast to be VFR marginal or IFR, assess whether an alternate route exists that avoids the issue, whether a later departure time would improve the situation, or whether the flight should be postponed.
+
+### Fuel Planning
+
+Fuel planning for commercial operations is more rigorous than for private flying. The CARs establish minimum fuel requirements, but sound commercial practice often requires carrying more than the minimum. CARs 602.88 specifies the following minimums: for VFR day flight, sufficient fuel to reach the destination plus 30 minutes at normal cruise speed; for VFR night flight, destination fuel plus 45 minutes; for IFR flight, destination fuel plus the fuel to reach the most distant alternate plus 45 minutes. These are floors, not targets.
+
+In commercial cross-country planning, you calculate fuel in segments. First, determine the fuel required to complete each leg at the planned power setting, using the aircraft's fuel flow data from the pilot's operating handbook. Second, add the reserve per CARs 602.88. Third, consider whether any additional contingency fuel is appropriate given forecast headwinds, weather deviations that might require longer routing, or the remoteness of the route. Fourth, check whether the calculated fuel load, added to the aircraft weight, keeps the aircraft within its maximum takeoff weight and centre of gravity limits.
+
+If the fuel required plus reserves exceeds the fuel that can be loaded within weight and balance limits, you have two options: reduce payload (passengers or cargo) or plan a fuel stop en route. There is no third option.
+
+### Alternate Aerodrome Selection
+
+For commercial VFR operations, selecting an alternate aerodrome is good practice even when not specifically required by the regulations. An alternate is an aerodrome to which you can divert if the destination becomes unavailable — due to weather, a sudden NOTAM for a runway closure, or any other reason.
+
+A good alternate must satisfy several criteria. It must be reachable with the fuel you will have on arrival at the decision point for diversion. It must have weather forecast to be at or above VFR minimums when you would arrive there. It must have the facilities you need — a fuel pump if you need fuel, appropriate hours of operation, and usable runways. It must have a usable communication frequency for arrival information.
+
+For IFR operations, CARs specify when a filed alternate is mandatory: an alternate is required when the destination does not have a published instrument approach, or when the forecast at the destination for the period from one hour before to one hour after the estimated time of arrival does not meet the alternate planning minima specified in the Canada Air Pilot. For commercial VFR, there is no equivalent mandatory alternate requirement in the regulations, but operating without an alternate plan in deteriorating weather is inconsistent with the PIC's duty under CARs 602.02. Source: CARs 602.02.
+
+### Filing and Closing the Flight Plan
+
+Filing a VFR flight plan with NAV CANADA FISE before departure is straightforward. The flight plan form requires: aircraft identification, aircraft type and equipment codes, departure point and time, estimated cruising speed and altitude, route, destination, estimated time en route, fuel on board in hours and minutes, number of persons on board, alternate aerodrome, aircraft colour and markings, pilot name and contact, and home aerodrome.
+
+The estimated time en route is particularly critical, because it determines when the FISE will begin their search communication actions if the flight plan has not been closed. Under standard NAV CANADA procedures, if a flight plan is not closed within one hour of the ETA, FISE begins a communication search — attempting to contact the aircraft and the destination aerodrome by radio and telephone. If contact cannot be established after that search, search and rescue action is initiated through the appropriate Joint Rescue Coordination Centre. For this reason, closing your flight plan immediately after landing is not just courteous — it is a regulatory and safety responsibility.
+
+You close a VFR flight plan by contacting FISE by radio on the ground frequency or by telephone, giving them your aircraft identification and advising that you have landed. If you land at an uncontrolled aerodrome without radio contact, you can close by telephone. If for any reason you cannot close the plan in a timely manner — for example, if you land at an uncontrolled remote strip — make every effort to contact someone who can relay the closure.
+
+### En Route Decision Making
+
+Even the best pre-flight planning cannot anticipate every contingency. Weather changes, mechanical discrepancies arise, and fuel burns may differ from planned due to wind variations. The commercial pilot must continuously monitor the situation en route and be prepared to make diversion decisions well before they become urgent.
+
+The standard for en route weather decision making is the same as for departure: if VFR conditions cannot be maintained at the planned altitude and on the planned route, the options are to find a route and altitude combination that does maintain VFR, or to divert. Continuing VFR into IMC is one of the most common causes of fatal accidents, and it remains a risk even for experienced commercial pilots under schedule pressure or passenger pressure.
+
+Fuel monitoring en route should be systematic. Check your fuel quantity against your planned fuel burn at regular checkpoints. If you are burning significantly more fuel than planned — due to higher than forecast headwinds, for example — you need to identify the revised range available and confirm whether the destination and alternate remain reachable with required reserves. If they are not, you must land at an intermediate aerodrome to refuel. Making this decision early, while you still have abundant options, is professional airmanship. Deferring the decision until you are marginal on fuel eliminates options and puts you in a high-pressure situation. Source: TP 12880E; CARs 602.02.
+
+### Passenger Handling in Commercial Operations
+
+For commercial operations carrying passengers, additional responsibilities apply. Before boarding, you must brief passengers on emergency procedures — the location and use of emergency exits, the seatbelt requirement for taxi, takeoff, and landing, the restriction on smoking, and the prohibition on interfering with the flight crew. In air taxi operations under CARs Part VII, there are additional passenger briefing requirements specified in the operations manual.
+
+During the flight, passengers in commercial operations are not just observers — you are providing a service, and your professional conduct in the cockpit affects their confidence in the operation. Announcing significant manoeuvres, explaining deviations from the planned route, and communicating weather-related decisions calmly and factually are all part of the commercial standard of service. Equally important is what you do not do: you do not allow passenger comfort preferences, schedule pressure, or commercial considerations to override safety decisions.
+
+### Summary
+
+In this lesson you learned that commercial cross-country planning requires checking NOTAMs for departure, en route, destination, and alternates; integrating METARs, TAFs, GFAs, SIGMETs, and PIREPs for a complete weather picture; calculating fuel to CARs 602.88 minimums — 30 minutes reserve for VFR day, 45 minutes for VFR night; filing a flight plan under CARs 602.73 for any flight beyond 25 nautical miles from departure; and closing the plan promptly after arrival to prevent unnecessary SAR action. Alternate aerodrome selection is a professional standard even when not mandated. En route decision making must be proactive, with fuel monitoring and weather evaluation at regular intervals. The PIC's authority and duty under CARs 602.02 is the overriding regulatory principle: safety cannot be compromised by commercial pressure. These principles form the core of the commercial cross-country planning questions on the Transport Canada CPL-A exam.
+
+---
+
+*End of Lesson ANV-003.*

--- a/lessons/cpl-a/013-high-speed-aerodynamics.md
+++ b/lessons/cpl-a/013-high-speed-aerodynamics.md
@@ -6,7 +6,7 @@ slug: high-speed-aerodynamics
 title: "High-Speed Aerodynamics and Compressibility Effects"
 duration_min: 20
 status: draft
-audio: null
+audio: https://media.suprun.workers.dev/ppl/lessons/cpl-a/013-high-speed-aerodynamics.m4a
 visual: null
 sources:
   - "TP 12880E (Aeroplane Flight Training Manual)"
@@ -81,4 +81,62 @@ Topics to be authored:
 
 ---
 
-*Skeleton only — full narration script to be added before audio production.*
+## Narration Script
+
+### Introduction
+
+As an aircraft flies faster, the rules of aerodynamics change in ways that have no parallel in the low-speed world you studied for your PPL. When airspeed approaches the speed of sound, compressibility effects alter how air flows over the wings, how much drag the aircraft produces, and how the controls respond. For commercial pilots who operate high-performance aircraft or who may eventually transition to jet equipment, understanding high-speed aerodynamics is not optional knowledge — it is essential. In this lesson you will learn the physics of compressibility, the concept of Mach number, what happens above the critical Mach number, and the design features that allow modern aircraft to operate efficiently at high subsonic speeds. Sources: TP 12880E; TP 1102 Vol. 4.
+
+### The Speed of Sound
+
+The speed of sound is the speed at which a pressure disturbance propagates through a medium. In air, this speed depends on temperature: specifically, it equals approximately 20.05 times the square root of the absolute temperature in Kelvin. At sea level on a standard day, where the temperature is 15 degrees Celsius or 288 Kelvin, the speed of sound is approximately 661 knots. At 36,000 feet in the standard atmosphere, where the temperature has fallen to minus 56.5 degrees Celsius, the speed of sound drops to approximately 574 knots. The key point is that the speed of sound depends on temperature, not on pressure or altitude directly. Higher altitude produces lower temperature, which produces a lower speed of sound — but it is the temperature that is the controlling variable.
+
+Mach number is defined as the ratio of the aircraft's speed to the local speed of sound in the surrounding air. An aircraft flying at the speed of sound is at Mach 1. An aircraft flying at half the speed of sound is at Mach 0.5. A Mach number below 1.0 is subsonic; above 1.0 is supersonic. The transonic regime covers the range roughly from Mach 0.75 to Mach 1.2, where some portions of the airflow around the aircraft are subsonic and others are supersonic simultaneously. No commercial piston or turboprop aircraft you will fly for a CPL-A operates above the transonic regime, but understanding transonic aerodynamics helps you understand why the high-speed limitations in the aircraft flight manual exist. Source: TP 12880E; TP 1102 Vol. 4.
+
+### The Critical Mach Number
+
+When an aircraft is flying at subsonic speeds, the air accelerates as it flows over the curved upper surface of the wing. This is the same process that generates lift: the accelerated airflow over the upper surface produces lower pressure than the slower flow beneath, and the pressure difference produces an upward force. The important consequence for high-speed aerodynamics is that the air over the upper surface of the wing is always moving faster than the aircraft as a whole. At some aircraft Mach number, the local airflow at the fastest point on the upper wing surface will first reach Mach 1 — even though the aircraft itself is still flying below Mach 1.
+
+The aircraft Mach number at which local airflow first reaches Mach 1 somewhere on the wing is called the critical Mach number, abbreviated Mcrit. Above Mcrit, a small region of locally supersonic airflow exists on the wing, bounded by a shock wave at the point where the flow decelerates back to subsonic. This is the beginning of the transonic regime for that aircraft. Source: TP 1102 Vol. 4.
+
+### Shock Waves and Their Effects
+
+A shock wave is a thin discontinuity in the flow field where pressure, temperature, and density change abruptly. In the transonic regime, shock waves form on the wing surface where the locally supersonic airflow is forced back to subsonic conditions. The shock wave causes several serious problems for aircraft operations.
+
+First, wave drag increases dramatically above Mcrit. In subsonic flight, pressure drag is the dominant drag component at cruise. When shock waves form, they add a new form of drag — called wave drag or compressibility drag — that rises very steeply with increasing Mach number. The total drag can increase by a factor of several times in a very small Mach number range, which is why early jet aircraft had great difficulty exceeding Mach 0.8 to 0.85.
+
+Second, shock waves cause buffet — the same phenomenon as low-speed stall buffet, but caused by a different mechanism. As the shock wave passes over the wing surface, it causes the boundary layer of airflow behind it to separate, generating turbulent unsteady forces that shake the airframe. This high-speed buffet is a warning that the aircraft is approaching its compressibility limits.
+
+Third, control surfaces may lose effectiveness or even reverse their effect when immersed in or behind a shock wave. The shock wave disrupts the smooth airflow that control surfaces depend on to generate control forces.
+
+Fourth, and most critically, shock waves cause a rearward shift in the centre of pressure — the point where the net aerodynamic lift force effectively acts. When the centre of pressure moves rearward, the aerodynamic moment about the aircraft's centre of gravity changes, creating a nose-down pitching tendency. This phenomenon is called Mach tuck, and it can become a runaway situation: the nose-down pitch increases speed, which moves the shock waves further aft and intensifies Mach tuck, which increases speed further. Without intervention, Mach tuck can lead to structural failure in a high-speed dive. Source: TP 1102 Vol. 4.
+
+### Mach Trim and VMO/MMO
+
+To compensate for Mach tuck, high-speed aircraft are fitted with a Mach trim system — an automatic device that applies progressive nose-up trim as the aircraft approaches its maximum Mach number, offsetting the nose-down tendency. If the Mach trim system fails, the pilot must manually apply trim corrections as Mach number increases.
+
+The maximum operating Mach number is called MMO — pronounced M-M-O — and is the highest Mach number at which the aircraft is permitted to operate in service. Similarly, VMO is the maximum indicated airspeed, also called the maximum operating speed. Both limits exist because of the high-speed aerodynamic effects described above: beyond these limits, buffet, control reversal, Mach tuck, or structural loads may exceed the aircraft's certification basis.
+
+In practical terms, at low altitudes the limiting factor is VMO — the indicated airspeed limit is reached first. At high altitudes, as the speed of sound decreases with falling temperature, the Mach number limit MMO becomes the binding constraint before the indicated airspeed limit. The aircraft's airspeed indicator on high-speed aircraft typically shows both an IAS barber pole at VMO and a Machmeter reading MMO, and the pilot must respect whichever limit is more restrictive. Source: TP 12880E; aircraft AFM.
+
+### Swept Wings and Supercritical Airfoils
+
+Aircraft designers have developed two primary aerodynamic strategies for delaying the onset of compressibility effects to higher Mach numbers, thereby allowing efficient high-speed cruise without encountering the drag rise and stability problems associated with shock waves.
+
+The first strategy is wing sweep. A swept-back wing presents an oblique angle to the oncoming airflow. The component of velocity perpendicular to the wing's leading edge is less than the total airspeed of the aircraft — by an amount that depends on the sweep angle. For a wing swept 35 degrees, the effective velocity component that drives the aerodynamic loading is reduced by the cosine of 35 degrees, which is approximately 82 percent. This means a swept-wing aircraft can fly at a higher total Mach number before the effective local velocity reaches the critical value on the wing. Modern jet airliners use sweep angles of 25 to 35 degrees, and some high-performance military aircraft use even more extreme sweep. The trade-off is that swept wings have lower lift at low speeds, requiring higher approach and landing speeds and more complex high-lift devices such as leading-edge slats and multi-segment trailing-edge flaps. Source: TP 1102 Vol. 4.
+
+The second strategy is the supercritical airfoil. A conventional airfoil has a highly curved upper surface that accelerates airflow strongly, producing lift efficiently at low speeds but also generating a high local velocity peak that drives Mcrit down. A supercritical airfoil has a flatter upper surface that distributes the lift more evenly, reducing the local velocity peak and therefore raising Mcrit. The lower surface of a supercritical airfoil typically has more camber than a conventional wing, contributing lift without requiring as much upper-surface curvature. The result is an airfoil that can operate at higher Mach numbers before encountering shock waves, and that produces less wave drag when shock waves do form. Many modern commercial aircraft combine swept wings with supercritical airfoils for maximum cruise efficiency at high subsonic Mach numbers.
+
+### Coffin Corner
+
+At very high altitudes, a phenomenon known colloquially as coffin corner creates an extremely narrow safe operating speed band. The stall speed — the minimum airspeed for level flight — increases with altitude because as air density decreases, the aircraft must fly faster to generate the same lift. Simultaneously, as the aircraft climbs to higher altitudes and the temperature and speed of sound continue to decrease, the Mach number at which high-speed buffet onset occurs in terms of indicated airspeed becomes lower and lower. At extreme altitudes — well above FL400 for most piston aircraft, and above FL500 for turbojet designs — the indicated airspeed for high-speed buffet onset and the indicated airspeed for low-speed stall converge. The gap between them may be only a few knots.
+
+At coffin corner, a small gust or turbulence encounter can simultaneously push the aircraft toward both the high-speed and low-speed limits. There is no recovery action available: slowing down risks a stall, and speeding up risks high-speed buffet and structural failure. The maximum altitude at which the aircraft can be safely operated is determined by the altitude where a minimum acceptable speed margin remains between stall and high-speed buffet — typically defined as a 1.3g buffet onset margin. Aircraft flight manuals specify a maximum certified altitude that respects this margin. Source: TP 1102 Vol. 4.
+
+### Summary
+
+In this lesson you learned that the speed of sound depends on temperature, and decreases with altitude in the standard atmosphere. Mach number is the ratio of aircraft speed to local speed of sound. The critical Mach number Mcrit is the flight Mach number at which local airflow first reaches Mach 1 somewhere on the wing. Above Mcrit, shock waves form, causing wave drag, buffet, control effectiveness changes, and Mach tuck — a nose-down pitch tendency caused by the rearward shift of the centre of pressure. MMO is the maximum permitted operating Mach number, and VMO is the maximum operating indicated airspeed; whichever is more restrictive applies at any given altitude. Swept wings delay Mcrit by reducing the effective velocity component perpendicular to the leading edge. Supercritical airfoils flatten the upper surface to reduce local velocity peaks. Coffin corner is the high-altitude condition where the stall speed and high-speed buffet speed converge, leaving an extremely narrow safe speed band. These concepts are core material for the CPL-A aerodynamics questions.
+
+---
+
+*End of Lesson ADE-001.*

--- a/lessons/cpl-a/014-advanced-engine-systems.md
+++ b/lessons/cpl-a/014-advanced-engine-systems.md
@@ -6,7 +6,7 @@ slug: advanced-engine-systems
 title: "Advanced Engine Systems and High-Altitude Performance"
 duration_min: 20
 status: draft
-audio: null
+audio: https://media.suprun.workers.dev/ppl/lessons/cpl-a/014-advanced-engine-systems.m4a
 visual: null
 sources:
   - "TP 12880E (Aeroplane Flight Training Manual)"
@@ -80,4 +80,62 @@ Topics to be authored:
 
 ---
 
-*Skeleton only — full narration script to be added before audio production.*
+## Narration Script
+
+### Introduction
+
+The piston engines you fly in general aviation training perform differently at altitude than they do near sea level, and understanding why requires a good grasp of how air density, fuel delivery, and the combustion process interact. For the commercial pilot, this knowledge underpins engine management decisions on every flight: how to lean correctly, when to worry about detonation, how turbocharging changes the equation, and what the regulations say about supplemental oxygen at altitude. This lesson builds on your PPL engine knowledge to the depth required for the CPL-A written exam. Sources: TP 12880E; TP 1102 Vol. 4; CARs 605.31.
+
+### Normally-Aspirated Engines at Altitude
+
+A normally-aspirated engine draws air into its cylinders through atmospheric pressure alone — there is no mechanical device compressing the intake air before it enters. This design works well at sea level and low altitudes, but it suffers a fundamental limitation: as altitude increases, the density of the atmosphere decreases, meaning each intake stroke draws in less mass of air. Because combustion requires a specific ratio of fuel mass to air mass, a less dense air supply produces less power.
+
+The rule of thumb for power loss in a normally-aspirated engine is approximately 3 percent of sea-level power per 1,000 feet of altitude gain above sea level. This is an approximation — the actual rate depends on the specific engine and atmospheric conditions — but it gives you a useful planning number. At 10,000 feet, a normally-aspirated engine that produced 150 horsepower at sea level will be producing roughly 150 minus 30 percent, or approximately 105 horsepower. At 12,000 feet, power is down to about 84 percent of sea level — about 126 horsepower in this example.
+
+The service ceiling of a normally-aspirated aircraft is the altitude at which the engine can produce only enough power to maintain a standard rate of climb — typically 100 feet per minute. Above the service ceiling, the aircraft can still fly, but it cannot climb at a meaningful rate and its performance margins shrink to the point where practical operations become impractical. Source: TP 12880E.
+
+### Turbocharged Engines
+
+Turbocharged engines address the altitude power-loss problem by compressing the intake air before it enters the cylinders, restoring the air density to a value close to what the engine would see at sea level. A turbocharger consists of two components connected by a common shaft: a turbine and a compressor. Exhaust gases from the engine pass through the turbine, spinning it at very high speed. The spinning turbine drives the compressor on the same shaft, and the compressor forces ambient air through an intake at higher pressure than it would otherwise have. This compressed air, once cooled by an intercooler in many designs, is delivered to the engine at a density comparable to sea-level conditions.
+
+The waste gate is a valve in the exhaust system that controls how much exhaust gas is directed through the turbocharger turbine. When the waste gate is open, some exhaust bypasses the turbine, reducing turbocharger output. When it is closed, all exhaust drives the turbine at maximum capacity. At low altitudes, a fully turbocharged engine would produce too much manifold pressure, so the waste gate is modulated open to limit boost. As altitude increases and the exhaust energy decreases, the waste gate progressively closes to maintain the target manifold pressure. The critical altitude is the highest altitude at which the turbocharger can maintain rated manifold pressure with the waste gate fully closed. Above the critical altitude, manifold pressure begins to fall off just as in a normally-aspirated engine.
+
+The practical benefit for the commercial pilot is that a turbocharged aircraft can operate at higher altitudes than its normally-aspirated equivalent — typically 20,000 feet or more — maintaining usable power levels that would be impossible for a normally-aspirated engine. This translates to faster cruise speeds, better terrain and weather clearance, and the ability to take advantage of favourable winds at higher flight levels. Source: TP 12880E.
+
+### Mixture Management
+
+In both normally-aspirated and turbocharged engines, managing the fuel-air mixture is a continuous responsibility at altitude. At sea level, the carburetor or fuel injection system is calibrated to deliver a mixture that is slightly rich of stoichiometric — that is, slightly more fuel than can be completely burned with the available air. This deliberate richening provides a safety margin against detonation and ensures complete combustion.
+
+As altitude increases and air density decreases, the same fuel delivery setting sends too much fuel for the available air — the mixture becomes progressively richer. A rich mixture burns more slowly and at lower temperatures, reducing power and increasing fuel consumption. To restore the correct fuel-to-air ratio at altitude, the pilot must lean the mixture by reducing the fuel flow.
+
+There are two target mixture settings in cruise. Best power mixture is the fuel-air ratio that produces the maximum power for a given throttle setting. It is typically found at approximately 100 degrees Fahrenheit rich of peak exhaust gas temperature, and it results in full cylinder combustion with a slight excess of fuel. Best economy mixture produces the best fuel economy — minimum fuel flow for a given power output. It is found at peak exhaust gas temperature or slightly lean of peak, where the mixture is as lean as possible without causing combustion problems. Best economy mixture delivers roughly 50 to 75 feet per minute less climb rate than best power, but it burns significantly less fuel, making it the preferred setting for long-distance cruise in many aircraft. Source: TP 12880E.
+
+### Detonation
+
+Detonation is a critical engine management topic for the commercial pilot because it can damage an engine rapidly and without obvious warning in the early stages. In normal combustion, the spark plug fires and a flame front propagates smoothly through the fuel-air charge, releasing energy in a controlled manner. In detonation, the unburned fuel-air mixture ahead of the normal flame front reaches such high temperature and pressure that it spontaneously ignites — exploding rather than burning. The resulting pressure spike is many times higher than the normal combustion pressure, and it strikes the piston crown, rings, and cylinder walls with tremendous force. Even a few seconds of severe detonation can cause piston holes, broken rings, scored cylinders, or connecting rod failure.
+
+Detonation is caused by a combination of three factors: fuel with insufficient octane rating for the power setting being used, excessively high manifold pressure relative to engine RPM, and leaning the mixture too aggressively at high power settings. The octane rating of aviation fuel indicates its resistance to detonation. Always use the minimum octane grade specified in the aircraft's engine limitations — never a lower grade, and higher grades are acceptable without risk. When operating at high power — above 75 percent, as a general guideline — the mixture should be kept rich enough to prevent detonation, even at the cost of higher fuel consumption. Only lean aggressively when operating at 65 percent power or below.
+
+The symptoms of detonation include rough engine operation, rising cylinder head temperature, and in severe cases, a loss of engine power as components begin to fail. If you suspect detonation, the immediate actions are to enrich the mixture, reduce manifold pressure by reducing throttle, increase airspeed for improved cooling, and if cylinder head temperature remains elevated, consider reducing altitude to access cooler, denser air. Source: TP 12880E.
+
+### Oxygen Requirements
+
+As altitude increases, the partial pressure of oxygen in the atmosphere decreases, even though the proportion of oxygen in air remains approximately 21 percent. At sea level, the combination of atmospheric pressure and oxygen concentration is more than adequate for normal human physiology. By 10,000 feet, the effects of hypoxia — reduced oxygen supply to the brain — begin to subtly affect cognitive function in some individuals. By 15,000 feet, the effects are significant for most people. At 18,000 feet and above, incapacitation can occur within minutes without supplemental oxygen.
+
+CARs 605.31 establishes the regulatory requirements for supplemental oxygen in Canadian aviation. When operating above Flight Level 130 — which is approximately 13,000 feet with the altimeter set to standard — supplemental oxygen must be available for all occupants. When operating above Flight Level 180, supplemental oxygen must be in use by all occupants. The pilot-in-command is specifically required to use oxygen when operating between Flight Level 130 and Flight Level 180 on any flight segment lasting more than 30 minutes. Source: CARs 605.31.
+
+These requirements apply to unpressurised aircraft. In a pressurised aircraft, the pressurisation system maintains a cabin altitude lower than the actual flight level — typically between 6,000 and 8,000 feet cabin altitude at cruise. The oxygen regulations apply to the cabin pressure altitude, not the flight altitude, for pressurised aircraft. However, CARs also require that pressurised aircraft carry emergency oxygen for all occupants sufficient to sustain them from the maximum certified altitude down to an altitude where oxygen is no longer required — typically 10,000 feet — in the event of rapid decompression.
+
+### Engine Failure at Altitude
+
+If the engine fails at altitude in a single-engine aircraft, the immediate priorities are to establish the best glide speed, identify a suitable landing area, attempt a restart if conditions and altitude permit, and prepare for a forced landing. The survival ceiling — the altitude to which the aircraft can glide before terrain, obstacles, or darkness eliminates safe landing options — depends on the glide ratio of the aircraft and the terrain beneath.
+
+In a turbocharged aircraft with a flat manifold pressure decay above the critical altitude, a sudden loss of turbocharger function can feel like a partial engine failure — power drops but the engine continues to run, now behaving like a normally-aspirated engine with reduced performance. Waste gate failure resulting in overboost — too much manifold pressure at low altitude — can cause engine damage if not corrected immediately by reducing throttle. Understanding the symptom differences between these failure modes is part of the advanced engine knowledge required at the commercial level. Source: TP 12880E.
+
+### Summary
+
+In this lesson you learned that normally-aspirated engines lose approximately 3 percent of their sea-level power per 1,000 feet of altitude gain due to the decreasing density of the atmosphere. Turbochargers compensate by using exhaust energy to compress intake air, maintaining near-sea-level density up to the critical altitude, above which power begins to fall off. The waste gate controls turbocharger output at low altitudes by bypassing exhaust. Mixture management requires leaning as altitude increases to maintain the correct fuel-to-air ratio; best power mixture is found rich of peak EGT, and best economy mixture at or lean of peak. Detonation is abnormal combustion caused by low-octane fuel, excessive manifold pressure, or aggressive leaning at high power, and can damage the engine rapidly. CARs 605.31 requires supplemental oxygen to be available above Flight Level 130 and in use above Flight Level 180. These are the core engine topics tested on the Transport Canada CPL-A exam, and mastering them will also make you a safer and more efficient operator in commercial service.
+
+---
+
+*End of Lesson ADE-002.*

--- a/lessons/cpl-a/015-propeller-theory.md
+++ b/lessons/cpl-a/015-propeller-theory.md
@@ -6,7 +6,7 @@ slug: propeller-theory
 title: "Propeller Theory and Variable-Pitch Systems"
 duration_min: 20
 status: draft
-audio: null
+audio: https://media.suprun.workers.dev/ppl/lessons/cpl-a/015-propeller-theory.m4a
 visual: null
 sources:
   - "TP 12880E (Aeroplane Flight Training Manual)"
@@ -79,4 +79,74 @@ Topics to be authored:
 
 ---
 
-*Skeleton only — full narration script to be added before audio production.*
+## Narration Script
+
+### Introduction
+
+The propeller is the most visible and mechanically complex component of a piston or turboprop aircraft, yet many pilots treat it as a given — something that just works. For the commercial pilot, understanding propeller theory is necessary at several levels: for the written exam, for understanding the performance implications of different propeller systems, for managing multi-engine asymmetric thrust situations, and for recognising and responding to propeller system failures. This lesson takes you from propeller blade physics through constant-speed governor operation, feathering, propeller asymmetric effects, and the critical engine concept on multi-engine aircraft. Sources: TP 12880E; TP 1102 Vol. 4.
+
+### The Propeller Blade as an Airfoil
+
+Each propeller blade is an airfoil in the same fundamental sense as a wing. It has a curved leading edge, a flatter trailing edge, and a chord line connecting them. When air flows over the blade, it generates lift — but in the case of the propeller, this aerodynamic force is directed forward, producing thrust rather than the upward lift of a wing.
+
+The blade angle — also called pitch — is the angle between the chord line of the propeller blade and the plane of rotation. A low blade angle, called fine pitch, means the blade is almost flat relative to the plane of rotation. A high blade angle, called coarse pitch, means the blade is twisted further toward parallel with the propeller's axis of rotation. This terminology can seem counterintuitive at first: fine pitch, despite the word "fine," is actually a small angle, while coarse pitch is a large angle.
+
+The propeller blade must be twisted from root to tip because the tip of the blade travels much faster than the root — the velocity at any point on the blade is proportional to its distance from the hub. If the blade had a uniform angle from root to tip, the tip would have a much higher angle of attack than the root relative to the incoming airflow, causing the tip to stall and lose efficiency while the root operated well below its best angle of attack. The twist ensures that all stations along the blade operate at approximately the same effective angle of attack. Source: TP 12880E.
+
+### Pitch, Slip, and Efficiency
+
+Geometric pitch is the theoretical distance the propeller would advance through the air in one revolution if it were operating in a solid medium with no slip — like a screw through wood. Effective pitch is the actual distance the aircraft advances per revolution in real flight. The difference between geometric pitch and effective pitch is called propeller slip, and it represents the "work lost" in the aerodynamic process of converting rotation to forward thrust. In a perfectly efficient propeller with no slip, all of the engine's power would be converted to useful thrust. In practice, propeller efficiency — the ratio of thrust horsepower output to the brake horsepower delivered to the shaft — is typically 75 to 85 percent for a well-matched propeller at its design speed.
+
+### Fixed-Pitch vs. Variable-Pitch vs. Constant-Speed Propellers
+
+A fixed-pitch propeller has its blade angle permanently set at manufacture. Because a given blade angle is aerodynamically efficient at only one combination of airspeed and engine RPM, a fixed-pitch propeller is always a compromise. A climb propeller is set to fine pitch, optimising performance at high power and low airspeed — useful during takeoff and initial climb, but inefficient at cruise where higher blade angles would be more appropriate. A cruise propeller is set to coarser pitch, optimising cruise efficiency but producing poor climb performance. Most training aircraft use a compromise setting that is acceptable for both phases but optimal for neither.
+
+A variable-pitch propeller allows the pilot to select different blade angles manually for different phases of flight. A two-position prop offers a fine pitch for takeoff and a coarse pitch for cruise. An adjustable-pitch prop might allow any angle within a range. These improve efficiency at different flight conditions but require the pilot to manage pitch changes manually.
+
+A constant-speed propeller goes one step further by automatically maintaining a selected RPM regardless of changes in throttle, airspeed, or aircraft attitude. The governor senses the actual RPM and adjusts blade pitch to keep it constant: if RPM starts to rise — because the throttle was advanced, airspeed increased, or the aircraft began a descent — the governor increases blade angle, loading the engine more and bringing RPM back to the selected value. If RPM begins to fall — throttle reduced, airspeed decreased, or aircraft climbing into thinner air — the governor decreases blade angle, reducing the load and allowing RPM to return to the target. This automatic RPM management allows the engine to operate at its most efficient RPM across a wide range of flight conditions, and it is the standard on all but the most basic training aircraft.
+
+### Governor Operation
+
+The constant-speed propeller governor is a centrifugal flyweight device driven by the engine. Inside the governor, a set of rotating flyweights are connected to the pilot valve by a spring-loaded linkage. When RPM equals the selected value, the flyweights are in a balanced position, and the pilot valve is centred, allowing neither oil in nor oil out of the propeller pitch-change mechanism. When RPM exceeds the selected value, the flyweights fly outward against the spring, moving the pilot valve to direct oil pressure to decrease blade pitch (on most governor designs, engine oil pressure drives the blades toward fine pitch). When RPM falls below the selected value, the flyweights collapse inward, the spring prevails, and the pilot valve directs oil flow to increase blade pitch. The result is a continuous, fast-acting feedback loop that maintains the selected RPM very precisely.
+
+The pilot selects the desired RPM using the propeller control lever, which preloads the governor spring. Increasing the spring preload requires more flyweight centrifugal force to reach equilibrium — which means a higher RPM. Decreasing preload allows the flyweights to balance at a lower RPM. In normal operation, the throttle controls manifold pressure (and therefore power for a given RPM), and the propeller lever controls RPM. These are adjusted together to achieve the desired power setting using the aircraft's power setting charts.
+
+### Feathering
+
+When an engine fails in flight in a multi-engine aircraft, the propeller of the failed engine continues to windmill — rotating in the airstream due to aerodynamic forces even though the engine is not producing power. A windmilling propeller creates significant drag — sometimes more drag than a fixed-pitch prop at cruise, because the blades are at a near-flat pitch that presents a large frontal area to the airstream. This drag significantly reduces the performance of the surviving engine.
+
+Feathering a propeller means rotating the blades to the feathered position, where the leading edge faces directly into the airflow — approximately 90 degrees of blade angle. In the feathered position, the blade presents its minimum frontal area to the airstream and creates minimal drag. On a twin-engine aircraft, feathering the failed engine's propeller typically reduces total drag by 60 to 80 percent compared to leaving it windmilling, and dramatically improves single-engine climb performance and altitude maintenance. Most multi-engine aircraft have a propeller governor that can be commanded to feather the prop by moving the propeller lever into the feather gate. Source: TP 12880E.
+
+### Propeller Asymmetric Effects
+
+Four separate propeller effects contribute to left-yaw tendency in a single-engine aircraft with a clockwise-rotating propeller as viewed from the cockpit. You need to understand all four for the exam.
+
+Torque is the reaction to the engine rotating the propeller clockwise. By Newton's third law, the engine experiences an equal and opposite reaction — the aircraft tends to rotate counterclockwise as seen from the pilot's perspective, which means the left wing is pushed down and the aircraft rolls left. Torque effect is most significant at high power settings.
+
+P-factor, or propeller asymmetric thrust, occurs at high angles of attack. When the aircraft nose is raised — as during takeoff rotation or initial climb — the propeller disc is tilted relative to the airstream. The descending blade on the right side of the disc has a greater effective angle of attack and therefore produces more thrust than the ascending blade on the left. The asymmetric thrust yaws the nose to the left. P-factor is most pronounced at high power and low airspeed — exactly the conditions that exist during takeoff and initial climb.
+
+Gyroscopic precession acts on the spinning propeller disc, which behaves as a gyroscope. Any force applied to change the plane of rotation produces a precession effect 90 degrees ahead in the direction of rotation. During a conventional tailwheel aircraft takeoff, when the tail is raised, a downward force is applied to the front of the propeller disc. Gyroscopic precession causes the resulting precession force to act 90 degrees ahead in the direction of rotation, which pushes the right side of the disc forward and the left side back — yawing the nose to the left.
+
+Slipstream effect occurs because the propeller accelerates air not just rearward but also in a rotating spiral around the fuselage. This rotating slipstream strikes the vertical tail from the left, producing a left-yaw-inducing force. At high power settings and low airspeed, the slipstream velocity is high relative to the aircraft forward speed, and the slipstream effect is significant. Source: TP 12880E.
+
+### The Critical Engine
+
+In a multi-engine aircraft, if an engine fails, the remaining engine must provide enough thrust to maintain controlled flight. However, the engines' thrust forces do not act through the aircraft's centreline — they act at the propeller disc locations, which are offset from the centreline. When an engine fails, the thrust offset of the remaining engine creates a yawing moment toward the failed engine.
+
+The critical engine is the engine whose failure creates the most asymmetric and hardest to control yawing moment. On a conventional twin with both propellers rotating clockwise as viewed from the cockpit, the left engine is the critical engine. Here is why: P-factor causes the effective thrust line of each engine to be displaced toward the descending blade side — to the right, for a clockwise-rotating propeller. This means the effective thrust of the left engine is closer to the centreline than the effective thrust of the right engine. When the left engine fails, the remaining right engine has its thrust line further from the centreline, creating a larger yawing moment, which is harder to counteract with the rudder. Left engine failure is therefore more critical than right engine failure.
+
+Vmc is the minimum control speed — the minimum airspeed at which the aircraft can be kept straight with maximum rudder when the critical engine has failed and the remaining engine is producing maximum power. Below Vmc, the rudder cannot generate enough force to overcome the asymmetric thrust yawing moment, and directional control is lost. Vyse is the best single-engine rate of climb speed — commonly called blue-line speed because it is marked in blue on the airspeed indicator — and is the target speed after an engine failure in a twin. Operating at blue-line gives the aircraft its best chance of maintaining or gaining altitude on the single remaining engine. Source: TP 12880E.
+
+### Governor Failure and Overspeed
+
+If the constant-speed governor fails, the propeller will typically move to the fine pitch stop — the blade angle is reduced to its minimum value. At fine pitch, the propeller loads the engine very lightly, and with the throttle advanced, the engine will overspeed — run above its red-line RPM. Overspeed is dangerous because it can cause bearing failure, propeller blade tip separation, valve float, and other catastrophic engine failures.
+
+If you experience an overspeed, the immediate action is to retard the throttle to reduce manifold pressure and bring the RPM down. In some aircraft, you can use the propeller control lever to attempt to load the propeller and reduce RPM, but if the governor is truly failed, the lever may have no effect. The priority is reducing power to prevent engine damage. Land as soon as practicable after a governor failure, and have the system inspected before the next flight. Source: TP 12880E.
+
+### Summary
+
+In this lesson you learned that the propeller blade is an airfoil producing thrust through the same lift principles as a wing. Blade angle, or pitch, is the angle between the chord line and the plane of rotation. Fine pitch is low blade angle; coarse pitch is high blade angle. Geometric pitch is the theoretical advance per revolution; effective pitch is the actual advance; propeller slip is the difference. Fixed-pitch propellers are a compromise between climb and cruise efficiency; constant-speed propellers use a centrifugal flyweight governor to maintain selected RPM by automatically adjusting blade angle. Feathering removes windmilling drag after engine failure in a multi-engine aircraft by rotating blades to face directly into the airflow. Four effects cause left-yaw in a clockwise-rotating single-engine aircraft: torque, P-factor, gyroscopic precession, and slipstream. The critical engine on a conventional twin is the left engine because its failure leaves the right engine's thrust line furthest from the centreline. Governor failure typically causes overspeed through propeller going to fine pitch, corrected immediately by reducing throttle.
+
+---
+
+*End of Lesson ADE-003.*

--- a/lessons/cpl-a/016-performance-charts-cruise.md
+++ b/lessons/cpl-a/016-performance-charts-cruise.md
@@ -6,7 +6,7 @@ slug: performance-charts-cruise
 title: "Performance Charts — Cruise and Range Computations"
 duration_min: 20
 status: draft
-audio: null
+audio: https://media.suprun.workers.dev/ppl/lessons/cpl-a/016-performance-charts-cruise.m4a
 visual: null
 sources:
   - "TP 12880E (Aeroplane Flight Training Manual)"
@@ -81,4 +81,80 @@ Topics to be authored:
 
 ---
 
-*Skeleton only — full narration script to be added before audio production.*
+## Narration Script
+
+### Introduction
+
+The performance section of your aircraft's pilot's operating handbook contains detailed charts and tables that predict the aircraft's capabilities under specific conditions. Using these charts accurately is a practical and regulatory requirement for commercial operations — you cannot legally fly a cross-country without confirming your fuel burn and range, and you cannot dispatch a charter flight without verifying that your aircraft can reach the destination with legal reserves. In this lesson you will learn to interpret cruise performance charts, understand the relationship between power setting and fuel flow, distinguish between range and endurance performance, account for wind and altitude, and apply the results to commercial flight planning. Sources: TP 12880E; AFM/POH examples.
+
+### Density Altitude: The Basis for All Performance
+
+All aircraft performance — takeoff distance, climb rate, cruise speed, and fuel flow — depends on the density of the air, not on the pressure altitude or geometric altitude directly. Density altitude is the altitude in the standard atmosphere that corresponds to the actual air density at the aircraft's location. It is calculated as pressure altitude corrected for non-standard temperature.
+
+Pressure altitude is what the altimeter reads when set to the standard setting of 29.92 inches of mercury. On a standard day, pressure altitude equals density altitude — they are the same thing. But on a hot day, the air is less dense than the standard atmosphere would predict for that pressure altitude, so the density altitude is higher than the pressure altitude. On a cold day, the reverse is true.
+
+The practical implication is significant. If you are operating at an airport with a pressure altitude of 5,000 feet on a day where the temperature is 30 degrees Celsius — 20 degrees above standard — the density altitude may be 8,000 feet or more. Your aircraft will perform as if it were operating at 8,000 feet, not 5,000. Takeoff distances are longer, climb rates are reduced, and true airspeed for a given indicated airspeed is higher. Performance charts use density altitude as their input variable, so you must derive density altitude from your pressure altitude and outside air temperature before entering the chart. Source: TP 12880E Chapter 5.
+
+### Reading Cruise Performance Charts
+
+A typical cruise performance chart in a piston aircraft POH is organised by altitude and power setting. The chart may present performance at several power percentages — commonly 55, 65, and 75 percent of rated brake horsepower — and for each, it lists the manifold pressure and RPM combination that achieves that power, the resulting true airspeed in knots, and the fuel flow in litres per hour or US gallons per hour.
+
+To use the chart, you enter with the pressure altitude (or density altitude if the chart requires it) and the temperature, and read off the performance values for your selected power setting. In some charts, temperature is an additional parameter that must be applied to correct the values, and you interpolate between the tabulated temperatures. In others, the table already incorporates a standard lapse rate temperature assumption, and you apply a temperature correction factor.
+
+Interpolation is the arithmetic process of finding a value between two tabulated entries. If the chart provides values for 6,000 feet and 8,000 feet, and you are operating at 7,000 feet, you interpolate: find the difference between the two chart values, take half of it, and add it to the lower entry. This linear interpolation is accurate enough for practical aviation purposes. More complex two-dimensional interpolation — where both altitude and temperature are between tabulated values — requires interpolating first on one variable, then on the other.
+
+### Power Settings: Manifold Pressure and RPM
+
+In a fixed-pitch propeller aircraft, the throttle directly controls engine power, and there is only one control to manage. In an aircraft with a constant-speed propeller, power is determined by the combination of manifold pressure — set with the throttle — and RPM — set with the propeller control. The performance chart tells you which combination of manifold pressure and RPM achieves a specific power percentage at a given altitude.
+
+For example, at 6,000 feet density altitude, 65 percent power might require 23 inches of manifold pressure at 2,400 RPM, while achieving the same 65 percent with a lower manifold pressure of 21 inches would require 2,600 RPM. Both produce similar power but through different loading of the engine. The manifold pressure and RPM limits in the POH define the operational boundaries — you may not operate above certain manifold pressures at given RPMs because doing so would exceed the engine's certification limits.
+
+The general rule in most piston engines with constant-speed propellers is to reduce RPM before increasing manifold pressure, and to reduce manifold pressure before increasing RPM. This sequencing prevents momentary overloading of the engine.
+
+### Best Power vs. Best Economy Mixture
+
+At any given power setting and altitude, the mixture setting significantly affects both fuel flow and cylinder head temperature. Best power mixture, approximately 100 degrees Fahrenheit rich of peak exhaust gas temperature, produces the maximum power for that throttle and RPM combination. More fuel than stoichiometrically required is being burned, the combustion is slightly cooler due to the excess fuel absorbing heat, and power is at its highest. Best economy mixture, at or just lean of peak exhaust gas temperature, reduces fuel flow and decreases power slightly, but the specific fuel consumption — litres burned per unit of power produced — is at its minimum. For long-distance commercial flights, best economy mixture at a power setting of 65 percent or below is typically the most efficient operating mode, provided cylinder head temperatures remain within limits.
+
+It is important to understand that operating lean of peak at high power settings — above approximately 75 percent — can cause detonation. The reduced cooling effect of the lean mixture combined with the high combustion pressure at high power creates conditions that can lead to premature ignition. This is why the lean-of-peak technique is approved only at reduced power settings, typically 65 percent or below in most aircraft. Source: TP 12880E.
+
+### Range vs. Endurance
+
+Range and endurance are related but distinct concepts. Range is the total distance the aircraft can travel on a given fuel load. Endurance is the total time the aircraft can remain airborne. Maximising one does not maximise the other, and understanding when to prioritise each is part of commercial flight planning.
+
+Maximum endurance is achieved at the airspeed that minimises fuel flow — minimum power speed, approximately the bottom of the power-required curve. This speed is slower than cruise speed and typically below the best rate of climb speed. You would use maximum endurance speed when you need to stay airborne as long as possible — for example, if your destination is below minimums and you are holding for conditions to improve.
+
+Maximum range is achieved at the airspeed that minimises fuel burn per nautical mile — equivalently, the speed that maximises nautical miles per litre. This is the speed at the tangent to the power-required curve from the origin, which corresponds to the best lift-to-drag ratio speed or very close to it. Flying at the best range speed and best economy mixture gives the maximum distance from a given fuel load, ignoring wind.
+
+Wind has a significant effect on the optimal range speed. With a tailwind, your effective range per litre improves because you cover more ground per hour. Counterintuitively, this means you should fly slightly faster than no-wind best range speed to take maximum advantage of the tailwind. With a headwind, you should fly slightly slower, because slowing down reduces fuel burn proportionally more than it reduces groundspeed. In practice, for most headwind and tailwind values encountered in normal commercial operations, the correction is small, and the no-wind best range speed is used as a practical approximation. Source: TP 12880E Chapter 5.
+
+### Effect of Wind on Fuel Planning
+
+When you calculate the fuel required for a commercial cross-country, you use the planned groundspeed — not the true airspeed — for time and therefore fuel calculations. If you plan to fly at 130 knots TAS into a 20-knot headwind, your groundspeed is 110 knots. A 200 nautical mile leg will take 200 divided by 110, or approximately 1.82 hours. If your fuel flow is 40 litres per hour, the fuel used is 40 times 1.82, or approximately 73 litres.
+
+If the headwind is stronger than forecast — say 30 knots instead of 20 — your groundspeed drops to 100 knots. The same 200 nautical mile leg now takes 2.0 hours and burns 80 litres. You must account for this uncertainty in your fuel planning by carrying contingency fuel above the CARs minimums, particularly on long legs where a significant forecast error could produce a material change in fuel consumption.
+
+The practical approach for commercial planning is to calculate fuel requirements for the forecast wind, add the CARs reserve, add a contingency allowance appropriate to the forecast confidence and route remoteness, and verify that this total fuel load keeps the aircraft within weight and balance limits.
+
+### Factors Reducing Actual vs. Chart Performance
+
+Aircraft performance charts are produced under controlled conditions in new aircraft with clean airframes, calibrated engines, and expert test pilots. Your actual performance in service will be somewhat different, and you should plan conservatively.
+
+Airframe contamination — dirt, bugs, or surface roughness on wings and control surfaces — increases drag and reduces both climb performance and cruise true airspeed. A typical figure used in commercial flight planning is a 1 to 2 percent reduction in fuel efficiency for normal airframe contamination. In winter operations, even light frost on the wing surfaces reduces lift and increases drag significantly.
+
+Engine wear reduces the power output below the new-engine chart values. An engine that has accumulated many hours since its last overhaul may produce 3 to 5 percent less power than the chart assumes. This translates to a higher fuel burn for the same airspeed, or a lower airspeed for the same fuel burn.
+
+Pilot technique matters. Failing to lean the mixture to the appropriate setting, running at higher power than the planned cruise setting, or flying at the wrong airspeed all increase fuel burn relative to chart predictions. Part of the value of systematic performance planning is that it creates a reference against which in-flight monitoring can detect deviations early.
+
+### Systematic Fuel Planning Process
+
+When planning fuel for a commercial cross-country, use this systematic process. First, determine the density altitude for each leg based on forecast temperature and pressure altitude. Second, enter the cruise performance chart to find the fuel flow at your planned power setting and density altitude. Third, calculate fuel burned per leg using fuel flow times estimated leg time, where leg time is leg distance divided by planned groundspeed. Fourth, sum the fuel for all legs to get total trip fuel. Fifth, add the reserve required by CARs 602.88 — 30 minutes for VFR day, 45 minutes for VFR night, or the IFR reserve including alternate if applicable. Sixth, add any contingency fuel appropriate to the forecast confidence, route remoteness, and your company's standard operating procedures. The result is your minimum required fuel for departure.
+
+Verify that the required fuel is available in the aircraft and that loading this fuel keeps the aircraft within weight and balance limits. If not, you must either reduce payload or plan a fuel stop.
+
+### Summary
+
+In this lesson you learned that density altitude — pressure altitude corrected for non-standard temperature — is the foundation of all performance chart calculations. Cruise performance charts are entered with altitude and power setting to find true airspeed and fuel flow. Interpolation between table entries is the standard method for intermediate values. Best power mixture maximises power for a given throttle setting; best economy mixture minimises fuel consumption per unit of power and is used at 65 percent power and below. Range is maximised at the specific airspeed that minimises fuel burn per nautical mile; endurance is maximised at a slower minimum-power speed. Tailwinds increase effective range; headwinds decrease it. Actual performance will be slightly less than chart performance due to airframe contamination, engine wear, and pilot technique, and contingency fuel should be added to the regulatory minimums accordingly. A systematic fuel planning process applied consistently to every commercial flight is both a regulatory requirement and professional best practice.
+
+---
+
+*End of Lesson PAL-001.*

--- a/lessons/cpl-a/017-weight-balance-commercial.md
+++ b/lessons/cpl-a/017-weight-balance-commercial.md
@@ -6,7 +6,7 @@ slug: weight-balance-commercial
 title: "Weight and Balance for Commercial Operations"
 duration_min: 20
 status: draft
-audio: null
+audio: https://media.suprun.workers.dev/ppl/lessons/cpl-a/017-weight-balance-commercial.m4a
 visual: null
 sources:
   - "TP 12880E (Aeroplane Flight Training Manual)"
@@ -83,4 +83,76 @@ Topics to be authored:
 
 ---
 
-*Skeleton only — full narration script to be added before audio production.*
+## Narration Script
+
+### Introduction
+
+Weight and balance is one of the most important pre-flight calculations you will perform on every commercial flight, and it is also one of the most frequently misunderstood. At the PPL level, weight and balance is often treated as a checkbox — you verify the aircraft is within limits and move on. At the commercial level, you need to understand the physics behind the limits, perform calculations accurately under time pressure, manage the effect of fuel burn on centre of gravity throughout the flight, and comply with the documentation requirements of CARs for commercial operations. This lesson builds the complete picture. Sources: TP 12880E Chapter 6; CARs 605.92.
+
+### Key Weight Definitions
+
+Several weight terms are used in aircraft documentation, and you must know each precisely.
+
+Basic empty weight is the weight of the aircraft as manufactured, including all permanent equipment, unusable fuel, and full engine oil. It is established by weighing the aircraft and is documented in the weight and balance report. Any permanent modifications or additions to the aircraft change the basic empty weight and require an updated weight and balance report.
+
+Useful load is the difference between the maximum takeoff weight and the basic empty weight. It represents the maximum payload — pilots, passengers, cargo, and usable fuel — the aircraft can carry.
+
+Maximum takeoff weight, abbreviated MTOW, is the maximum certified weight at which the aircraft may begin its takeoff roll. It is established by structural certification and documented in the approved flight manual. No commercial loading may result in a weight above MTOW.
+
+Maximum landing weight, sometimes abbreviated MLW, is the maximum weight at which the aircraft may touch down. In many light aircraft, the MTOW and MLW are the same. In heavier aircraft — particularly those that may need to dump fuel before landing in an emergency — the MLW is lower than the MTOW because landing loads on the structure are higher than takeoff loads.
+
+Maximum zero fuel weight, or MZFW, is the maximum weight of the aircraft excluding all usable fuel. This limit exists because of the bending loads on the wing root during flight: the wing produces upward lift distributed along its span, while the fuselage weight acts downward at the wing root. Fuel stored in wing tanks is in between the wing root and the tip, and it reduces this bending moment. When all fuel is burned, the full bending moment of the fuselage weight must be sustained by the wing structure without the partial relief provided by wing-mounted fuel. MZFW is therefore the structural limit for zero-fuel loading: all weight above MZFW must be usable fuel. Source: TP 12880E.
+
+### The Moment Calculation
+
+The centre of gravity — abbreviated CG — is the point where the aircraft's total weight acts vertically downward. To find the CG, you need to know not just the weight of each item but also where each item is located relative to a reference point called the datum.
+
+Moment is the product of a weight and its distance from the datum. The formula is moment equals weight times arm, where arm is the distance from the datum to the point where the weight is applied. If a passenger weighing 80 kilograms sits in a seat located 2.5 metres from the datum, the moment is 80 times 2.5, which equals 200 kilogram-metres.
+
+To find the aircraft's CG, you sum all the individual moments — engine, airframe, fuel, passengers, cargo — and divide by the total weight. The result gives the CG location as a distance from the datum. You then verify that this distance falls within the forward and aft CG limits specified in the aircraft's weight and balance data.
+
+In practice, the calculation proceeds in four steps. First, list all items and their weights. Second, multiply each weight by its arm to find each moment. Third, add all weights to get total weight and all moments to get total moment. Fourth, divide total moment by total weight to find the CG location. Compare the CG location to the envelope, and confirm both total weight and CG are within limits. Source: TP 12880E Chapter 6.
+
+### CG Limits: Forward and Aft
+
+The approved flight manual specifies a CG envelope — a range of CG positions, expressed as distances from the datum, within which the aircraft must be loaded for all phases of flight. The envelope typically narrows at higher weights because structural and aerodynamic loads are greater.
+
+The forward CG limit is determined by elevator authority. The further forward the CG, the greater the nose-down pitching moment the elevator must counteract during takeoff rotation, flare, and stall recovery. If the CG is too far forward, the elevator may not have sufficient authority to raise the nose to the required angle, making takeoff rotation difficult or impossible at some weight and flap configurations, and making a flare for landing impossible at the appropriate airspeed. Forward CG also increases the stick force required to pull up to stall, which in some respects is a safety feature — it makes inadvertent stalls less likely — but it also means a higher approach speed may be required, increasing landing distance.
+
+The aft CG limit is determined by static stability. When an aircraft with an aft CG is disturbed by a gust or pitch input, the aerodynamic restoring moment from the horizontal tail is reduced because the tail's moment arm to the CG is shorter. At the certified aft CG limit, the aircraft still has adequate static stability — it will return to trimmed flight when disturbed. If the CG is pushed beyond the aft limit, the aircraft may have near-neutral or negative static stability, meaning it will not return to trimmed flight on its own and may diverge from its flight path after a disturbance. In severe cases, the aircraft can enter a deep stall — an unrecoverable stall condition — or become uncontrollable. Operating with an aft CG that exceeds limits is a certification violation and a potentially fatal situation. Source: TP 12880E Chapter 6; CARs 605.92.
+
+### The Loading Envelope
+
+The loading envelope is a graph with CG location on the horizontal axis and gross weight on the vertical axis. The approved operating region is shown as a polygon bounded by the forward CG limit, the aft CG limit, the maximum weight, and in some aircraft, a minimum weight. To confirm that a particular loading is within limits, you calculate the CG location and total weight, then plot this point on the envelope. If the point falls inside the polygon, the loading is within limits. If it falls outside — even slightly — the loading must be adjusted before flight.
+
+Some aircraft use index units instead of actual moments to simplify calculation. An index unit is a reduced-scale moment calculated by dividing the actual moment by a convenient constant and then offsetting by a fixed number. This reduces the arithmetic and the size of the numbers involved, making manual computation more practical. The resulting CG check is performed on an index envelope rather than a moment envelope, but the principle is identical.
+
+### Effect of Fuel Burn on CG
+
+An aspect of weight and balance that is often underappreciated is that burning fuel changes the CG position throughout the flight. Fuel has a weight and a moment — its arm is the distance from the datum to the fuel tank. As fuel is consumed, both the total weight and the total moment decrease, and the CG shifts. The direction of shift depends on whether the fuel tank arm is forward or aft of the current CG.
+
+If the fuel tanks are located forward of the CG, burning fuel reduces the forward moment more than the aft moment, and the CG moves aft during the flight. If the tanks are aft of the CG, the opposite occurs — fuel burn moves the CG forward. In many aircraft, fuel burn moves the CG aft, which means the aircraft that was comfortably within limits at departure may approach or exceed the aft CG limit as fuel burns off in cruise.
+
+For this reason, the weight and balance check for a commercial flight must be conducted at multiple fuel states: at takeoff weight with full fuel, at an intermediate fuel state representing the en route cruise phase, and at landing weight with minimum fuel. If any of these conditions produces a CG outside the envelope, the loading must be adjusted. You cannot simply check takeoff weight and assume all will be well on landing. Source: TP 12880E Chapter 6.
+
+### Moving or Adding Loads
+
+A simple formula allows quick calculation of how moving a weight from one location to another changes the CG. The CG shift equals the weight moved times the distance it was moved, divided by the new total weight. This formula is useful when you discover that the calculated CG is close to a limit and you want to know how much a load shift would help.
+
+For example, if the CG is 5 centimetres forward of the desired position, and you want to move a cargo item weighing 50 kilograms from near the front of the cargo hold to the rear — a distance of 3 metres — the CG shift would be 50 times 3, divided by the total aircraft weight. If the aircraft weighs 1,500 kilograms, the shift would be 150 divided by 1,500, or 0.10 metres or 10 centimetres. Moving the cargo rearward would shift the CG 10 centimetres aft, more than correcting the 5-centimetre forward displacement. In this case, you might move the cargo only partway to get exactly to your target CG. Source: TP 12880E.
+
+### Commercial Documentation Requirements
+
+CARs 605.92 places the responsibility for weight and balance compliance on the pilot-in-command. Before every commercial flight, the PIC must verify that the aircraft is loaded within its approved weight and CG limits. This verification must be documented.
+
+For air taxi operations under CARs Part VII, the documentation requirements may include a passenger manifest listing each passenger, a cargo manifest listing freight weights and locations, and a weight and balance calculation or trim sheet showing the derived CG and total weight. These documents may be required to be retained for a specified period after the flight.
+
+In some commercial operations, a load controller or operations agent prepares the initial weight and balance calculation. The PIC reviews and verifies it before accepting the aircraft for flight. If the PIC disagrees with the calculation or believes the loading is incorrect, the PIC has the authority and the responsibility to require the load to be adjusted before departure. This authority cannot be overridden by schedule pressure or operator instruction. Source: CARs 605.92; CARs 703.
+
+### Summary
+
+In this lesson you learned the key weight definitions: basic empty weight, useful load, MTOW, maximum landing weight, and MZFW. The CG is calculated as total moment divided by total weight, where moment equals weight times arm for each item. The forward CG limit is determined by elevator authority; the aft CG limit is determined by static stability. Loading outside either limit is both a regulatory violation and a serious safety hazard. The loading envelope graph allows rapid visual confirmation that a given weight and CG combination is within limits. Fuel burn changes the CG position during flight, so the check must be done at multiple fuel states. Moving a load changes CG by an amount equal to the weight moved times distance moved, divided by the new total weight. CARs 605.92 places the weight and balance responsibility firmly on the pilot-in-command, who cannot delegate this duty.
+
+---
+
+*End of Lesson PAL-002.*

--- a/lessons/cpl-a/018-aircraft-limitations.md
+++ b/lessons/cpl-a/018-aircraft-limitations.md
@@ -6,7 +6,7 @@ slug: aircraft-limitations
 title: "Aircraft Limitations — Operating Envelope and Flight Manual"
 duration_min: 20
 status: draft
-audio: null
+audio: https://media.suprun.workers.dev/ppl/lessons/cpl-a/018-aircraft-limitations.m4a
 visual: null
 sources:
   - "TP 12880E (Aeroplane Flight Training Manual)"
@@ -81,4 +81,84 @@ Topics to be authored:
 
 ---
 
-*Skeleton only — full narration script to be added before audio production.*
+## Narration Script
+
+### Introduction
+
+Every aircraft has a defined envelope of conditions within which it is certified to operate. Fly within the envelope and the aircraft performs as the manufacturer designed it. Exceed the envelope and you enter unknown territory — potentially structurally dangerous territory — where the manufacturer's guarantees no longer apply and structural failure becomes a real possibility. For the commercial pilot, knowing and respecting the aircraft's limitations is not just an exam topic — it is a professional and legal responsibility. In this lesson you will learn to interpret the approved flight manual, understand the V-speed system, recognise airspeed indicator markings, apply load factor limits, and meet the pre-flight airworthiness obligations imposed by CARs. Sources: TP 12880E; CARs 602.02; CARs 625; AFM/POH.
+
+### The Approved Flight Manual
+
+The Approved Flight Manual, or AFM, is a Transport Canada-approved document that forms part of the aircraft's type certificate. It is not just a manufacturer's reference guide — it has legal standing. The limitations section of the AFM contains regulatory limits, not advisory guidelines. If the AFM states that maximum demonstrated crosswind is 17 knots, that is a published limitation that defines the certification basis. If the AFM lists an airspeed as VNE, that speed must never be exceeded, by regulation.
+
+The AFM is required to be carried on board for all Canadian-registered aircraft. Along with the Certificate of Airworthiness, the maintenance release in the aircraft journey log, and the current weight and balance report, it is one of the documents that must be on board for the aircraft to be legally airworthy. Before every flight, you are responsible for ensuring these documents are current and on board.
+
+The AFM is typically divided into sections: limitations, normal procedures, emergency procedures, and performance. The limitations section specifies the operating envelope within which the aircraft must remain. Any operation that exceeds a stated limitation renders the aircraft operation non-compliant with the certificate of airworthiness, and depending on the severity, may constitute a danger to persons and property in violation of the Aeronautics Act. Source: CARs 605.84; TP 12880E.
+
+### V-Speeds
+
+V-speeds are specific airspeed values, defined in the AFM, that mark boundaries of the operating envelope. You need to know the primary V-speeds for the CPL-A exam, their definitions, and their airspeed indicator markings.
+
+VNE is the never-exceed speed. It is the absolute upper airspeed limit, beyond which structural damage or failure due to aeroelastic effects — flutter — may occur. VNE is marked on the airspeed indicator by a red radial line. No operation may exceed VNE under any circumstances. If you inadvertently exceed VNE, an engineering evaluation may be required before the next flight.
+
+VNO is the maximum structural cruising speed. It is the highest airspeed for routine operations in smooth air. Above VNO and below VNE, the yellow arc on the airspeed indicator indicates the caution range — flight in smooth air only. In turbulence, you must not exceed VNO because a gust load added to the aerodynamic load above VNO could exceed the aircraft's limit load factor.
+
+VA is the manoeuvring speed, also called the design manoeuvring speed. At or below VA, full and abrupt deflection of a single control surface will not exceed the aircraft's certified limit load factor. Above VA, the full deflection of a control surface could generate aerodynamic loads that exceed the structural limit. VA is not marked on the airspeed indicator but is published in the AFM. Critically, VA decreases as aircraft weight decreases. This is because at light weights, the wing stalls at a lower airspeed than at heavy weights. At VA, the wing will stall before reaching the limit load factor — the stall acts as a natural load limiter. At a lighter weight, stall occurs at an even lower airspeed, and the structural limit could be exceeded at the published heavy-weight VA value. Always use the VA appropriate to your actual weight. Source: TP 12880E.
+
+VFE is the maximum flap extended speed. Extending flaps above VFE risks structural damage to the flaps and their attachments. VFE is marked on the airspeed indicator as the upper end of the white arc. The lower end of the white arc is VS0 — the stall speed in the landing configuration.
+
+VLO is the maximum speed at which the landing gear may be operated — either extended or retracted. VLE is the maximum speed with the landing gear extended. These speeds apply to retractable-gear aircraft. Exceeding VLO can cause the gear doors or actuating mechanisms to fail. Exceeding VLE can cause structural damage to the extended gear assembly in the airstream. Source: TP 12880E.
+
+### Airspeed Indicator Markings
+
+The airspeed indicator colour coding provides immediate visual reference for V-speeds and operating ranges.
+
+The white arc extends from VS0, the stall speed in the landing configuration at maximum weight, to VFE, the maximum flap extended speed. Flight within the white arc is permitted with flaps extended.
+
+The green arc extends from VS1, the stall speed in the clean configuration at maximum weight, to VNO, the maximum structural cruising speed. Flight within the green arc represents normal operations.
+
+The yellow arc extends from VNO to VNE. Flight in the yellow arc is permitted only in smooth air — this is the caution range. Avoid the yellow arc in turbulence or rough air.
+
+The red radial line at VNE marks the absolute airspeed limit. Never exceed this indication.
+
+Some aircraft also have a white radial line at a specific speed — for example, VY or VX for the aircraft type — though these are less common as standard markings. On multi-engine aircraft, a blue radial line marks VYSE, the best single-engine rate of climb speed. Source: TP 12880E; CARs 605.
+
+### Load Factors and G-Limits
+
+A load factor is the ratio of the aerodynamic lift supporting the aircraft to the aircraft's actual weight. In straight and level flight, lift equals weight and the load factor is 1g. In a 60-degree bank level turn, the load factor is 2g. In a steep spiral or abrupt pullout from a dive, the load factor can be much higher.
+
+Aircraft are certified in different categories that specify the maximum load factors they are designed to withstand. Normal category aircraft are certified for a positive limit load factor of 3.8g and a negative limit load factor of 1.52g. Utility category aircraft are certified for positive 4.4g and negative 1.76g. Aerobatic category aircraft are certified for positive 6.0g and negative 3.0g. These are limit load factors — the aircraft must withstand them without permanent deformation. The ultimate load factor, which is 1.5 times the limit load factor, is the level the aircraft must withstand without structural failure, though some permanent deformation may occur.
+
+Operating above the limit load factor can cause the aircraft to deform permanently — bent spars, buckled skin, distorted control surfaces. Operating above the ultimate load factor can cause structural failure. Structural damage from overstress may not be immediately obvious to the pilot: the aircraft may appear to fly normally but be significantly weakened. Any operation that may have resulted in exceeding the limit load factor requires an inspection by a licensed aircraft maintenance engineer before the next flight.
+
+Turbulence increases load factors because gusts add to or subtract from the aerodynamic lift almost instantaneously, generating large acceleration spikes. This is why VNO — not VNE — is the turbulence speed limit. At VNO, the structural margin above the limit load factor is adequate to absorb the gust loads likely to be encountered in routine turbulence. Above VNO, the margin decreases, and severe turbulence could push the load factor above the limit. Source: TP 12880E; CARs 625 Appendix C.
+
+### Operating Limitations and MEL
+
+Beyond the V-speeds and load factors, the AFM contains other categories of limitations that the commercial pilot must know and respect. Temperature limits define the range of outside air temperatures within which the aircraft may be operated — both for engine start and for flight. Operating below the minimum temperature limit may prevent proper oil circulation on engine start; operating above the maximum temperature limit may affect structural integrity of composite components or seal materials.
+
+Altitude limits specify the maximum certified operating altitude. This may be the service ceiling for normally-aspirated aircraft, or a specific certified maximum altitude for pressurised or turbocharged aircraft. Operating above the certified maximum altitude is a limitation violation regardless of the aircraft's actual performance capability.
+
+Some aircraft are approved with a Minimum Equipment List, or MEL. An MEL lists specific items of equipment that may be inoperative under defined conditions, allowing the aircraft to continue in service with certain systems unserviceable rather than grounding it for every minor defect. Operating with an inoperative item not covered by an MEL — or operating with an item inoperative in conditions not permitted by the MEL — makes the aircraft unairworthy. Not all aircraft have approved MELs: if no MEL exists, all required equipment must be serviceable. Source: CARs 605.
+
+### PIC Airworthiness Responsibility
+
+CARs 602.02 establishes the pilot-in-command's responsibility to ensure the aircraft is airworthy before flight. This means conducting a thorough pre-flight inspection, checking that the required documents are on board and current, verifying the maintenance release in the journey log has been completed by a licensed AME, and checking for any maintenance deferrals or open defects.
+
+A maintenance release — also called a technical log or journey log entry — is the AME's certification that the aircraft has been inspected and is airworthy for the next flight. The PIC must review the journey log before flight and check whether any defects are logged. If a defect is logged that has not been resolved or deferred under an MEL, the aircraft is unairworthy and the flight must not begin.
+
+Annual inspections are required every 12 calendar months for most aircraft. 100-hour inspections are required for aircraft operating commercially for hire, every 100 hours of flight time. Airworthiness directives, issued by Transport Canada when a safety-critical defect is identified in a fleet, are mandatory compliance items that must be completed within the specified time limits. The PIC does not perform the inspection, but is responsible for knowing whether the required inspections are current before accepting the aircraft for a commercial flight. Source: CARs 602.02; CARs 625.
+
+### Pre-Flight Airworthiness Check
+
+The physical pre-flight inspection — the walk-around — is the PIC's personal verification that the aircraft is in the expected condition for flight. For commercial operations, this inspection must be systematic and thorough. You check the airframe structure for visible damage, the control surfaces for freedom of movement and correct direction of travel, the fuel and oil levels against planned requirements, the landing gear and tyres, the pitot-static system for obstructions, and the cockpit instruments and avionics for proper operation.
+
+Any discrepancy found during the pre-flight — a low oil level, a dent in a control surface, a soft tyre, a loose inspection panel — must be resolved before flight. For minor items, you consult the MEL to determine whether flight is permitted. For anything that is not clearly within MEL provisions, you consult the maintenance organisation before departing. The commercial standard is simple: if in doubt, do not depart.
+
+### Summary
+
+In this lesson you learned that the Approved Flight Manual is a regulatory document whose limitations section is legally binding, and it must be carried on board along with the Certificate of Airworthiness, maintenance release, and weight and balance report. VNE — marked by the red radial line — must never be exceeded. VNO marks the upper edge of the green arc and the lower edge of the yellow caution range. VA is the manoeuvring speed that decreases with lower aircraft weight. VFE marks the top of the white arc. Normal category aircraft are approved for positive 3.8g, utility for 4.4g, and aerobatic for 6.0g. Operating above limit load factor risks permanent deformation; above ultimate load factor risks structural failure. MELs provide a framework for operating with specific equipment inoperative. CARs 602.02 places pre-flight airworthiness responsibility squarely on the pilot-in-command, who must verify that inspections are current, the journey log shows a valid maintenance release, and the physical pre-flight inspection reveals no unresolved defects. These principles are tested throughout the CPL-A exam and are the foundation of safe commercial aircraft operations.
+
+---
+
+*End of Lesson PAL-003.*


### PR DESCRIPTION
Closes #499

## Changes

**Content authoring (13 lessons):** Added complete `## Narration Script` sections to CPL-A lessons 006–018. Each script is approximately 1,800–2,100 words of second-person teaching prose, factually accurate against Transport Canada sources (TP 1102 Vol. 5, TP 12880E, CARs), with no markdown tables or symbols (TTS-safe formatting).

| Lesson | ID | Topic |
|--------|-----|-------|
| 006 | AMT-001 | Upper Level Charts and SIGWX Forecasts |
| 007 | AMT-002 | Icing — Causes, Types, and Avoidance |
| 008 | AMT-003 | Thunderstorm Structure and Aviation Hazards |
| 009 | AMT-004 | Mountain Wave Turbulence and Orographic Effects |
| 010 | ANV-001 | RNAV and High-Level Navigation |
| 011 | ANV-002 | Time, Distance, and Fuel Calculations |
| 012 | ANV-003 | Commercial Cross-Country Flight Planning |
| 013 | ADE-001 | High-Speed Aerodynamics |
| 014 | ADE-002 | Advanced Engine Systems |
| 015 | ADE-003 | Propeller Theory and Control |
| 016 | PAL-001 | Performance Charts: Cruise and Range |
| 017 | PAL-002 | Weight and Balance — Commercial Operations |
| 018 | PAL-003 | Aircraft Limitations and Airworthiness |

**Audio generation:** Kokoro TTS (voice `am_echo`, speed 1.1) run for all 13 lessons. `.m4a` files uploaded to Cloudflare R2 under `ppl/lessons/cpl-a/`. `audio:` frontmatter updated in each lesson file.

## Test Plan

- [ ] Each of lessons 006–018 contains a `## Narration Script` section (grep check)
- [ ] All 13 `audio:` frontmatter fields contain a non-null Cloudflare Workers URL
- [ ] `scripts/validate-lesson-schema.sh` passes (101 lessons, 0 failures)
- [ ] Audio URLs are accessible via the Cloudflare Workers proxy
- [ ] Content is factually consistent with Transport Canada CPL-A exam material