### PR TITLE
[PPL-490] Generate Kokoro narration for CPL-A lessons (partial: 001–005)

### DIFF
--- a/lessons/cpl-a/001-cpl-licensing-requirements.md
+++ b/lessons/cpl-a/001-cpl-licensing-requirements.md
@@ -6,7 +6,7 @@ slug: cpl-licensing-requirements
 title: "CPL Licensing Requirements"
 duration_min: 20
 status: draft
-audio: null
+audio: https://media.suprun.workers.dev/ppl/lessons/cpl-a/001-cpl-licensing-requirements.m4a
 visual: null
 sources:
   - "CARs Part IV (Personnel Licensing)"

--- a/lessons/cpl-a/002-commercial-air-services.md
+++ b/lessons/cpl-a/002-commercial-air-services.md
@@ -6,7 +6,7 @@ slug: commercial-air-services
 title: "Commercial Air Services and Operator Certificates"
 duration_min: 20
 status: draft
-audio: null
+audio: https://media.suprun.workers.dev/ppl/lessons/cpl-a/002-commercial-air-services.m4a
 visual: null
 sources:
   - "CARs Part VII (Commercial Air Services)"

--- a/lessons/cpl-a/003-air-taxi-operations.md
+++ b/lessons/cpl-a/003-air-taxi-operations.md
@@ -6,7 +6,7 @@ slug: air-taxi-operations
 title: "Air Taxi Operations (CARs 703)"
 duration_min: 20
 status: draft
-audio: null
+audio: https://media.suprun.workers.dev/ppl/lessons/cpl-a/003-air-taxi-operations.m4a
 visual: null
 sources:
   - "CARs 703 (Air Taxi Operations)"

--- a/lessons/cpl-a/004-pic-authority-responsibilities.md
+++ b/lessons/cpl-a/004-pic-authority-responsibilities.md
@@ -6,7 +6,7 @@ slug: pic-authority-responsibilities
 title: "PIC Authority and Commercial Crew Responsibilities"
 duration_min: 20
 status: draft
-audio: null
+audio: https://media.suprun.workers.dev/ppl/lessons/cpl-a/004-pic-authority-responsibilities.m4a
 visual: null
 sources:
   - "CARs 700.15 (Pilot-in-Command Authority)"

--- a/lessons/cpl-a/005-commercial-vfr-night-regulations.md
+++ b/lessons/cpl-a/005-commercial-vfr-night-regulations.md
@@ -6,7 +6,7 @@ slug: commercial-vfr-night-regulations
 title: "Commercial VFR and Night Regulations"
 duration_min: 20
 status: draft
-audio: null
+audio: https://media.suprun.workers.dev/ppl/lessons/cpl-a/005-commercial-vfr-night-regulations.m4a
 visual: null
 sources:
   - "CARs 602.114–602.116 (VFR Weather Minimums)"


### PR DESCRIPTION
Closes #490 (partial — see blocker below)

## Changes

Generated Kokoro TTS narration (`am_echo`, speed 1.1, AAC/M4A 64 kbps) for the first 5 CPL-A lessons and updated their `audio:` frontmatter fields:

| Lesson | URL |
|---|---|
| 001-cpl-licensing-requirements | https://media.suprun.workers.dev/ppl/lessons/cpl-a/001-cpl-licensing-requirements.m4a |
| 002-commercial-air-services | https://media.suprun.workers.dev/ppl/lessons/cpl-a/002-commercial-air-services.m4a |
| 003-air-taxi-operations | https://media.suprun.workers.dev/ppl/lessons/cpl-a/003-air-taxi-operations.m4a |
| 004-pic-authority-responsibilities | https://media.suprun.workers.dev/ppl/lessons/cpl-a/004-pic-authority-responsibilities.m4a |
| 005-commercial-vfr-night-regulations | https://media.suprun.workers.dev/ppl/lessons/cpl-a/005-commercial-vfr-night-regulations.m4a |

All 5 URLs verified with `curl -I` → HTTP 200, `audio/mp4`.

## Blocker: Missing `## Narration Script` in lessons 006–018

Lessons 006–018 (13 files) are missing the `## Narration Script` section required by `docs/audio-standards.md`. The generation script exits with an error for each:

```
ERROR: no '## Narration Script' section found in lessons/cpl-a/006-upper-level-charts-sigwx.md
```

Per the issue instructions: "stop and report it rather than working around it — that's a content bug for a separate ticket." The following files need the section added before audio can be generated:

- `lessons/cpl-a/006-upper-level-charts-sigwx.md`
- `lessons/cpl-a/007-icing-types-avoidance.md`
- `lessons/cpl-a/008-thunderstorm-hazards.md`
- `lessons/cpl-a/009-mountain-wave-turbulence.md`
- `lessons/cpl-a/010-rnav-high-level-navigation.md`
- `lessons/cpl-a/011-time-distance-calculations.md`
- `lessons/cpl-a/012-cross-country-commercial.md`
- `lessons/cpl-a/013-high-speed-aerodynamics.md`
- `lessons/cpl-a/014-advanced-engine-systems.md`
- `lessons/cpl-a/015-propeller-theory.md`
- `lessons/cpl-a/016-performance-charts-cruise.md`
- `lessons/cpl-a/017-weight-balance-commercial.md`
- `lessons/cpl-a/018-aircraft-limitations.md`

## Test Plan

- [x] `curl -I` each of the 5 uploaded URLs → HTTP 200, `audio/mp4`
- [x] Only `audio:` frontmatter changed, no lesson body content modified
- [ ] Remaining 13 lessons require content fix (separate ticket) before audio generation