### PR TITLE
[PPL-492] Add helicopter-full curated playlist for PPL-H track

### DIFF
--- a/web-app/src/data/curated-playlists.ts
+++ b/web-app/src/data/curated-playlists.ts
@@ -41,4 +41,11 @@ export const CURATED_PLAYLISTS: CuratedPlaylist[] = [
     lessonIds: ['NIGHT-001', 'NIGHT-002', 'NIGHT-003', 'NIGHT-004', 'NIGHT-005', 'NIGHT-006'],
     badge: 'Night',
   },
+  {
+    id: 'helicopter-full',
+    name: 'PPL-H Full Listen',
+    tagline: 'Air law through human factors — the complete helicopter PPL ground-school curriculum',
+    lessonIds: ['HEL-001', 'HEL-002', 'HEL-003', 'HEL-004', 'HEL-005', 'HEL-006', 'HEL-007', 'HEL-008'],
+    badge: 'H',
+  },
 ];


### PR DESCRIPTION
Closes #492

## Changes
- Appended `helicopter-full` entry to `CURATED_PLAYLISTS` in `web-app/src/data/curated-playlists.ts`
- Entry includes all 8 HEL lessons (`HEL-001` through `HEL-008`) in curriculum order, badge `'H'`, and the specified name/tagline

## Test Plan
- `npm run build` passes in `web-app/` (verified locally — no TS errors)
- Navigate to `/playlist` on the PPL-H exam track: Helicopter playlist card should be visible
- Queue the playlist and confirm all 8 lessons play in order