### PR TITLE
[PPL-493] Add CPL-A full curated playlist

### DIFF
--- a/web-app/src/data/curated-playlists.ts
+++ b/web-app/src/data/curated-playlists.ts
@@ -48,4 +48,17 @@ export const CURATED_PLAYLISTS: CuratedPlaylist[] = [
     lessonIds: ['HEL-001', 'HEL-002', 'HEL-003', 'HEL-004', 'HEL-005', 'HEL-006', 'HEL-007', 'HEL-008'],
     badge: 'H',
   },
+  {
+    id: 'cpl-a-full',
+    name: 'CPL-A Full Listen',
+    tagline: 'Licensing through limitations — complete commercial airplane ground-school curriculum',
+    lessonIds: [
+      'CAL-001', 'CAL-002', 'CAL-003', 'CAL-004', 'CAL-005',
+      'AMT-001', 'AMT-002', 'AMT-003', 'AMT-004',
+      'ANV-001', 'ANV-002', 'ANV-003',
+      'ADE-001', 'ADE-002', 'ADE-003',
+      'PAL-001', 'PAL-002', 'PAL-003',
+    ],
+    badge: 'CPL',
+  },
 ];


### PR DESCRIPTION
Closes #493

## Changes
Appended a new `cpl-a-full` entry to `CURATED_PLAYLISTS` in `web-app/src/data/curated-playlists.ts`. The entry contains all 18 CPL-A lesson IDs in the required order (CAL-001–005, AMT-001–004, ANV-001–003, ADE-001–003, PAL-001–003), with badge `CPL` and the tagline from the issue brief. No UI components, types, or other data files were touched.

## Test Plan
- `tsc --noEmit` passes with zero errors after `npm install`
- Navigate to `/playlist` with CPL-A track active — confirm "CPL-A Full Listen" card appears
- Click the card and verify CAL-001 loads and plays
- Verify no other track playlists are affected